### PR TITLE
C51-204: Task icon to turn green when task is checked

### DIFF
--- a/ang/civicase/ActivityIcon.html
+++ b/ang/civicase/ActivityIcon.html
@@ -3,12 +3,12 @@
   ng-class="{'civicase__activity-icon-container--ribbon': activity.category.indexOf('milestone') > -1}">
   <span>
     <i
-      ng-class="{'text-danger': activity.is_overdue}"
+      ng-class="{'text-danger': activity.is_overdue && !activity.is_completed, 'text-success': activity.is_completed}"
       class="civicase__activity-icon fa {{activity.icon}}"></i>
 
     <i
       ng-if="direction"
-      ng-class="{'text-danger': activity.is_overdue}"
+      ng-class="{'text-danger': activity.is_overdue && !activity.is_completed, 'text-success': activity.is_completed}"
       class="civicase__activity-icon-arrow fa fa-arrow-{{ direction }}"></i>
   </span>
   <!-- Activity Ribbon -->


### PR DESCRIPTION
## Overview
This PR covers fix for making the task icon of next activity card to turn `green` when the task is checked.

## After
![c51-204](https://user-images.githubusercontent.com/3340537/45942267-5b0dd900-bfff-11e8-973f-69c3ed597b94.gif)

## Technical Details.
* Removes `text-danger` class on the icon and adds `text-success` class if the activity is completed.