### PR TITLE
C51-280: New cases block

### DIFF
--- a/ang/civicase/Dashboard.html
+++ b/ang/civicase/Dashboard.html
@@ -8,7 +8,7 @@
         uib-tabset-class="nav-pills-horizontal nav-pills-horizontal-primary clearfix">
         <!-- Dashboard Tab -->
         <uib-tab index="0" heading="{{ ts('Dashboard') }}" select="navTabs()">
-          <civicase-dashboard-tab></civicase-dashboard-tab>
+          <civicase-dashboard-tab ng-if="activeTab == 0"></civicase-dashboard-tab>
         </uib-tab>
         <!-- End - Dashboard Tab -->
         <!-- Activities Tab -->

--- a/ang/civicase/Dashboard.html
+++ b/ang/civicase/Dashboard.html
@@ -8,12 +8,12 @@
         uib-tabset-class="nav-pills-horizontal nav-pills-horizontal-primary clearfix">
         <!-- Dashboard Tab -->
         <uib-tab index="0" heading="{{ ts('Dashboard') }}" select="navTabs()">
-          <civicase-dashboard-tab ng-if="activeTab == 0"></civicase-dashboard-tab>
+          <civicase-dashboard-tab ng-if="activeTab === 0"></civicase-dashboard-tab>
         </uib-tab>
         <!-- End - Dashboard Tab -->
         <!-- Activities Tab -->
         <uib-tab index="1" heading="{{ts('Activities')}}">
-          <div ng-if="activeTab == 1" civicase-activity-feed="{filters: activityFilters}" class="civicase__dashboard-activites-feed"></div>
+          <div ng-if="activeTab === 1" civicase-activity-feed="{filters: activityFilters}" class="civicase__dashboard-activites-feed"></div>
         </uib-tab>
         <!-- End - Activities Tab -->
         <div class="pull-right">

