### PR TITLE
C51-185: fix contact popover fields

### DIFF
--- a/ang/civicase/ContactsDataService.js
+++ b/ang/civicase/ContactsDataService.js
@@ -12,12 +12,12 @@
       'contact_type',
       'display_name',
       'email',
-      'gender',
+      'gender_id',
       'image_URL',
       'postal_code',
       'state_province',
       'street_address',
-      'tags'
+      'tag'
     ];
 
     /**
@@ -68,6 +68,7 @@
       contact.mobile = phones['Mobile'];
       contact.phone = phones['Phone'];
       contact.groups = _.map(contact['api.GroupContact.get'].values, 'title').join(', ');
+      contact.tags = (contact.tags + '').split(',').join(', '); // Adds spacing to the tags
 
       delete contact['api.Phone.get'];
       delete contact['api.GroupContact.get'];

--- a/ang/test/civicase/ContactsDataService.spec.js
+++ b/ang/test/civicase/ContactsDataService.spec.js
@@ -11,7 +11,7 @@
       $q = _$q_;
       $rootScope = _$rootScope_;
       ContactsDataService = _ContactsDataService_;
-      ContactsData = _ContactsData_;
+      ContactsData = _.cloneDeep(_ContactsData_);
       crmApi = _crmApi_;
     }));
 
@@ -37,12 +37,12 @@
             'contact_type',
             'display_name',
             'email',
-            'gender',
+            'gender_id',
             'image_URL',
             'postal_code',
             'state_province',
             'street_address',
-            'tags'
+            'tag'
           ],
           'api.Phone.get': {
             'contact_id': '$value.id',
@@ -92,12 +92,14 @@
       describe('when the contact exists', function () {
         beforeEach(function () {
           var phones;
+          ContactsData.values[0].tags = 'tag1,tag2,tag3';
 
           crmApi.and.returnValue($q.resolve(ContactsData));
           ContactsDataService.add(ContactsData.values);
           $rootScope.$digest();
 
-          expectedContact = _.clone(ContactsData.values[0]);
+          expectedContact = _.cloneDeep(ContactsData.values[0]);
+          expectedContact.tags = expectedContact.tags.split(',').join(', ');
           phones = _.indexBy(expectedContact['api.Phone.get'].values, 'phone_type_id.name');
 
           expectedContact.mobile = phones['Mobile'];


### PR DESCRIPTION
This PR fixes the field names for the contact popover so they can be displayed properly.

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/45721182-0a1c6180-bb75-11e8-9664-a828b8e0cdfe.png)
The information exists, but it's not being displayed.

## After
![pr-after](https://user-images.githubusercontent.com/1642119/45721134-e48f5800-bb74-11e8-91bf-314e4107e4fa.png)


## Technical details

The issue happened because the name of the fields are different in the request VS the response. To get the `gender` field one must request the `gender_id` field, and to get the `tags` field one must request the `tag` field.

Also, the tags field returns the tags without space between them so the following transformation was done in order to display the tags with proper spacing between them:

```js
contact.tags = (contact.tags + '').split(',').join(', ');
```