### PR TITLE
C51-271: civicase-panel-query directive

### DIFF
--- a/ang/civicase/PanelQuery.html
+++ b/ang/civicase/PanelQuery.html
@@ -49,6 +49,8 @@
       text-next="{{ ts('Next') }}"
       text-prev="{{ ts('Prev') }}"
     ></paging>
-    <div>Showing {{pagination.range.from}} to {{pagination.range.to}} of {{total}} {{customData.itemName || 'items'}}</div>
+    <div ng-show="total > 0">
+      Showing {{pagination.range.from}} to {{pagination.range.to}} of {{total}} {{customData.itemName || 'items'}}
+    </div>
   </footer>
 </div>

--- a/ang/civicase/PanelQuery.html
+++ b/ang/civicase/PanelQuery.html
@@ -1,7 +1,11 @@
 <div class="panel panel-secondary">
   <header class="panel-heading">
     <div class="clearfix">
-      <h2 class="panel-title pull-left">{{title}}</h2>
+      <h2 class="panel-title pull-left">
+        <div ng-transclude="title">
+          {{loading ? '-' : total}} {{customData.itemName || 'items'}}
+        </div>
+      </h2>
       <div class="panel-heading-control crm_custom-select pull-left">
         <select ng-options="range.value as range.label for range in periodRange" ng-model="selectedRange"></select>
         <span class="crm_custom-select__arrow"></span>

--- a/ang/civicase/PanelQuery.html
+++ b/ang/civicase/PanelQuery.html
@@ -10,7 +10,28 @@
     </div>
   </header>
   <div class="panel-body">
-    <div ng-transclude="results"></div>
+    <div ng-hide="loading" ng-transclude="results"></div>
+    <div ng-if="loading">
+      <div class="panel panel-default" ng-repeat="i in [0,1]">
+        <div class="panel-body" style="border-top: 0;">
+          <div class="civicase__activity-card-row" style="margin-bottom: 8px;">
+            <div
+              class="civicase__loading-placeholder__oneline"
+              style="width: 0.8em; font-size: 24px; margin-right: 10px;">
+            </div>
+            <div class="civicase__loading-placeholder__oneline" style="width: 8em; font-size: 18px;"></div>
+            <div
+              class="civicase__activity__right-container civicase__loading-placeholder__oneline"
+              style="width: 7em;">
+            </div>
+          </div>
+          <div
+            class="civicase__activity-card-row--file civicase__loading-placeholder__oneline"
+            style="width: 8em; margin-bottom: 10px;">
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
   <footer class="panel-footer">
     <paging

--- a/ang/civicase/PanelQuery.html
+++ b/ang/civicase/PanelQuery.html
@@ -3,10 +3,7 @@
     <div class="clearfix">
       <h2 class="panel-title pull-left">{{title}}</h2>
       <div class="panel-heading-control crm_custom-select pull-left">
-        <select>
-          <option value="week">This Week</option>
-          <option value="month">This Month</option>
-        </select>
+        <select ng-options="range.value as range.label for range in periodRange" ng-model="selectedRange"></select>
         <span class="crm_custom-select__arrow"></span>
       </div>
       <div class="pull-right" ng-transclude="actions"></div>

--- a/ang/civicase/PanelQuery.html
+++ b/ang/civicase/PanelQuery.html
@@ -13,10 +13,9 @@
     <div ng-transclude="results"></div>
   </div>
   <footer class="panel-footer">
-    {{pagination}}
     <paging
       class="pull-right"
-      ng-show="results.length > 1"
+      ng-show="total > 1"
       page="pagination.page"
       page-size="pagination.size"
       total="total"

--- a/ang/civicase/PanelQuery.html
+++ b/ang/civicase/PanelQuery.html
@@ -28,6 +28,6 @@
       text-next="{{ ts('Next') }}"
       text-prev="{{ ts('Prev') }}"
     ></paging>
-    <div>Showing {{pagination.range.from}} to {{pagination.range.to}} of {{total}} items</div>
+    <div>Showing {{pagination.range.from}} to {{pagination.range.to}} of {{total}} {{customData.itemName || 'items'}}</div>
   </footer>
 </div>

--- a/ang/civicase/PanelQuery.html
+++ b/ang/civicase/PanelQuery.html
@@ -13,6 +13,22 @@
     <div ng-transclude="results"></div>
   </div>
   <footer class="panel-footer">
-    <!-- the pagination directive -->
+    {{pagination}}
+    <paging
+      class="pull-right"
+      ng-show="results.length > 1"
+      page="pagination.page"
+      page-size="pagination.size"
+      total="total"
+      adjacent="1"
+      dots="..."
+      show-prev-next="true"
+      show-first-last="true"
+      text-first="{{ ts('First') }}"
+      text-last="{{ ts('Last') }}"
+      text-next="{{ ts('Next') }}"
+      text-prev="{{ ts('Prev') }}"
+    ></paging>
+    <div>Showing {{pagination.range.from}} to {{pagination.range.to}} of {{total}} items</div>
   </footer>
 </div>

--- a/ang/civicase/PanelQuery.html
+++ b/ang/civicase/PanelQuery.html
@@ -50,7 +50,7 @@
         text-prev="{{ ts('Previous') }}"
       ></paging>
       <div>
-        Showing {{pagination.range.from}} to {{pagination.range.to}} of {{total}} {{customData.itemName || 'items'}}
+        Showing {{loading ? '-' : pagination.range.from}} to {{loading ? '-' : pagination.range.to}} of {{loading ? '-' : total}} {{customData.itemName || 'items'}}
       </div>
     </div>
   </footer>

--- a/ang/civicase/PanelQuery.html
+++ b/ang/civicase/PanelQuery.html
@@ -53,8 +53,11 @@
         text-next="{{ ts('Next') }}"
         text-prev="{{ ts('Previous') }}"
       ></paging>
-      <div>
-        Showing {{loading ? '-' : pagination.range.from}} to {{loading ? '-' : pagination.range.to}} of {{loading ? '-' : total}} {{customData.itemName || 'items'}}
+      <div ng-if="loading">
+        Showing - to - of - {{customData.itemName || 'items'}}
+      </div>
+      <div ng-if="!loading">
+        Showing {{pagination.range.from}} to {{pagination.range.to}} of {{total}} {{customData.itemName || 'items'}}
       </div>
     </div>
   </footer>

--- a/ang/civicase/PanelQuery.html
+++ b/ang/civicase/PanelQuery.html
@@ -1,0 +1,21 @@
+<div class="panel panel-secondary">
+  <header class="panel-heading">
+    <div class="clearfix">
+      <h2 class="panel-title pull-left">{{title}}</h2>
+      <div class="panel-heading-control crm_custom-select pull-left">
+        <select>
+          <option value="week">This Week</option>
+          <option value="month">This Month</option>
+        </select>
+        <span class="crm_custom-select__arrow"></span>
+      </div>
+      <div class="pull-right" ng-transclude="actions"></div>
+    </div>
+  </header>
+  <div class="panel-body">
+    <div ng-transclude="results"></div>
+  </div>
+  <footer class="panel-footer">
+    <!-- the pagination directive -->
+  </footer>
+</div>

--- a/ang/civicase/PanelQuery.html
+++ b/ang/civicase/PanelQuery.html
@@ -34,23 +34,24 @@
     </div>
   </div>
   <footer class="panel-footer">
-    <paging
-      class="pull-right"
-      ng-show="total > 1"
-      page="pagination.page"
-      page-size="pagination.size"
-      total="total"
-      adjacent="1"
-      dots="..."
-      show-prev-next="true"
-      show-first-last="true"
-      text-first="{{ ts('First') }}"
-      text-last="{{ ts('Last') }}"
-      text-next="{{ ts('Next') }}"
-      text-prev="{{ ts('Prev') }}"
-    ></paging>
     <div ng-show="total > 0">
-      Showing {{pagination.range.from}} to {{pagination.range.to}} of {{total}} {{customData.itemName || 'items'}}
+      <paging
+        class="pull-right"
+        page="pagination.page"
+        page-size="pagination.size"
+        total="total"
+        adjacent="1"
+        dots="..."
+        show-prev-next="true"
+        show-first-last="true"
+        text-first="{{ ts('First') }}"
+        text-last="{{ ts('Last') }}"
+        text-next="{{ ts('Next') }}"
+        text-prev="{{ ts('Previous') }}"
+      ></paging>
+      <div>
+        Showing {{pagination.range.from}} to {{pagination.range.to}} of {{total}} {{customData.itemName || 'items'}}
+      </div>
     </div>
   </footer>
 </div>

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -1,4 +1,4 @@
-(function (angular, _) {
+(function (angular, _, ts) {
   var module = angular.module('civicase');
 
   module.directive('civicasePanelQuery', function () {
@@ -42,6 +42,7 @@
     $scope.results = [];
     $scope.title = '---';
     $scope.total = 0;
+    $scope.ts = ts;
     $scope.selectedRange = 'week';
     $scope.periodRange = [
       { label: 'This Week', value: 'week' },
@@ -193,4 +194,4 @@
       }
     }
   }
-}(angular, CRM._));
+}(angular, CRM._, CRM.ts('civicase')));

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -14,7 +14,8 @@
       },
       transclude: {
         actions: '?panelQueryActions',
-        results: 'panelQueryResults'
+        results: 'panelQueryResults',
+        title: '?panelQueryTitle'
       }
     };
 
