### PR TITLE
C51-187: Contact Type Icons not displayed for some users

### DIFF
--- a/ang/civicase/ContactsDataService.js
+++ b/ang/civicase/ContactsDataService.js
@@ -36,6 +36,7 @@
         'sequential': 1,
         'id': { 'IN': newContacts },
         'return': requiredContactFields,
+        'options': { 'limit': 0 },
         'api.Phone.get': {
           'contact_id': '$value.id',
           'phone_type_id.name': { 'IN': [ 'Mobile', 'Phone' ] },

--- a/ang/test/civicase/ContactsDataService.spec.js
+++ b/ang/test/civicase/ContactsDataService.spec.js
@@ -31,6 +31,7 @@
       beforeEach(function () {
         expectedApiParams = {
           'sequential': 1,
+          'options': { 'limit': 0 },
           'return': [
             'birth_date',
             'city',


### PR DESCRIPTION
## Overview
Contact Type Icons not displayed for some users, this PR fixes that issue.

## Technical Details
`ContactsDataService.js` was only loading 25 records so some of the records had missing data. 
Added `'options': { 'limit': 0 }` to load all contacts.
This is not reproducible in local so screenshots are not provided.