### PR TITLE
C51-248: Fix case refresh when creating new tasks

### DIFF
--- a/ang/civicase/CaseDetails--tabs--summary--RecentCommunications.html
+++ b/ang/civicase/CaseDetails--tabs--summary--RecentCommunications.html
@@ -29,7 +29,8 @@
       </div>
       <civicase-add-activity-menu
         case="item"
-        filter-activities-by="communication">
+        filter-activities-by="communication"
+        crm-popup-form-success="pushCaseData($data.civicase_reload[0])">
       </civicase-add-activity-menu>
     </span>
   </div>

--- a/ang/civicase/CaseDetails--tabs--summary--Tasks.html
+++ b/ang/civicase/CaseDetails--tabs--summary--Tasks.html
@@ -34,7 +34,8 @@
       </div>
       <civicase-add-activity-menu
         case="item"
-        filter-activities-by="task">
+        filter-activities-by="task"
+        crm-popup-form-success="pushCaseData($data.civicase_reload[0])">
       </civicase-add-activity-menu>
     </span>
   </div>


### PR DESCRIPTION
## Overview

This PR refreshes the case details when creating a new task or communication from their respective details panels.

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/47563506-04423a80-d8f0-11e8-80c1-99e8c30b9e2f.gif)

## After
![pr-after](https://user-images.githubusercontent.com/1642119/47563402-b7f6fa80-d8ef-11e8-98fc-7ebc8b2c91d1.gif)

## Technical details

The issue happens the `civicase-add-activity-menu` needs to have a `crm-popup-form-success` property added to it and pass a refresh function to reload the case data:

```html
<civicase-add-activity-menu
  case="item"
  filter-activities-by="communication"
  crm-popup-form-success="pushCaseData($data.civicase_reload[0])">
</civicase-add-activity-menu>
```

`crm-popup-form-success` is a directive that triggers an event when the activity modal form is submitted. It passes a `$data` object with the details of the activity. One of this properties is `civicase_reload` which contains query params to pass to the reload function. This params were constructed by `civicase-add-activity-menu` and among other things it specify the original case id, etc. Finally, `pushCaseData` is defined in the case details directive and it reloads the case data when called.