### PR TITLE
C51-227: Fix next activity tile overdue date issue and next activity order issue

### DIFF
--- a/ang/civicase/ActivityCard--Big.html
+++ b/ang/civicase/ActivityCard--Big.html
@@ -55,7 +55,7 @@
         </div>
         <!-- End - top section -->
         <div ng-if="activity.category.indexOf('milestone') == -1">
-          <span class="civicase__activity-date" ng-class="{'civicase__overdue-activity-icon': isOverdue(activity)}">{{formatDate(activity.activity_date_time, 'DD MMM YYYY') }}</span>
+          <span class="civicase__activity-date" ng-class="{'civicase__overdue-activity-icon': activity.is_overdue}">{{formatDate(activity.activity_date_time, 'DD MMM YYYY') }}</span>
           <!-- Attachments to show for milestones-->
           <div class="btn-group civicase__activity-attachment__container" ng-if="activity.file_id && activity.category.indexOf('milestone') == -1">
             <i ng-mouseover="getAttachments(activity)" class="civicase__activity-attachment__icon material-icons">attach_file</i>
@@ -108,7 +108,7 @@
         </div>
         <!-- End - With -->
         <!-- Big Date -->
-        <div ng-if="activity.category.indexOf('milestone') > -1" class="civicase__highlighted-date" ng-class="{'civicase__highlighted-date--overdue': isOverdue(activity)}">
+        <div ng-if="activity.category.indexOf('milestone') > -1" class="civicase__highlighted-date" ng-class="{'civicase__highlighted-date--overdue': activity.is_overdue}">
           <div class="civicase__highlighted-date__inner">
             <span class="civicase__highlighted-date__due-on"> Due on </span>
             <span class="civicase__highlighted-date__ddmm"> {{formatDate(activity.activity_date_time, 'DD MMM') }} </span>

--- a/ang/civicase/ActivityCard--Long.html
+++ b/ang/civicase/ActivityCard--Long.html
@@ -80,7 +80,7 @@
           <!-- End - Rating -->
 
           <!-- Activity Date -->
-          <span class="civicase__activity-date" ng-class="{'civicase__overdue-activity-icon': isOverdue(activity)}">{{formatDate(activity.activity_date_time, 'DD MMM YYYY')}}</span>
+          <span class="civicase__activity-date" ng-class="{'civicase__overdue-activity-icon': activity.is_overdue}">{{formatDate(activity.activity_date_time, 'DD MMM YYYY')}}</span>
           <!-- End - Activity Date -->
 
           <!-- Avatar -->

--- a/ang/civicase/ActivityCard--Short.html
+++ b/ang/civicase/ActivityCard--Short.html
@@ -12,7 +12,7 @@
         <span ng-if="activity.icon || activity.category.indexOf('milestone') > -1" activity-icon="activity"></span>
 
         <!-- Activity Date -->
-        <span class="civicase__activity-date" ng-class="{'civicase__overdue-activity-icon': isOverdue(activity)}">{{ formatDate(activity.activity_date_time, 'DD MMM YYYY') }}</span>
+        <span class="civicase__activity-date" ng-class="{'civicase__overdue-activity-icon': activity.is_overdue}">{{ formatDate(activity.activity_date_time, 'DD MMM YYYY') }}</span>
         <!-- End - Activity Date -->
 
         <span class="civicase__activity__right-container">

--- a/ang/civicase/ActivityCard.js
+++ b/ang/civicase/ActivityCard.js
@@ -32,7 +32,6 @@
     $scope.activityFeedUrl = getActivityFeedUrl;
     $scope.templateExists = templateExists;
     $scope.formatDate = DateHelper.formatDate;
-    $scope.isOverdue = DateHelper.isOverdue;
 
     $scope.isActivityEditable = function (activity) {
       var type = CRM.civicase.activityTypes[activity.activity_type_id].name;

--- a/ang/civicase/ActivityIcon.js
+++ b/ang/civicase/ActivityIcon.js
@@ -9,8 +9,7 @@
       scope: {
         activity: '=activityIcon'
       },
-      link: activityIconLink,
-      controller: activityIconController
+      link: activityIconLink
     };
 
     /**
@@ -33,14 +32,4 @@
       }
     }
   });
-
-  /**
-   * Controller function for activityIcon directive
-   *
-   * @param {object} $scope
-   * @param {object} DateHelper
-   */
-  function activityIconController ($scope, DateHelper) {
-    $scope.isOverdue = DateHelper.isOverdue;
-  }
 })(angular, CRM.$, CRM._, CRM);

