### PR TITLE
C51-233: Mark calendar overdue date using is_overdue field

### DIFF
--- a/ang/civicase/ActivitiesCalendar.js
+++ b/ang/civicase/ActivitiesCalendar.js
@@ -169,30 +169,6 @@
     })();
 
     /**
-     * Determines if all the given activities have been completed.
-     *
-     * @param {Array} activities
-     * @return {Boolean}
-     */
-    function checkIfAllActivitiesHaveBeenCompleted (activities) {
-      return _.every(activities, function (activity) {
-        return _.includes(CRM.civicase.activityStatusTypes.completed, +activity.status_id);
-      });
-    }
-
-    /**
-     * Determines if at least one of the given activities is overdue.
-     *
-     * @param {Array} activities
-     * @return {Boolean}
-     */
-    function checkIfOneActivityIsOverdue (activities) {
-      return _.some(activities, function (activity) {
-        return activity.is_overdue;
-      });
-    }
-
-    /**
      * Returns the activities that belong to the given date.
      *
      * @param {Date} date
@@ -213,7 +189,6 @@
      *   can be "day", "month", or "year".
      */
     function getDayCustomClass (params) {
-      var allActivitiesHaveBeenCompleted, isOneActivityOverdue;
       var activities = getActivitiesForDate(params.date);
       var isInCurrentMonth = this.datepicker.activeDate.getMonth() === params.date.getMonth();
 
@@ -225,16 +200,37 @@
         return;
       }
 
-      allActivitiesHaveBeenCompleted = checkIfAllActivitiesHaveBeenCompleted(activities);
-      isOneActivityOverdue = checkIfOneActivityIsOverdue(activities);
-
-      if (allActivitiesHaveBeenCompleted) {
+      if (haveAllActivitiesBeenCompleted(activities)) {
         return 'civicase__activities-calendar__day-status civicase__activities-calendar__day-status--completed';
-      } else if (isOneActivityOverdue) {
+      } else if (isAnyActivityOverdue(activities)) {
         return 'civicase__activities-calendar__day-status civicase__activities-calendar__day-status--overdue';
       } else {
         return 'civicase__activities-calendar__day-status civicase__activities-calendar__day-status--scheduled';
       }
+    }
+
+    /**
+     * Determines if all the given activities have been completed.
+     *
+     * @param {Array} activities
+     * @return {Boolean}
+     */
+    function haveAllActivitiesBeenCompleted (activities) {
+      return _.every(activities, function (activity) {
+        return _.includes(CRM.civicase.activityStatusTypes.completed, +activity.status_id);
+      });
+    }
+
+    /**
+     * Determines if at least one of the given activities is overdue.
+     *
+     * @param {Array} activities
+     * @return {Boolean}
+     */
+    function isAnyActivityOverdue (activities) {
+      return _.some(activities, function (activity) {
+        return activity.is_overdue;
+      });
     }
 
     /**

--- a/ang/civicase/ActivitiesCalendar.js
+++ b/ang/civicase/ActivitiesCalendar.js
@@ -172,10 +172,23 @@
      * Determines if all the given activities have been completed.
      *
      * @param {Array} activities
+     * @return {Boolean}
      */
     function checkIfAllActivitiesHaveBeenCompleted (activities) {
       return _.every(activities, function (activity) {
         return _.includes(CRM.civicase.activityStatusTypes.completed, +activity.status_id);
+      });
+    }
+
+    /**
+     * Determines if at least one of the given activities is overdue.
+     *
+     * @param {Array} activities
+     * @return {Boolean}
+     */
+    function checkIfOneActivityIsOverdue (activities) {
+      return _.some(activities, function (activity) {
+        return activity.is_overdue;
       });
     }
 
@@ -200,9 +213,8 @@
      *   can be "day", "month", or "year".
      */
     function getDayCustomClass (params) {
-      var allActivitiesHaveBeenCompleted;
+      var allActivitiesHaveBeenCompleted, isOneActivityOverdue;
       var activities = getActivitiesForDate(params.date);
-      var isDateInThePast = moment().isAfter(params.date, 'day');
       var isInCurrentMonth = this.datepicker.activeDate.getMonth() === params.date.getMonth();
 
       if (!isInCurrentMonth && params.mode === 'day') {
@@ -214,10 +226,11 @@
       }
 
       allActivitiesHaveBeenCompleted = checkIfAllActivitiesHaveBeenCompleted(activities);
+      isOneActivityOverdue = checkIfOneActivityIsOverdue(activities);
 
       if (allActivitiesHaveBeenCompleted) {
         return 'civicase__activities-calendar__day-status civicase__activities-calendar__day-status--completed';
-      } else if (isDateInThePast) {
+      } else if (isOneActivityOverdue) {
         return 'civicase__activities-calendar__day-status civicase__activities-calendar__day-status--overdue';
       } else {
         return 'civicase__activities-calendar__day-status civicase__activities-calendar__day-status--scheduled';

--- a/ang/test/civicase/ActivitiesCalendar.spec.js
+++ b/ang/test/civicase/ActivitiesCalendar.spec.js
@@ -142,9 +142,9 @@
       describe('when there is at least one activity that is overdue for a given date in the past', function () {
         beforeEach(function () {
           var activities = [
-            { activity_date_time: dates.yesterday, status_id: _.sample(CRM.civicase.activityStatusTypes.completed) },
-            { activity_date_time: dates.yesterday, status_id: _.sample(CRM.civicase.activityStatusTypes.completed) },
-            { activity_date_time: dates.yesterday, status_id: _.sample(CRM.civicase.activityStatusTypes.incomplete) }
+            { activity_date_time: dates.yesterday, status_id: _.sample(CRM.civicase.activityStatusTypes.completed), is_overdue: false },
+            { activity_date_time: dates.yesterday, status_id: _.sample(CRM.civicase.activityStatusTypes.completed), is_overdue: false },
+            { activity_date_time: dates.yesterday, status_id: _.sample(CRM.civicase.activityStatusTypes.incomplete), is_overdue: true }
           ];
 
           initController(activities);


### PR DESCRIPTION
## Overview

This PR changes the way overdue dates are calculated for the activities calendar. Before they were calculated when all activities were in the past. Now they just take into consideration the `is_overdue` field.

## Before
![record](https://user-images.githubusercontent.com/1642119/46371395-3c8a8c00-c656-11e8-9fdc-b9a22643cada.gif)

## After
![record](https://user-images.githubusercontent.com/1642119/46371297-f9301d80-c655-11e8-8680-e7e4ab9acff9.gif)


## Technical details

The `getDayCustomClass` was refactored so it checks if at least one activity is overdue to mark the date as `overdue`:

```js
function getDayCustomClass (params) {
  var allActivitiesHaveBeenCompleted, isOneActivityOverdue;

  // ...

  allActivitiesHaveBeenCompleted = checkIfAllActivitiesHaveBeenCompleted(activities);
  isOneActivityOverdue = checkIfOneActivityIsOverdue(activities); // checked here

  if (allActivitiesHaveBeenCompleted) {
    return 'civicase__activities-calendar__day-status civicase__activities-calendar__day-status--completed';
  } else if (isOneActivityOverdue) { // used here
    return 'civicase__activities-calendar__day-status civicase__activities-calendar__day-status--overdue';
  } else {
    return 'civicase__activities-calendar__day-status civicase__activities-calendar__day-status--scheduled';
  }
}

function checkIfOneActivityIsOverdue (activities) {
  return _.some(activities, function (activity) {
    return activity.is_overdue;
  });
}
```

