### PR TITLE
C51-250: Disable autofill for crmUiSelect

### DIFF
--- a/ang/civicase/Search.js
+++ b/ang/civicase/Search.js
@@ -6,7 +6,6 @@
       replace: true,
       templateUrl: '~/civicase/Search.html',
       controller: 'civicaseSearchController',
-      link: civicaseSearchLink,
       scope: {
         defaults: '=filters',
         hiddenFilters: '=',
@@ -14,26 +13,6 @@
         expanded: '='
       }
     };
-
-    /**
-     * Link function for the directive
-     *
-     * @param {object} scope
-     * @param {object} element
-     * @param {object} attr
-     */
-    function civicaseSearchLink (scope, element, attr) {
-      /**
-       * The logic is for disabling chrome autofills. New chrome version needs auto complete to be set to 'new-password'.
-       * Refer - https://stackoverflow.com/questions/15738259/disabling-chrome-autofill
-       * This should be the part of select 2 library implementation and till this is not implemented in the select2 library,
-       * this should be kept here.
-       *
-       * Todo -
-       * Move this logic into crmUiSelect Directive so that this can be implemented for all input single select elements.
-       */
-      $('input[autocomplete]', element).attr('autocomplete', 'new-password');
-    }
   });
 
   /**

--- a/ang/civicase/Utils.js
+++ b/ang/civicase/Utils.js
@@ -715,6 +715,32 @@
     };
   });
 
+  module.config(function ($provide) {
+    $provide.decorator('crmUiSelectDirective', function ($delegate) {
+      var directive = $delegate[0];
+      var link = directive.link;
+
+      directive.compile = function () {
+        return function (scope, element, attrs) {
+          link.apply(this, arguments);
+
+          /**
+           * The logic is for disabling chrome autofills. New chrome version needs auto complete to be set to 'new-password'.
+           * Refer - https://stackoverflow.com/questions/15738259/disabling-chrome-autofill
+           * This should be the part of select 2 library implementation and till this is not implemented in the select2 library,
+           * this should be kept here.
+           *
+           * Todo -
+           * Move this logic into crmUiSelect Directive so that this can be implemented for all input single select elements.
+           */
+          element.siblings('.select2-container').find('input[autocomplete]').attr('autocomplete', 'new-password');
+        };
+      };
+
+      return $delegate;
+    });
+  });
+
   function getStatusType (statusId) {
     var statusType;
     _.each(CRM.civicase.activityStatusTypes, function (statuses, type) {


### PR DESCRIPTION
## Overview
As part of this PR the autofill has been disabled for all `crmUiSelect`.

## Before
![2018-10-05 at 6 17 pm](https://user-images.githubusercontent.com/5058867/46536072-f1c57a00-c8ca-11e8-87b0-0adc28b6ca1e.png)

## After
![2018-10-05 at 6 16 pm](https://user-images.githubusercontent.com/5058867/46536037-dd817d00-c8ca-11e8-84c6-f30c6b499534.png)

## Technical Details
1. Added a decorator to disable the autofill for the `crmUiSelect` directive.
2. Removed similar code from `Search.js`