@@ -26,6 +27,10 @@
       $transclude($scope, function (clone, scope) {
         $element.find('[ng-transclude="results"]').html(clone);
       }, false, 'results');
+
+      $transclude($scope, function (clone, scope) {
+        $element.find('[ng-transclude="title"]').html(clone);
+      }, false, 'title');
     }
   });
 
@@ -40,7 +45,6 @@
     $scope.handlers = $scope.handlers || {};
     $scope.loading = false;
     $scope.results = [];
-    $scope.title = '---';
     $scope.total = 0;
     $scope.ts = ts;
     $scope.selectedRange = 'week';
@@ -135,7 +139,6 @@
         .then(updatePaginationRange)
         .then(function () {
           if (!skipCount) {
-            $scope.title = $scope.handlers.title ? $scope.handlers.title($scope.total) : $scope.title;
             $scope.loading = false;
           }
         });

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -74,6 +74,12 @@
       $scope.$watchCollection('query.params', function (newParams, oldParams) {
         (newParams !== oldParams) && loadData();
       }, true);
+
+      $scope.$watch('selectedRange', function (newRange, oldRange) {
+        if (newRange !== oldRange && $scope.handlers.range) {
+          $scope.handlers.range($scope.selectedRange, $scope.query.params);
+        }
+      });
     }
 
     /**

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -34,6 +34,8 @@
   panelQueryCtrl.$inject = ['$log', '$scope', 'crmApi'];
 
   function panelQueryCtrl ($log, $scope, crmApi) {
+    var PAGE_SIZE = 5;
+
     $scope.customData = $scope.customData || {};
     $scope.handlers = $scope.handlers || {};
     $scope.results = [];
@@ -44,6 +46,11 @@
       { label: 'This Week', value: 'week' },
       { label: 'This Month', value: 'month' }
     ];
+    $scope.pagination = {
+      page: 1,
+      size: PAGE_SIZE,
+      range: { from: 1, to: PAGE_SIZE }
+    };
 
     (function init () {
       initWatchers();
@@ -82,6 +89,17 @@
           $scope.handlers.range($scope.selectedRange, $scope.query.params);
         }
       });
+
+      $scope.$watch('pagination.page', function (newPage, oldPage) {
+        if (newPage !== oldPage) {
+          $scope.pagination.range.from = (($scope.pagination.page - 1) * $scope.pagination.size) + 1;
+          $scope.pagination.range.to = ($scope.pagination.page * $scope.pagination.size);
+
+          if ($scope.pagination.range.to > $scope.total) {
+            $scope.pagination.range.to = $scope.total;
+          }
+        }
+      });
     }
 
     /**
@@ -101,7 +119,11 @@
      */
     function prepareRequestParams () {
       return _.assign({}, $scope.query.params, {
-        sequential: 1
+        sequential: 1,
+        options: {
+          limit: $scope.pagination.size,
+          offset: $scope.pagination.page + $scope.pagination.size
+        }
       });
     }
 

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -9,6 +9,7 @@
       controller: 'panelQueryCtrl',
       scope: {
         query: '<',
+        customData: '<?',
         handlers: '<?'
       },
       transclude: {
@@ -33,6 +34,7 @@
   panelQueryCtrl.$inject = ['$log', '$scope', 'crmApi'];
 
   function panelQueryCtrl ($log, $scope, crmApi) {
+    $scope.customData = $scope.customData || {};
     $scope.handlers = $scope.handlers || {};
     $scope.results = [];
     $scope.title = '---';

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -31,9 +31,9 @@
 
   module.controller('panelQueryCtrl', panelQueryCtrl);
 
-  panelQueryCtrl.$inject = ['$log', '$scope', 'crmApi'];
+  panelQueryCtrl.$inject = ['$log', '$q', '$scope', 'crmApi'];
 
-  function panelQueryCtrl ($log, $scope, crmApi) {
+  function panelQueryCtrl ($log, $q, $scope, crmApi) {
     var PAGE_SIZE = 5;
 
     $scope.customData = $scope.customData || {};
@@ -85,8 +85,12 @@
 
       return crmApi(apiCalls)
         .then(function (result) {
-          $scope.results = processResults(result.get.values);
           !skipCount && ($scope.total = result.count);
+
+          return processResults(result.get.values);
+        })
+        .then(function (processed) {
+          $scope.results = processed;
         });
     }
 
@@ -149,10 +153,10 @@
      * before storing it
      *
      * @param {Array} results
-     * @return {Array}
+     * @return {Promise}
      */
     function processResults (results) {
-      return $scope.handlers.results ? results.map($scope.handlers.results) : results;
+      return $q.resolve($scope.handlers.results ? $scope.handlers.results(results) : results);
     }
 
     /**

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -66,15 +66,13 @@
      */
     function initWatchers () {
       // Trigger a refresh when the query params change
-      $scope.$watch('query.params', function (newParams, oldParams) {
-        _.isObject(newParams) && loadData();
+      $scope.$watchCollection('query.params', function (newParams, oldParams) {
+        (newParams !== oldParams) && loadData();
       }, true);
     }
 
     /**
-     * Loads the data and triggers any triggers any subsequent logic
-     *
-     * @return {Promise}
+     * Loads the data and triggers any subsequent logic
      */
     function loadData () {
       fetchDataViaApi()

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -42,11 +42,24 @@
       initWatchers();
       verifyData();
 
-      loadData()
-        .then(function () {
-          $scope.title = $scope.handlers.title ? $scope.handlers.title($scope.total) : $scope.title;
-        });
+      loadData();
     }());
+
+    /**
+     * Fetches the data via the Civi API and stores the response
+     *
+     * @return {Promise}
+     */
+    function fetchDataViaApi () {
+      return crmApi({
+        get: [ $scope.query.entity, 'get', prepareRequestParams() ],
+        count: [ $scope.query.entity, 'getcount', $scope.query.params ]
+      })
+        .then(function (result) {
+          $scope.results = processResults(result.get.values);
+          $scope.total = result.count;
+        });
+    }
 
     /**
      * Initializes the directive's watchers
@@ -59,18 +72,14 @@
     }
 
     /**
-     * Loads the data via the api
+     * Loads the data and triggers any triggers any subsequent logic
      *
      * @return {Promise}
      */
     function loadData () {
-      return crmApi({
-        get: [ $scope.query.entity, 'get', prepareRequestParams() ],
-        count: [ $scope.query.entity, 'getcount', $scope.query.params ]
-      })
-        .then(function (result) {
-          $scope.results = processResults(result.get.values);
-          $scope.total = result.count;
+      fetchDataViaApi()
+        .then(function () {
+          $scope.title = $scope.handlers.title ? $scope.handlers.title($scope.total) : $scope.title;
         });
     }
 

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -37,6 +37,11 @@
     $scope.results = [];
     $scope.title = '---';
     $scope.total = 0;
+    $scope.selectedRange = 'week';
+    $scope.periodRange = [
+      { label: 'This Week', value: 'week' },
+      { label: 'This Month', value: 'month' }
+    ];
 
     (function init () {
       initWatchers();

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -1,4 +1,4 @@
-(function (angular) {
+(function (angular, _) {
   var module = angular.module('civicase');
 
   module.directive('civicasePanelQuery', function () {
@@ -6,6 +6,7 @@
       restrict: 'E',
       templateUrl: '~/civicase/PanelQuery.html',
       link: linkFn,
+      controller: 'panelQueryCtrl',
       scope: {
         queryData: '<'
       },
@@ -25,4 +26,69 @@
       }, false, 'results');
     }
   });
-}(angular));
+
+  module.controller('panelQueryCtrl', panelQueryCtrl);
+
+  panelQueryCtrl.$inject = ['$log', '$scope', 'crmApi'];
+
+  function panelQueryCtrl ($log, $scope, crmApi) {
+    $scope.results = [];
+    $scope.total = 0;
+
+    (function init () {
+      initWatchers();
+      verifyData();
+      loadData();
+    }());
+
+    /**
+     * Initializes the directive's watchers
+     */
+    function initWatchers () {
+      // Trigger a refresh when the query params change
+      $scope.$watch('queryData.query.params', function (newParams, oldParams) {
+        _.isObject(newParams) && loadData();
+      }, true);
+    }
+
+    /**
+     * Loads the data via the api
+     */
+    function loadData () {
+      crmApi({
+        get: [ $scope.queryData.query.entity, 'get', prepareRequestParams() ],
+        count: [ $scope.queryData.query.entity, 'getcount', $scope.queryData.query.params ]
+      })
+        .then(function (result) {
+          $scope.results = result.get.values;
+          $scope.total = result.count;
+        });
+    }
+
+    /**
+     * Prepare the parameters of the request before passing them to the API
+     *
+     * @return {String}
+     */
+    function prepareRequestParams () {
+      return _.assign({}, $scope.queryData.query.params, {
+        sequential: 1
+      });
+    }
+
+    /**
+     * Verifies that the given data has at least the mandatory properties
+     *
+     * @throws Error
+     */
+    function verifyData () {
+      if (!$scope.queryData.query) {
+        throw new Error('You need to provide a `query` object');
+      }
+
+      if (!$scope.queryData.query.entity) {
+        throw new Error('The `query` object needs to have a `entity` value');
+      }
+    }
+  }
+}(angular, CRM._));

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -77,7 +77,7 @@
      */
     function fetchDataViaApi (skipCount) {
       var apiCalls = {
-        get: [ $scope.query.entity, 'get', prepareRequestParams() ],
+        get: [ $scope.query.entity, $scope.query.action || 'get', prepareRequestParams() ],
         count: [ $scope.query.entity, 'getcount', $scope.query.params ]
       };
 

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -20,17 +20,11 @@
     };
 
     function linkFn ($scope, $element, $attrs, $controller, $transclude) {
-      $transclude($scope, function (clone, scope) {
-        $element.find('[ng-transclude="actions"]').html(clone);
-      }, false, 'actions');
-
-      $transclude($scope, function (clone, scope) {
-        $element.find('[ng-transclude="results"]').html(clone);
-      }, false, 'results');
-
-      $transclude($scope, function (clone, scope) {
-        $element.find('[ng-transclude="title"]').html(clone);
-      }, false, 'title');
+      ['actions', 'results', 'title'].forEach(function (slot) {
+        $transclude($scope, function (clone, scope) {
+          $element.find('[ng-transclude="' + slot + '"]').html(clone);
+        }, false, slot);
+      });
     }
   });
 

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -1,0 +1,28 @@
+(function (angular) {
+  var module = angular.module('civicase');
+
+  module.directive('civicasePanelQuery', function () {
+    return {
+      restrict: 'E',
+      templateUrl: '~/civicase/PanelQuery.html',
+      link: linkFn,
+      scope: {
+        queryData: '<'
+      },
+      transclude: {
+        actions: '?panelQueryActions',
+        results: 'panelQueryResults'
+      }
+    };
+
+    function linkFn ($scope, $element, $attrs, $controller, $transclude) {
+      $transclude($scope, function (clone, scope) {
+        $element.find('[ng-transclude="actions"]').html(clone);
+      }, false, 'actions');
+
+      $transclude($scope, function (clone, scope) {
+        $element.find('[ng-transclude="results"]').html(clone);
+      }, false, 'results');
+    }
+  });
+}(angular));

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -8,7 +8,7 @@
       link: linkFn,
       controller: 'panelQueryCtrl',
       scope: {
-        queryData: '<'
+        query: '<'
       },
       transclude: {
         actions: '?panelQueryActions',
@@ -46,7 +46,7 @@
      */
     function initWatchers () {
       // Trigger a refresh when the query params change
-      $scope.$watch('queryData.query.params', function (newParams, oldParams) {
+      $scope.$watch('query.params', function (newParams, oldParams) {
         _.isObject(newParams) && loadData();
       }, true);
     }
@@ -56,8 +56,8 @@
      */
     function loadData () {
       crmApi({
-        get: [ $scope.queryData.query.entity, 'get', prepareRequestParams() ],
-        count: [ $scope.queryData.query.entity, 'getcount', $scope.queryData.query.params ]
+        get: [ $scope.query.entity, 'get', prepareRequestParams() ],
+        count: [ $scope.query.entity, 'getcount', $scope.query.params ]
       })
         .then(function (result) {
           $scope.results = result.get.values;
@@ -71,7 +71,7 @@
      * @return {String}
      */
     function prepareRequestParams () {
-      return _.assign({}, $scope.queryData.query.params, {
+      return _.assign({}, $scope.query.params, {
         sequential: 1
       });
     }
@@ -82,11 +82,11 @@
      * @throws Error
      */
     function verifyData () {
-      if (!$scope.queryData.query) {
+      if (!$scope.query) {
         throw new Error('You need to provide a `query` object');
       }
 
-      if (!$scope.queryData.query.entity) {
+      if (!$scope.query.entity) {
         throw new Error('The `query` object needs to have a `entity` value');
       }
     }

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -109,19 +109,7 @@
       // Triggers a new request and a recalculation of the pagination range
       // when the current page changes
       $scope.$watch('pagination.page', function (newPage, oldPage) {
-        if (newPage === oldPage) {
-          return;
-        }
-
-        loadData(true)
-          .then(function () {
-            $scope.pagination.range.from = calculatePageOffset() + 1;
-            $scope.pagination.range.to = ($scope.pagination.page * $scope.pagination.size);
-
-            if ($scope.pagination.range.to > $scope.total) {
-              $scope.pagination.range.to = $scope.total;
-            }
-          });
+        (newPage !== oldPage) && loadData(true);
       });
     }
 
@@ -133,6 +121,7 @@
      */
     function loadData (skipCount) {
       return fetchDataViaApi(skipCount)
+        .then(updatePaginationRange)
         .then(function () {
           if (!skipCount && $scope.handlers.title) {
             $scope.title = $scope.handlers.title($scope.total);
@@ -164,6 +153,18 @@
      */
     function processResults (results) {
       return $scope.handlers.results ? results.map($scope.handlers.results) : results;
+    }
+
+    /**
+     * Updates the from..to range displayed in the pagination
+     */
+    function updatePaginationRange () {
+      $scope.pagination.range.from = calculatePageOffset() + 1;
+      $scope.pagination.range.to = ($scope.pagination.page * $scope.pagination.size);
+
+      if ($scope.pagination.range.to > $scope.total) {
+        $scope.pagination.range.to = $scope.total;
+      }
     }
 
     /**

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -125,7 +125,10 @@
      * @return {Promise}
      */
     function loadData (skipCount) {
-      (!skipCount) && ($scope.loading = true);
+      if (!skipCount) {
+        $scope.pagination.page = 1;
+        $scope.loading = true;
+      }
 
       return fetchDataViaApi(skipCount)
         .then(updatePaginationRange)

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -55,7 +55,6 @@
     (function init () {
       initWatchers();
       verifyData();
-
       loadData();
     }());
 

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -60,6 +60,16 @@
     }());
 
     /**
+     * Calculates the offset of the results list based
+     * on the current page number and page size
+     *
+     * @return {String}
+     */
+    function calculatePageOffset () {
+      return ($scope.pagination.page - 1) * $scope.pagination.size;
+    }
+
+    /**
      * Fetches the data via the Civi API and stores the response
      *
      * @return {Promise}
@@ -79,20 +89,22 @@
      * Initializes the directive's watchers
      */
     function initWatchers () {
-      // Trigger a refresh when the query params change
+      // Triggers a refresh when the query params change
       $scope.$watchCollection('query.params', function (newParams, oldParams) {
         (newParams !== oldParams) && loadData();
       }, true);
 
+      // Triggers the range handler (if present) when the selected range changes
       $scope.$watch('selectedRange', function (newRange, oldRange) {
         if (newRange !== oldRange && $scope.handlers.range) {
           $scope.handlers.range($scope.selectedRange, $scope.query.params);
         }
       });
 
+      // Triggers a recalculation of the pagination range when the current page changes
       $scope.$watch('pagination.page', function (newPage, oldPage) {
         if (newPage !== oldPage) {
-          $scope.pagination.range.from = (($scope.pagination.page - 1) * $scope.pagination.size) + 1;
+          $scope.pagination.range.from = calculatePageOffset() + 1;
           $scope.pagination.range.to = ($scope.pagination.page * $scope.pagination.size);
 
           if ($scope.pagination.range.to > $scope.total) {
@@ -122,7 +134,7 @@
         sequential: 1,
         options: {
           limit: $scope.pagination.size,
-          offset: $scope.pagination.page + $scope.pagination.size
+          offset: calculatePageOffset()
         }
       });
     }

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -38,6 +38,7 @@
 
     $scope.customData = $scope.customData || {};
     $scope.handlers = $scope.handlers || {};
+    $scope.loading = false;
     $scope.results = [];
     $scope.title = '---';
     $scope.total = 0;
@@ -124,11 +125,14 @@
      * @return {Promise}
      */
     function loadData (skipCount) {
+      (!skipCount) && ($scope.loading = true);
+
       return fetchDataViaApi(skipCount)
         .then(updatePaginationRange)
         .then(function () {
-          if (!skipCount && $scope.handlers.title) {
-            $scope.title = $scope.handlers.title($scope.total);
+          if (!skipCount) {
+            $scope.title = $scope.handlers.title ? $scope.handlers.title($scope.total) : $scope.title;
+            $scope.loading = false;
           }
         });
     }

--- a/ang/test/civicase/PanelQuery.spec.js
+++ b/ang/test/civicase/PanelQuery.spec.js
@@ -1,0 +1,102 @@
+/* eslint-env jasmine */
+(function ($) {
+  describe('panelQuery', function () {
+    var element, $compile, $rootScope, $scope;
+
+    beforeEach(module('civicase.templates', 'civicase'));
+
+    beforeEach(inject(function (_$compile_, _$rootScope_) {
+      $compile = _$compile_;
+      $rootScope = _$rootScope_;
+      $scope = $rootScope.$new();
+    }));
+
+    describe('attributes', function () {
+      var isolatedScope;
+
+      beforeEach(function () {
+        $scope.mockQueryData = { foo: 'foo', bar: 'bar' };
+        compileDirective('query-data="mockQueryData"', { results: '<div></div>' });
+        isolatedScope = element.isolateScope();
+      });
+
+      it('supports a [query-data] attribute and store its value in its scope', function () {
+        expect(isolatedScope.queryData).toBeDefined();
+        expect(isolatedScope.queryData).toEqual($scope.mockQueryData);
+      });
+
+      describe('one-way binding', function () {
+        var originalSource;
+
+        beforeEach(function () {
+          originalSource = $scope.mockQueryData;
+          isolatedScope.queryData = { baz: 'baz' };
+
+          $scope.$digest();
+        });
+
+        it('has a one-way binding on the [query-data] value', function () {
+          expect($scope.mockQueryData).toEqual(originalSource);
+        });
+      });
+    });
+
+    describe('transclude slots', function () {
+      it('requires the <panel-query-results> slot to be present', function () {
+        expect(function () {
+          compileDirective(null);
+        }).toThrow();
+      });
+
+      it('is optional to pass the <panel-query-actions> slot', function () {
+        expect(function () {
+          compileDirective(null, { results: '<div></div>' });
+        }).not.toThrow();
+      });
+
+      describe('scope compile', function () {
+        beforeEach(function () {
+          $scope.queryData = { foo: 'outer-foo', bar: 'outer-bar' };
+          $scope.passedData = { foo: 'isolated-foo', bar: 'isolated-bar' };
+
+          compileDirective('query-data="passedData"', {
+            actions: '<div>{{queryData.foo}}</div>',
+            results: '<div>{{queryData.bar}}</div>'
+          });
+        });
+
+        it('compiles the slot on its own isolated scope', function () {
+          var actionsHtml = element.find('[ng-transclude="actions"]').html();
+          var resultsHtml = element.find('[ng-transclude="results"]').html();
+
+          expect(actionsHtml).toContain($scope.passedData.foo);
+          expect(resultsHtml).toContain($scope.passedData.bar);
+        });
+      });
+    });
+
+    /**
+     * Function responsible for setting up compilation of the directive
+     *
+     * @param {String} attributes the attributes to add to the directive tag
+     * @param {Object} slot the transclude slots with their markup
+     */
+    function compileDirective (attributes, slot) {
+      var content = '';
+      var html = '<civicase-panel-query %{attributes}>%{content}</civicase-panel-query>';
+
+      attributes = attributes || '';
+      slot = slot || {};
+
+      content += slot.actions ? '<panel-query-actions>' + slot.actions + '</panel-query-actions>' : '';
+      content += slot.results ? '<panel-query-results>' + slot.results + '</panel-query-results>' : '';
+
+      html = html.replace('%{attributes}', attributes);
+      html = html.replace('%{content}', content);
+
+      element = $compile(html)($scope);
+
+      $scope.$digest();
+    }
+  });
+}(CRM.$));

--- a/ang/test/civicase/PanelQuery.spec.js
+++ b/ang/test/civicase/PanelQuery.spec.js
@@ -263,9 +263,14 @@
     });
 
     describe('watchers', function () {
+      var titleHandler = jasmine.createSpy();
+
       beforeEach(function () {
+        $scope.handlersData = { title: titleHandler };
+
         compileDirective();
         crmApi.calls.reset();
+        titleHandler.calls.reset();
       });
 
       describe('when the query params change', function () {
@@ -286,6 +291,10 @@
         it('passes the new params to the api', function () {
           expect(getRequest[2]).toEqual(jasmine.objectContaining({ baz: 'baz' }));
           expect(countRequest[2]).toEqual(jasmine.objectContaining({ baz: 'baz' }));
+        });
+
+        it('calls the title handler again', function () {
+          expect(titleHandler).toHaveBeenCalled();
         });
       });
     });

--- a/ang/test/civicase/PanelQuery.spec.js
+++ b/ang/test/civicase/PanelQuery.spec.js
@@ -254,10 +254,34 @@
           expect(entity).toBe($scope.queryData.entity);
         });
 
-        it('is for fetching the data', function () {
-          var action = request[1];
+        describe('action', function () {
+          describe('when none is specified', function () {
+            it('is "get"', function () {
+              var action = request[1];
 
-          expect(action).toBe('get');
+              expect(action).toBe('get');
+            });
+          });
+
+          describe('when it is specified', function () {
+            var requests, request;
+
+            beforeEach(function () {
+              $scope.queryData.action = 'customaction';
+
+              crmApi.calls.reset();
+              compileDirective();
+
+              requests = crmApi.calls.argsFor(0)[0];
+              request = requests[Object.keys(requests)[0]];
+            });
+
+            it('is the given action', function () {
+              var action = request[1];
+
+              expect(action).toBe($scope.queryData.action);
+            });
+          });
         });
 
         describe('params', function () {

--- a/ang/test/civicase/PanelQuery.spec.js
+++ b/ang/test/civicase/PanelQuery.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env jasmine */
 (function ($, _) {
   describe('panelQuery', function () {
-    var element, $compile, $q, $rootScope, $scope, crmApi, isolatedScope, mockedResults;
+    var element, $compile, $q, $rootScope, $scope, crmApi, panelQueryScope, mockedResults;
     var NO_OF_RESULTS = 10;
 
     beforeEach(module('civicase.templates', 'civicase', 'crmUtil'));
@@ -30,8 +30,8 @@
       });
 
       it('store its value in its scope', function () {
-        expect(isolatedScope.query).toBeDefined();
-        expect(isolatedScope.query).toEqual($scope.queryData);
+        expect(panelQueryScope.query).toBeDefined();
+        expect(panelQueryScope.query).toEqual($scope.queryData);
       });
 
       describe('one-way binding', function () {
@@ -39,7 +39,7 @@
 
         beforeEach(function () {
           originalSource = $scope.queryData;
-          isolatedScope.query = { baz: 'baz' };
+          panelQueryScope.query = { baz: 'baz' };
 
           $scope.$digest();
         });
@@ -100,7 +100,7 @@
         });
 
         it('allows to modify the list before it is stored', function () {
-          expect(isolatedScope.results).toBe(newResults);
+          expect(panelQueryScope.results).toBe(newResults);
         });
       });
 
@@ -124,8 +124,8 @@
           beforeEach(function () {
             rangeHandler.calls.reset();
 
-            isolatedScope.selectedRange = newRange;
-            isolatedScope.$digest();
+            panelQueryScope.selectedRange = newRange;
+            panelQueryScope.$digest();
           });
 
           it('is called when the selected range changes', function () {
@@ -158,8 +158,8 @@
       });
 
       it('is stored in the isolated scope', function () {
-        expect(_.isEmpty(isolatedScope.customData)).toBe(false);
-        expect(isolatedScope.customData).toEqual(jasmine.objectContaining($scope.customData));
+        expect(_.isEmpty(panelQueryScope.customData)).toBe(false);
+        expect(panelQueryScope.customData).toEqual(jasmine.objectContaining($scope.customData));
       });
     });
 
@@ -280,15 +280,15 @@
           describe('pagination', function () {
             it('adds the pagination params', function () {
               expect(requestParams.options).toBeDefined();
-              expect(requestParams.options.limit).toBe(isolatedScope.pagination.size);
-              expect(requestParams.options.offset).toBeDefined(isolatedScope.pagination.page + isolatedScope.pagination.size);
+              expect(requestParams.options.limit).toBe(panelQueryScope.pagination.size);
+              expect(requestParams.options.offset).toBeDefined(panelQueryScope.pagination.page + panelQueryScope.pagination.size);
             });
           });
         });
 
         describe('results', function () {
           it('stores the list of results', function () {
-            expect(isolatedScope.results).toEqual(mockedResults);
+            expect(panelQueryScope.results).toEqual(mockedResults);
           });
         });
       });
@@ -317,7 +317,7 @@
         });
 
         it('stores the count', function () {
-          expect(isolatedScope.total).toEqual(NO_OF_RESULTS);
+          expect(panelQueryScope.total).toEqual(NO_OF_RESULTS);
         });
       });
     });
@@ -332,7 +332,7 @@
 
       describe('when the query params change', function () {
         beforeEach(function () {
-          isolatedScope.pagination.page = 2;
+          panelQueryScope.pagination.page = 2;
           $scope.queryData.params.baz = 'baz';
           $scope.$digest();
 
@@ -350,14 +350,14 @@
         });
 
         it('resets the pagination', function () {
-          expect(isolatedScope.pagination.page).toBe(1);
+          expect(panelQueryScope.pagination.page).toBe(1);
         });
       });
 
-      describe('when the current page change', function () {
+      describe('when the current page changes', function () {
         beforeEach(function () {
-          isolatedScope.pagination.page = 2;
-          isolatedScope.$digest();
+          panelQueryScope.pagination.page = 2;
+          panelQueryScope.$digest();
 
           getRequest = crmApi.calls.argsFor(0)[0].get;
           countRequest = crmApi.calls.argsFor(0)[0].count;
@@ -387,42 +387,42 @@
       });
 
       it('starts from page 1', function () {
-        expect(isolatedScope.pagination.page).toBe(1);
+        expect(panelQueryScope.pagination.page).toBe(1);
       });
 
       it('has a default page size of 5', function () {
-        expect(isolatedScope.pagination.size).toBe(5);
+        expect(panelQueryScope.pagination.size).toBe(5);
       });
 
       describe('range calculation', function () {
         describe('from', function () {
           it('calculated from: current page and page size', function () {
-            expect(isolatedScope.pagination.range.from).toBe(1);
+            expect(panelQueryScope.pagination.range.from).toBe(1);
 
-            isolatedScope.pagination.page = 3;
-            isolatedScope.$digest();
+            panelQueryScope.pagination.page = 3;
+            panelQueryScope.$digest();
 
-            expect(isolatedScope.pagination.range.from).toBe(11);
+            expect(panelQueryScope.pagination.range.from).toBe(11);
           });
         });
 
         describe('to', function () {
           beforeEach(function () {
-            isolatedScope.total = 19;
+            panelQueryScope.total = 19;
           });
 
           it('calculated from: current page, page size, total count', function () {
-            expect(isolatedScope.pagination.range.to).toBe(5);
+            expect(panelQueryScope.pagination.range.to).toBe(5);
 
-            isolatedScope.pagination.page = 3;
-            isolatedScope.$digest();
+            panelQueryScope.pagination.page = 3;
+            panelQueryScope.$digest();
 
-            expect(isolatedScope.pagination.range.to).toBe(15);
+            expect(panelQueryScope.pagination.range.to).toBe(15);
 
-            isolatedScope.pagination.page = 4;
-            isolatedScope.$digest();
+            panelQueryScope.pagination.page = 4;
+            panelQueryScope.$digest();
 
-            expect(isolatedScope.pagination.range.to).toBe(19);
+            expect(panelQueryScope.pagination.range.to).toBe(19);
           });
         });
       });
@@ -434,13 +434,13 @@
       });
 
       it('has a list of available ranges to select from', function () {
-        expect(isolatedScope.periodRange.map(function (range) {
+        expect(panelQueryScope.periodRange.map(function (range) {
           return range.value;
         })).toEqual(['week', 'month']);
       });
 
       it('has the week range selected by default', function () {
-        expect(isolatedScope.selectedRange).toBe('week');
+        expect(panelQueryScope.selectedRange).toBe('week');
       });
     });
 
@@ -472,7 +472,7 @@
 
       element = $compile(html)($scope);
       $scope.$digest();
-      isolatedScope = element.isolateScope();
+      panelQueryScope = element.isolateScope();
     }
   });
 }(CRM.$, CRM._));

--- a/ang/test/civicase/PanelQuery.spec.js
+++ b/ang/test/civicase/PanelQuery.spec.js
@@ -74,13 +74,13 @@
 
     describe('[handlers] attribute', function () {
       describe('results handler', function () {
-        var resultsHandler = jasmine.createSpy().and.callFake(function (item) {
-          item.baz = 'baz';
-
-          return item;
-        });
+        var resultsHandler;
+        var newResults = ['foo', 'bar', 'baz'];
 
         beforeEach(function () {
+          resultsHandler = jasmine.createSpy().and.callFake(function (results) {
+            return newResults;
+          });
           $scope.handlersData = { results: resultsHandler };
 
           compileDirective();
@@ -90,16 +90,17 @@
           expect(resultsHandler).toHaveBeenCalled();
         });
 
-        it('receives a result item as an argument', function () {
+        it('receives the full results list as an argument', function () {
           var arg = resultsHandler.calls.argsFor(0)[0];
 
-          expect(arg.id).toBeDefined();
+          expect(arg.length).toBe(NO_OF_RESULTS);
+          expect(arg.every(function (item) {
+            return typeof item.id !== 'undefined';
+          })).toBe(true);
         });
 
-        it('allows to modify the items before they are stored', function () {
-          expect(isolatedScope.results.every(function (item) {
-            return typeof item.baz !== 'undefined';
-          })).toBe(true);
+        it('allows to modify the list before it is stored', function () {
+          expect(isolatedScope.results).toBe(newResults);
         });
       });
 

--- a/ang/test/civicase/PanelQuery.spec.js
+++ b/ang/test/civicase/PanelQuery.spec.js
@@ -91,20 +91,20 @@
       describe('scope compile', function () {
         beforeEach(function () {
           $scope.query = { entity: 'OuterEntity', params: { foo: 'outerParam' } };
-          $scope.passedData = { entity: 'IsolatedEntity', params: { foo: 'isolatedParam' } };
+          $scope.queryData = { entity: 'IsolatedEntity', params: { foo: 'isolatedParam' } };
 
           compileDirective({
             actions: '<div>{{query.entity}}</div>',
             results: '<div>{{query.params.foo}}</div>'
-          }, 'passedData');
+          });
         });
 
         it('compiles the slot on its own isolated scope', function () {
           var actionsHtml = element.find('[ng-transclude="actions"]').html();
           var resultsHtml = element.find('[ng-transclude="results"]').html();
 
-          expect(actionsHtml).toContain($scope.passedData.entity);
-          expect(resultsHtml).toContain($scope.passedData.params.foo);
+          expect(actionsHtml).toContain($scope.queryData.entity);
+          expect(resultsHtml).toContain($scope.queryData.params.foo);
         });
       });
     });
@@ -234,23 +234,22 @@
     /**
      * Function responsible for setting up compilation of the directive
      *
-     * @param {Object} slot the transclude slots with their markup
+     * @param {Object} slots the transclude slots with their markup
      */
-    function compileDirective (slots, queryProperty) {
+    function compileDirective (slots) {
       var content = '';
       var html = '<civicase-panel-query query="%{queryProperty}">%{content}</civicase-panel-query>';
 
-      queryProperty = queryProperty || 'queryData';
       slots = slots || { results: '<div></div>' };
 
-      $scope[queryProperty] = $scope[queryProperty] || {
+      $scope.queryData = $scope.queryData || {
         entity: 'FooBar', params: []
       };
 
       content += slots.actions ? '<panel-query-actions>' + slots.actions + '</panel-query-actions>' : '';
       content += slots.results ? '<panel-query-results>' + slots.results + '</panel-query-results>' : '';
 
-      html = html.replace('%{queryProperty}', queryProperty);
+      html = html.replace('%{queryProperty}', 'queryData');
       html = html.replace('%{content}', content);
 
       element = $compile(html)($scope);

--- a/ang/test/civicase/PanelQuery.spec.js
+++ b/ang/test/civicase/PanelQuery.spec.js
@@ -359,6 +359,7 @@
 
       describe('when the query params change', function () {
         beforeEach(function () {
+          isolatedScope.pagination.page = 2;
           $scope.queryData.params.baz = 'baz';
           $scope.$digest();
 
@@ -377,6 +378,10 @@
 
         it('calls the title handler again', function () {
           expect(titleHandler).toHaveBeenCalled();
+        });
+
+        it('resets the pagination', function () {
+          expect(isolatedScope.pagination.page).toBe(1);
         });
       });
 

--- a/ang/test/civicase/PanelQuery.spec.js
+++ b/ang/test/civicase/PanelQuery.spec.js
@@ -23,18 +23,18 @@
       }));
     }));
 
-    describe('[query-data] attribute', function () {
+    describe('[query] attribute', function () {
       var isolatedScope;
 
       beforeEach(function () {
-        $scope.queryData = { query: { entity: 'Foo', params: { foo: 'foo' } } };
+        $scope.queryData = { entity: 'Foo', params: { foo: 'foo' } };
         compileDirective();
         isolatedScope = element.isolateScope();
       });
 
       it('store its value in its scope', function () {
-        expect(isolatedScope.queryData).toBeDefined();
-        expect(isolatedScope.queryData).toEqual($scope.queryData);
+        expect(isolatedScope.query).toBeDefined();
+        expect(isolatedScope.query).toEqual($scope.queryData);
       });
 
       describe('one-way binding', function () {
@@ -42,7 +42,7 @@
 
         beforeEach(function () {
           originalSource = $scope.queryData;
-          isolatedScope.queryData = { baz: 'baz' };
+          isolatedScope.query = { baz: 'baz' };
 
           $scope.$digest();
         });
@@ -53,19 +53,9 @@
       });
 
       describe('`query` object', function () {
-        describe('when it is not present', function () {
-          beforeEach(function () {
-            $scope.queryData = {};
-          });
-
-          it('throws', function () {
-            expect(compileDirective).toThrowError(/query/);
-          });
-        });
-
         describe('when it doesn\'t have the `entity` property', function () {
           beforeEach(function () {
-            $scope.queryData = { query: { params: {} } };
+            $scope.queryData = { params: {} };
           });
 
           it('sends an error message', function () {
@@ -75,7 +65,7 @@
 
         describe('when the `entity` property is an empty string', function () {
           beforeEach(function () {
-            $scope.queryData = { query: { entity: '', params: {} } };
+            $scope.queryData = { entity: '', params: {} };
           });
 
           it('sends an error message', function () {
@@ -100,12 +90,12 @@
 
       describe('scope compile', function () {
         beforeEach(function () {
-          $scope.queryData = { query: { entity: 'OuterEntity', params: { foo: 'outerParam' } } };
-          $scope.passedData = { query: { entity: 'IsolatedEntity', params: { foo: 'isolatedParam' } } };
+          $scope.query = { entity: 'OuterEntity', params: { foo: 'outerParam' } };
+          $scope.passedData = { entity: 'IsolatedEntity', params: { foo: 'isolatedParam' } };
 
           compileDirective({
-            actions: '<div>{{queryData.query.entity}}</div>',
-            results: '<div>{{queryData.query.params.foo}}</div>'
+            actions: '<div>{{query.entity}}</div>',
+            results: '<div>{{query.params.foo}}</div>'
           }, 'passedData');
         });
 
@@ -113,8 +103,8 @@
           var actionsHtml = element.find('[ng-transclude="actions"]').html();
           var resultsHtml = element.find('[ng-transclude="results"]').html();
 
-          expect(actionsHtml).toContain($scope.passedData.query.entity);
-          expect(resultsHtml).toContain($scope.passedData.query.params.foo);
+          expect(actionsHtml).toContain($scope.passedData.entity);
+          expect(resultsHtml).toContain($scope.passedData.params.foo);
         });
       });
     });
@@ -124,10 +114,8 @@
 
       beforeEach(function () {
         $scope.queryData = {
-          query: {
-            entity: 'SomeEntity',
-            params: { foo: 'foo', bar: 'bar' }
-          }
+          entity: 'SomeEntity',
+          params: { foo: 'foo', bar: 'bar' }
         };
         compileDirective();
 
@@ -151,7 +139,7 @@
         it('is for the given entity', function () {
           var entity = request[0];
 
-          expect(entity).toBe($scope.queryData.query.entity);
+          expect(entity).toBe($scope.queryData.entity);
         });
 
         it('is for fetching the data', function () {
@@ -168,7 +156,7 @@
           });
 
           it('passes to the api the params in the `query` object', function () {
-            expect(requestParams).toEqual(jasmine.objectContaining($scope.queryData.query.params));
+            expect(requestParams).toEqual(jasmine.objectContaining($scope.queryData.params));
           });
 
           it('automatically adds `sequential` to the params', function () {
@@ -193,7 +181,7 @@
         it('is for the given entity', function () {
           var entity = request[0];
 
-          expect(entity).toBe($scope.queryData.query.entity);
+          expect(entity).toBe($scope.queryData.entity);
         });
 
         it('is for getting the total count', function () {
@@ -203,7 +191,7 @@
         });
 
         it('passes to the api the params in the `query` object', function () {
-          expect(request[2]).toEqual($scope.queryData.query.params);
+          expect(request[2]).toEqual($scope.queryData.params);
         });
 
         it('stores the count', function () {
@@ -215,10 +203,8 @@
     describe('watchers', function () {
       beforeEach(function () {
         $scope.queryData = {
-          query: {
-            entity: 'SomeEntity',
-            params: { foo: 'foo', bar: 'bar' }
-          }
+          entity: 'SomeEntity',
+          params: { foo: 'foo', bar: 'bar' }
         };
         compileDirective();
         crmApi.calls.reset();
@@ -228,7 +214,7 @@
         var getRequest, countRequest;
 
         beforeEach(function () {
-          $scope.queryData.query.params.baz = 'baz';
+          $scope.queryData.params.baz = 'baz';
           $scope.$digest();
 
           getRequest = crmApi.calls.argsFor(0)[0].get;
@@ -250,21 +236,21 @@
      *
      * @param {Object} slot the transclude slots with their markup
      */
-    function compileDirective (slots, dataProperty) {
+    function compileDirective (slots, queryProperty) {
       var content = '';
-      var html = '<civicase-panel-query query-data="%{dataProperty}">%{content}</civicase-panel-query>';
+      var html = '<civicase-panel-query query="%{queryProperty}">%{content}</civicase-panel-query>';
 
-      dataProperty = dataProperty || 'queryData';
+      queryProperty = queryProperty || 'queryData';
       slots = slots || { results: '<div></div>' };
 
-      $scope[dataProperty] = $scope[dataProperty] || {
-        query: { entity: 'FooBar', params: [] }
+      $scope[queryProperty] = $scope[queryProperty] || {
+        entity: 'FooBar', params: []
       };
 
       content += slots.actions ? '<panel-query-actions>' + slots.actions + '</panel-query-actions>' : '';
       content += slots.results ? '<panel-query-results>' + slots.results + '</panel-query-results>' : '';
 
-      html = html.replace('%{dataProperty}', dataProperty);
+      html = html.replace('%{queryProperty}', queryProperty);
       html = html.replace('%{content}', content);
 
       element = $compile(html)($scope);

--- a/ang/test/civicase/PanelQuery.spec.js
+++ b/ang/test/civicase/PanelQuery.spec.js
@@ -104,32 +104,6 @@
         });
       });
 
-      describe('title handler', function () {
-        var titleHandler = jasmine.createSpy().and.callFake(function (total) {
-          return 'The total number of items is' + total;
-        });
-
-        beforeEach(function () {
-          $scope.handlersData = { title: titleHandler };
-
-          compileDirective();
-        });
-
-        it('is called', function () {
-          expect(titleHandler).toHaveBeenCalled();
-        });
-
-        it('receives the total count as an argument', function () {
-          var arg = titleHandler.calls.argsFor(0)[0];
-
-          expect(arg).toBe(NO_OF_RESULTS);
-        });
-
-        it('allows to modify the title of the panel', function () {
-          expect(isolatedScope.title).toBe('The total number of items is' + NO_OF_RESULTS);
-        });
-      });
-
       describe('range handler', function () {
         var rangeHandler;
 
@@ -196,7 +170,7 @@
         }).toThrow();
       });
 
-      it('is optional to pass the <panel-query-actions> slot', function () {
+      it('is optional to pass the <panel-query-actions> and/or <panel-query-title> slots', function () {
         expect(function () {
           compileDirective({ results: '<div></div>' });
         }).not.toThrow();
@@ -204,21 +178,24 @@
 
       describe('scope compile', function () {
         beforeEach(function () {
-          $scope.query = { entity: 'OuterEntity', params: { foo: 'outerParam' } };
-          $scope.queryData = { entity: 'IsolatedEntity', params: { foo: 'isolatedParam' } };
+          $scope.query = { entity: 'OuterEntity', params: { foo: 'outerFoo', bar: 'outerBar' } };
+          $scope.queryData = { entity: 'IsolatedEntity', params: { foo: 'isolatedFoo', bar: 'isolatedBar' } };
 
           compileDirective({
             actions: '<div>{{query.entity}}</div>',
-            results: '<div>{{query.params.foo}}</div>'
+            results: '<div>{{query.params.foo}}</div>',
+            title: '<div>{{query.params.bar}}</div>'
           });
         });
 
         it('compiles the slot on its own isolated scope', function () {
           var actionsHtml = element.find('[ng-transclude="actions"]').html();
           var resultsHtml = element.find('[ng-transclude="results"]').html();
+          var titleHtml = element.find('[ng-transclude="title"]').html();
 
           expect(actionsHtml).toContain($scope.queryData.entity);
           expect(resultsHtml).toContain($scope.queryData.params.foo);
+          expect(titleHtml).toContain($scope.queryData.params.bar);
         });
       });
     });
@@ -347,14 +324,10 @@
 
     describe('new api request triggers', function () {
       var getRequest, countRequest;
-      var titleHandler = jasmine.createSpy();
 
       beforeEach(function () {
-        $scope.handlersData = { title: titleHandler };
-
         compileDirective();
         crmApi.calls.reset();
-        titleHandler.calls.reset();
       });
 
       describe('when the query params change', function () {
@@ -374,10 +347,6 @@
         it('passes the new params to the api', function () {
           expect(getRequest[2]).toEqual(jasmine.objectContaining({ baz: 'baz' }));
           expect(countRequest[2]).toEqual(jasmine.objectContaining({ baz: 'baz' }));
-        });
-
-        it('calls the title handler again', function () {
-          expect(titleHandler).toHaveBeenCalled();
         });
 
         it('resets the pagination', function () {
@@ -408,10 +377,6 @@
 
         it('does not trigger the api request to get the total count', function () {
           expect(countRequest).not.toBeDefined();
-        });
-
-        it('does not call the title handler again', function () {
-          expect(titleHandler).not.toHaveBeenCalled();
         });
       });
     });
@@ -500,6 +465,7 @@
 
       content += slots.actions ? '<panel-query-actions>' + slots.actions + '</panel-query-actions>' : '';
       content += slots.results ? '<panel-query-results>' + slots.results + '</panel-query-results>' : '';
+      content += slots.title ? '<panel-query-title>' + slots.title + '</panel-query-title>' : '';
 
       html = html.replace('%{attributes}', attributes);
       html = html.replace('%{content}', content);

--- a/ang/test/civicase/PanelQuery.spec.js
+++ b/ang/test/civicase/PanelQuery.spec.js
@@ -286,6 +286,20 @@
           it('automatically adds `sequential` to the params', function () {
             expect(requestParams).toEqual(jasmine.objectContaining({ sequential: 1 }));
           });
+
+          describe('pagination', function () {
+            var isolatedScope;
+
+            beforeEach(function () {
+              isolatedScope = element.isolateScope();
+            });
+
+            it('adds the pagination params', function () {
+              expect(requestParams.options).toBeDefined();
+              expect(requestParams.options.limit).toBe(isolatedScope.pagination.size);
+              expect(requestParams.options.offset).toBeDefined(isolatedScope.pagination.page + isolatedScope.pagination.size);
+            });
+          });
         });
 
         describe('results', function () {
@@ -357,6 +371,56 @@
 
         it('calls the title handler again', function () {
           expect(titleHandler).toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('pagination', function () {
+      var isolatedScope;
+
+      beforeEach(function () {
+        compileDirective();
+        isolatedScope = element.isolateScope();
+      });
+
+      it('starts from page 1', function () {
+        expect(isolatedScope.pagination.page).toBe(1);
+      });
+
+      it('has a default page size of 5', function () {
+        expect(isolatedScope.pagination.size).toBe(5);
+      });
+
+      describe('range calculation', function () {
+        describe('from', function () {
+          it('calculated from: current page and page size', function () {
+            expect(isolatedScope.pagination.range.from).toBe(1);
+
+            isolatedScope.pagination.page = 3;
+            isolatedScope.$digest();
+
+            expect(isolatedScope.pagination.range.from).toBe(11);
+          });
+        });
+
+        describe('to', function () {
+          beforeEach(function () {
+            isolatedScope.total = 19;
+          });
+
+          it('calculated from: current page, page size, total count', function () {
+            expect(isolatedScope.pagination.range.to).toBe(5);
+
+            isolatedScope.pagination.page = 3;
+            isolatedScope.$digest();
+
+            expect(isolatedScope.pagination.range.to).toBe(15);
+
+            isolatedScope.pagination.page = 4;
+            isolatedScope.$digest();
+
+            expect(isolatedScope.pagination.range.to).toBe(19);
+          });
         });
       });
     });

--- a/ang/test/civicase/PanelQuery.spec.js
+++ b/ang/test/civicase/PanelQuery.spec.js
@@ -299,6 +299,25 @@
       });
     });
 
+    describe('period range', function () {
+      var isolatedScope;
+
+      beforeEach(function () {
+        compileDirective();
+        isolatedScope = element.isolateScope();
+      });
+
+      it('has a list of available ranges to select from', function () {
+        expect(isolatedScope.periodRange.map(function (range) {
+          return range.value;
+        })).toEqual(['week', 'month']);
+      });
+
+      it('has the week range selected by default', function () {
+        expect(isolatedScope.selectedRange).toBe('week');
+      });
+    });
+
     /**
      * Function responsible for setting up compilation of the directive
      *

--- a/ang/test/civicase/PanelQuery.spec.js
+++ b/ang/test/civicase/PanelQuery.spec.js
@@ -135,6 +135,50 @@
           expect(isolatedScope.title).toBe('The total number of items is' + NO_OF_RESULTS);
         });
       });
+
+      describe('range handler', function () {
+        var rangeHandler;
+
+        beforeEach(function () {
+          rangeHandler = jasmine.createSpy().and.callFake(function (selectedRange) {});
+          $scope.handlersData = { range: rangeHandler };
+
+          compileDirective();
+        });
+
+        it('is not called on init', function () {
+          expect(rangeHandler).not.toHaveBeenCalled();
+        });
+
+        describe('when the selected range changes', function () {
+          var isolatedScope;
+          var newRange = 'month';
+
+          beforeEach(function () {
+            rangeHandler.calls.reset();
+            isolatedScope = element.isolateScope();
+
+            isolatedScope.selectedRange = newRange;
+            isolatedScope.$digest();
+          });
+
+          it('is called when the selected range changes', function () {
+            expect(rangeHandler).toHaveBeenCalled();
+          });
+
+          it('receives the new selected range as an argument', function () {
+            var arg = rangeHandler.calls.argsFor(0)[0];
+
+            expect(arg).toBe(newRange);
+          });
+
+          it('receives the query params as an argument', function () {
+            var arg = rangeHandler.calls.argsFor(0)[1];
+
+            expect(arg).toEqual($scope.queryData.params);
+          });
+        });
+      });
     });
 
     describe('transclude slots', function () {

--- a/ang/test/civicase/PanelQuery.spec.js
+++ b/ang/test/civicase/PanelQuery.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env jasmine */
 (function ($, _) {
-  fdescribe('panelQuery', function () {
+  describe('panelQuery', function () {
     var element, $compile, $q, $rootScope, $scope, crmApi, mockedResults;
     var NO_OF_RESULTS = 10;
 
@@ -178,6 +178,24 @@
             expect(arg).toEqual($scope.queryData.params);
           });
         });
+      });
+    });
+
+    describe('[custom-data] attribute', function () {
+      var isolatedScope;
+      beforeEach(function () {
+        $scope.customData = {
+          customProp: 'foobarbaz',
+          customFn: function () {}
+        };
+
+        compileDirective();
+        isolatedScope = element.isolateScope();
+      });
+
+      it('is stored in the isolated scope', function () {
+        expect(_.isEmpty(isolatedScope.customData)).toBe(false);
+        expect(isolatedScope.customData).toEqual(jasmine.objectContaining($scope.customData));
       });
     });
 
@@ -378,9 +396,8 @@
         entity: 'FooBar', params: { foo: 'foo', bar: 'bar' }
       };
 
-      if ($scope.handlersData) {
-        attributes += ' handlers="handlersData"';
-      }
+      attributes += $scope.handlersData ? ' handlers="handlersData"' : '';
+      attributes += $scope.customData ? ' custom-data="customData"' : '';
 
       content += slots.actions ? '<panel-query-actions>' + slots.actions + '</panel-query-actions>' : '';
       content += slots.results ? '<panel-query-results>' + slots.results + '</panel-query-results>' : '';

--- a/ang/test/civicase/PanelQuery.spec.js
+++ b/ang/test/civicase/PanelQuery.spec.js
@@ -338,7 +338,8 @@
       });
     });
 
-    describe('watchers', function () {
+    describe('new api request triggers', function () {
+      var getRequest, countRequest;
       var titleHandler = jasmine.createSpy();
 
       beforeEach(function () {
@@ -350,8 +351,6 @@
       });
 
       describe('when the query params change', function () {
-        var getRequest, countRequest;
-
         beforeEach(function () {
           $scope.queryData.params.baz = 'baz';
           $scope.$digest();
@@ -371,6 +370,39 @@
 
         it('calls the title handler again', function () {
           expect(titleHandler).toHaveBeenCalled();
+        });
+      });
+
+      describe('when the current page change', function () {
+        var isolatedScope;
+
+        beforeEach(function () {
+          isolatedScope = element.isolateScope();
+          isolatedScope.pagination.page = 2;
+          isolatedScope.$digest();
+
+          getRequest = crmApi.calls.argsFor(0)[0].get;
+          countRequest = crmApi.calls.argsFor(0)[0].count;
+        });
+
+        it('triggers an api request', function () {
+          expect(crmApi).toHaveBeenCalled();
+        });
+
+        it('triggers the api request to fetch the data', function () {
+          expect(getRequest).toBeDefined();
+        });
+
+        it('passes the new pagination offset to the request', function () {
+          expect(getRequest[2].options.offset).toEqual(5);
+        });
+
+        it('does not trigger the api request to get the total count', function () {
+          expect(countRequest).not.toBeDefined();
+        });
+
+        it('does not call the title handler again', function () {
+          expect(titleHandler).not.toHaveBeenCalled();
         });
       });
     });

--- a/ang/test/civicase/PanelQuery.spec.js
+++ b/ang/test/civicase/PanelQuery.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env jasmine */
 (function ($, _) {
   describe('panelQuery', function () {
-    var element, $compile, $q, $rootScope, $scope, crmApi, mockedResults;
+    var element, $compile, $q, $rootScope, $scope, crmApi, isolatedScope, mockedResults;
     var NO_OF_RESULTS = 10;
 
     beforeEach(module('civicase.templates', 'civicase', 'crmUtil'));
@@ -24,12 +24,9 @@
     }));
 
     describe('[query] attribute', function () {
-      var isolatedScope;
-
       beforeEach(function () {
         $scope.queryData = { entity: 'Foo', params: { foo: 'foo' } };
         compileDirective();
-        isolatedScope = element.isolateScope();
       });
 
       it('store its value in its scope', function () {
@@ -77,7 +74,6 @@
 
     describe('[handlers] attribute', function () {
       describe('results handler', function () {
-        var isolatedScope;
         var resultsHandler = jasmine.createSpy().and.callFake(function (item) {
           item.baz = 'baz';
 
@@ -88,7 +84,6 @@
           $scope.handlersData = { results: resultsHandler };
 
           compileDirective();
-          isolatedScope = element.isolateScope();
         });
 
         it('is called', function () {
@@ -109,7 +104,6 @@
       });
 
       describe('title handler', function () {
-        var isolatedScope;
         var titleHandler = jasmine.createSpy().and.callFake(function (total) {
           return 'The total number of items is' + total;
         });
@@ -118,7 +112,6 @@
           $scope.handlersData = { title: titleHandler };
 
           compileDirective();
-          isolatedScope = element.isolateScope();
         });
 
         it('is called', function () {
@@ -151,12 +144,10 @@
         });
 
         describe('when the selected range changes', function () {
-          var isolatedScope;
           var newRange = 'month';
 
           beforeEach(function () {
             rangeHandler.calls.reset();
-            isolatedScope = element.isolateScope();
 
             isolatedScope.selectedRange = newRange;
             isolatedScope.$digest();
@@ -182,7 +173,6 @@
     });
 
     describe('[custom-data] attribute', function () {
-      var isolatedScope;
       beforeEach(function () {
         $scope.customData = {
           customProp: 'foobarbaz',
@@ -190,7 +180,6 @@
         };
 
         compileDirective();
-        isolatedScope = element.isolateScope();
       });
 
       it('is stored in the isolated scope', function () {
@@ -234,7 +223,7 @@
     });
 
     describe('api requests', function () {
-      var isolatedScope, requests;
+      var requests;
 
       beforeEach(function () {
         $scope.queryData = {
@@ -243,7 +232,6 @@
         };
         compileDirective();
 
-        isolatedScope = element.isolateScope();
         requests = crmApi.calls.argsFor(0)[0];
       });
 
@@ -288,12 +276,6 @@
           });
 
           describe('pagination', function () {
-            var isolatedScope;
-
-            beforeEach(function () {
-              isolatedScope = element.isolateScope();
-            });
-
             it('adds the pagination params', function () {
               expect(requestParams.options).toBeDefined();
               expect(requestParams.options.limit).toBe(isolatedScope.pagination.size);
@@ -374,10 +356,7 @@
       });
 
       describe('when the current page change', function () {
-        var isolatedScope;
-
         beforeEach(function () {
-          isolatedScope = element.isolateScope();
           isolatedScope.pagination.page = 2;
           isolatedScope.$digest();
 
@@ -408,11 +387,8 @@
     });
 
     describe('pagination', function () {
-      var isolatedScope;
-
       beforeEach(function () {
         compileDirective();
-        isolatedScope = element.isolateScope();
       });
 
       it('starts from page 1', function () {
@@ -458,11 +434,8 @@
     });
 
     describe('period range', function () {
-      var isolatedScope;
-
       beforeEach(function () {
         compileDirective();
-        isolatedScope = element.isolateScope();
       });
 
       it('has a list of available ranges to select from', function () {
@@ -502,8 +475,8 @@
       html = html.replace('%{content}', content);
 
       element = $compile(html)($scope);
-
       $scope.$digest();
+      isolatedScope = element.isolateScope();
     }
   });
 }(CRM.$, CRM._));


### PR DESCRIPTION
This PR adds a new directive, `<civicase-panel-query>` that provides an out-of-the-box panel that takes care of
* running a given query via the API
* displaying the results on custom markup
* paginating the results (with deferred loading)
* doing a live-reload of the results in case the query parameters have changed
* provide a a date range select dropdown
* providing customization options for title, items name in the pagination, and top-right corner actions

This is what the directive looks like in a simple scenario where a list of cases are fetched and displayed in `<civicase-case-card>` directives:
![directive](https://user-images.githubusercontent.com/6400898/47462094-b4298200-d7e2-11e8-825d-29778f89f11e.gif)
_(please note that the style of the case cards in the panel is temporary)_

## Usage
### Minimum configuration
```html
<civicase-panel-query query="queryData">
  <panel-query-results>
    <div ng-repeat="item in results">{{item}}</div>
  </panel-query-results>
</civicase-panel-query>
```

#### `[query]`
The `query` object is mandatory, and itself has only one mandatory property: `entity`
```js
var queryData = {
  entity: 'MyEntity'
};
```
Passing the above object to the directive is equivalent of calling the `MyEntity.get` endpoint with no additional parameters.

If you want to pass some parameters to the endpoint, add a `params` property, whose content is a standard CiviCRM API object
```js
var queryData = {
  entity: 'MyEntity',
  params: {
    entity_id: 0,
    // ...
  }
};
```

If you don't want to call a different endpoint than `get`, add an `action` property
```js
var queryData = {
  entity: 'MyEntity',
  action: 'getcustom'
};
```
#### `<panel-query-results>`
The `<panel-query-results>` transclude slot is mandatory, and it used to display the results list. The content is completely custom and up to the directive's consumer to define.
```html
<panel-query-results>
  <div ng-repeat="item in results">{{item}}</div>  <!-- or ... -->
  <some-other-directive item="item"></some-other-directive> <!-- or ... -->
  {{results.length}}  <!-- etc ... -->
</panel-query-results>
```
The slot is explicitly compiled against the isolated scope of the directive, so that it can access the `$scope.results` to be able to display the results

This mean that property that are defined in the outer scope and that are not passed to the directive, will not be accessible in the slot
```html
<div>{{outerScopeProperty}}><div>
<civicase-panel-query query="queryData">
  <panel-query-results>
    {{outerScopeProperty}} <!-- doesn't render -->
  </panel-query-results>
</civicase-panel-query>
```

### Optional transclude slots
#### `<panel-query-title>`
It's a optional slot that the directive's consumer can use to inject a custom title for the panel. This slot too is explicitly compiled against the isolated scope of the directive.

<img width="550" alt="custom-title" src="https://user-images.githubusercontent.com/6400898/47462380-83961800-d7e3-11e8-8264-2b7fdcb76e43.png">

```html
<civicase-panel-query query="queryData">
  <panel-query-title>
    You have {{total}} items!
  </panel-query-title>
  <panel-query-results>
    <div ng-repeat="item in results">{{item.id}}</div>
  </panel-query-results>
</civicase-panel-query>
```

#### `<panel-query-actions>`
It's a optional slot that the directive's consumer can use to inject custom markup on the top right corner of the panel. This slot too is explicitly compiled against the isolated scope of the directive.

The custom markup can be a simple link
<img width="773" alt="actions-link" src="https://user-images.githubusercontent.com/6400898/47462118-c4d9f800-d7e2-11e8-8882-3250128cedc7.png">

```html
<civicase-panel-query query="queryData" handlers="handlers">
  <panel-query-actions>
    <a href class="panel-heading-control">My Cases</a>
  </panel-query-actions>
  <panel-query-results><!-- --></panel-query-results>
</civicase-panel-query>
```

or another directive
<img width="550" alt="actions-directive" src="https://user-images.githubusercontent.com/6400898/47462126-cb686f80-d7e2-11e8-99da-f70ac881ea37.png">

```html
<civicase-panel-query query="queryData" handlers="handlers">
  <panel-query-actions>
    <div civicase-activity-filters-contact="filters"></div>
  </panel-query-actions>
  <panel-query-results><!-- --></panel-query-results>
</civicase-panel-query>
```

### Handlers
#### `results`
This handler is called after the api request is finished and before the results are stored in the directive's scope. This is useful in case some custom logic needs to be called on each item, or if some custom api calls needs to be made based on the results

<img width="550" alt="handler-results" src="https://user-images.githubusercontent.com/6400898/47462137-d3281400-d7e2-11e8-87e7-0268b8decf70.png">

```js
$scope.queryData = {
  entity: 'Case'
};

$scope.handlers = {
  results: function (results) {
    return results.map(function (item) {
      item.id += ' foobar';
      return item;
    })
  }
}
```

#### `range`
The directives comes out-of-the-box with a period range select dropdown and this handler is called whenever the selected range has changed. 

It is the only way to make the selected range influence the list of results, given that the directive can't know in advance how to map the range value to the fields of whichever entity is being queried

By using the value of the new selected range to change the original query params (passed in the handler as an argument), the directive will automatically trigger a new api request

![handler-range](https://user-images.githubusercontent.com/6400898/47462167-e20ec680-d7e2-11e8-95df-8fff7e83cd15.gif)

```js
$scope.queryData = {
  entity: 'Case',
  params: { id: { 'IN': [1, 2] }}
};

$scope.handlers = {
  range: function (newPeriod, queryParams) {
    if (newPeriod === 'month') {
      queryParams.id = { 'IN': [1, 2, 3, 4, 5] };
    }
  },
  results: // ...
  }
}
```

### Custom Data
Given that the directive has an isolated scope, if one needs to pass some custom data to use on the transcluded slot, they can do so by using the `[custom-data]` attribute

<img width="550" alt="custom-data" src="https://user-images.githubusercontent.com/6400898/47462184-e9ce6b00-d7e2-11e8-9002-5e878f1bedb8.png">

```js
$scope.queryData = {
  entity: 'Case'
};

$scope.customData = {
  foo: 'foo'
}
```
```html
<civicase-panel-query query="queryData" custom-data="customData">
  <panel-query-results>
    {{customData.foo}}
  </panel-query-results>
</civicase-panel-query>
```

One particular case of custom data is `itemName`, which can be used to change the item's name (which is "items" by default) used by the pagination and the default title

<img width="550" alt="customitename" src="https://user-images.githubusercontent.com/6400898/47462245-184c4600-d7e3-11e8-9eb9-bc25ab0ee228.png">

```js
$scope.queryData = {
  entity: 'Case'
};

$scope.customData = {
  foo: 'foo',
  itemName: 'cases'
}
```