--- a/ang/civicase/CaseCard--case-list.html
+++ b/ang/civicase/CaseCard--case-list.html
@@ -21,7 +21,7 @@
     <div class="civicase__case-card__next-milestone" ng-if="data.activity_summary.milestone.length > 0">
       <span>Next Milestone: </span>
       <a class="civicase__case-card__next-milestone-date"
-         ng-class="{'civicase__overdue-activity-icon': isOverdue(data.activity_summary.milestone[0])}"
+         ng-class="{'civicase__overdue-activity-icon': data.activity_summary.milestone[0].is_overdue}"
          ng-href="#{{ activityFeedUrl(data.id, 'milestone', 'incomplete', null, data.activity_summary.milestone[0].id) }}"
          title="{{data.activity_summary.milestone[0].subject || data.activity_summary.milestone[0].type;}}"
       >{{ formatDate(data.activity_summary.milestone[0].activity_date_time, 'DD/MM/YYYY') }} </a>

--- a/ang/civicase/CaseCard--other-cases.html
+++ b/ang/civicase/CaseCard--other-cases.html
@@ -22,7 +22,7 @@
     <span class="civicase__case-card__next-milestone" ng-if="data.activity_summary.milestone.length > 0">
       <span>Next Milestone: </span>
       <a class="civicase__case-card__next-milestone-date"
-          ng-class="{'civicase__overdue-activity-icon': isOverdue(data.activity_summary.milestone[0])}"
+          ng-class="{'civicase__overdue-activity-icon': data.activity_summary.milestone[0].is_overdue}"
           ng-href="#{{ activityFeedUrl(data.id, 'milestone', 'incomplete', null, data.activity_summary.milestone[0].id) }}"
           title="{{data.activity_summary.milestone[0].subject || data.activity_summary.milestone[0].type;}}"
       >{{ formatDate(data.activity_summary.milestone[0].activity_date_time) }} </a>

--- a/ang/civicase/CaseCard.js
+++ b/ang/civicase/CaseCard.js
@@ -16,7 +16,6 @@
 
   module.controller('CivicaseCaseCardController', function ($scope, getActivityFeedUrl, DateHelper) {
     $scope.activityFeedUrl = getActivityFeedUrl;
-    $scope.isOverdue = DateHelper.isOverdue;
     $scope.formatDate = DateHelper.formatDate;
   });
 })(angular, CRM.$, CRM._, CRM);

