### PR TITLE
C51-34: Add BEM classes to HTML and move the title inside panel header and misc fixes

### DIFF
--- a/ang/civicase/CaseList.html
+++ b/ang/civicase/CaseList.html
@@ -1,15 +1,14 @@
 <div crm-ui-debug="cases"></div>
 <div crm-ui-debug="viewingCase"></div>
 <div crm-ui-debug="viewingCaseTab"></div>
-<h1 crm-page-title>{{ pageTitle }}</h1>
 <div id="bootstrap-theme" class="clearfix civicase__container">
-
-  <div class="panel panel-default civicase-search-panel clearfix" ng-class="{'case-is-focused': caseIsFocused}" civicase-search="filters" hidden-filters="hiddenFilters" expanded="searchIsOpen" on-search="applyAdvSearch(selectedFilters)">
+  <h1 crm-page-title>Manage Cases</h1>  <!-- Added for SEO purpose (This will be hidden through css) -->
+  <civicase-search filters="filters" hidden-filters="hiddenFilters" expanded="searchIsOpen" on-search="applyAdvSearch(selectedFilters)">
     <div class="civicase-filters-placeholder" ng-click="unfocusCase()">
       <i class="fa fa-angle-double-down" aria-hidden="true"></i>
       {{ ts('Filters') }}
       <i class="fa fa-angle-double-down" aria-hidden="true"></i>
     </div>
-  </div>
+  </civicase-search>
   <civicase-case-list-table></civicase-case-list-table>
 </div>

--- a/ang/civicase/CaseListDirectives.js
+++ b/ang/civicase/CaseListDirectives.js
@@ -64,6 +64,11 @@
               .on('affixed.bs.affix', function () {
                 $header.scrollLeft($table.scrollLeft());
                 $header.css('top', bodyPadding + 'px');
+                $table.css('padding-top', $header.height() + 'px');
+              })
+              .on('affixed-top.bs.affix', function () {
+                $header.css('top', 0);
+                $table.css('padding-top', 0);
               });
 
             // Attach scroll function

--- a/ang/civicase/CaseListDirectives.js
+++ b/ang/civicase/CaseListDirectives.js
@@ -62,13 +62,13 @@
             })
             // After element is affixed set scrolling pos (to avoid glitch) and top position
               .on('affixed.bs.affix', function () {
-                $header.scrollLeft($table.scrollLeft());
-                $header.css('top', bodyPadding + 'px');
-                $table.css('padding-top', $header.height() + 'px');
+                $header.scrollLeft($table.scrollLeft()); // Bind scrolling
+                $header.css('top', bodyPadding + 'px'); // Set top pos to body padding so that it don't overlap with the toolbar
+                $table.css('padding-top', $header.height() + 'px'); // Add top padding to remove the glitch when header moves out of DOM relative position
               })
               .on('affixed-top.bs.affix', function () {
-                $header.css('top', 0);
-                $table.css('padding-top', 0);
+                $header.css('top', 0); // Resets top pos when in default state
+                $table.css('padding-top', 0); // Resets padding top when in default state
               });
 
             // Attach scroll function

--- a/ang/civicase/Search.html
+++ b/ang/civicase/Search.html
@@ -1,79 +1,78 @@
-<div class="panel-header">
+<div class="panel panel-default civicase__filter-search-panel clearfix" ng-class="{'case-is-focused': $parent.caseIsFocused}">
   <div crm-ui-debug="filters"></div>
