### PR TITLE
C51-323: Fix filter persistance issue when reload case page

### DIFF
--- a/ang/civicase/CaseListTable.js
+++ b/ang/civicase/CaseListTable.js
@@ -25,6 +25,7 @@
     $scope.viewingCaseDetails = null;
 
     $scope.bulkAllowed = BulkActions.isAllowed();
+
     (function init () {
       bindRouteParamsToScope();
       // calculate after page size is calculated from Route Params;
@@ -123,7 +124,7 @@
           $scope.viewingCaseTab = 'summary';
         }
       }
-      $rootScope.$broadcast('civicase::case-search::page-title-updated', getDisplayNameOfSelectedItem(), $scope.totalCount);
+      setPageTitle();
       $($window).scrollTop(0); // Scrolls the window to top once new data loads
     };
 
@@ -245,7 +246,7 @@
      */
     function getCases () {
       $scope.isLoading = true;
-      $rootScope.$broadcast('civicase::case-search::page-title-updated', getDisplayNameOfSelectedItem(), $scope.totalCount);
+      setPageTitle();
       crmThrottle(makeApiCallToLoadCases)
         .then(function (result) {
           var cases = _.each(result[0].values, formatCase);
@@ -272,7 +273,7 @@
           $scope.page.num = result[0].page || $scope.page.num;
           $scope.totalCount = result[1];
           $scope.page.total = Math.ceil(result[1] / $scope.page.size);
-          $rootScope.$broadcast('civicase::case-search::page-title-updated', getDisplayNameOfSelectedItem(), $scope.totalCount);
+          setPageTitle();
           firstLoad = $scope.isLoading = false;
           $($window).scrollTop(0); // Scrolls the window to top once new data loads
         });
@@ -436,6 +437,13 @@
       $scope.selectedCases = [];
       $scope.selectedCases = _.each(allCases, formatCase);
       selectDisplayedCases(); // Update the UI model with displayed cases selected;
+    }
+
+    /**
+     * Emits event for page title
+     */
+    function setPageTitle () {
+      $scope.$emit('civicase::case-search::page-title-updated', getDisplayNameOfSelectedItem(), $scope.totalCount);
     }
 
     /**

--- a/ang/civicase/CaseListTable.js
+++ b/ang/civicase/CaseListTable.js
@@ -10,30 +10,28 @@
 
   module.controller('CivicaseCaseListTableController', function ($rootScope, $scope, $window, BulkActions, crmApi, crmStatus, crmUiHelp, crmThrottle, $timeout, formatCase, ContactsDataService) {
     var firstLoad = true;
-    var caseTypes = CRM.civicase.caseTypes;
     var allCases;
 
     $scope.activityCategories = CRM.civicase.activityCategories;
     $scope.activityTypes = CRM.civicase.activityTypes;
+    $scope.page = {total: 0};
     $scope.cases = [];
     $scope.caseStatuses = CRM.civicase.caseStatuses;
     $scope.CRM = CRM;
     $scope.isLoading = true;
-    $scope.page = {total: 0};
-    $scope.pageTitle = '';
     $scope.selectedCases = [];
     $scope.sort = {sortable: true};
     $scope.ts = CRM.ts('civicase');
     $scope.viewingCaseDetails = null;
-    $scope.bulkAllowed = BulkActions.isAllowed();
 
+    $scope.bulkAllowed = BulkActions.isAllowed();
     (function init () {
       bindRouteParamsToScope();
+      // calculate after page size is calculated from Route Params;
+      $scope.casePlaceholders = _.range($scope.page.size);
       initiateWatchers();
       initSubscribers();
-      getCases();
       getAllCasesforSelectAll();
-      $scope.casePlaceholders = $scope.filters.id ? [0] : _.range($scope.page.size);
     }());
 
     $scope.applyAdvSearch = function (newFilters) {
@@ -49,6 +47,12 @@
       $scope.sort.dir = ($scope.sort.dir === 'ASC' ? 'DESC' : 'ASC');
     };
 
+    /**
+     * Checks if selection is active on based of
+     * the passed params.
+     *
+     * @param {String} condition
+     */
     $scope.isSelection = function (condition) {
       if (!$scope.cases) {
         return false;
@@ -119,7 +123,7 @@
           $scope.viewingCaseTab = 'summary';
         }
       }
-      setPageTitle();
+      $rootScope.$broadcast('civicase::case-search::page-title-updated', getDisplayNameOfSelectedItem(), $scope.totalCount);
       $($window).scrollTop(0); // Scrolls the window to top once new data loads
     };
 
