### PR TITLE
C51-299: Fix ContactDataService logic

### DIFF
--- a/ang/civicase/ContactsDataService.js
+++ b/ang/civicase/ContactsDataService.js
@@ -4,6 +4,7 @@
   module.service('ContactsDataService', ContactsDataService);
 
   function ContactsDataService (crmApi, $q) {
+    var defer;
     var savedContacts = [];
     var savedContactDetails = {};
     var requiredContactFields = [
@@ -19,7 +20,6 @@
       'street_address',
       'tag'
     ];
-    var defer;
 
     /**
      * Add data to the ContactsData service and fetches Profile Pic and Contact Type
@@ -39,6 +39,7 @@
       }
 
       defer = $q.defer();
+
       return crmApi('Contact', 'get', {
         'sequential': 1,
         'id': { 'IN': newContacts },

--- a/ang/civicase/ContactsDataService.js
+++ b/ang/civicase/ContactsDataService.js
@@ -3,7 +3,7 @@
 
   module.service('ContactsDataService', ContactsDataService);
 
-  function ContactsDataService (crmApi) {
+  function ContactsDataService (crmApi, $q) {
     var savedContacts = [];
     var savedContactDetails = {};
     var requiredContactFields = [
@@ -19,6 +19,7 @@
       'street_address',
       'tag'
     ];
+    var defer;
 
     /**
      * Add data to the ContactsData service and fetches Profile Pic and Contact Type
@@ -33,9 +34,11 @@
       savedContacts = savedContacts.concat(newContacts);
 
       if (newContacts.length === 0) {
-        return;
+        // if a previous API call is in progress wait for it to finish;
+        return defer ? defer.promise : $q.resolve();
       }
 
+      defer = $q.defer();
       return crmApi('Contact', 'get', {
         'sequential': 1,
         'id': { 'IN': newContacts },
@@ -57,6 +60,7 @@
         }
       }).then(function (data) {
         savedContactDetails = _.extend(savedContactDetails, _.indexBy(data.values, 'contact_id'));
+        defer.resolve();
       });
     };
 

--- a/ang/test/civicase/ContactsDataService.spec.js
+++ b/ang/test/civicase/ContactsDataService.spec.js
@@ -20,7 +20,8 @@
         expect(ContactsDataService).toEqual(jasmine.objectContaining({
           add: jasmine.any(Function),
           getImageUrlOf: jasmine.any(Function),
-          getContactIconOf: jasmine.any(Function)
+          getContactIconOf: jasmine.any(Function),
+          getCachedContact: jasmine.any(Function)
         }));
       });
     });
@@ -29,6 +30,9 @@
       var expectedApiParams;
 
       beforeEach(function () {
+        crmApi.and.returnValue($q.resolve({
+          values: []
+        }));
         expectedApiParams = {
           'sequential': 1,
           'options': { 'limit': 0 },
@@ -88,6 +92,21 @@
 
         it('gets the details of new contacts only', function () {
           expect(crmApi.calls.mostRecent().args).toEqual(['Contact', 'get', expectedApiParams]);
+        });
+      });
+
+      describe('when called again before first calls data is not returned', function () {
+        var contactsForTheFirstCall;
+        var promise1, promise2;
+
+        beforeEach(function () {
+          contactsForTheFirstCall = [ContactsData.values[0]];
+          promise1 = ContactsDataService.add(contactsForTheFirstCall);
+          promise2 = ContactsDataService.add(contactsForTheFirstCall);
+        });
+
+        it('second call waits for the first one to finish', function () {
+          expect(promise1).toEqual(promise2);
         });
       });
     });


### PR DESCRIPTION
## Overview
This PR fixes a bug with Activity Feed where Contact initials were not shown.

## Technical Details
Suppose `ContactsDataService.add()` is called with Contact A and Contact B, then it will make an api call to fetch more details about those. But before this API call ends, if another call is made to again fetch Contact A and Contact B, then `newContacts.length` will be equal to 0, and the code will return directly. This was a problem because 2nd call to `ContactsDataService.add()` returned before the respective data is loaded.
To fix this, a deferred object is created. And whenever there is no new data to be loaded, it checks whether a previous call is already in progress, if yes it waits for the call to finish.