-  <form class="form-inline civicase-filters">
-    <input class="form-control" ng-list crm-ui-select="{allowClear: true, multiple: true, placeholder: ts('Case Type: Any'), data: caseTypeOptions}" ng-model="filters.case_type_id" />
-    <input class="form-control" ng-list crm-ui-select="{allowClear: true, multiple: true, placeholder: ts('Status: All open cases'), data: caseStatusOptions}" ng-model="filters.status_id" />
-    <button class="btn btn-primary btn-sm pull-right" ng-click="showMore()" ng-show="!expanded">
-      <i class="fa fa-gear"></i> {{ filterDescription.length ? ts('Edit Search') : ts('Other Criteria') }}
-    </button>
-    <button class="btn btn-primary btn-sm pull-right" ng-click="doSearch()" ng-show="expanded">
-      <i class="fa fa-search"></i> {{ ts('Search') }}
-    </button>
-  </form>
-</div>
-<form class="panel-body form-horizontal" ng-show="expanded">
-  <div class="form-group">
-    <label ng-if="isEnabled('id')" class="control-label col-lg-2">{{ ts('Case ID') }}</label>
-    <div class="col-lg-4">
-      <input ng-if="isEnabled('id')" class="form-control" type="number" ng-model="filters.id" />
-    </div>
+  <div class="panel-header civicase__filter-search-panel__header">
+    <h3 class="civicase__filter-search-panel__header-title"> {{ $parent.pageTitle }} </h3>
+    <form class="form-inline civicase-filters civicase__filter-search-panel__filters-container">
+      <input class="form-control civicase__filter-search-panel__filter" ng-list crm-ui-select="{allowClear: true, multiple: true, placeholder: ts('Case Type: Any'), data: caseTypeOptions}" ng-model="filters.case_type_id" />
+      <input class="form-control civicase__filter-search-panel__filter" ng-list crm-ui-select="{allowClear: true, multiple: true, placeholder: ts('Status: All open cases'), data: caseStatusOptions}" ng-model="filters.status_id" />
+      <input class="form-control civicase__filter-search-panel__filter" ng-list crm-ui-select="{allowClear: true, multiple: true, placeholder: ts('Status: All open cases'), data: caseStatusOptions}" ng-model="filters.status_id" />
+      <button class="btn btn-primary btn-sm pull-right civicase__filter-search-panel__button civicase__filter-search-panel__button--others" ng-click="showMore()" ng-show="!expanded">
+        <i class="fa fa-gear"></i> {{ filterDescription.length ? ts('Edit Search') : ts('Other Criteria') }}
+      </button>
+      <button class="btn btn-primary btn-sm pull-right civicase__filter-search-panel__button civicase__filter-search-panel__button--search" ng-click="doSearch()" ng-show="expanded">
+        <i class="fa fa-search"></i> {{ ts('Search') }}
+      </button>
+    </form>
   </div>
-  <div class="form-group">
-    <label ng-if="isEnabled('contact_id')" class="control-label col-lg-2">{{ ts('Client Name or Email') }}</label>
-    <div class="col-lg-4">
-      <input ng-if="isEnabled('contact_id')" class="form-control" ng-list crm-entityref="{entity: 'Contact', select: {multiple: true}}" ng-model="filters.contact_id" />
-    </div>
-    <div class="col-lg-6">
-      <div ng-if="checkPerm('administer CiviCase') && isEnabled('is_deleted')">
-        <input type="checkbox" ng-model="filters.is_deleted" id="case_search_field_is_deleted" />
-        <label for="case_search_field_is_deleted" class="control-label">{{ ts('Deleted Cases') }}</label>
+  <form class="panel-body form-horizontal civicase__filter-search-panel__form" ng-show="expanded">
+    <div class="form-group">
+      <label ng-if="isEnabled('id')" class="control-label col-lg-2">{{ ts('Case ID') }}</label>
+      <div class="col-lg-4">
+        <input ng-if="isEnabled('id')" class="form-control" type="number" ng-model="filters.id" />
       </div>
     </div>
-  </div>
-  <div class="form-group" ng-if="isEnabled('case_manager')">
-    <label for="case_search_field_case_manager" class="control-label col-lg-2">{{ ts('Case Manager') }}</label>
-    <div class="col-lg-4">
-      <input class="form-control" ng-list crm-entityref="{entity: 'Contact', select: {multiple: true}}" ng-model="filters.case_manager" id="case_search_field_case_manager" />
+    <div class="form-group">
+      <label ng-if="isEnabled('contact_id')" class="control-label col-lg-2">{{ ts('Client Name or Email') }}</label>
+      <div class="col-lg-4">
+        <input ng-if="isEnabled('contact_id')" class="form-control" ng-list crm-entityref="{entity: 'Contact', select: {multiple: true}}" ng-model="filters.contact_id" />
+      </div>
+      <div class="col-lg-6">
+        <div ng-if="checkPerm('administer CiviCase') && isEnabled('is_deleted')">
+          <input type="checkbox" ng-model="filters.is_deleted" id="case_search_field_is_deleted" />
+          <label for="case_search_field_is_deleted" class="control-label">{{ ts('Deleted Cases') }}</label>
+        </div>
+      </div>
     </div>
-    <div class="col-lg-6">
-      <input type="checkbox" ng-click="setCaseManager()" ng-checked="caseManagerIsMe()" id="case_search_field_case_manager_me" />
-      <label for="case_search_field_case_manager_me" class="control-label">{{ ts('Only my cases') }}</label>
+    <div class="form-group" ng-if="isEnabled('case_manager')">
+      <label for="case_search_field_case_manager" class="control-label col-lg-2">{{ ts('Case Manager') }}</label>
+      <div class="col-lg-4">
+        <input class="form-control" ng-list crm-entityref="{entity: 'Contact', select: {multiple: true}}" ng-model="filters.case_manager" id="case_search_field_case_manager" />
+      </div>
     </div>