@@ -127,11 +131,9 @@
      * Binds all route parameters to scope
      */
     function bindRouteParamsToScope () {
-      $scope.$bindToRoute({expr: 'searchIsOpen', param: 'sx', format: 'bool', default: false});
       $scope.$bindToRoute({expr: 'sort.field', param: 'sf', format: 'raw', default: 'contact_id.sort_name'});
       $scope.$bindToRoute({expr: 'sort.dir', param: 'sd', format: 'raw', default: 'ASC'});
       $scope.$bindToRoute({expr: 'caseIsFocused', param: 'focus', format: 'bool', default: false});
-      $scope.$bindToRoute({expr: 'filters', param: 'cf', default: {}});
       $scope.$bindToRoute({expr: 'viewingCase', param: 'caseId', format: 'raw'});
       $scope.$bindToRoute({expr: 'viewingCaseTab', param: 'tab', format: 'raw', default: 'summary'});
       $scope.$bindToRoute({expr: 'page.size', param: 'cps', format: 'int', default: 15});
@@ -243,7 +245,7 @@
      */
     function getCases () {
       $scope.isLoading = true;
-      setPageTitle();
+      $rootScope.$broadcast('civicase::case-search::page-title-updated', getDisplayNameOfSelectedItem(), $scope.totalCount);
       crmThrottle(makeApiCallToLoadCases)
         .then(function (result) {
           var cases = _.each(result[0].values, formatCase);
@@ -270,7 +272,7 @@
           $scope.page.num = result[0].page || $scope.page.num;
           $scope.totalCount = result[1];
           $scope.page.total = Math.ceil(result[1] / $scope.page.size);
-          setPageTitle();
+          $rootScope.$broadcast('civicase::case-search::page-title-updated', getDisplayNameOfSelectedItem(), $scope.totalCount);
           firstLoad = $scope.isLoading = false;
           $($window).scrollTop(0); // Scrolls the window to top once new data loads
         });
@@ -387,6 +389,9 @@
     function initSubscribers () {
       $scope.$on('civicase::bulk-actions::bulk-selections', bulkSelectionsListener);
       $scope.$on('civicase::bulk-actions::check-box-toggled', bulkSelectionCheckboxClickedListener);
+      $scope.$on('civicase::case-search::filters-updated', function (event, filters) {
+        $scope.applyAdvSearch(filters.selectedFilters);
+      });
     }
 
     /**
@@ -434,46 +439,6 @@
     }
 
     /**
-     * Set the title of the page
-     */
-    function setPageTitle () {
-      var viewingCase = $scope.viewingCase;
-      var cases = $scope.cases;
-      var filters = $scope.filters;
-      // Hide page title when case is selected
-      $('h1.crm-page-title').toggle(!viewingCase);
-      if (viewingCase) {
-        var item = _.findWhere(cases, {id: viewingCase});
-        if (item) {
-          $scope.pageTitle = item.client[0].display_name + ' - ' + item.case_type;
-        }
-        return;
-      }
-      if (_.size(_.omit(filters, ['status_id', 'case_type_id']))) {
-        $scope.pageTitle = $scope.ts('Case Search Results');
-      } else {
-        var status = [];
-        if (filters.status_id && filters.status_id.length) {
-          _.each(filters.status_id, function (s) {
-            status.push(_.findWhere($scope.caseStatuses, {name: s}).label);
-          });
-        } else {
-          status = [$scope.ts('All Open')];
-        }
-        var type = [];
-        if (filters.case_type_id && filters.case_type_id.length) {
-          _.each(filters.case_type_id, function (t) {
-            type.push(_.findWhere(caseTypes, {name: t}).title);
-          });
-        }
-        $scope.pageTitle = status.join(' & ') + ' ' + type.join(' & ') + ' ' + $scope.ts('Cases');
-      }
-      if (typeof $scope.totalCount === 'number') {
-        $scope.pageTitle += ' (' + $scope.totalCount + ')';
-      }
-    }
-
-    /**
      * Update Cases when watch parameters has changed
      *
      * @param {object} newValue
@@ -483,6 +448,28 @@
       if (newValue !== oldValue) {
         getCases();
       }
+    }
+
+    /**
+     * Returns the display name of a selected case
+     *
+     * @return {String} display name to be used in page title
+     */
+    function getDisplayNameOfSelectedItem () {
+      var viewingCase = $scope.viewingCase;
+      var cases = $scope.cases;
+
+      if (!viewingCase) {
+        return;
+      }
+
+      var selectedCase = _.findWhere(cases, {id: viewingCase});
+
+      if (!selectedCase) {
+        return false;
+      }
+
+      return selectedCase.client[0].display_name + ' - ' + selectedCase.case_type;
     }
   });
 })(angular, CRM.$, CRM._);

--- a/ang/civicase/Search.html
+++ b/ang/civicase/Search.html
@@ -1,7 +1,7 @@
 <div class="panel panel-default civicase__case-filter-panel clearfix" ng-class="{'case-is-focused': $parent.caseIsFocused}">
   <div crm-ui-debug="filters"></div>
   <div class="panel-header">
