### PR TITLE
C51-202: Fix color logic for due date

### DIFF
--- a/ang/civicase/ActivityCard--Big.html
+++ b/ang/civicase/ActivityCard--Big.html
@@ -55,7 +55,7 @@
         </div>
         <!-- End - top section -->
         <div ng-if="activity.category.indexOf('milestone') == -1">
-          <span class="civicase__activity-date" ng-class="{'civicase__overdue-activity-icon': activity.is_overdue}">{{formatDate(activity.activity_date_time, 'DD MMM YYYY') }}</span>
+          <span class="civicase__activity-date" ng-class="{'civicase__overdue-activity-icon': isOverdue(activity)}">{{formatDate(activity.activity_date_time, 'DD MMM YYYY') }}</span>
           <!-- Attachments to show for milestones-->
           <div class="btn-group civicase__activity-attachment__container" ng-if="activity.file_id && activity.category.indexOf('milestone') == -1">
             <i ng-mouseover="getAttachments(activity)" class="civicase__activity-attachment__icon material-icons">attach_file</i>
@@ -108,7 +108,7 @@
         </div>
         <!-- End - With -->
         <!-- Big Date -->
-        <div ng-if="activity.category.indexOf('milestone') > -1" class="civicase__highlighted-date" ng-class="{'civicase__highlighted-date--overdue': isOverdue(activity.activity_date_time)}">
+        <div ng-if="activity.category.indexOf('milestone') > -1" class="civicase__highlighted-date" ng-class="{'civicase__highlighted-date--overdue': isOverdue(activity)}">
           <div class="civicase__highlighted-date__inner">
             <span class="civicase__highlighted-date__due-on"> Due on </span>
             <span class="civicase__highlighted-date__ddmm"> {{formatDate(activity.activity_date_time, 'DD MMM') }} </span>

--- a/ang/civicase/ActivityCard--Long.html
+++ b/ang/civicase/ActivityCard--Long.html
@@ -80,7 +80,7 @@
           <!-- End - Rating -->
 
           <!-- Activity Date -->
-          <span class="civicase__activity-date" ng-class="{'civicase__overdue-activity-icon': activity.is_overdue}">{{formatDate(activity.activity_date_time, 'DD MMM YYYY')}}</span>
+          <span class="civicase__activity-date" ng-class="{'civicase__overdue-activity-icon': isOverdue(activity)}">{{formatDate(activity.activity_date_time, 'DD MMM YYYY')}}</span>
           <!-- End - Activity Date -->
 
           <!-- Avatar -->

--- a/ang/civicase/ActivityCard--Short.html
+++ b/ang/civicase/ActivityCard--Short.html
@@ -12,7 +12,7 @@
         <span ng-if="activity.icon || activity.category.indexOf('milestone') > -1" activity-icon="activity"></span>
 
         <!-- Activity Date -->
-        <span class="civicase__activity-date" ng-class="{'civicase__overdue-activity-icon': activity.is_overdue}">{{ formatDate(activity.activity_date_time, 'DD MMM YYYY') }}</span>
+        <span class="civicase__activity-date" ng-class="{'civicase__overdue-activity-icon': isOverdue(activity)}">{{ formatDate(activity.activity_date_time, 'DD MMM YYYY') }}</span>
         <!-- End - Activity Date -->
 
         <span class="civicase__activity__right-container">

--- a/ang/civicase/ActivityIcon.js
+++ b/ang/civicase/ActivityIcon.js
@@ -9,7 +9,8 @@
       scope: {
         activity: '=activityIcon'
       },
-      link: activityIconLink
+      link: activityIconLink,
+      controller: activityIconController
     };
 
     /**
@@ -32,4 +33,14 @@
       }
     }
   });
+
+  /**
+   * Controller function for activityIcon directive
+   *
+   * @param {object} $scope
+   * @param {object} DateHelper
+   */
+  function activityIconController ($scope, DateHelper) {
+    $scope.isOverdue = DateHelper.isOverdue;
+  }
 })(angular, CRM.$, CRM._, CRM);

--- a/ang/civicase/CaseCard--case-list.html
+++ b/ang/civicase/CaseCard--case-list.html
@@ -21,7 +21,7 @@
     <div class="civicase__case-card__next-milestone" ng-if="data.activity_summary.milestone.length > 0">
       <span>Next Milestone: </span>
       <a class="civicase__case-card__next-milestone-date"