-  </div>
-  <div class="form-group">
-    <label ng-if="isEnabled('start_date')" class="control-label col-lg-2">{{ ts('Case Start Date') }}</label>
-    <div class="col-lg-4">
-      <div ng-if="isEnabled('start_date')" crm-ui-date-range="filters.start_date"></div>
+    <div class="form-group">
+      <label ng-if="isEnabled('start_date')" class="control-label col-lg-2">{{ ts('Case Start Date') }}</label>
+      <div class="col-lg-4">
+        <div ng-if="isEnabled('start_date')" crm-ui-date-range="filters.start_date"></div>
+      </div>
     </div>
-  </div>
-  <div class="form-group">
-    <label ng-if="isEnabled('end_date')" class="control-label col-lg-2">{{ ts('Case End Date') }}</label>
-    <div class="col-lg-4">
-      <div ng-if="isEnabled('end_date')" crm-ui-date-range="filters.end_date"></div>
+    <div class="form-group">
+      <label ng-if="isEnabled('end_date')" class="control-label col-lg-2">{{ ts('Case End Date') }}</label>
+      <div class="col-lg-4">
+        <div ng-if="isEnabled('end_date')" crm-ui-date-range="filters.end_date"></div>
+      </div>
     </div>
-  </div>
-  <div class="form-group">
-    <label class="control-label col-lg-2">{{ ts('Tagged') }}</label>
-    <div class="col-lg-4">
-      <input class="form-control" ng-list crm-entityref="{entity: 'Tag', api: {params: {used_for: {'LIKE':'%civicrm_case%'}, is_selectable: 1}}, select: {multiple: true}}" ng-model="filters.tag_id">
+    <div class="form-group">
+      <label class="control-label col-lg-2">{{ ts('Tagged') }}</label>
+      <div class="col-lg-4">
+        <input class="form-control" ng-list crm-entityref="{entity: 'Tag', api: {params: {used_for: {'LIKE':'%civicrm_case%'}, is_selectable: 1}}, select: {multiple: true}}" ng-model="filters.tag_id">
+      </div>
     </div>
-  </div>
-  
-  <div ng-include="'~/civicase/CaseSearchCustom.html'"></div>
-  <hr />
-  <div>
-    <button class="btn btn-primary btn-sm" ng-click="doSearch()" ng-show="expanded">
-      <i class="fa fa-search"></i> {{ ts('Search') }}
+    <div ng-include="'~/civicase/CaseSearchCustom.html'"></div>
+    <hr />
+    <div>
+      <button class="btn btn-primary btn-sm civicase__filter-search-panel__button civicase__filter-search-panel__button--search" ng-click="doSearch()" ng-show="expanded">
+        <i class="fa fa-search"></i> {{ ts('Search') }}
+      </button>
+    </div>
+  </form>
+  <div class="panel-body civicase__filter-search-panel__description" ng-if="!expanded && filterDescription.length">
+    <button class="btn btn-danger btn-sm pull-right civicase__filter-search-panel__button civicase__filter-search-panel__button--clear" ng-click="clearSearch()">
+      <i class="fa fa-ban"></i> {{ ts('Clear Search') }}
     </button>
+    <ul class="civicase__filter-search-description">
+      <li ng-repeat="des in filterDescription" class="col-lg-6">
+        <strong>{{ des.label }}:</strong> {{ des.text }}
+      </li>
+    </ul>
   </div>
-</form>
-<div class="panel-body" ng-if="!expanded && filterDescription.length">
-  <button class="btn btn-danger btn-sm pull-right" ng-click="clearSearch()">
-    <i class="fa fa-ban"></i> {{ ts('Clear Search') }}
-  </button>
-  <ul class="civicase-search-description">
-    <li ng-repeat="des in filterDescription" class="col-lg-6">
-      <strong>{{ des.label }}:</strong> {{ des.text }}
-    </li>
-  </ul>
 </div>

--- a/ang/civicase/Search.html
+++ b/ang/civicase/Search.html
@@ -1,20 +1,20 @@
-<div class="panel panel-default civicase__filter-search-panel clearfix" ng-class="{'case-is-focused': $parent.caseIsFocused}">
+<div class="panel panel-default civicase__case-filter-panel clearfix" ng-class="{'case-is-focused': $parent.caseIsFocused}">
   <div crm-ui-debug="filters"></div>
