### PR TITLE
C51-261 - Dialog box alignment for change case for bulk actions

### DIFF
--- a/ang/civicase/Actions.js
+++ b/ang/civicase/Actions.js
@@ -177,12 +177,14 @@
                 }
               });
 
-              CRM.confirm({
+              var dialog = CRM.confirm({
                 title: action.title,
                 message: msg,
                 open: function () {
                   $('input[name=change_case_status]', this).crmSelect2({data: statuses});
-                  CRM.wysiwyg.create('#change_case_status_details');
+                  CRM.wysiwyg.create('#change_case_status_details').then(function () {
+                    alignDialogBoxCenter(dialog);
+                  });
                 }
               })
                 .on('crmConfirm:yes', function () {
@@ -347,6 +349,17 @@
             }
           }
         });
+
+        /**
+         * Aligns the dialog box center to the screen
+         *
+         * @params {jQuery} dialog box to be aligned center
+         */
+        function alignDialogBoxCenter (dialog) {
+          if (dialog && $(dialog).data('uiDialog')) {
+            $(dialog).parent().position({ 'my': 'center', 'at': 'center', 'of': window });
+          }
+        }
       }
     };
   });

--- a/ang/civicase/Actions.js
+++ b/ang/civicase/Actions.js
@@ -353,11 +353,11 @@
         /**
          * Aligns the dialog box center to the screen
          *
-         * @params {jQuery} dialog box to be aligned center
+         * @param {jQuery} dialog box to be aligned center
          */
         function alignDialogBoxCenter (dialog) {
-          if (dialog && $(dialog).data('uiDialog')) {
-            $(dialog).parent().position({ 'my': 'center', 'at': 'center', 'of': window });
+          if (dialog && dialog.data('uiDialog')) {
+            dialog.parent().position({ 'my': 'center', 'at': 'center', 'of': window });
           }
         }
       }


### PR DESCRIPTION
## Overview
As a part of this PR the "dialog box clipping from the bottom when selecting change case status for case list bulk action" bug is fixed.

## Before

![c51-261 - before](https://user-images.githubusercontent.com/3340537/47553018-a3345a00-d923-11e8-8154-f0ec176f5ffb.gif)


## After

![c51-261 - after](https://user-images.githubusercontent.com/3340537/47553093-c9f29080-d923-11e8-9963-ced76f9f3411.gif)


## Technical Details

#### Problem
 When jQuery UI align the CRM popup box it aligns it correctly but after it gets rendered to the screen it appends extra markup (loads wysiwyg inside it) making it grow from the bottom which eventually hides the extra part that crosses the browser screen bottom.


#### Fix

Fixed by hooking on the resolve callback of load wysiwyg (as CRM.wysiwyg.create which is responsible for loading the editor returns a promise) and telling dialog popup box to re adjust itself using 
```js
 $(dialog).parent().position({ 'my': 'center', 'at': 'center', 'of': window });
```