-         ng-class="{'civicase__overdue-activity-icon': isOverdue(data.activity_summary.milestone[0].activity_date_time)}"
+         ng-class="{'civicase__overdue-activity-icon': isOverdue(data.activity_summary.milestone[0])}"
          ng-href="#{{ activityFeedUrl(data.id, 'milestone', 'incomplete', null, data.activity_summary.milestone[0].id) }}"
          title="{{data.activity_summary.milestone[0].subject || data.activity_summary.milestone[0].type;}}"
       >{{ formatDate(data.activity_summary.milestone[0].activity_date_time, 'DD/MM/YYYY') }} </a>

--- a/ang/civicase/CaseCard--other-cases.html
+++ b/ang/civicase/CaseCard--other-cases.html
@@ -22,7 +22,7 @@
     <span class="civicase__case-card__next-milestone" ng-if="data.activity_summary.milestone.length > 0">
       <span>Next Milestone: </span>
       <a class="civicase__case-card__next-milestone-date"
-          ng-class="{'civicase__overdue-activity-icon': isOverdue(data.activity_summary.milestone[0].activity_date_time)}"
+          ng-class="{'civicase__overdue-activity-icon': isOverdue(data.activity_summary.milestone[0])}"
           ng-href="#{{ activityFeedUrl(data.id, 'milestone', 'incomplete', null, data.activity_summary.milestone[0].id) }}"
           title="{{data.activity_summary.milestone[0].subject || data.activity_summary.milestone[0].type;}}"
       >{{ formatDate(data.activity_summary.milestone[0].activity_date_time) }} </a>

--- a/ang/civicase/CaseDetails.js
+++ b/ang/civicase/CaseDetails.js
@@ -362,8 +362,6 @@
         crmApi('Case', 'getdetails', caseGetParams()).then(function (info) {
           $scope.pushCaseData(info.values[0]);
         });
-
-        $scope.item.nextActivityNotMilestone = findNextIncompleteActivityWhichIsNotMilestone($scope.item.allActivities); // to be removed after performace fix
       }
     }
 

