### PR TITLE
C51-31: Change extension name to uk.co.compucorp.civicase and its occurences.

### DIFF
--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -171,7 +171,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
    */
   private function createManageCasesMenuItem() {
     $this->addNav(array(
-      'label' => ts('Manage Cases', array('domain' => 'org.civicrm.civicase')),
+      'label' => ts('Manage Cases', array('domain' => 'uk.co.compucorp.civicase')),
       'name' => 'Manage Cases',
       'url' => 'civicrm/case/a/#/case/list',
       'permission' => 'access my cases and activities,access all cases and activities',

--- a/CRM/Civicase/Upgrader/Base.php
+++ b/CRM/Civicase/Upgrader/Base.php
@@ -45,7 +45,7 @@ class CRM_Civicase_Upgrader_Base {
     if (!self::$instance) {
       // FIXME auto-generate
       self::$instance = new CRM_Civicase_Upgrader(
-        'org.civicrm.civicase',
+        'uk.co.compucorp.civicase',
         realpath(__DIR__ . '/../../../')
       );
     }

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,4 @@
 Package: uk.co.compucorp.civicase
-Copyright (C) 2018, Compucorp
 Licensed under the GNU Affero Public License 3.0 (below).
 
 -------------------------------------------------------------------------------

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
-Package: org.civicrm.civicase
-Copyright (C) 2016, Coleman Watts <info@civicrm.org>
+Package: uk.co.compucorp.civicase
+Copyright (C) 2018, Compucorp
 Licensed under the GNU Affero Public License 3.0 (below).
 
 -------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CiviCase v5
 
-The CiviCase v5 extension (`org.civicrm.civicase`) is an overhaul of the
+The CiviCase v5 extension (`uk.co.compucorp.civicase`) is an overhaul of the
 CiviCase UI.  It provides a richer experience with more thoughtful layouts
 and interactions.
 
@@ -25,7 +25,7 @@ To install the extension on an existing CiviCRM site:
 mkdir sites/all/modules/civicrm/ext
 cd sites/all/modules/civicrm/ext
 git clone https://github.com/civicrm/org.civicrm.shoreditch shoreditch
-git clone https://github.com/civicrm/org.civicrm.civicase civicase
+git clone https://github.com/civicrm/uk.co.compucorp.civicase civicase
 cv en shoreditch civicase
 cv api setting.create customCSSURL=$(cv url -x shoreditch/css/custom-civicrm.css --out=list)
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To install the extension on an existing CiviCRM site:
 mkdir sites/all/modules/civicrm/ext
 cd sites/all/modules/civicrm/ext
 git clone https://github.com/civicrm/org.civicrm.shoreditch shoreditch
-git clone https://github.com/civicrm/uk.co.compucorp.civicase civicase
+git clone https://github.com/compucorp/uk.co.compucorp.civicase civicase
 cv en shoreditch civicase
 cv api setting.create customCSSURL=$(cv url -x shoreditch/css/custom-civicrm.css --out=list)
 ```

--- a/civicase.civix.php
+++ b/civicase.civix.php
@@ -8,7 +8,7 @@
  */
 class CRM_Civicase_ExtensionUtil {
   const SHORT_NAME = "civicase";
-  const LONG_NAME = "org.civicrm.civicase";
+  const LONG_NAME = "uk.co.compucorp.civicase";
   const CLASS_PREFIX = "CRM_Civicase";
 
   /**

--- a/info.xml
+++ b/info.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
-<extension key="org.civicrm.civicase" type="module">
+<extension key="uk.co.compucorp.civicase" type="module">
   <file>civicase</file>
   <name>CiviCase</name>
   <description>Manage cases, clients, activities, etc.</description>
   <license>AGPL-3.0</license>
   <maintainer>
-    <author>Coleman Watts</author>
-    <email>info@civicrm.org</email>
+    <author>Compucorp</author>
+    <email>info@compucorp.co.uk</email>
   </maintainer>
   <urls>
     <url desc="Main Extension Page">http://FIXME</url>


### PR DESCRIPTION
## Overview
PR changes extension name from `org.civicrm.civicase` to `uk.co.compucorp.civicase` and all its occurence from the codebase.

## Before
In the extension list (`civicrm/admin/extensions?reset=1&action=browse`)
<img width="1644" alt="c51-31 - before" src="https://user-images.githubusercontent.com/3340537/43768957-36995d3e-9a56-11e8-9826-94d1b7c5c922.png">

## After 
In the extension list (`civicrm/admin/extensions?reset=1&action=browse`)
<img width="1680" alt="c51-31 - after" src="https://user-images.githubusercontent.com/3340537/43768990-48bf688c-9a56-11e8-8ef5-66240865f2db.png">