-    <h3 class="civicase__case-filter-panel__title"> {{ $parent.pageTitle }} </h3>
+    <h3 class="civicase__case-filter-panel__title"> {{ pageTitle }} </h3>
     <form class="form-inline civicase__case-filters-container">
       <input class="form-control civicase__case-filter__input" ng-list crm-ui-select="{allowClear: true, multiple: true, placeholder: ts('Case Type: Any'), data: caseTypeOptions}" ng-model="filters.case_type_id" />
       <input class="form-control civicase__case-filter__input" ng-list crm-ui-select="{allowClear: true, multiple: true, placeholder: ts('Status: All open cases'), data: caseStatusOptions}" ng-model="filters.status_id" />

--- a/ang/civicase/Search.js
+++ b/ang/civicase/Search.js
@@ -18,7 +18,7 @@
   /**
    * Controller Function for civicase-search directive
    */
-  module.controller('civicaseSearchController', function ($scope, $timeout) {
+  module.controller('civicaseSearchController', function ($scope, $rootScope, $timeout) {
     // The ts() functions help load strings for this module.
     var ts = $scope.ts = CRM.ts('civicase');
     var caseTypes = CRM.civicase.caseTypes;
@@ -63,6 +63,7 @@
       }
     ];
 
+    $scope.pageTitle = '';
     $scope.caseTypeOptions = _.map(caseTypes, mapSelectOptions);
     $scope.caseStatusOptions = _.map(caseStatuses, mapSelectOptions);
     $scope.customGroups = CRM.civicase.customSearchFields;
@@ -72,39 +73,11 @@
     $scope.filters = angular.extend({}, $scope.defaults);
 
     (function init () {
+      bindRouteParamsToScope();
+      initiateWatchers();
+      initSubscribers();
       setCustomSearchFieldsAsSearchFilters();
-
-      $scope.$watch('expanded', expandedWatcher);
-      $scope.$watch('relationshipType', relationshipTypeWatcher);
-      $scope.$watchCollection('filters', filtersWatcher);
     }());
-
-    /**
-     * Watcher for expanded state and update tableHeader top offset likewise
-     */
-    function expandedWatcher () {
-      $scope.$emit('civicase::case-search::dropdown-toggle');
-    }
-
-    /**
-     * Watcher for relationshipType filter
-     */
-    function relationshipTypeWatcher () {
-      if ($scope.relationshipType) {
-        $scope.relationshipType[0] === 'is_case_manager' ? $scope.filters.case_manager = [CRM.config.user_contact_id] : delete ($scope.filters.case_manager);
-        $scope.relationshipType[0] === 'is_involved' ? $scope.filters.contact_id = [CRM.config.user_contact_id] : delete ($scope.filters.contact_id);
-      }
-    }
-
-    /**
-     * Watcher for filter collection to update the search
-     * Only works when dropdown is unexpanded
-     */
-    function filtersWatcher () {
-      if (!$scope.expanded) {
-        $scope.doSearch();
-      }
-    }
 
     /**
      * Check/Uncheck `Show deleted` filters
@@ -145,7 +118,7 @@
     $scope.doSearch = function () {
       $scope.filterDescription = buildDescription();
       $scope.expanded = false;
-      $scope.$parent.$eval($scope.onSearch, {
+      $rootScope.$broadcast('civicase::case-search::filters-updated', {
         selectedFilters: formatSearchFilters($scope.filters)
       });
     };
@@ -159,35 +132,10 @@
     };
 
     /**
-     * Map the option parameter from API
-     * to show up correctly on the UI.
-     *
-     * @param {object} opt object for caseTypes
-     * @return {object} mapped value to be used in UI
+     * Binds all route parameters to scope
      */
-    function mapSelectOptions (opt) {
-      return {
-        id: opt.value || opt.name,
-        text: opt.label || opt.title,
-        color: opt.color,
-        icon: opt.icon
-      };
-    }
-
-    /**
-     * Formats search filter as per the API request header format
-     *
-     * @params {object} inp - Object for input option to be formatted
-     * @return (object} search - returns formatted key value pair of filters
-     */
-    function formatSearchFilters (inp) {
-      var search = {};
-      _.each(inp, function (val, key) {
-        if (!_.isEmpty(val) || ((typeof val === 'number') && val) || ((typeof val === 'boolean') && val)) {
-          search[key] = val;
-        }
-      });
-      return search;
+    function bindRouteParamsToScope () {
+      $scope.$bindToRoute({expr: 'filters', param: 'cf', default: {}});
     }
 
     /**
@@ -234,6 +182,81 @@
     }
 
     /**
+     * Watcher for expanded state and update tableHeader top offset likewise
+     */
+    function expandedWatcher () {
+      $scope.$emit('civicase::case-search::dropdown-toggle');
+    }
+
+    /**
+     * Formats search filter as per the API request header format
+     *
+     * @params {object} inp - Object for input option to be formatted
+     * @return (object} search - returns formatted key value pair of filters
+     */
+    function formatSearchFilters (inp) {
+      var search = {};
+      _.each(inp, function (val, key) {
+        if (!_.isEmpty(val) || ((typeof val === 'number') && val) || ((typeof val === 'boolean') && val)) {
+          search[key] = val;
+        }
+      });
+      return search;
+    }
+
+    /**
+     * Watcher for filter collection to update the search
+     * Only works when dropdown is unexpanded
+     */
+    function filtersWatcher () {
+      if (!$scope.expanded) {
+        $scope.doSearch();
+      }
+    }
+
+    /**
+     * All subscribers are initiated here
+     */
+    function initSubscribers () {
+      $rootScope.$on('civicase::case-search::page-title-updated', setPageTitle);
+    }
+
+    /**
+     * All watchers are initiated here
+     */
+    function initiateWatchers () {
+      $scope.$watch('expanded', expandedWatcher);
+      $scope.$watch('relationshipType', relationshipTypeWatcher);
+      $scope.$watchCollection('filters', filtersWatcher);
+    }
+
+    /**
+     * Map the option parameter from API
+     * to show up correctly on the UI.
+     *
+     * @param {object} opt object for caseTypes
+     * @return {object} mapped value to be used in UI
+     */
+    function mapSelectOptions (opt) {
+      return {
+        id: opt.value || opt.name,
+        text: opt.label || opt.title,
+        color: opt.color,
+        icon: opt.icon
+      };
+    }
+
+    /**
+     * Watcher for relationshipType filter
+     */
+    function relationshipTypeWatcher () {
+      if ($scope.relationshipType) {
+        $scope.relationshipType[0] === 'is_case_manager' ? $scope.filters.case_manager = [CRM.config.user_contact_id] : delete ($scope.filters.case_manager);
+        $scope.relationshipType[0] === 'is_involved' ? $scope.filters.contact_id = [CRM.config.user_contact_id] : delete ($scope.filters.contact_id);
+      }
+    }
+
+    /**
      * Set custom search fields to search filter fields object
      */
     function setCustomSearchFieldsAsSearchFilters () {
@@ -242,6 +265,45 @@
           allSearchFields['custom_' + field.id] = field;
         });
       });
