### PR TITLE
C51-253: Fix activities count and calendar

### DIFF
--- a/ang/civicase/CaseListTable.js
+++ b/ang/civicase/CaseListTable.js
@@ -289,6 +289,7 @@
       var returnActivityParams = {
         case_id: '$value.id',
         options: {
+          limit: '0',
           sort: 'activity_date_time ASC'
         },
         return: [

--- a/ang/civicase/Utils.js
+++ b/ang/civicase/Utils.js
@@ -283,6 +283,7 @@
       var allActivitiesParams = {
         case_id: caseId,
         options: {
+          limit: '0',
           sort: 'activity_date_time ASC'
         },
         return: activityReturnParams


### PR DESCRIPTION
## Overview

## Activities Count

### Before
<img width="401" alt="screen shot 2018-10-22 at 10 39 37 pm" src="https://user-images.githubusercontent.com/1642119/47331848-6890a000-d64b-11e8-802f-1f3226f4fac5.png">
Notice the -28.

### After
<img width="402" alt="screen shot 2018-10-22 at 10 25 37 pm" src="https://user-images.githubusercontent.com/1642119/47331704-fa4bdd80-d64a-11e8-9a7e-463b236e0ad2.png">


## Activities Calendar

### Before
![scroll-with-limit](https://user-images.githubusercontent.com/1642119/47331898-97a71180-d64b-11e8-8790-a1a4a6a4e78c.gif)


### After
![scroll-without-limit](https://user-images.githubusercontent.com/1642119/47331770-2cf5d600-d64b-11e8-8878-1e8cb0a53060.gif)
The scrollbar is longer because it contains all the activities for the day.


## Technical details

The issue happens because when the case list and the case details are loaded they don't specify a limit for the activities and the default limit is `25`. The activities are needed to count how many scheduled/completed tasks there are for each case. Also, the activities are needed because they are passed to the calendar. It doesn't requests them itself.

To solve it, the limit was changed to `0` which means that all activities will be requested.

To test the request sizes a few activities were created using the following command from the console:

```js
var caseIds = [43, 70, 85, 120, 84, 87];

caseIds.forEach((caseId) => {
  CRM._.times(50).forEach((i) => CRM.api3('Activity', 'create', {
    "source_contact_id": 202,
    "case_id": caseId,
    "activity_type_id": "Case Task",
    "activity_date_time": "2018-10-20",
    "status_id": "Scheduled"
  }).done(function(result) {
    console.log('done:', i);
  }));
});
```

The request results with the default 25 limit:

<img width="774" alt="screen shot 2018-10-22 at 10 49 58 pm" src="https://user-images.githubusercontent.com/1642119/47332292-da1d1e00-d64c-11e8-9657-83a4dd499ac2.png">


And the requests without the activity limit:

<img width="772" alt="screen shot 2018-10-22 at 10 20 04 pm" src="https://user-images.githubusercontent.com/1642119/47332255-bd80e600-d64c-11e8-9504-f686e9041ce9.png">


