### PR TITLE
C51-231: Add start date to the Case role assignment

### DIFF
--- a/ang/civicase/CaseDetailsPeople.js
+++ b/ang/civicase/CaseDetailsPeople.js
@@ -345,8 +345,9 @@
                 var selectedActivity = _.find(res.values, function (act) {
                   return act.target_contact_id.indexOf(role.contact_id) > -1;
                 });
-
-                $scope.roles[key].start_date = selectedActivity.activity_date_time;
+                if (selectedActivity) {
+                  $scope.roles[key].start_date = selectedActivity.activity_date_time;
+                }
               }
             }
           });

--- a/ang/civicase/CaseDetailsPeople.js
+++ b/ang/civicase/CaseDetailsPeople.js
@@ -313,7 +313,45 @@
         // Reset if out of range
         $scope.rolesPage = 1;
       }
+
       $scope.roles = _.slice(caseRoles, (25 * ($scope.rolesPage - 1)), 25 * $scope.rolesPage);
+      setStartDateToClients(item.case_id);
+    }
+
+    /**
+     * Function to get the start date of the contacts with the
+     * Client roles
+     *
+     * @params {Integer} case_id
+     */
+    function setStartDateToClients (caseId) {
+      var params = {
+        'sequential': 1,
+        'return': ['activity_type_id', 'activity_date_time', 'target_contact_id'],
+        'case_id': caseId,
+        'options': {
+          sort: 'activity_type_id DESC'
+        },
+        'activity_type_id': {
+          IN: ['Add Client To Case', 'Reassigned Case']
+        }
+      };
+
+      crmApi('Activity', 'get', params).then(function (res) {
+        if ($scope.roles.length > 0) {
+          _.each($scope.roles, function (role, key) {
+            if (role) {
+              if (role.role === 'Client') {
+                var selectedActivity = _.find(res.values, function (act) {
+                  return act.target_contact_id.indexOf(role.contact_id) > -1;
+                });
+
+                $scope.roles[key].start_date = selectedActivity.activity_date_time;
+              }
+            }
+          });
+        }
+      });
     }
 
     /**


### PR DESCRIPTION
## Overview 
 Adds Start Date to the case roles on People's tab.

## Before 
 
<img width="1665" alt="c51-231 - before" src="https://user-images.githubusercontent.com/3340537/46143106-a120a200-c276-11e8-95c0-50a8302ffdb4.png">

## After
<img width="1668" alt="c51-231 - after" src="https://user-images.githubusercontent.com/3340537/46143123-ac73cd80-c276-11e8-8be7-b60462832740.png">


## Technical Details


For fetching the start dates for Clients contact . The logic was to fetch the list of all the activities on the case which has activity type either `Add Client To Case` or  `Reassigned Case` and then match the contact ID of the activities with the client's contact ID and add assign activity date to the start date of the case role.