+    }
+
+    /**
+     * Set the title of the page
+     *
+     * @params {Object} event
+     * @params {String} displayNameOfSelectedItem
+     * @params {String} totalCount
+     */
+    function setPageTitle (event, displayNameOfSelectedItem, totalCount) {
+      var filters = $scope.filters;
+
+      if (displayNameOfSelectedItem) {
+        $scope.pageTitle = displayNameOfSelectedItem;
+        return;
+      }
+
+      if (_.size(_.omit(filters, ['status_id', 'case_type_id']))) {
+        $scope.pageTitle = $scope.ts('Case Search Results');
+      } else {
+        var status = [];
+        if (filters.status_id && filters.status_id.length) {
+          _.each(filters.status_id, function (s) {
+            status.push(_.findWhere(caseStatuses, {name: s}).label);
+          });
+        } else {
+          status = [$scope.ts('All Open')];
+        }
+        var type = [];
+        if (filters.case_type_id && filters.case_type_id.length) {
+          _.each(filters.case_type_id, function (t) {
+            type.push(_.findWhere(caseTypes, {name: t}).title);
+          });
+        }
+        $scope.pageTitle = status.join(' & ') + ' ' + type.join(' & ') + ' ' + $scope.ts('Cases');
+      }
+      if (typeof totalCount === 'number') {
+        $scope.pageTitle += ' (' + totalCount + ')';
+      }
     }
   });
 })(angular, CRM.$, CRM._);

--- a/ang/civicase/Search.js
+++ b/ang/civicase/Search.js
@@ -135,6 +135,7 @@
      * Binds all route parameters to scope
      */
     function bindRouteParamsToScope () {
+      $scope.$bindToRoute({expr: 'expanded', param: 'sx', format: 'bool', default: false});
       $scope.$bindToRoute({expr: 'filters', param: 'cf', default: {}});
     }
 

