### PR TITLE
C51 312 fix bugs for contact record

### DIFF
--- a/ang/civicase/ContactCaseTab.html
+++ b/ang/civicase/ContactCaseTab.html
@@ -28,7 +28,8 @@
             <civicase-contact-case-tab-case-details
               class="civicase__contact-cases-tab-details"
               selected-case="selectedCase"
-              ng-if="caseDetailsLoaded">
+              ng-if="caseDetailsLoaded",
+              refresh-callback="refresh">
             </civicase-contact-case-tab-case-details>
             <!-- Loading placeholder -->
             <div ng-if="!caseDetailsLoaded" class="panel panel-default civicase__contact-cases-tab-details">

--- a/ang/civicase/ContactCaseTab.js
+++ b/ang/civicase/ContactCaseTab.js
@@ -43,9 +43,13 @@
         'name': 'related',
         'title': 'Other cases for this contact',
         'filterParams': {
-          'case_manager': Contact.getContactIDFromUrl()
+          'case_manager': Contact.getContactIDFromUrl(),
+          'options': {
+            'limit': 0
+          }
         },
-        'showContactRole': true
+        'showContactRole': true,
+        'disableLoadMore': true // Todo: Should be removed after Fixing count API response for case list.
       }
     ];
 

--- a/ang/civicase/ContactCaseTab.js
+++ b/ang/civicase/ContactCaseTab.js
@@ -44,12 +44,12 @@
         'title': 'Other cases for this contact',
         'filterParams': {
           'case_manager': Contact.getContactIDFromUrl(),
-          'options': {
+          'options': { // Todo: Should be removed after Fixing count API response for case list. C51-277
             'limit': 0
           }
         },
         'showContactRole': true,
-        'disableLoadMore': true // Todo: Should be removed after Fixing count API response for case list.
+        'disableLoadMore': true // Todo: Should be removed after Fixing count API response for case list. C51-277
       }
     ];
 
@@ -147,7 +147,7 @@
         totalCountApi.push(params.count);
       });
 
-      getTotalCasesCount(totalCountApi);
+      // getTotalCasesCount(totalCountApi); // Todo: Uncommented after Fixing count API response for case list. C51-277
     }
 
     /**
@@ -241,6 +241,7 @@
         }, []);
 
         fetchContactsData(allCases);
+        $scope.totalCount = allCases.length; // Todo: Should be removed after Fixing count API response for case list. C51-277
 
         if (!$scope.selectedCase) {
           setCaseAsSelected(allCases[0]);

--- a/ang/civicase/ContactCaseTab.js
+++ b/ang/civicase/ContactCaseTab.js
@@ -33,7 +33,7 @@
         'showContactRole': false
       }, {
         'name': 'closed',
-        'title': 'Closed Case',
+        'title': 'Resolved cases',
         'filterParams': {
           'status_id.grouping': 'Closed',
           'contact_id': Contact.getContactIDFromUrl()

--- a/ang/civicase/ContactCaseTabCaseDetails.html
+++ b/ang/civicase/ContactCaseTabCaseDetails.html
@@ -20,7 +20,7 @@
             </li>
             <li ng-repeat="(id, status) in allowedCaseStatuses" ng-if="id !== item.status_id">
               <a
-                crm-popup-form-success="pushCaseData($data.civicase_reload[0])"
+                crm-popup-form-success="pushCaseData($data.civicase_reload[0]); refreshCases()"
                 class="crm-popup"
                 ng-href="{{ 
                   'civicrm/case/activity' | civicaseCrmUrl:

--- a/ang/civicase/ContactCaseTabCaseDetails.js
+++ b/ang/civicase/ContactCaseTabCaseDetails.js
@@ -7,7 +7,8 @@
       replace: true,
       templateUrl: '~/civicase/ContactCaseTabCaseDetails.html',
       scope: {
-        item: '=selectedCase'
+        item: '=selectedCase',
+        refreshCases: '=refreshCallback'
       }
     };
   });

--- a/ang/civicase/ContactCaseTabCaseList.html
+++ b/ang/civicase/ContactCaseTabCaseList.html
@@ -29,7 +29,7 @@
       ng-click="loadMore()">Load More Cases</button>
     <div ng-if="!casesList.isLoadMoreAvailable">
       <span ng-if="casesList.cases.length > 0"> Showing all {{ casesList.cases.length }}</span>
-      <p ng-if="casesList.cases.length == 0 && casesList.isLoaded" class="text-left"> None Found </p>
     </div>
+    <p ng-if="casesList.cases.length == 0 && casesList.isLoaded" class="text-left"> None Found </p>
   </div>
 </div>

--- a/ang/civicase/ContactCaseTabCaseList.html
+++ b/ang/civicase/ContactCaseTabCaseList.html
@@ -25,7 +25,7 @@
     <div ng-if="casesList.showSpinner" class="civicase__spinner"></div>
     <button 
       class="btn btn-default" 
-      ng-if="casesList.isLoadMoreAvailable && casesList.isLoaded && !casesList.showSpinner"
+      ng-if="casesList.isLoadMoreAvailable && casesList.isLoaded && !casesList.showSpinner  && !casesList.disableLoadMore" 
       ng-click="loadMore()">Load More Cases</button>
     <div ng-if="!casesList.isLoadMoreAvailable">
       <span ng-if="casesList.cases.length > 0"> Showing all {{ casesList.cases.length }}</span>


### PR DESCRIPTION
## Overview
As a part of this PR some minor bugs and improvements are done on contact records
##Issue list

### Problem 1 
Since the count API for cases where contact is case manager is not returning right response, we decided to disable load more for `Other cases where the contact is related` on contact record screen under cases tab

<img width="1599" alt="c51-312 - after" src="https://user-images.githubusercontent.com/3340537/47582870-3c3e9180-d973-11e8-85e2-0225435ee230.png">


### Fix 1 
 
db02d63

### Problem 2 
Due to same API issue the no result was broken


### Fix 2

So for now the count is calculated from the length of the cases arrays when all of them are loaded

910483c

<img width="1673" alt="c51-312 - after 3" src="https://user-images.githubusercontent.com/3340537/47582927-6b550300-d973-11e8-8488-2be036f2d2dc.png">


### Problem 3
Make the left case list to refresh when status is changed

### Fix 3

Passed `refresh` function inside the `ContactCaseTabCaseDetails` from `ContactCaseTab` Directive
90b269c

### Fix 4 
Changed the text to `Resolved case`
18d8d53

![c51-312](https://user-images.githubusercontent.com/3340537/47582971-90497600-d973-11e8-9e16-2af847663a58.gif)
