### PR TITLE
C51-190: Remove contact popover for manager

### DIFF
--- a/ang/civicase/ContactCard.html
+++ b/ang/civicase/ContactCard.html
@@ -28,14 +28,8 @@
       class="civicase__contact-avatar crm_notification-badge"
       ng-class="{'civicase__contact-avatar--image': contacts[0].image_URL}"
       title="{{contacts[0].display_name}}">
-      <span uib-popover-template="'contact-popover.html'"
-        popover-class="contact-popover-container"
-        popover-append-to-body="true"
-        popover-placement="auto bottom"
-        popover-trigger="'mouseenter'">
-        <img ng-if="contacts[0].image_URL" ng-src={{contacts[0].image_URL}}>
-        <span ng-if="!contacts[0].image_URL">{{contacts[0].avatar}}</span>
-      </span>
+      <img ng-if="contacts[0].image_URL" ng-src={{contacts[0].image_URL}}>
+      <span ng-if="!contacts[0].image_URL">{{contacts[0].avatar}}</span>
     </a>
     <!-- End - Contact Avatar -->
   </span>


### PR DESCRIPTION
This PR removes the contact popover when hovering the activity manager icon.

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/45820290-72be2800-bcb4-11e8-900b-6beb4f520d87.gif)

## After
![pr-after](https://user-images.githubusercontent.com/1642119/45820188-49050100-bcb4-11e8-8f50-158e485641c6.gif)


## Technical details

The solution was just removing the contact popover trigger from the manager icon:

```html
<span ng-if="isAvatar">
  <!-- Contact Avatar -->
  <a
    href="{{ url('civicrm/contact/view', {cid: contacts[0].contact_id}) }}"
    class="civicase__contact-avatar crm_notification-badge"
    ng-class="{'civicase__contact-avatar--image': contacts[0].image_URL}"
    title="{{contacts[0].display_name}}">
    <img ng-if="contacts[0].image_URL" ng-src={{contacts[0].image_URL}}>
    <span ng-if="!contacts[0].image_URL">{{contacts[0].avatar}}</span>
  </a>
  <!-- End - Contact Avatar -->
</span>
```