### PR TITLE
C51-321: Activities block

### DIFF
--- a/ang/civicase/DashboardTab.html
+++ b/ang/civicase/DashboardTab.html
@@ -222,6 +222,7 @@
           <panel-query-results>
             <div ng-repeat="activity in results"
               case-activity-card="activity"
+              refresh-callback="loadData"
               mode="long"
               refresh-on-checkbox-toggle="false"
               bulk-allowed="false">
@@ -248,6 +249,7 @@
           <panel-query-results>
             <div ng-repeat="activity in results"
               case-activity-card="activity"
+              refresh-callback="loadData"
               mode="long"
               refresh-on-checkbox-toggle="false"
               bulk-allowed="false">

--- a/ang/civicase/DashboardTab.html
+++ b/ang/civicase/DashboardTab.html
@@ -237,6 +237,32 @@
             </div>
           </panel-query-empty>
         </civicase-panel-query>
+        <!-- Activities -->
+        <civicase-panel-query query="activitiesPanel.query" handlers="activitiesPanel.handlers" custom-data="activitiesPanel.custom">
+          <panel-query-title>
+            You have {{loading.full ? '-' : total}} {{customData.itemName}} due
+          </panel-query-title>
+          <panel-query-actions>
+            <div ng-if="customData.involvementFilter" civicase-activity-filters-contact="customData.involvementFilter" class="panel-heading-control"></div>
+          </panel-query-actions>
+          <panel-query-results>
+            <div ng-repeat="activity in results"
+              case-activity-card="activity"
+              mode="long"
+              refresh-on-checkbox-toggle="false"
+              bulk-allowed="false">
+            </div>
+          </panel-query-results>
+          <panel-query-empty>
+            <div class="civicase__activity-card--empty">
+              <div class="civicase__activity-no-result-icon civicase__activity-no-result-icon--activity"></div>
+              <div class="civicase__activity-card--big--empty-title">No upcoming {{customData.itemName}}</div>
+              <div class="civicase__activity-card--big--empty-description">
+                You have no {{customData.itemName}} due this {{selectedRange}}
+              </div>
+            </div>
+          </panel-query-empty>
+        </civicase-panel-query>
       </div>
     </div>
   </div>

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -54,6 +54,8 @@
       range: { from: 1, to: PAGE_SIZE }
     };
 
+    $scope.loadData = loadData;
+
     (function init () {
       initWatchers();
       verifyData();


### PR DESCRIPTION
## Overview
As part of this PR, the Activities block in Dashboard has been developed.

## How it looks
![after](https://user-images.githubusercontent.com/5058867/47658386-ed823900-dbb8-11e8-8d2c-10159011779b.gif)

## Technical Details
1. One more `civicase-panel-query` component has been added to show the activity block.
2. `ACTIVITIES_QUERY_PARAMS_DEFAULTS ` and `$scope.activitiesPanel` is also added for the same block with its parameters.

## Note
When an Activity Card is edited from the Popup, the blocks pager resets to 1, instead of remembering its old state. Because of time crunch this could not be implemented.