--- a/ang/civicase/Dashboard.js
+++ b/ang/civicase/Dashboard.js
@@ -75,7 +75,8 @@
      */
     function prepareCaseFilterOption () {
       var options = [
-        { 'text': 'My cases', 'id': 'is_case_manager' },
+        // @NOTE Disabled, see C51-277
+        // { 'text': 'My cases', 'id': 'is_case_manager' },
         { 'text': 'Cases I am involved in', 'id': 'is_involved' }
       ];
 

--- a/ang/civicase/DashboardTab.html
+++ b/ang/civicase/DashboardTab.html
@@ -4,25 +4,15 @@
     <div class="civicase__dashboard__tab__col-wrapper">
       <div class="civicase__dashboard__tab__col civicase__dashboard__tab__col--left"></div>
       <div class="civicase__dashboard__tab__col civicase__dashboard__tab__col--right">
-        <div class="panel panel-secondary">
-          <header class="panel-heading">
-            <div class="clearfix">
-              <h2 class="panel-title pull-left">You have 4 new cases</h2>
-              <div class="panel-heading-control crm_custom-select pull-left">
-                <select>
-                  <option value="week">This Week</option>
-                  <option value="month">This Month</option>
-                </select>
-                <span class="crm_custom-select__arrow"></span>
-              </div>
-              <a href class="pull-right panel-heading-control">My Activities</a>
-            </div>
-          </header>
-          <div class="panel-body">----</div>
-          <footer class="panel-footer">
-            Showing 1 to 4 of 4 cases
-          </footer>
-        </div>
+        <!-- New Cases -->
+        <civicase-panel-query query="newCasesPanel.query" handlers="newCasesPanel.handlers" custom-data="newCasesPanel.custom">
+          <panel-query-title>
+            You have {{loading ? '-' : total}} new cases
+          </panel-query-title>
+          <panel-query-results>
+            <civicase-case-card ng-repeat="case in results" ng-click="customData.caseClick(case)" mode="dashboard" case="case"></civicase-case-card>
+          </panel-query-results>
+        </civicase-panel-query>
         <div class="panel panel-secondary">
           <header class="panel-heading">
             <div class="clearfix">

--- a/ang/civicase/DashboardTab.html
+++ b/ang/civicase/DashboardTab.html
@@ -7,7 +7,7 @@
         <!-- New Cases -->
         <civicase-panel-query query="newCasesPanel.query" handlers="newCasesPanel.handlers" custom-data="newCasesPanel.custom">
           <panel-query-title>
-            You have {{loading ? '-' : total}} new cases
+            You have {{loading.full ? '-' : total}} new cases
           </panel-query-title>
           <panel-query-results>
             <civicase-case-card ng-repeat="case in results" ng-click="customData.caseClick(case)" mode="dashboard" case="case"></civicase-case-card>

--- a/ang/civicase/DashboardTab.html
+++ b/ang/civicase/DashboardTab.html
@@ -13,56 +13,6 @@
             <civicase-case-card ng-repeat="case in results" ng-click="customData.caseClick(case)" mode="dashboard" case="case"></civicase-case-card>
           </panel-query-results>
         </civicase-panel-query>
-        <div class="panel panel-secondary">
-          <header class="panel-heading">
-            <div class="clearfix">
-              <h2 class="panel-title pull-left">You have 2 milestones due</h2>
-              <div class="panel-heading-control crm_custom-select pull-left">
-                <select>
-                  <option value="week">This Week</option>
-                  <option value="month">This Month</option>
-                </select>
-                <span class="crm_custom-select__arrow"></span>
-              </div>
-              <div class="pull-right">
-                <div class="panel-heading-control btn-group btn-group-sm civicase__activity-filter__contact">
-                  <a href class="active btn btn-default">My Activities</a>
-                  <a href class="btn btn-default">Delegated</a>
-                  <a href class="btn btn-default">All</a>
-                </div>
-              </div>
-            </div>
-          </header>
-          <div class="panel-body">----</div>
-          <footer class="panel-footer">
-            Showing 1 to 4 of 4 cases
-          </footer>
-        </div>
-        <div class="panel panel-secondary">
-          <header class="panel-heading">
-            <div class="clearfix">
-              <h2 class="panel-title pull-left">You have 22 overdue activities and 16 due</h2>
-              <div class="panel-heading-control crm_custom-select pull-left">
-                <select>
-                  <option value="week">This Week</option>
-                  <option value="month">This Month</option>
-                </select>
-                <span class="crm_custom-select__arrow"></span>
-              </div>
-              <div class="pull-right">
-                <div class="panel-heading-control btn-group btn-group-sm civicase__activity-filter__contact">
-                  <a href class="active btn btn-default">My Activities</a>
-                  <a href class="btn btn-default">Delegated</a>
-                  <a href class="btn btn-default">All</a>
-                </div>
-              </div>
-            </div>
-          </header>
-          <div class="panel-body">----</div>
-          <footer class="panel-footer">
-            Showing 1 to 4 of 4 cases
-          </footer>
-        </div>
       </div>
     </div>
   </div>

--- a/ang/civicase/DashboardTab.js
+++ b/ang/civicase/DashboardTab.js
@@ -1,10 +1,109 @@
-(function (angular) {
+(function (angular, $, _) {
   var module = angular.module('civicase');
 
   module.directive('civicaseDashboardTab', function () {
     return {
       restrict: 'E',
+      controller: 'dashboardTabCtrl',
       templateUrl: '~/civicase/DashboardTab.html'
     };
   });
-})(angular);
+
+  module.controller('dashboardTabCtrl', dashboardTabCtrl);
+
+  dashboardTabCtrl.$inject = ['$location', '$scope', 'ContactsDataService', 'formatCase'];
+
+  function dashboardTabCtrl ($location, $scope, ContactsDataService, formatCase) {
+    var CASES_QUERY_PARAMS_DEFAULTS = {
+      'status_id.grouping': 'Opened',
+      'options': { 'sort': 'start_date DESC' }
+    };
+
+    $scope.newCasesPanel = {
+      query: {
+        entity: 'Case',
+        action: 'getcaselist',
+        params: casesQueryParams()
+      },
+      handlers: {
+        range: casesRangeHandler,
+        results: casesResultsHandler
+      },
+      custom: {
+        itemName: 'cases',
+        caseClick: casesCustomClick
+      }
+    };
+
+    (function init () {
+      initWatchers();
+    }());
+
+    /**
+     * Click handler that redirects the browser to the given case's details page
+     *
+     * @param {Object} theCase
+     */
+    function casesCustomClick (theCase) {
+      $location.path('case/list').search('caseId', theCase.id);
+    }
+
+    /**
+     * Returns a copy of the default query params for cases, interpolated with
+     * the currently selected relationship type filter's params
+     *
+     * @return {Object}
+     */
+    function casesQueryParams () {
+      return _.assign({}, CASES_QUERY_PARAMS_DEFAULTS, $scope.activityFilters.case_filter);
+    }
+
+    /**
+     * Sets the range of the case start date
+     *
+     * @param {String} selectedRange the currently selected period range
+     * @param {Object} queryParams
+     */
+    function casesRangeHandler (selectedRange, queryParams) {
+      var now = moment();
+      var end = now.endOf(selectedRange).format('YYYY-MM-DD');
+      var start = now.startOf(selectedRange).format('YYYY-MM-DD');
+
+      queryParams.start_date = { 'BETWEEN': [start, end] };
+    }
+
+    /**
+     * Formats each cases returned by the api call, and fetches the data
+     * of all the contacts referenced in every case
+     *
+     * @param {Array} results
+     */
+    function casesResultsHandler (results) {
+      // Flattened list of all the contact ids of all the contacts of all the cases
+      var contactIds = _(results).pluck('contacts').flatten().pluck('contact_id').uniq().value();
+      var formattedResults = results.map(formatCase);
+
+      // The try/catch block is necessary because the service does not
+      // return a Promise if it doesn't find any new contacts to fetch
+      try {
+        return ContactsDataService.add(contactIds)
+          .then(function () {
+            return formattedResults;
+          });
+      } catch (e) {
+        return formattedResults;
+      }
+    }
+
+    /**
+     * Initializes the controller watchers
+     */
+    function initWatchers () {
+      $scope.$watchCollection('filters.caseRelationshipType', function (newType, oldType) {
+        if (newType !== oldType) {
+          $scope.newCasesPanel.query.params = casesQueryParams();
+        }
+      });
+    }
+  }
+})(angular, CRM.$, CRM._);

--- a/ang/civicase/DashboardTab.js
+++ b/ang/civicase/DashboardTab.js
@@ -4,16 +4,14 @@
   module.directive('civicaseDashboardTab', function () {
     return {
       restrict: 'E',
-      controller: 'dashboardTabCtrl',
+      controller: 'dashboardTabController',
       templateUrl: '~/civicase/DashboardTab.html'
     };
   });
 
-  module.controller('dashboardTabCtrl', dashboardTabCtrl);
+  module.controller('dashboardTabController', dashboardTabController);
 
-  dashboardTabCtrl.$inject = ['$location', '$scope', 'ContactsDataService', 'formatCase'];
-
-  function dashboardTabCtrl ($location, $scope, ContactsDataService, formatCase) {
+  function dashboardTabController ($location, $scope, ContactsDataService, formatCase) {
     var CASES_QUERY_PARAMS_DEFAULTS = {
       'status_id.grouping': 'Opened',
       'options': { 'sort': 'start_date DESC' }
@@ -42,10 +40,10 @@
     /**
      * Click handler that redirects the browser to the given case's details page
      *
-     * @param {Object} theCase
+     * @param {Object} caseObj
      */
-    function casesCustomClick (theCase) {
-      $location.path('case/list').search('caseId', theCase.id);
+    function casesCustomClick (caseObj) {
+      $location.path('case/list').search('caseId', caseObj.id);
     }
 
     /**

--- a/ang/civicase/PanelQuery.html
+++ b/ang/civicase/PanelQuery.html
@@ -3,7 +3,7 @@
     <div class="clearfix">
       <h2 class="panel-title pull-left">
         <div ng-transclude="title">
-          {{loading ? '-' : total}} {{customData.itemName || 'items'}}
+          {{loading.full ? '-' : total}} {{customData.itemName || 'items'}}
         </div>
       </h2>
       <div class="panel-heading-control crm_custom-select pull-left">
@@ -13,9 +13,9 @@
       <div class="pull-right" ng-transclude="actions"></div>
     </div>
   </header>
-  <div class="panel-body">
-    <div ng-hide="loading" ng-transclude="results"></div>
-    <div ng-if="loading">
+  <div class="panel-body" style="transition: opacity 0.2s linear;" ng-style="loading.partial && { 'opacity': 0.7 }">
+    <div ng-hide="loading.full" ng-transclude="results"></div>
+    <div ng-if="loading.full">
       <div class="panel panel-default" ng-repeat="i in [0,1]">
         <div class="panel-body" style="border-top: 0;">
           <div class="civicase__activity-card-row" style="margin-bottom: 8px;">
@@ -53,10 +53,10 @@
         text-next="{{ ts('Next') }}"
         text-prev="{{ ts('Previous') }}"
       ></paging>
-      <div ng-if="loading">
+      <div ng-if="loading.full">
         Showing - to - of - {{customData.itemName || 'items'}}
       </div>
-      <div ng-if="!loading">
+      <div ng-if="!loading.full">
         Showing {{pagination.range.from}} to {{pagination.range.to}} of {{total}} {{customData.itemName || 'items'}}
       </div>
     </div>

--- a/ang/civicase/PanelQuery.html
+++ b/ang/civicase/PanelQuery.html
@@ -46,6 +46,7 @@
         total="total"
         adjacent="1"
         dots="..."
+        disabled="{{loading.full || loading.partial}}"
         show-prev-next="true"
         show-first-last="true"
         text-first="{{ ts('First') }}"

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -37,7 +37,7 @@
 
     $scope.customData = $scope.customData || {};
     $scope.handlers = $scope.handlers || {};
-    $scope.loading = false;
+    $scope.loading = { full: false, partial: false };
     $scope.results = [];
     $scope.total = 0;
     $scope.ts = ts;
@@ -129,17 +129,21 @@
      * @return {Promise}
      */
     function loadData (skipCount) {
+      // Prevents accidental additional call by watchers
+      if ($scope.loading.full || $scope.loading.partial) {
+        return;
+      }
+
       if (!skipCount) {
         $scope.pagination.page = 1;
-        $scope.loading = true;
       }
+
+      toggleLoadingState(skipCount);
 
       return fetchDataViaApi(skipCount)
         .then(updatePaginationRange)
         .then(function () {
-          if (!skipCount) {
-            $scope.loading = false;
-          }
+          toggleLoadingState(skipCount);
         });
     }
 
@@ -172,6 +176,15 @@
      */
     function processResults (results) {
       return $q.resolve($scope.handlers.results ? $scope.handlers.results(results) : results);
+    }
+
+    /**
+     * Activates / Deactivates the loading state of the directive
+     */
+    function toggleLoadingState (partial) {
+      var mode = partial ? 'partial' : 'full';
+
+      $scope.loading[mode] = !$scope.loading[mode];
     }
 
     /**

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -53,9 +53,11 @@
     };
 
     (function init () {
-      initWatchers();
       verifyData();
-      loadData();
+      // the range handler must be invoked immediately on init to
+      // include the selected period range in the first api request
+      invokeRangeHandler();
+      loadData().then(initWatchers);
     }());
 
     /**
@@ -102,11 +104,9 @@
         (newParams !== oldParams) && loadData();
       }, true);
 
-      // Triggers the range handler (if present) when the selected range changes
+      // Triggers the range handler when the selected range changes
       $scope.$watch('selectedRange', function (newRange, oldRange) {
-        if (newRange !== oldRange && $scope.handlers.range) {
-          $scope.handlers.range($scope.selectedRange, $scope.query.params);
-        }
+        (newRange !== oldRange) && invokeRangeHandler();
       });
 
       // Triggers a new request and a recalculation of the pagination range
@@ -114,6 +114,14 @@
       $scope.$watch('pagination.page', function (newPage, oldPage) {
         (newPage !== oldPage) && loadData(true);
       });
+    }
+
+    /**
+     * Invokes the period range handler, if present
+     */
+    function invokeRangeHandler () {
+      $scope.handlers.range &&
+      $scope.handlers.range($scope.selectedRange, $scope.query.params);
     }
 
     /**

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -180,6 +180,7 @@
      * @NOTE: The cumbersome implementation was necessary because the current
      * version of lodash in Civi does not have the _.defaultsDeep() method
      *
+     * @param {Object} queryParams
      * @return {String}
      */
     function prepareGetParams (queryParams) {
@@ -207,6 +208,8 @@
 
     /**
      * Activates / Deactivates the loading state of the directive
+     *
+     * @param {Boolean} partial whether the loading mode is "partial" instead of "full"
      */
     function toggleLoadingState (partial) {
       var mode = partial ? 'partial' : 'full';

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -140,16 +140,21 @@
     /**
      * Prepare the parameters of the request before passing them to the API
      *
+     * @NOTE: The cumbersome implementation was necessary because the current
+     * version of lodash in Civi does not have the _.defaultsDeep() method
+     *
      * @return {String}
      */
     function prepareRequestParams () {
-      return _.assign({}, $scope.query.params, {
-        sequential: 1,
-        options: {
-          limit: $scope.pagination.size,
-          offset: calculatePageOffset()
-        }
-      });
+      var requestParams = _.assign({}, $scope.query.params);
+
+      requestParams.sequential = 1;
+      requestParams.options = _.defaults({}, {
+        limit: $scope.pagination.size,
+        offset: calculatePageOffset()
+      }, requestParams.options);
+
+      return requestParams;
     }
 
     /**

--- a/ang/civicase/Search.js
+++ b/ang/civicase/Search.js
@@ -51,10 +51,13 @@
       {
         'text': 'All Cases',
         'id': 'all'
-      }, {
-        'text': 'My cases',
-        'id': 'is_case_manager'
-      }, {
+      },
+      // @NOTE Disabled, see C51-277
+      // {
+      //   'text': 'My cases',
+      //   'id': 'is_case_manager'
+      // },
+      {
         'text': 'Cases I am involved',
         'id': 'is_involved'
       }

--- a/ang/test/civicase/Dashboard.spec.js
+++ b/ang/test/civicase/Dashboard.spec.js
@@ -25,7 +25,8 @@
 
         it('shows the `All Cases` filter option', function () {
           expect($scope.caseRelationshipOptions).toEqual([
-            { 'text': 'My cases', 'id': 'is_case_manager' },
+            // @NOTE Disabled, see C51-277
+            // { 'text': 'My cases', 'id': 'is_case_manager' },
             { 'text': 'Cases I am involved in', 'id': 'is_involved' },
             { 'text': 'All Cases', 'id': 'all' }
           ]);
@@ -40,7 +41,8 @@
 
         it('does not show the `All Cases` filter option', function () {
           expect($scope.caseRelationshipOptions).toEqual([
-            { 'text': 'My cases', 'id': 'is_case_manager' },
+            // @NOTE Disabled, see C51-277
+            // { 'text': 'My cases', 'id': 'is_case_manager' },
             { 'text': 'Cases I am involved in', 'id': 'is_involved' }
           ]);
         });

--- a/ang/test/civicase/DashboardTab.spec.js
+++ b/ang/test/civicase/DashboardTab.spec.js
@@ -1,0 +1,219 @@
+/* eslint-env jasmine */
+(function ($, _, moment) {
+  describe('dashboardTabCtrl', function () {
+    var $controller, $rootScope, $scope, formatCaseMock;
+
+    beforeEach(module('civicase.templates', 'civicase', 'crmUtil'));
+    beforeEach(inject(function (_$controller_, _$rootScope_, formatCase) {
+      $controller = _$controller_;
+      $rootScope = _$rootScope_;
+      $scope = $rootScope.$new();
+
+      $scope.filters = { caseRelationshipType: 'all' };
+      $scope.activityFilters = {
+        case_filter: { foo: 'foo' }
+      };
+
+      formatCaseMock = jasmine.createSpy(formatCase).and.callFake(function (aCase) {
+        return aCase;
+      });
+
+      initController();
+    }));
+
+    describe('panel-query panel: new cases', function () {
+      it('is defined', function () {
+        expect($scope.newCasesPanel).toBeDefined();
+      });
+
+      describe('query', function () {
+        it('is defined', function () {
+          expect($scope.newCasesPanel.query).toBeDefined();
+        });
+
+        it('is for the Case entity', function () {
+          expect($scope.newCasesPanel.query.entity).toBe('Case');
+        });
+
+        it('is calls the getcaselist endpoint', function () {
+          expect($scope.newCasesPanel.query.action).toBe('getcaselist');
+        });
+
+        it('adds the params defined in the relationship filter', function () {
+          expect($scope.newCasesPanel.query.params)
+            .toEqual(jasmine.objectContaining($scope.activityFilters.case_filter));
+        });
+
+        it('fetches only the cases with the "Opened" class', function () {
+          expect($scope.newCasesPanel.query.params['status_id.grouping']).toBe('Opened');
+        });
+
+        it('sorts by start_date, descending order', function () {
+          expect($scope.newCasesPanel.query.params.options.sort).toBe('start_date DESC');
+        });
+      });
+
+      describe('handlers', function () {
+        describe('results handler', function () {
+          var mockedResults = _.times(5, function () {
+            return {
+              contacts: _.times(2, function () {
+                return { contact_id: _.random(1, 5) };
+              })
+            };
+          });
+
+          it('is defined', function () {
+            expect($scope.newCasesPanel.handlers.results).toBeDefined();
+          });
+
+          describe('when invoked', function () {
+            var contactsCount, ContactsDataService;
+
+            beforeEach(inject(function (_ContactsDataService_) {
+              ContactsDataService = _ContactsDataService_;
+            }));
+
+            beforeEach(function () {
+              spyOn(ContactsDataService, 'add');
+
+              contactsCount = countTotalAndUniqueContactIds(mockedResults);
+              $scope.newCasesPanel.handlers.results(mockedResults);
+            });
+
+            it('calls the formatCase service on each result item', function () {
+              expect(formatCaseMock.calls.count()).toBe(mockedResults.length);
+            });
+
+            it('calls ContactsDataService.add() with a duplicate-free list of the results\'s contacts', function () {
+              var contactIds = ContactsDataService.add.calls.argsFor(0)[0];
+
+              expect(ContactsDataService.add).toHaveBeenCalled();
+              expect(contactIds).not.toEqual(contactsCount.total);
+              expect(contactIds).toEqual(contactsCount.uniq);
+            });
+
+            function countTotalAndUniqueContactIds (mockedResults) {
+              var total, uniq;
+
+              uniq = _(mockedResults)
+                .pluck('contacts').flatten()
+                .pluck('contact_id')
+                .tap(function (nonUniq) {
+                  total = nonUniq;
+                  return nonUniq;
+                })
+                .uniq().value();
+
+              return { total: total, uniq: uniq };
+            }
+          });
+        });
+
+        describe('range handler', function () {
+          it('is defined', function () {
+            expect($scope.newCasesPanel.handlers.range).toBeDefined();
+          });
+
+          describe('when invoked', function () {
+            describe('when the week range is selected', function () {
+              beforeEach(function () {
+                $scope.newCasesPanel.handlers.range('week', $scope.newCasesPanel.query.params);
+              });
+
+              it('filters by `start_date` between start and end of the current week', function () {
+                expect($scope.newCasesPanel.query.params.start_date).toBeDefined();
+                expect($scope.newCasesPanel.query.params.start_date).toEqual({
+                  'BETWEEN': getStartEndOfRange('week')
+                });
+              });
+            });
+
+            describe('when the month range is selected', function () {
+              beforeEach(function () {
+                $scope.newCasesPanel.handlers.range('month', $scope.newCasesPanel.query.params);
+              });
+
+              it('filters by `start_date` between start and end of the current month', function () {
+                expect($scope.newCasesPanel.query.params.start_date).toBeDefined();
+                expect($scope.newCasesPanel.query.params.start_date).toEqual({
+                  'BETWEEN': getStartEndOfRange('month')
+                });
+              });
+            });
+
+            function getStartEndOfRange (range) {
+              return [
+                moment().startOf(range).format('YYYY-MM-DD'),
+                moment().endOf(range).format('YYYY-MM-DD')
+              ];
+            }
+          });
+        });
+      });
+
+      describe('custom data', function () {
+        it('is defined', function () {
+          expect($scope.newCasesPanel.custom).toBeDefined();
+        });
+
+        it('sets the custom name of the items to "cases"', function () {
+          expect($scope.newCasesPanel.custom.itemName).toBe('cases');
+        });
+
+        describe('custom click handler', function () {
+          it('is defined', function () {
+            expect($scope.newCasesPanel.custom.caseClick).toBeDefined();
+          });
+
+          describe('when invoked', function () {
+            var $location, mockCase;
+
+            beforeEach(inject(function (_$location_) {
+              $location = _$location_;
+              mockCase = { id: _.random(1, 10) };
+
+              spyOn($location, 'path').and.callThrough();
+              spyOn($location, 'search');
+
+              $scope.newCasesPanel.custom.caseClick(mockCase);
+            }));
+
+            it('redirects to the individual case details page', function () {
+              expect($location.path).toHaveBeenCalledWith('case/list');
+              expect($location.search).toHaveBeenCalledWith('caseId', mockCase.id);
+            });
+          });
+        });
+      });
+
+      describe('when the relationship type changes', function () {
+        var newFilterValue, newType;
+
+        beforeEach(function () {
+          newType = 'is_involed';
+          newFilterValue = 'bar';
+
+          $scope.filters.caseRelationshipType = newType;
+          $scope.activityFilters.case_filter.foo = newFilterValue;
+
+          $scope.$digest();
+        });
+
+        it('adds the properties of the `case_filter` object to the query params', function () {
+          expect($scope.newCasesPanel.query.params).toEqual(jasmine.objectContaining({
+            foo: newFilterValue
+          }));
+        });
+      });
+    });
+
+    function initController () {
+      $controller('dashboardTabCtrl', {
+        $scope: $scope,
+        formatCase: formatCaseMock
+      });
+      $scope.$digest();
+    }
+  });
+}(CRM.$, CRM._, moment));

--- a/ang/test/civicase/DashboardTab.spec.js
+++ b/ang/test/civicase/DashboardTab.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env jasmine */
 (function ($, _, moment) {
-  describe('dashboardTabCtrl', function () {
+  describe('dashboardTabController', function () {
     var $controller, $rootScope, $scope, formatCaseMock;
 
     beforeEach(module('civicase.templates', 'civicase', 'crmUtil'));
@@ -209,7 +209,7 @@
     });
 
     function initController () {
-      $controller('dashboardTabCtrl', {
+      $controller('dashboardTabController', {
         $scope: $scope,
         formatCase: formatCaseMock
       });

--- a/ang/test/civicase/PanelQuery.spec.js
+++ b/ang/test/civicase/PanelQuery.spec.js
@@ -114,8 +114,8 @@
           compileDirective();
         });
 
-        it('is not called on init', function () {
-          expect(rangeHandler).not.toHaveBeenCalled();
+        it('is called', function () {
+          expect(rangeHandler).toHaveBeenCalled();
         });
 
         describe('when the selected range changes', function () {

--- a/ang/test/civicase/PanelQuery.spec.js
+++ b/ang/test/civicase/PanelQuery.spec.js
@@ -408,6 +408,18 @@
           expect(countRequest).not.toBeDefined();
         });
       });
+
+      describe('when a watcher is triggered while already loading', function () {
+        beforeEach(function () {
+          panelQueryScope.loading.full = true;
+          panelQueryScope.pagination.page = 2;
+          $scope.$digest();
+        });
+
+        it('does not make an additional api call', function () {
+          expect(crmApi.calls.count()).toBe(0);
+        });
+      });
     });
 
     describe('pagination', function () {

--- a/ang/test/civicase/PanelQuery.spec.js
+++ b/ang/test/civicase/PanelQuery.spec.js
@@ -283,6 +283,35 @@
               expect(requestParams.options.limit).toBe(panelQueryScope.pagination.size);
               expect(requestParams.options.offset).toBeDefined(panelQueryScope.pagination.page + panelQueryScope.pagination.size);
             });
+
+            describe('when the given params already have an `option` property', function () {
+              var requests, request, requestParams;
+
+              beforeEach(function () {
+                $scope.queryData.params.options = {
+                  limit: 10,
+                  offset: 20,
+                  sort: 'some_field ASC'
+                };
+
+                crmApi.calls.reset();
+                compileDirective();
+
+                requests = crmApi.calls.argsFor(0)[0];
+                request = requests[Object.keys(requests)[0]];
+                requestParams = request[2];
+              });
+
+              it('overrides the `limit` and `offset` property, enforcing its own', function () {
+                expect(requestParams.options.limit).toBe(panelQueryScope.pagination.size);
+                expect(requestParams.options.offset).toBeDefined(panelQueryScope.pagination.page + panelQueryScope.pagination.size);
+              });
+
+              it('leaves the other properties unchanged', function () {
+                expect(requestParams.options.sort).toBeDefined();
+                expect(requestParams.options.sort).toBe($scope.queryData.params.options.sort);
+              });
+            });
           });
         });
 

--- a/ang/test/civicase/PanelQuery.spec.js
+++ b/ang/test/civicase/PanelQuery.spec.js
@@ -381,6 +381,19 @@
         it('resets the pagination', function () {
           expect(panelQueryScope.pagination.page).toBe(1);
         });
+
+        describe('cache', function () {
+          beforeEach(function () {
+            crmApi.calls.reset();
+
+            panelQueryScope.pagination.page = 2;
+            $scope.$digest();
+          });
+
+          it('clears the cache', function () {
+            expect(crmApi).toHaveBeenCalled();
+          });
+        });
       });
 
       describe('when the current page changes', function () {
@@ -406,6 +419,35 @@
 
         it('does not trigger the api request to get the total count', function () {
           expect(countRequest).not.toBeDefined();
+        });
+
+        describe('when the page was not visited already', function () {
+          beforeEach(function () {
+            panelQueryScope.pagination.page = 2;
+            panelQueryScope.$digest();
+          });
+
+          it('makes an api request', function () {
+            expect(crmApi).toHaveBeenCalled();
+          });
+        });
+
+        describe('when the page was already visited', function () {
+          beforeEach(function () {
+            panelQueryScope.pagination.page = 2;
+            panelQueryScope.$digest();
+            panelQueryScope.pagination.page = 3;
+            panelQueryScope.$digest();
+
+            crmApi.calls.reset();
+
+            panelQueryScope.pagination.page = 2;
+            panelQueryScope.$digest();
+          });
+
+          it('does not make an api request', function () {
+            expect(crmApi).not.toHaveBeenCalled();
+          });
         });
       });
 


### PR DESCRIPTION
This PR improves the `<civicase-panel-query />` directive and uses it to display the "new cases" block in the dashboard

<img width="550" alt="block" src="https://user-images.githubusercontent.com/6400898/47544923-b9bdbf80-d8e9-11e8-9a39-5844182869cf.png">

### Improvements to `<civicase-panel-query />`
The main improvements are to the ux

![panel-query-ux](https://user-images.githubusercontent.com/6400898/47545061-96dfdb00-d8ea-11e8-8bbb-514d71b7e96e.gif)
_(Just for illustrative purposes in this gif, the page size has been reduced and the period range filter has been disabled)_

* Two different loading statuses:
    * Full (when the query params changes): empty the results cache, show placeholders, make a new `getcount` request
    * Partial (when the current page changes): Keep the results cache, change the opacity of `.panel-body`, don't make a new `getcount` request
* Cache: when doing a "partial" loading, the results are cached so that they are not fetched again if the user goes to a page he's already been on
* Prevent multiple requests: the directive disables the pagination when loading, and has an internal guard as well to prevent accidental multiple requests by watchers 

Additional improvements:
  * Always override `options.limit` and `options.sort` if are present in the `[query`] value, but keep the rest of the `options` property
  * The range handler is now invoked whenever the data has to be loaded, including on init. This allows the initial query to use the default value of the range selector, something that would have been impossible if the handler was invoked only when the selector value changed
  * The original `$scope.query.params` are now deep-copied, and its copy is the one been modified and sent to the civi api. This allows the watcher on `query.params` to trigger only if the params are changed at the source (= if it's the directive's consumer that changes them)

### Temporarily disable "My Cases" relationship type filter
The "My Cases" relationship type filter makes use of the `case_manager` query param (ie `case_manager: { 'IN': [<id>] }`), which is currently understood only by the custom `getcaselist` endpoint, and ignored by the standard endpoint such as `get` and `getcount`.

This leads to a bug in the pagination in any page where the filter is used, given that the list of results displayed (which uses `getcaselist` is filtered by it, but the pagination of said results (which uses `getcount`) is not

It was decided that for the time being this filter will be removed while we figure out a fix for the issue

#### Before
<img width="700" alt="dashboard-filter-before" src="https://user-images.githubusercontent.com/6400898/47545258-9267f200-d8eb-11e8-9d87-ad5115a797b5.png">
<img width="770" alt="manage-filter-before" src="https://user-images.githubusercontent.com/6400898/47545260-9267f200-d8eb-11e8-9a77-b2afbc978e18.png">

#### After
<img width="700" alt="dashboard-filter-after" src="https://user-images.githubusercontent.com/6400898/47545257-9267f200-d8eb-11e8-95f8-b704bdf3fbd9.png">
<img width="770" alt="manage-filter-after" src="https://user-images.githubusercontent.com/6400898/47545259-9267f200-d8eb-11e8-965b-8d278b739adc.png">