-  <div class="panel-header civicase__filter-search-panel__header">
-    <h3 class="civicase__filter-search-panel__header-title"> {{ $parent.pageTitle }} </h3>
-    <form class="form-inline civicase-filters civicase__filter-search-panel__filters-container">
-      <input class="form-control civicase__filter-search-panel__filter" ng-list crm-ui-select="{allowClear: true, multiple: true, placeholder: ts('Case Type: Any'), data: caseTypeOptions}" ng-model="filters.case_type_id" />
-      <input class="form-control civicase__filter-search-panel__filter" ng-list crm-ui-select="{allowClear: true, multiple: true, placeholder: ts('Status: All open cases'), data: caseStatusOptions}" ng-model="filters.status_id" />
-      <input class="form-control civicase__filter-search-panel__filter" ng-list crm-ui-select="{allowClear: true, multiple: true, placeholder: ts('Status: All open cases'), data: caseStatusOptions}" ng-model="filters.status_id" />
-      <button class="btn btn-primary btn-sm pull-right civicase__filter-search-panel__button civicase__filter-search-panel__button--others" ng-click="showMore()" ng-show="!expanded">
+  <div class="panel-header">
+    <h3 class="civicase__case-filter-panel__title"> {{ $parent.pageTitle }} </h3>
+    <form class="form-inline civicase-filters civicase__case-filters-container">
+      <input class="form-control civicase__case-filter__input" ng-list crm-ui-select="{allowClear: true, multiple: true, placeholder: ts('Case Type: Any'), data: caseTypeOptions}" ng-model="filters.case_type_id" />
+      <input class="form-control civicase__case-filter__input" ng-list crm-ui-select="{allowClear: true, multiple: true, placeholder: ts('Status: All open cases'), data: caseStatusOptions}" ng-model="filters.status_id" />
+      <input class="form-control civicase__case-filter__input" ng-list crm-ui-select="{allowClear: true, multiple: true, placeholder: ts('Status: All open cases'), data: caseStatusOptions}" ng-model="filters.status_id" />
+      <button class="btn btn-primary btn-sm pull-right civicase__case-filter-panel__button civicase__case-filter-panel__button--others" ng-click="showMore()" ng-show="!expanded">
         <i class="fa fa-gear"></i> {{ filterDescription.length ? ts('Edit Search') : ts('Other Criteria') }}
       </button>
-      <button class="btn btn-primary btn-sm pull-right civicase__filter-search-panel__button civicase__filter-search-panel__button--search" ng-click="doSearch()" ng-show="expanded">
+      <button class="btn btn-primary btn-sm pull-right civicase__case-filter-panel__button civicase__case-filter-panel__button--search" ng-click="doSearch()" ng-show="expanded">
         <i class="fa fa-search"></i> {{ ts('Search') }}
       </button>
     </form>
   </div>
-  <form class="panel-body form-horizontal civicase__filter-search-panel__form" ng-show="expanded">
+  <form class="panel-body form-horizontal civicase__case-filter-panel__form" ng-show="expanded">
     <div class="form-group">
       <label ng-if="isEnabled('id')" class="control-label col-lg-2">{{ ts('Case ID') }}</label>
       <div class="col-lg-4">
@@ -60,13 +60,13 @@
     <div ng-include="'~/civicase/CaseSearchCustom.html'"></div>
     <hr />
     <div>
-      <button class="btn btn-primary btn-sm civicase__filter-search-panel__button civicase__filter-search-panel__button--search" ng-click="doSearch()" ng-show="expanded">
+      <button class="btn btn-primary btn-sm civicase__case-filter-panel__button civicase__case-filter-panel__button--search" ng-click="doSearch()" ng-show="expanded">
         <i class="fa fa-search"></i> {{ ts('Search') }}
       </button>
     </div>
   </form>
-  <div class="panel-body civicase__filter-search-panel__description" ng-if="!expanded && filterDescription.length">
-    <button class="btn btn-danger btn-sm pull-right civicase__filter-search-panel__button civicase__filter-search-panel__button--clear" ng-click="clearSearch()">
+  <div class="panel-body civicase__case-filter-panel__description" ng-if="!expanded && filterDescription.length">
+    <button class="btn btn-danger btn-sm pull-right civicase__case-filter-panel__button civicase__case-filter-panel__button--clear" ng-click="clearSearch()">
       <i class="fa fa-ban"></i> {{ ts('Clear Search') }}
     </button>
     <ul class="civicase__filter-search-description">