--- a/ang/civicase/CaseDetails.js
+++ b/ang/civicase/CaseDetails.js
@@ -200,6 +200,9 @@
     function caseGetParams () {
       var activityParams = {
         case_id: '$value.id',
+        options: {
+          sort: 'activity_date_time ASC'
+        },
         return: [
           'subject', 'details', 'activity_type_id', 'status_id', 'source_contact_name',
           'target_contact_name', 'assignee_contact_name', 'activity_date_time', 'is_star',

--- a/ang/civicase/DateHelperService.js
+++ b/ang/civicase/DateHelperService.js
@@ -5,18 +5,6 @@
 
   function DateHelper () {
     /**
-     * To check if the date is overdue
-     *
-     * @param {Object} activity object
-     * @return {Boolean} if the date is overdue.
-     */
-    this.isOverdue = function (activity) {
-      if (typeof activity.is_overdue !== 'undefined') {
-        return typeof (activity.is_overdue) !== 'boolean' ? activity.is_overdue === '1' : activity.is_overdue;
-      }
-    };
-
-    /**
      * Formats Date in sent format
      * Default format is (DD/MM/YYYY)
      *

--- a/ang/civicase/Utils.js
+++ b/ang/civicase/Utils.js
@@ -143,7 +143,10 @@
 
       // Save all activities in a new meaningful key
       if (item['api.Activity.get.1']) {
-        item.allActivities = item['api.Activity.get.1'].values;
+        item.allActivities = _.each(_.cloneDeep(item['api.Activity.get.1'].values), function (act) {
+          formatActivity(act, item.id);
+        });
+
         delete item['api.Activity.get.1'];
 
         countOverdueTasks(item);

--- a/ang/test/civicase/DateHelperService.spec.js
+++ b/ang/test/civicase/DateHelperService.spec.js
@@ -1,69 +1,18 @@
 /* eslint-env jasmine */
 (function ($) {
   describe('DateHelper', function () {
-    var DateHelper, activitiesMockData, activity;
+    var DateHelper;
 
-    beforeEach(module('civicase', 'civicase.data'));
+    beforeEach(module('civicase'));
 
     describe('DateHelper', function () {
-      beforeEach(inject(function (_DateHelper_, _activitiesMockData_) {
+      beforeEach(inject(function (_DateHelper_) {
         DateHelper = _DateHelper_;
-        activitiesMockData = _activitiesMockData_.get();
       }));
 
       describe('formatDate()', function () {
         it('returns the date in the DD/MM/YYYY format', function () {
           expect(DateHelper.formatDate('2017-11-20 00:00:00', 'DD/MM/YYYY')).toBe('20/11/2017');
-        });
-      });
-
-      describe('isOverdue()', function () {
-        beforeEach(function () {
-          activity = activitiesMockData[0];
-        });
-
-        describe('when api returns boolean value for is_overdue', function () {
-          describe('when is_overdue is true', function () {
-            beforeEach(function () {
-              activity.is_overdue = true;
-            });
-
-            it('returns true if date is overdue', function () {
-              expect(DateHelper.isOverdue(activity)).toBe(true);
-            });
-          });
-
-          describe('when is_overdue is false', function () {
-            beforeEach(function () {
-              activity.is_overdue = false;
-            });
-
-            it('returns false if date is not overdue', function () {
-              expect(DateHelper.isOverdue(activity)).toBe(false);
-            });
-          });
-        });
-
-        describe('when api returns string value for is_overdue', function () {
-          describe('when is_overdue is true', function () {
-            beforeEach(function () {
-              activity.is_overdue = '1';
-            });
-
-            it('returns true if date is overdue', function () {
-              expect(DateHelper.isOverdue(activity)).toBe(true);
-            });
-          });
-
-          describe('when is_overdue is false', function () {
-            beforeEach(function () {
-              activity.is_overdue = '0';
-            });
-
-            it('returns false if date is not overdue', function () {
-              expect(DateHelper.isOverdue(activity)).toBe(false);
-            });
-          });
         });
       });
     });


### PR DESCRIPTION
## Overview
This PR covers the code refactoring for overdue dates and fix the order of next activity to come on the case summary with some UI fixes.

## Before 
![image](https://user-images.githubusercontent.com/3340537/46150515-5d379800-c28a-11e8-854b-c98ee945227f.png)

## After
<img width="429" alt="aftter" src="https://user-images.githubusercontent.com/3340537/46150535-66286980-c28a-11e8-822e-fd7fab1bace6.png">


## Technical Details
There is already a factory `formatActivity` which formats the activity's keys with correct values and types. It also fix the type and value of `is_overdue` key. So we technically don't need another service `isOverdue` for this.
```
  module.factory('formatActivity', function (ContactsDataService) {
    var activityTypes = CRM.civicase.activityTypes;
    var activityStatuses = CRM.civicase.activityStatuses;
    var caseTypes = CRM.civicase.caseTypes;
    var caseStatuses = CRM.civicase.caseStatuses;

    return function (act, caseId) {
      act.category = (activityTypes[act.activity_type_id].grouping ? activityTypes[act.activity_type_id].grouping.split(',') : []);
      act.icon = activityTypes[act.activity_type_id].icon;
      act.type = activityTypes[act.activity_type_id].label;
      act.status = activityStatuses[act.status_id].label;
      act.status_name = activityStatuses[act.status_id].name;
      act.status_type = getStatusType(act.status_id);
      act.is_completed = act.status_type !== 'incomplete'; // FIXME doesn't distinguish cancelled from completed
      act.is_overdue = (typeof act.is_overdue === 'string') ? (act.is_overdue === '1') : act.is_overdue;
   ....
 ....
  }
});
```

* The next activity order was not correct because all activities fetched under `api.activities.1` is not fetched in the correct sorting order.
Adding sorting option in the req. fixed the issue
```
    options: {
          sort: 'activity_date_time ASC'
        },
```
Also the results for  `api.activities.1` are not formatted using the factory. Doing it fixed the overdue date bug too. C51-225.
```
        item.allActivities = _.each(_.cloneDeep(item['api.Activity.get.1'].values), function (act) {
          formatActivity(act, item.id);
        });
```