### PR TITLE
C51-237: Fix Copy activity / Delete activity for Activity Feed and Files Feed,

### DIFF
--- a/ang/civicase/ActivityFeed.html
+++ b/ang/civicase/ActivityFeed.html
@@ -23,7 +23,7 @@
               refresh-on-checkbox-toggle="true"
               bulk-allowed="bulkAllowed"
               ng-click="viewActivity(activity.id, $event)"
-              refresh-callback="refreshAll">
+              refresh-callback="refreshCase">
             </div>
           </div>
         </div>

--- a/ang/civicase/FileList.html
+++ b/ang/civicase/FileList.html
@@ -11,7 +11,7 @@
       refresh-on-checkbox-toggle="true"
       bulk-allowed="bulkAllowed"
       ng-click="viewActivity(activity.id, $event)"
-      refresh-callback="fileLists.refresh"
+      refresh-callback="refresh"
       ng-repeat="activity in activities"
       >
     </div>

--- a/ang/civicase/FileList.js
+++ b/ang/civicase/FileList.js
@@ -35,6 +35,7 @@
      */
     $scope.refresh = function (apiCalls) {
       if (!_.isArray(apiCalls)) apiCalls = [];
+
       crmApi(apiCalls, true).then(function (result) {
         $scope.fileLists.refresh();
       });

--- a/ang/civicase/FileList.js
+++ b/ang/civicase/FileList.js
@@ -29,6 +29,18 @@
     }());
 
     /**
+     * Refreshes the UI state after updating the db from the api calls
+     *
+     * @params {Array} apiCalls
+     */
+    $scope.refresh = function (apiCalls) {
+      if (!_.isArray(apiCalls)) apiCalls = [];
+      crmApi(apiCalls, true).then(function (result) {
+        $scope.fileLists.refresh();
+      });
+    };
+
+    /**
      * Watcher function for fileLists.result collection
      *
      * @params {Object} response


### PR DESCRIPTION
## Overview
PR covers the fix for the `Copy activity` and `Delete Activity` feature on Activity feed and Files Feed

## After
![copy delete](https://user-images.githubusercontent.com/3340537/46355439-69eb3000-c67e-11e8-9bd0-820a23662d01.gif)


## Technical Details
* Since the refresh function on activity feed was wrongly passed to activity card the functionality broke for activity feed
* Adding the same refresh function implementation for `FileList` directive fixed the issue.