--- a/ang/test/civicase/CaseListTable.spec.js
+++ b/ang/test/civicase/CaseListTable.spec.js
@@ -2,7 +2,7 @@
 
 (function (_) {
   describe('CaseListTable', function () {
-    var $controller, $q, $scope, CasesData, crmApi, formatCase;
+    var $controller, $q, $scope, CasesData, crmApi;
 
     beforeEach(module('civicase', 'civicase.data', 'crmUtil'));
 
@@ -13,15 +13,14 @@
       $scope = $rootScope.$new();
       CasesData = _CasesData_.get();
       crmApi = _crmApi_;
-      formatCase = _formatCase_;
       // custom function added by civicrm:
       $scope.$bindToRoute = jasmine.createSpy('$bindToRoute');
       $scope.filters = {
         id: _.uniqueId()
       };
     }));
-    describe('on init', function () {
-      var expectedApiCallParams, expectedCases;
+    describe('on calling applyAdvSearch()', function () {
+      var expectedApiCallParams;
 
       beforeEach(function () {
         expectedApiCallParams = [
@@ -58,17 +57,12 @@
         ];
 
         crmApi.and.returnValue($q.resolve([_.cloneDeep(CasesData)]));
-        expectedCases = _.chain(CasesData.values).cloneDeep().map(formatCase).value();
         initController();
-        $scope.$digest();
+        $scope.applyAdvSearch($scope.filters);
       });
 
       it('requests the cases data', function () {
         expect(crmApi).toHaveBeenCalledWith(expectedApiCallParams);
-      });
-
-      it('stores the cases after formatting them', function () {
-        expect($scope.cases).toEqual(expectedCases);
       });
     });
 

--- a/ang/test/civicase/Search.spec.js
+++ b/ang/test/civicase/Search.spec.js
@@ -1,12 +1,12 @@
 /* eslint-env jasmine */
 (function ($) {
   describe('civicaseSearch', function () {
-    var element, $compile, $rootScope, $scope, event, CaseFilters, affixOriginalFunction, offsetOriginalFunction, originalDoSearch, orginalParentScope, affixReturnValue;
+    var $controller, $rootScope, $scope, CaseFilters, affixOriginalFunction, offsetOriginalFunction, originalDoSearch, orginalParentScope, affixReturnValue, originalBindToRoute;
 
     beforeEach(module('civicase.templates', 'civicase', 'civicase.data'));
 
-    beforeEach(inject(function (_$compile_, _$rootScope_, _CaseFilters_) {
-      $compile = _$compile_;
+    beforeEach(inject(function (_$controller_, _$rootScope_, _CaseFilters_) {
+      $controller = _$controller_;
       $rootScope = _$rootScope_;
       $scope = $rootScope.$new();
       CaseFilters = _CaseFilters_;
@@ -28,50 +28,47 @@
       affixReturnValue = jasmine.createSpyObj('affix', ['on']);
       affixReturnValue.on.and.returnValue(affixReturnValue);
       CRM.$.fn.affix.and.returnValue(affixReturnValue);
+      originalBindToRoute = $scope.$bindToRoute;
+      $scope.$bindToRoute = jasmine.createSpy('$bindToRoute');
     });
 
     beforeEach(function () {
-      compileDirective();
+      initController();
     });
 
     afterEach(function () {
       CRM.$.fn.affix = affixOriginalFunction;
       CRM.$.fn.affix = offsetOriginalFunction;
-    });
-
-    describe('basic test', function () {
-      it('complies civicaseSearch directive', function () {
-        expect(element.hasClass('civicase__case-filter-panel')).toBe(true);
-      });
+      $scope.$bindToRoute = originalBindToRoute;
     });
 
     describe('$scope variables', function () {
       it('checks $scope.caseTypeOptions', function () {
-        expect(element.isolateScope().caseTypeOptions).toEqual(jasmine.any(Object));
+        expect($scope.caseTypeOptions).toEqual(jasmine.any(Object));
       });
 
       it('checks $scope.caseStatusOptions', function () {
-        expect(element.isolateScope().caseStatusOptions).toEqual(jasmine.any(Object));
+        expect($scope.caseStatusOptions).toEqual(jasmine.any(Object));
       });
 
       it('checks $scope.customGroups', function () {
-        expect(element.isolateScope().customGroups).toEqual(jasmine.any(Object));
+        expect($scope.customGroups).toEqual(jasmine.any(Object));
       });
 
       it('checks $scope.caseRelationshipOptions', function () {
-        expect(element.isolateScope().caseRelationshipOptions).toEqual(jasmine.any(Object));
+        expect($scope.caseRelationshipOptions).toEqual(jasmine.any(Object));
       });
 
       it('checks $scope.checkPerm', function () {
-        expect(element.isolateScope().checkPerm).toEqual(jasmine.any(Function));
+        expect($scope.checkPerm).toEqual(jasmine.any(Function));
       });
 
       it('checks $scope.filterDescription', function () {
-        expect(element.isolateScope().filterDescription).toEqual(jasmine.any(Array));
+        expect($scope.filterDescription).toEqual(jasmine.any(Array));
       });
 
       it('checks $scope.filters', function () {
-        expect(element.isolateScope().filterDescription).toEqual(jasmine.any(Object));
+        expect($scope.filterDescription).toEqual(jasmine.any(Object));
       });
     });
 
@@ -79,195 +76,55 @@
       describe('when updating the relationship types', function () {
         describe('when I am the case manager', function () {
           beforeEach(function () {
-            element.isolateScope().relationshipType = ['is_case_manager'];
+            $scope.relationshipType = ['is_case_manager'];
             $scope.$digest();
           });
 
           it('sets the case manager filter equal to my id', function () {
-            expect(element.isolateScope().filters.case_manager).toEqual([CRM.config.user_contact_id]);
+            expect($scope.filters.case_manager).toEqual([CRM.config.user_contact_id]);
           });
         });
 
         describe('when I am involved in the case', function () {
           beforeEach(function () {
-            element.isolateScope().relationshipType = ['is_involved'];
+            $scope.relationshipType = ['is_involved'];
             $scope.$digest();
           });
 
           it('sets the contact id filter equal to my id', function () {
-            expect(element.isolateScope().filters.contact_id).toEqual([CRM.config.user_contact_id]);
+            expect($scope.filters.contact_id).toEqual([CRM.config.user_contact_id]);
           });
         });
       });
 
       describe('$scope.filters', function () {
         beforeEach(function () {
-          originalDoSearch = element.isolateScope().doSearch;
-          element.isolateScope().doSearch = jasmine.createSpy('doSearch');
-          element.isolateScope().filters = CaseFilters.filter;
+          originalDoSearch = $scope.doSearch;
+          $scope.doSearch = jasmine.createSpy('doSearch');
+          $scope.filters = CaseFilters.filter;
         });
 
         afterEach(function () {
-          element.isolateScope().doSearch = originalDoSearch;
+          $scope.doSearch = originalDoSearch;
         });
 
         describe('when $scope.expanded is false', function () {
           beforeEach(function () {
-            element.isolateScope().expanded = false;
+            $scope.expanded = false;
             $scope.$digest();
           });
           it('calls $scope.doSearch()', function () {
-            expect(element.isolateScope().doSearch).toHaveBeenCalled();
+            expect($scope.doSearch).toHaveBeenCalled();
           });
         });
         describe('when $scope.expanded is true', function () {
           beforeEach(function () {
-            element.isolateScope().expanded = true;
+            $scope.expanded = true;
             $scope.$digest();
           });
           it('does not calls $scope.doSearch()', function () {
-            expect(element.isolateScope().doSearch).not.toHaveBeenCalled();
+            expect($scope.doSearch).not.toHaveBeenCalled();
           });
-        });
-      });
-    });
-
-    describe('toggleIsDeleted($event)', function () {
-      describe('when is_deleted is true', function () {
-        beforeEach(function () {
-          element.isolateScope().filters.is_deleted = true;
-        });
-
-        describe('click event triggered', function () {
-          beforeEach(function () {
-            event = $.Event('click');
-            spyOn(event, 'preventDefault');
-            element.find('.civicase__checkbox').trigger(event);
-          });
-
-          it('hides the checkbox', function () {
-            expect(element.find('.civicase__checkbox').find('.civicase__checkbox--checked').length).toBe(0);
-          });
-
-          it('event.preventDefault to be called', function () {
-            expect(event.preventDefault).toHaveBeenCalled();
-          });
-        });
-
-        describe('Enter button is pressed', function () {
-          beforeEach(function () {
-            event = $.Event('keydown', {keyCode: 13});
-            spyOn(event, 'preventDefault');
-            element.find('.civicase__checkbox').trigger(event);
-          });
-
-          it('hides the checkbox', function () {
-            expect(element.find('.civicase__checkbox').find('.civicase__checkbox--checked').length).toBe(0);
-          });
-
-          it('event.preventDefault to be called', function () {
-            expect(event.preventDefault).toHaveBeenCalled();
-          });
-        });
-
-        describe('Space button is pressed', function () {
-          beforeEach(function () {
-            event = $.Event('keydown', {keyCode: 32});
-            spyOn(event, 'preventDefault');
-            element.find('.civicase__checkbox').trigger(event);
-          });
-
-          it('hides the checkbox', function () {
-            expect(element.find('.civicase__checkbox').find('.civicase__checkbox--checked').length).toBe(0);
-          });
-
-          it('event.preventDefault to be called', function () {
-            expect(event.preventDefault).toHaveBeenCalled();
-          });
-        });
-      });
-
-      describe('when is_deleted is false', function () {
-        beforeEach(function () {
-          element.isolateScope().filters.is_deleted = false;
-        });
-
-        describe('click event triggered', function () {
-          beforeEach(function () {
-            event = $.Event('click');
-            spyOn(event, 'preventDefault');
-            element.find('.civicase__checkbox').trigger(event);
-          });
-
-          it('shows the checkbox', function () {
-            expect(element.find('.civicase__checkbox').find('.civicase__checkbox--checked').length).toBe(1);
-          });
-
-          it('event.preventDefault to be called', function () {
-            expect(event.preventDefault).toHaveBeenCalled();
-          });
-        });
-
-        describe('Enter button is pressed', function () {
-          beforeEach(function () {
-            event = $.Event('keydown', {keyCode: 13});
-            spyOn(event, 'preventDefault');
-            element.find('.civicase__checkbox').trigger(event);
-          });
-
-          it('shows the checkbox', function () {
-            expect(element.find('.civicase__checkbox').find('.civicase__checkbox--checked').length).toBe(1);
-          });
-
-          it('event.preventDefault to be called', function () {
-            expect(event.preventDefault).toHaveBeenCalled();
-          });
-        });
-
-        describe('Space button is pressed', function () {
-          beforeEach(function () {
-            event = $.Event('keydown', {keyCode: 32});
-            spyOn(event, 'preventDefault');
-            element.find('.civicase__checkbox').trigger(event);
-          });
-
-          it('shows the checkbox', function () {
-            expect(element.find('.civicase__checkbox').find('.civicase__checkbox--checked').length).toBe(1);
-          });
-
-          it('event.preventDefault to be called', function () {
-            expect(event.preventDefault).toHaveBeenCalled();
-          });
-        });
-      });
-    });
-
-    describe('isEnabled(field)', function () {
-      describe('when hiddenFilters are enabled', function () {
-        it('should return false', function () {
-          expect(element.isolateScope().isEnabled('hiddenfilter1')).toBe(false);
-        });
-
-        it('should return true', function () {
-          expect(element.isolateScope().isEnabled('hiddenfilter3')).toBe(true);
-        });
-      });
-
-      describe('when no hiddenfilters', function () {
-        beforeEach(function () {
-          element.isolateScope().hiddenFilters = undefined;
-        });
-
-        afterEach(function () {
-          element.isolateScope().hiddenFilters = CaseFilters.hiddenFilters;
-        });
-
-        it('should return true', function () {
-          expect(element.isolateScope().isEnabled('hiddenfilter1')).toBe(true);
-        });
-
-        it('should return true', function () {
-          expect(element.isolateScope().isEnabled('hiddenfilter3')).toBe(true);
         });
       });
     });
@@ -275,32 +132,32 @@
     describe('caseManagerIsMe()', function () {
       describe('when case_manager is me', function () {
         beforeEach(function () {
-          element.isolateScope().filters.case_manager = [203];
+          $scope.filters.case_manager = [203];
         });
 
         it('should return true', function () {
-          expect(element.isolateScope().caseManagerIsMe()).toBe(true);
+          expect($scope.caseManagerIsMe()).toBe(true);
         });
       });
 
       describe('when case_manager is not me', function () {
         describe('when case id is different', function () {
           beforeEach(function () {
-            element.isolateScope().filters.case_manager = [201];
+            $scope.filters.case_manager = [201];
           });
 
           it('should return false', function () {
-            expect(element.isolateScope().caseManagerIsMe()).toBe(false);
+            expect($scope.caseManagerIsMe()).toBe(false);
           });
         });
 
         describe('when case id undefined', function () {
           beforeEach(function () {
-            element.isolateScope().filters.case_manager = undefined;
+            $scope.filters.case_manager = undefined;
           });
 
           it('should return undefined', function () {
-            expect(element.isolateScope().caseManagerIsMe()).toBeUndefined();
+            expect($scope.caseManagerIsMe()).toBeUndefined();
           });
         });
       });
@@ -308,72 +165,66 @@
 
     describe('doSearch()', function () {
       beforeEach(function () {
-        orginalParentScope = element.isolateScope().$parent;
-        element.isolateScope().$parent = {};
-        element.isolateScope().$parent.$eval = jasmine.createSpy('eval');
+        orginalParentScope = $scope.$parent;
+        $scope.$parent = {};
       });
 
       beforeEach(function () {
-        element.isolateScope().expanded = true;
-        element.isolateScope().filters.contact_id = [203];
-        element.isolateScope().doSearch();
+        $scope.expanded = true;
+        $scope.filters.contact_id = [203];
+        $scope.doSearch();
       });
 
       afterEach(function () {
-        element.isolateScope().$parent = orginalParentScope;
+        $scope.$parent = orginalParentScope;
       });
 
       it('should build filter description', function () {
-        expect(element.isolateScope().filterDescription).toEqual([ { label: 'Case Client', text: '1 selected' } ]);
+        expect($scope.filterDescription).toEqual([ { label: 'Case Client', text: '1 selected' } ]);
       });
 
       it('should close the dropdown', function () {
-        expect(element.isolateScope().expanded).toBe(false);
-      });
-
-      it('should call $eval', function () {
-        expect(element.isolateScope().$parent.$eval).toHaveBeenCalledWith('applyAdvSearch(selectedFilters)', jasmine.objectContaining({selectedFilters: jasmine.any(Object)}));
+        expect($scope.expanded).toBe(false);
       });
     });
 
     describe('clearSearch()', function () {
       beforeEach(function () {
-        originalDoSearch = element.isolateScope().doSearch;
-        element.isolateScope().doSearch = jasmine.createSpy('doSearch');
-        element.isolateScope().filters = CaseFilters.filter;
-        element.isolateScope().clearSearch();
+        originalDoSearch = $scope.doSearch;
+        $scope.doSearch = jasmine.createSpy('doSearch');
+        $scope.filters = CaseFilters.filter;
+        $scope.clearSearch();
       });
 
       afterEach(function () {
-        element.isolateScope().doSearch = originalDoSearch;
+        $scope.doSearch = originalDoSearch;
       });
 
       it('clears filters object', function () {
-        expect(element.isolateScope().filters).toEqual({});
+        expect($scope.filters).toEqual({});
       });
 
       it('calls doSearch()', function () {
-        expect(element.isolateScope().doSearch).toHaveBeenCalled();
+        expect($scope.doSearch).toHaveBeenCalled();
       });
     });
 
     describe('mapSelectOptions()', function () {
       it('returns a mapped response', function () {
-        expect(element.isolateScope().caseTypeOptions[0]).toEqual(jasmine.objectContaining({id: jasmine.any(String), text: jasmine.any(String), color: jasmine.any(String), icon: jasmine.any(String)}));
+        expect($scope.caseTypeOptions[0]).toEqual(jasmine.objectContaining({id: jasmine.any(String), text: jasmine.any(String), color: jasmine.any(String), icon: jasmine.any(String)}));
       });
     });
 
     /**
-     * Function responsible for setting up compilation of the directive
-     * @param {Object} Case card object
+     * Initiate controller
      */
-    function compileDirective () {
+    function initController () {
       $scope.filters = {};
-      $scope.hiddenFilters = CaseFilters.hiddenFilters;
       $scope.searchIsOpentrue = true;
       $scope.applyAdvSearch = function () { };
-      element = $compile('<civicase-search filters="filters" hidden-filters="hiddenFilters" expanded="searchIsOpen" on-search="applyAdvSearch(selectedFilters)"></civicase-search>')($scope);
-      $scope.$digest();
+      $controller('civicaseSearchController', {
+        $scope: $scope
+      });
     }
   });
 }(CRM.$));


### PR DESCRIPTION
## Overview 
PR covers fix for URL being read by the case list filter after reloading it or going directly on it.

## Before
![c51-323 - before](https://user-images.githubusercontent.com/3340537/47652054-e7855b80-dbaa-11e8-9be8-8c7e3085320b.gif)

## After
![c51-323 - after](https://user-images.githubusercontent.com/3340537/47652075-f3711d80-dbaa-11e8-982c-18a0ed47a343.gif)

## Technical Details.

* The filter objects were binded to the routeparams to `CaseListTable` directive, but are also used by `Search.js`. 
Since they both are sibling to each other, they don't share the same scope (and also `filter` object).
* The solution to this was binding the route params to filter object in `Search.js` and make its member fns to use it and then fire `civicase::case-search::filters-updated` which will be caught by its other sibling `CaseListTable` and then the cases filters are updated there 

`CaseListTable.js`
```
      $scope.$on('civicase::case-search::filters-updated', function (event, filters) {
        $scope.applyAdvSearch(filters.selectedFilters);
      });


    $scope.applyAdvSearch = function (newFilters) {
      $scope.filters = newFilters;
      getAllCasesforSelectAll();
      getCases();
    };
```
`Search.js`
```
    /**
     * Setup filter params and call search API
     * to feed results for cases
     */
    $scope.doSearch = function () {
      $scope.filterDescription = buildDescription();
      $scope.expanded = false;
      $rootScope.$broadcast('civicase::case-search::filters-updated', {
        selectedFilters: formatSearchFilters($scope.filters)
      });
    };
      
$scope.$watchCollection('filters', filtersWatcher);
    function filtersWatcher () {
      if (!$scope.expanded) {
        $scope.doSearch();
      }
    }
```

Other logics used by filter are transferred to their respective controller.

For e.g. page title function is also moved to `Search.js`. It calculates the page title, when it listens to the `civicase::case-search::page-title-updated`, after its sibling Controller `CaseListTable.js`passes counts object to it.