--- a/ang/civicase/DateHelperService.js
+++ b/ang/civicase/DateHelperService.js
@@ -11,15 +11,9 @@
      * @return {Boolean} if the date is overdue.
      */
     this.isOverdue = function (activity) {
-      var isOverdue;
-
-      if (activity.is_overdue) {
-        isOverdue = typeof (activity.is_overdue) !== 'boolean' ? activity.is_overdue === '1' : activity.is_overdue;
-      } else {
-        isOverdue = moment(activity.activity_date_time).isBefore(moment());
+      if (typeof activity.is_overdue !== 'undefined') {
+        return typeof (activity.is_overdue) !== 'boolean' ? activity.is_overdue === '1' : activity.is_overdue;
       }
-
-      return isOverdue;
     };
 
     /**

--- a/ang/civicase/DateHelperService.js
+++ b/ang/civicase/DateHelperService.js
@@ -7,11 +7,19 @@
     /**
      * To check if the date is overdue
      *
-     * @param {String} date ISO string
+     * @param {Object} activity object
      * @return {Boolean} if the date is overdue.
      */
-    this.isOverdue = function (date) {
-      return moment(date).isBefore(moment());
+    this.isOverdue = function (activity) {
+      var isOverdue;
+
+      if (activity.is_overdue) {
+        isOverdue = typeof (activity.is_overdue) !== 'boolean' ? activity.is_overdue === '1' : activity.is_overdue;
+      } else {
+        isOverdue = moment(activity.activity_date_time).isBefore(moment());
+      }
+
+      return isOverdue;
     };
 
     /**

--- a/ang/test/civicase/DateHelperService.spec.js
+++ b/ang/test/civicase/DateHelperService.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env jasmine */
 (function ($) {
   describe('DateHelper', function () {
-    var DateHelper, activitiesMockData, activitiyWithStringOverdue, activitiyWithBooleanOverdue, activitiyWithoutOverdue;
+    var DateHelper, activitiesMockData, activity;
 
     beforeEach(module('civicase', 'civicase.data'));
 
@@ -19,26 +19,51 @@
 
       describe('isOverdue()', function () {
         beforeEach(function () {
-          activitiyWithBooleanOverdue = activitiesMockData[0];
-          activitiyWithBooleanOverdue.is_overdue = true;
-
-          activitiyWithStringOverdue = activitiesMockData[0];
-          activitiyWithStringOverdue.is_overdue = '1';
-
-          activitiyWithoutOverdue = activitiesMockData[0];
-          delete (activitiyWithoutOverdue.is_overdue);
+          activity = activitiesMockData[0];
         });
 
-        it('returns true is_overdue is boolean', function () {
-          expect(DateHelper.isOverdue(activitiyWithBooleanOverdue)).toBe(true);
+        describe('when api returns boolean value for is_overdue', function () {
+          describe('when is_overdue is true', function () {
+            beforeEach(function () {
+              activity.is_overdue = true;
+            });
+
+            it('returns true if date is overdue', function () {
+              expect(DateHelper.isOverdue(activity)).toBe(true);
+            });
+          });
+
+          describe('when is_overdue is false', function () {
+            beforeEach(function () {
+              activity.is_overdue = false;
+            });
+
+            it('returns false if date is not overdue', function () {
+              expect(DateHelper.isOverdue(activity)).toBe(false);
+            });
+          });
         });
 
-        it('returns true is_overdue is String', function () {
-          expect(DateHelper.isOverdue(activitiyWithStringOverdue)).toBe(true);
-        });
+        describe('when api returns string value for is_overdue', function () {
+          describe('when is_overdue is true', function () {
+            beforeEach(function () {
+              activity.is_overdue = '1';
+            });
 
-        it('is not undefined when is_overdue is not present', function () {
-          expect(DateHelper.isOverdue(activitiyWithStringOverdue)).toBeDefined();
+            it('returns true if date is overdue', function () {
+              expect(DateHelper.isOverdue(activity)).toBe(true);
+            });
+          });
+
+          describe('when is_overdue is false', function () {
+            beforeEach(function () {
+              activity.is_overdue = '0';
+            });
+
+            it('returns false if date is not overdue', function () {
+              expect(DateHelper.isOverdue(activity)).toBe(false);
+            });
+          });
         });
       });
     });

--- a/ang/test/civicase/DateHelperService.spec.js
+++ b/ang/test/civicase/DateHelperService.spec.js
@@ -1,13 +1,14 @@
 /* eslint-env jasmine */
 (function ($) {
   describe('DateHelper', function () {
-    var DateHelper, pastDate, futureDate;
+    var DateHelper, activitiesMockData, activitiyWithStringOverdue, activitiyWithBooleanOverdue, activitiyWithoutOverdue;
 
-    beforeEach(module('civicase'));
+    beforeEach(module('civicase', 'civicase.data'));
 
     describe('DateHelper', function () {
-      beforeEach(inject(function (_DateHelper_) {
+      beforeEach(inject(function (_DateHelper_, _activitiesMockData_) {
         DateHelper = _DateHelper_;
+        activitiesMockData = _activitiesMockData_.get();
       }));
 
       describe('formatDate()', function () {
@@ -18,16 +19,26 @@
 
       describe('isOverdue()', function () {
         beforeEach(function () {
-          pastDate = moment().subtract(7, 'd');
-          futureDate = moment().add(7, 'd');
+          activitiyWithBooleanOverdue = activitiesMockData[0];
+          activitiyWithBooleanOverdue.is_overdue = true;
+
+          activitiyWithStringOverdue = activitiesMockData[0];
+          activitiyWithStringOverdue.is_overdue = '1';
+
+          activitiyWithoutOverdue = activitiesMockData[0];
+          delete (activitiyWithoutOverdue.is_overdue);
         });
 
-        it('returns true when date is in past', function () {
-          expect(DateHelper.isOverdue(pastDate)).toBe(true);
+        it('returns true is_overdue is boolean', function () {
+          expect(DateHelper.isOverdue(activitiyWithBooleanOverdue)).toBe(true);
         });
 
-        it('returns false when date is not in past', function () {
-          expect(DateHelper.isOverdue(futureDate)).toBe(false);
+        it('returns true is_overdue is String', function () {
+          expect(DateHelper.isOverdue(activitiyWithStringOverdue)).toBe(true);
+        });
+
+        it('is not undefined when is_overdue is not present', function () {
+          expect(DateHelper.isOverdue(activitiyWithStringOverdue)).toBeDefined();
         });
       });
     });


### PR DESCRIPTION
## Overview
 PR contains fix for the incorrect overdue styles on next activity card.

## Before

<img width="314" alt="c51-202 - before" src="https://user-images.githubusercontent.com/3340537/46125279-090ac480-c246-11e8-8e23-12b578fda127.png">


## After

<img width="305" alt="c51-202 - after" src="https://user-images.githubusercontent.com/3340537/46125287-10ca6900-c246-11e8-9ae8-f159b09d9dc8.png">

## Technical Details

Checking the activity is overdue was not implemented generically throughout the app and hence was creating issues at some activities.
As there were three cases
* is_overdue was sent as Boolean for some activities
* is_overdue was sent as String for some activities
* is_overdue might not be present for some activities.

So to fix this we have a single function which will take care of this is used throughout the app now. At
* Activity Icon directive
* Case Card Variant
  * Case Card List view
  * Case Card Other cases view
* Activity Card Variant
  * Activity Card Big
  * Activity Card Short
  * Activity Card Long