--- a/ang/civicase/Search.js
+++ b/ang/civicase/Search.js
@@ -147,11 +147,11 @@
 
   angular.module('civicase').directive('civicaseSearch', function () {
     return {
-      restrict: 'A',
+      replace: true,
       templateUrl: '~/civicase/Search.html',
       controller: searchController,
       scope: {
-        defaults: '=civicaseSearch',
+        defaults: '=filters',
         hiddenFilters: '=',
         onSearch: '@',
         expanded: '='

--- a/ang/test/civicase/CaseListDirectives.spec.js
+++ b/ang/test/civicase/CaseListDirectives.spec.js
@@ -20,6 +20,7 @@ describe('CaseListDirective', function () {
       affixOriginalFunction = CRM.$.fn.affix;
       CRM.$.fn.affix = jasmine.createSpy('affix');
       affixReturnValue = jasmine.createSpyObj('affix', ['on']);
+      affixReturnValue.on.and.returnValue(affixReturnValue);
       CRM.$.fn.affix.and.returnValue(affixReturnValue);
     });
 
@@ -44,6 +45,10 @@ describe('CaseListDirective', function () {
       it('does not binds the scroll position of table content to the table header', function () {
         expect(affixReturnValue.on).not.toHaveBeenCalledWith('affixed.bs.affix', jasmine.any(Function));
       });
+
+      it('does not resets the padding for top header and when the header gets back to its state', function () {
+        expect(affixReturnValue.on).not.toHaveBeenCalledWith('affixed-top.bs.affix', jasmine.any(Function));
+      });
     });
 
     describe('if loading is complete', function () {
@@ -63,6 +68,10 @@ describe('CaseListDirective', function () {
 
       it('binds the scroll position of table content to the table header', function () {
         expect(affixReturnValue.on).toHaveBeenCalledWith('affixed.bs.affix', jasmine.any(Function));
+      });
+
+      it('resets the padding for top header and when the header gets back to its state', function () {
+        expect(affixReturnValue.on).toHaveBeenCalledWith('affixed-top.bs.affix', jasmine.any(Function));
       });
     });
   });


### PR DESCRIPTION
## Overview
This PR covers UI enhacements for sticky header and basic HTML fixes for fitler panel on case list

## Before/After

* For the HTML fixes

### Before
<img width="1680" alt="c51-34 - before" src="https://user-images.githubusercontent.com/3340537/45286005-419a6680-b502-11e8-9a39-d32b7edf1466.png">

### After

<img width="1680" alt="c51-34 - after" src="https://user-images.githubusercontent.com/3340537/45286004-4101d000-b502-11e8-9d1a-870d762fd257.png">

* Sticky header fixes 

### Before
![c51-39 - header glitch before](https://user-images.githubusercontent.com/3340537/45286955-bd95ae00-b504-11e8-9b87-8f272f1c674b.gif)

### After
![c51-39 - header glitch after](https://user-images.githubusercontent.com/3340537/45286954-bcfd1780-b504-11e8-92de-ee3ed6cac0da.gif)


## Technical Details
 * This PR fixes sticky header scroll glitch by adding top padding to the table element when the header sticks to the top by hooking in `affixed-top.bs.affix` event and add logic
 * Update Unit tests
 * Fix the civicaseSearch directive. 
 ** Changed selector from just attribute to all. 
 ** Add `replace: true` to cut down the extra wrapper divs
 ** Renamed `civicase-search` attribute to `filter` attrbute to increase readability.
 * Add BEM classes to the HTML. Classes used
 ** **civicase__case-filter-panel** : For search panel container
 ** **civicase__case-filter-panel .panel-header** : For search panel header
 ** **civicase__case-filter-panel__title** : For search panel title
 ** **civicase__case-filter-container**: For search panel filters container
 ** **civicase__case-filter__input**: For search panel filter dropdowns
 ** **civicase__case-filter-panel__button**: For search panel filter buttons
 *** **civicase__case-filter-panel__button--search**: For search panel search filter buttons
 *** **civicase__case-filter-panel__button--other**: For search panel other criterion filter buttons
 *** **civicase__case-filter-panel__button--clear**: For search panel clear filter buttons

## Other details
* All the HTML classes are not fixed as per BEM as these will be taken under styling ticket which is C51-36
* For now the third dropdown is added as a copy of second filter dropdown so this could be themed properly in the style C51-36 ticket. The functionality will be fixed as a part of C51-35 ticket.
