### PR TITLE
C51-241: Change case contact popover data loading from init to mouseover

### DIFF
--- a/ang/civicase/ContactCard.html
+++ b/ang/civicase/ContactCard.html
@@ -6,7 +6,8 @@
         popover-class="contact-popover-container"
         popover-append-to-body="true"
         popover-placement="auto bottom"
-        popover-trigger="'mouseenter'">
+        popover-trigger="'mouseenter'"
+        ng-mouseover="initMainContact()">
         <i class="civicase__contact-icon material-icons" ng-if="getContactIconOf(contacts[0].contact_id) === 'Individual'">person</i>
         <i class="civicase__contact-icon material-icons" ng-if="getContactIconOf(contacts[0].contact_id) === 'Household'">home</i>
         <i class="civicase__contact-icon material-icons" ng-if="getContactIconOf(contacts[0].contact_id) === 'Organisation'">domain</i>
@@ -46,7 +47,8 @@
       popover-trigger="'outsideClick'"
       popover-class="civicase__contact-additional__popover"
       civicase-popover-append-to-element="#bootstrap-theme"
-      ng-click="$event.stopPropagation()">+{{ contacts.length - 1 }}
+      ng-click="$event.stopPropagation()"
+      ng-mouseover="initMainContact()">+{{ contacts.length - 1 }}
     </span>
   <!-- End - Additional Contact Dropdown -->
 

--- a/ang/civicase/ContactCard.js
+++ b/ang/civicase/ContactCard.js
@@ -27,6 +27,13 @@
       }());
 
       /**
+       * Initializes the main contact that is featured on the contact card's popover.
+       */
+      scope.initMainContact = function () {
+        scope.mainContact = ContactsDataService.getCachedContact(scope.contacts[0].contact_id);
+      };
+
+      /**
        * Watch function for data refresh
        */
       function refresh () {
@@ -49,8 +56,6 @@
         } else {
           scope.contacts = _.cloneDeep(scope.data);
         }
-
-        scope.mainContact = ContactsDataService.getCachedContact(scope.contacts[0].contact_id);
       }
 
       /**

--- a/ang/test/civicase/ContactCard.spec.js
+++ b/ang/test/civicase/ContactCard.spec.js
@@ -83,6 +83,7 @@
 
         spyOn(ContactsDataService, 'getCachedContact').and.returnValue(expectedContact);
         compileDirective(false, expectedContact.contact_id, expectedContact.display_name);
+        element.isolateScope().initMainContact();
       });
 
       it('provides the main contact information to the popover', function () {


### PR DESCRIPTION
# C51-241: Fix contact popover missing details

## Overview

This PR fixes the contact card's popover. In some instances the contact information
may be missing.

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/46632909-2418e680-cb1a-11e8-92f9-25fa8fcda239.gif)


## After
![pr-after](https://user-images.githubusercontent.com/1642119/46633235-131ca500-cb1b-11e8-972e-8dae03ed1618.gif)


## Technical details

The reason for this is that the contact information may not be ready by the time the
contact card is displayed since the activity information and the contact information
are fetched one after the other.

To fix this, the contact information is fetched on mouseover instead, which is when
the contact popover is requested.

```html
<span uib-popover-template="'contact-popover.html'"
        popover-class="contact-popover-container"
        popover-append-to-body="true"
        popover-placement="auto bottom"
        popover-trigger="'mouseenter'">
        popover-trigger="'mouseenter'"
        ng-mouseover="initMainContact()">
        <!-- ... -->
</span>
```

```js
scope.initMainContact = function () {
  scope.mainContact = ContactsDataService.getCachedContact(scope.contacts[0].contact_id);
};
```
