### PR TITLE
C51-318:Add API param to case list to fetch non-case-manager cases

### DIFF
--- a/Civi/CCase/Utils.php
+++ b/Civi/CCase/Utils.php
@@ -6,35 +6,14 @@ namespace Civi\CCase;
 class Utils {
 
   /**
-   * Add a case_manager join
-   *
-   * @param \CRM_Utils_SQL_Select $sql
-   * @param String $relationship
-   */
-  public static function joinOnRelationship($sql, $relationship) {
-    $caseTypeManagers = self::getRelationshipTypes($relationship);
-    $managerTypeClause = array();
-
-    foreach ($caseTypeManagers as $caseTypeId => $relationshipTypeIds) {
-      foreach ($relationshipTypeIds as $index => $relationshipTypeId) {
-        $managerTypeClause[] = "(a.case_type_id = $caseTypeId AND manager_relationship.relationship_type_id = $relationshipTypeId)";
-      }
-    }
-    $managerTypeClause = implode(' OR ', $managerTypeClause);
-    $sql->join('ccc', 'LEFT JOIN (SELECT * FROM civicrm_case_contact WHERE id IN (SELECT MIN(id) FROM civicrm_case_contact GROUP BY case_id)) AS ccc ON ccc.case_id = a.id');
-    $sql->join('manager_relationship', "LEFT JOIN civicrm_relationship AS manager_relationship ON ccc.contact_id = manager_relationship.contact_id_a AND manager_relationship.is_active AND ($managerTypeClause) AND manager_relationship.case_id = a.id");
-    $sql->join('manager', 'LEFT JOIN civicrm_contact AS manager ON manager_relationship.contact_id_b = manager.id AND manager.is_deleted <> 1');
-  }
-
-  /**
-   * Gets a list of manager roles for each case type.
+   * Gets a list of case roles (relationship) types foe each case type.
    *
    * @param String $type of relationship.
    *
    * @return array
    *   [caseTypeId => relationshipTypeId]
    */
-  public static function getRelationshipTypes($type) {
+  public static function getRelationshipTypesListByCaseRole($roleName) {
     $ret = array();
     $caseTypes = civicrm_api3('CaseType', 'get', array(
       'options' => array('limit' => 0),
@@ -47,19 +26,47 @@ class Utils {
     $relationshipTypes = \CRM_Utils_Array::rekey($relationshipTypes['values'], 'name_b_a');
 
     foreach ($caseTypes['values'] as $caseType) {
-      $lists = array();
+      $caseTypeToCaseRolesList = array();
       foreach ($caseType['definition']['caseRoles'] as $role) {
-        if ($type == 'all') {
-          $lists[] =  $relationshipTypes[$role['name']]['id'];
+        if ($roleName == 'all') {
+          $caseTypeToCaseRolesList[] =  $relationshipTypes[$role['name']]['id'];
         } else {
-          if (!empty($role[$type])) {
-            $lists[] = $relationshipTypes[$role['name']]['id'];
+          if (!empty($role[$roleName])) {
+            $caseTypeToCaseRolesList[] = $relationshipTypes[$role['name']]['id'];
           }
         }
       }
-      $ret[$caseType['id']] = $lists;
+      $ret[$caseType['id']] = $caseTypeToCaseRolesList;
     }
+
     return $ret;
+  }
+
+
+  /**
+   * Adds a join with relationships
+   * This is done to get all records where the relationship is associated with a case.
+   *
+   * @param \CRM_Utils_SQL_Select $sql
+   * @param String $relationship
+   */
+  public static function joinOnRelationship($sql, $relationship) {
+    $caseTypeToRelationshipList = self::getRelationshipTypesListByCaseRole($relationship);
+    $relationshipTypeClause = array();
+
+    foreach ($caseTypeToRelationshipList as $caseTypeId => $relationshipTypeIds) {
+      foreach ($relationshipTypeIds as $index => $relationshipTypeId) {
+        $relationshipTypeClause[] = "(a.case_type_id = {$caseTypeId} AND manager_relationship.relationship_type_id = {$relationshipTypeId})";
+      }
+    }
+    // Creates  OR relationship string with the casetype <-> relationship list.
+    $relationshipTypeClause = implode(' OR ', $relationshipTypeClause);
+    // Selects uniques cases<->contact link/relationship for each case
+    $sql->join('ccc', 'LEFT JOIN (SELECT * FROM civicrm_case_contact WHERE id IN (SELECT MIN(id) FROM civicrm_case_contact GROUP BY case_id)) AS ccc ON ccc.case_id = a.id');
+    // Joins (get records) where the relationship type clause (case-type <-> relationship type)  lies in relation a to b)
+    $sql->join('manager_relationship', "LEFT JOIN civicrm_relationship AS manager_relationship ON ccc.contact_id = manager_relationship.contact_id_a AND manager_relationship.is_active AND ({$relationshipTypeClause}) AND manager_relationship.case_id = a.id");
+    // Join where selected contact lie in relationship b to a  (case_manager)
+    $sql->join('manager', 'LEFT JOIN civicrm_contact AS manager ON manager_relationship.contact_id_b = manager.id AND manager.is_deleted <> 1');
   }
 
   /**

--- a/Civi/CCase/Utils.php
+++ b/Civi/CCase/Utils.php
@@ -28,7 +28,7 @@ class Utils {
     foreach ($caseTypes['values'] as $caseType) {
       $caseTypeToCaseRolesList = array();
       foreach ($caseType['definition']['caseRoles'] as $role) {
-        if ($roleName == 'all') {
+        if ($roleName == 'involved') {
           $caseTypeToCaseRolesList[] =  $relationshipTypes[$role['name']]['id'];
         } else {
           if (!empty($role[$roleName])) {
@@ -56,17 +56,17 @@ class Utils {
 
     foreach ($caseTypeToRelationshipList as $caseTypeId => $relationshipTypeIds) {
       foreach ($relationshipTypeIds as $index => $relationshipTypeId) {
-        $relationshipTypeClause[] = "(a.case_type_id = {$caseTypeId} AND manager_relationship.relationship_type_id = {$relationshipTypeId})";
+        $relationshipTypeClause[] = "(a.case_type_id = {$caseTypeId} AND {$relationship}_relationship.relationship_type_id = {$relationshipTypeId})";
       }
     }
     // Creates  OR relationship string with the casetype <-> relationship list.
     $relationshipTypeClause = implode(' OR ', $relationshipTypeClause);
     // Selects uniques cases<->contact link/relationship for each case
-    $sql->join('ccc', 'LEFT JOIN (SELECT * FROM civicrm_case_contact WHERE id IN (SELECT MIN(id) FROM civicrm_case_contact GROUP BY case_id)) AS ccc ON ccc.case_id = a.id');
+    $sql->join("ccc", "LEFT JOIN (SELECT * FROM civicrm_case_contact WHERE id IN (SELECT MIN(id) FROM civicrm_case_contact GROUP BY case_id)) AS ccc ON ccc.case_id = a.id");
     // Joins (get records) where the relationship type clause (case-type <-> relationship type)  lies in relation a to b)
-    $sql->join('manager_relationship', "LEFT JOIN civicrm_relationship AS manager_relationship ON ccc.contact_id = manager_relationship.contact_id_a AND manager_relationship.is_active AND ({$relationshipTypeClause}) AND manager_relationship.case_id = a.id");
+    $sql->join("{$relationship}_relationship", "LEFT JOIN civicrm_relationship AS {$relationship}_relationship ON ccc.contact_id = {$relationship}_relationship.contact_id_a AND {$relationship}_relationship.is_active AND ({$relationshipTypeClause}) AND {$relationship}_relationship.case_id = a.id");
     // Join where selected contact lie in relationship b to a  (case_manager)
-    $sql->join('manager', 'LEFT JOIN civicrm_contact AS manager ON manager_relationship.contact_id_b = manager.id AND manager.is_deleted <> 1');
+    $sql->join("{$relationship}", "LEFT JOIN civicrm_contact AS {$relationship} ON {$relationship}_relationship.contact_id_b = {$relationship}.id AND {$relationship}.is_deleted <> 1");
   }
 
   /**

--- a/ang/civicase/CaseListTable.js
+++ b/ang/civicase/CaseListTable.js
@@ -300,7 +300,7 @@
         }
       });
       // Filter out deleted contacts
-      if (!params.contact_id) {
+      if (!params.contact_involved) {
         params.contact_is_deleted = 0;
       }
       // If no status specified, default to all open cases

--- a/ang/civicase/Dashboard.js
+++ b/ang/civicase/Dashboard.js
@@ -59,8 +59,8 @@
         : delete ($scope.activityFilters.case_filter.case_manager);
 
       newValue === 'is_involved'
-        ? $scope.activityFilters.case_filter.contact_id = [CRM.config.user_contact_id]
-        : delete ($scope.activityFilters.case_filter.contact_id);
+        ? $scope.activityFilters.case_filter.contact_involved = {'IN': [CRM.config.user_contact_id]}
+        : delete ($scope.activityFilters.case_filter.contact_involved);
     }
 
     /**

--- a/ang/civicase/Search.js
+++ b/ang/civicase/Search.js
@@ -252,7 +252,7 @@
     function relationshipTypeWatcher () {
       if ($scope.relationshipType) {
         $scope.relationshipType[0] === 'is_case_manager' ? $scope.filters.case_manager = [CRM.config.user_contact_id] : delete ($scope.filters.case_manager);
-        $scope.relationshipType[0] === 'is_involved' ? $scope.filters.contact_id = [CRM.config.user_contact_id] : delete ($scope.filters.contact_id);
+        $scope.relationshipType[0] === 'is_involved' ? $scope.filters.contact_involved = [CRM.config.user_contact_id] : delete ($scope.filters.contact_involved);
       }
     }
 

--- a/ang/test/civicase/Dashboard.spec.js
+++ b/ang/test/civicase/Dashboard.spec.js
@@ -71,7 +71,7 @@
 
         it('filters the cases and activties where the user is involved', function () {
           expect($scope.activityFilters.case_filter).toEqual(jasmine.objectContaining({
-            contact_id: [ CRM.config.user_contact_id ]
+            contact_involved: {'IN': [CRM.config.user_contact_id]}
           }));
         });
       });

--- a/ang/test/civicase/Search.spec.js
+++ b/ang/test/civicase/Search.spec.js
@@ -86,7 +86,7 @@
           });
 
           it('sets the contact id filter equal to my id', function () {
-            expect($scope.filters.contact_id).toEqual([CRM.config.user_contact_id]);
+            expect($scope.filters.contact_involved).toEqual([CRM.config.user_contact_id]);
           });
         });
       });

--- a/api/v3/Case/Getcaselist.php
+++ b/api/v3/Case/Getcaselist.php
@@ -16,7 +16,7 @@ function _civicrm_api3_case_getcaselist_spec(&$spec) {
 
   $spec['contact_involved'] = array(
     'title' => 'Contact Involved',
-    'description' => 'Contact id of the contact involved as case roles',
+    'description' => 'Id of the contact involved as case roles',
     'type' => CRM_Utils_Type::T_INT,
   );
 

--- a/api/v3/Case/Getcaselist.php
+++ b/api/v3/Case/Getcaselist.php
@@ -14,6 +14,12 @@ function _civicrm_api3_case_getcaselist_spec(&$spec) {
     'type' => CRM_Utils_Type::T_INT,
   );
 
+  $spec['contact_involved'] = array(
+    'title' => 'Contact Involved',
+    'description' => 'Contact id of the contact involved as case roles',
+    'type' => CRM_Utils_Type::T_INT,
+  );
+
   $spec['contact_is_deleted'] = array(
     'title' => 'Contact Is Deleted',
     'description' => 'Set FALSE to filter out cases for deleted contacts, TRUE to return only cases of deleted contacts',

--- a/api/v3/Case/Getdetails.php
+++ b/api/v3/Case/Getdetails.php
@@ -40,7 +40,7 @@ function _civicrm_api3_case_getdetails_spec(&$spec) {
  */
 function _civicrm_api3_case_add_contact_involved_clause($params, &$sql) {
   $caseClient = CRM_Core_DAO::createSQLFilter('contact_id', $params['contact_involved']);
-  $nonCaseClient = CRM_Core_DAO::createSQLFilter('manager.id', $params['contact_involved']);
+  $nonCaseClient = CRM_Core_DAO::createSQLFilter('involved.id', $params['contact_involved']);
   $sql->where("a.id IN (SELECT case_id FROM civicrm_case_contact WHERE ($nonCaseClient OR $caseClient))");
 }
 
@@ -80,7 +80,7 @@ function civicrm_api3_case_getdetails($params) {
     if (!is_array($params['contact_involved'])) {
       $params['contact_involved'] = array('=' => $params['contact_involved']);
     }
-    \Civi\CCase\Utils::joinOnRelationship($sql, 'all');
+    \Civi\CCase\Utils::joinOnRelationship($sql, 'involved');
     _civicrm_api3_case_add_contact_involved_clause($params, $sql);
   }
 

--- a/api/v3/Case/Getdetails.php
+++ b/api/v3/Case/Getdetails.php
@@ -17,6 +17,12 @@ function _civicrm_api3_case_getdetails_spec(&$spec) {
     'type' => CRM_Utils_Type::T_INT,
   );
 
+  $spec['contact_involved'] = array(
+    'title' => 'Contact Involved',
+    'description' => 'Contact id of the contact involved as case roles',
+    'type' => CRM_Utils_Type::T_INT,
+  );
+
   $spec['contact_is_deleted'] = array(
     'title' => 'Contact Is Deleted',
     'description' => 'Set FALSE to filter out cases for deleted contacts, TRUE to return only cases of deleted contacts',
@@ -52,8 +58,19 @@ function civicrm_api3_case_getdetails($params) {
     if (!is_array($params['case_manager'])) {
       $params['case_manager'] = array('=' => $params['case_manager']);
     }
-    \Civi\CCase\Utils::joinOnManager($sql);
+    \Civi\CCase\Utils::joinOnRelationship($sql, 'manager');
     $sql->where(CRM_Core_DAO::createSQLFilter('manager.id', $params['case_manager']));
+  }
+
+  // Add clause to search by non manager role and non client
+  if (!empty($params['contact_involved'])) {
+    if (!is_array($params['contact_involved'])) {
+      $params['contact_involved'] = array('=' => $params['contact_involved']);
+    }
+    \Civi\CCase\Utils::joinOnRelationship($sql, 'all');
+    $caseClient = CRM_Core_DAO::createSQLFilter('contact_id', $params['contact_involved']);
+    $nonCaseClient = CRM_Core_DAO::createSQLFilter('manager.id', $params['contact_involved']);
+    $sql->where("a.id IN (SELECT case_id FROM civicrm_case_contact WHERE ($nonCaseClient OR $caseClient))");
   }
 
   // Filter deleted contacts from results
@@ -232,7 +249,7 @@ function _civicrm_api3_case_getdetails_extrasort(&$params) {
         if (!array_key_exists($sortField, CRM_Contact_DAO_Contact::fieldKeys()) || ($dir != 'ASC' && $dir != 'DESC')) {
           throw new API_Exception("Unknown field specified for sort. Cannot order by '$sortString'");
         }
-        \Civi\CCase\Utils::joinOnManager($sql);
+        \Civi\CCase\Utils::joinOnRelationship($sql, 'manager');
         $sql->orderBy("manager.$sortField $dir", NULL, $index);
         $sortString = '(1)';
       }

--- a/api/v3/Case/Getstats.php
+++ b/api/v3/Case/Getstats.php
@@ -27,7 +27,7 @@ function civicrm_api3_case_getstats($params) {
   $query = CRM_Utils_SQL_Select::from('civicrm_case a');
   $query->select(array('a.case_type_id as case_type_id, a.status_id as status_id, COUNT(a.id) as count'));
   if (!empty($params['my_cases'])) {
-    \Civi\CCase\Utils::joinOnManager($query);
+    \Civi\CCase\Utils::joinOnRelationship($sql, 'manager');
     $query->where('manager.id = ' . CRM_Core_Session::getLoggedInContactID());
   }
   $query->groupBy('a.case_type_id, a.status_id');

--- a/api/v3/Case/Gettypestats.php
+++ b/api/v3/Case/Gettypestats.php
@@ -46,7 +46,7 @@ function civicrm_api3_case_gettypestats($params) {
   $query->select(array('a.case_type_id as case_type_id, a.status_id as status_id, COUNT(a.id) as count'));
   $query->select('avg(datediff(coalesce(a.end_date, date(now())), a.start_date)) AS average_duration');
   if (!empty($params['my_cases'])) {
-    \Civi\CCase\Utils::joinOnManager($query);
+    \Civi\CCase\Utils::joinOnRelationship($sql, 'manager');
     $query->where('manager.id = ' . CRM_Core_Session::getLoggedInContactID());
   }
   if (!empty($params['status_id.grouping'])) {


### PR DESCRIPTION
## Overview

This PR creates a new parameter `contact_involved` for the `getCaseDetails` and `getcaselist` endpoint for `case` entity. 
`contact_involved` returns all the cases for a contact in which the contact is involved as either a case client or with some other relationship.

## After 
![c51-318 after](https://user-images.githubusercontent.com/3340537/48048485-aea84080-e1c1-11e8-8290-3575ef53fa34.gif)


## Technical Details / Solution 

* Updated `getCaseManagerRelationshipTypes ` function to more generic one. which will get the casetype <-> case-relationship keys on basis of parameter passed
```php
 // prepares list of links between casetypeid <-> case relationship
  public static function getRelationshipTypes($type) {
  .....
  ....  
    foreach ($caseTypes['values'] as $caseType) {
      $lists = array();
      foreach ($caseType['definition']['caseRoles'] as $role) {
        if ($type == 'all') {
          $lists[] =  $relationshipTypes[$role['name']]['id'];
        } else {
          if (!empty($role[$type])) {
            $lists[] = $relationshipTypes[$role['name']]['id'];
          }
        }
      }
      $ret[$caseType['id']] = $lists;
    }
```

Now this list is again fed to another generic form of `JoinOnManager` function which creates a join on basis of the list links passed.
```php
  public static function joinOnRelationship($sql, $relationship) {
    $caseTypeManagers = self::getRelationshipTypes($relationship);
    $managerTypeClause = array();
    foreach ($caseTypeManagers as $caseTypeId => $relationshipTypeIds) {
      foreach ($relationshipTypeIds as $index => $relationshipTypeId) {
        $managerTypeClause[] = "(a.case_type_id = $caseTypeId AND manager_relationship.relationship_type_id = $relationshipTypeId)";
      }
    }
    $managerTypeClause = implode(' OR ', $managerTypeClause);
    $sql->join('ccc', 'LEFT JOIN (SELECT * FROM civicrm_case_contact WHERE id IN (SELECT MIN(id) FROM civicrm_case_contact GROUP BY case_id)) AS ccc ON ccc.case_id = a.id');
    $sql->join('manager_relationship', "LEFT JOIN civicrm_relationship AS manager_relationship ON ccc.contact_id = manager_relationship.contact_id_a AND manager_relationship.is_active AND ($managerTypeClause) AND manager_relationship.case_id = a.id");
    $sql->join('manager', 'LEFT JOIN civicrm_contact AS manager ON manager_relationship.contact_id_b = manager.id AND manager.is_deleted <> 1');
  }
```
This then called in according to the API params passed to the API end point 
```php
  // Add clause to search by non manager role and non client
  if (!empty($params['contact_involved'])) {
    if (!is_array($params['contact_involved'])) {
      $params['contact_involved'] = array('=' => $params['contact_involved']);
    }
    \Civi\CCase\Utils::joinOnRelationship($sql, 'all');
    $caseClient = CRM_Core_DAO::createSQLFilter('contact_id', $params['contact_involved']);
    $nonCaseClient = CRM_Core_DAO::createSQLFilter('manager.id', $params['contact_involved']);
    $sql->where("a.id IN (SELECT case_id FROM civicrm_case_contact WHERE ($nonCaseClient OR $caseClient))");
  }
```

### Frontend Changes
The frontend changes(https://github.com/compucorp/uk.co.compucorp.civicase/pull/102/commits/0492b93550058870960b2ed26659e066114cb85b) has been made to update the filter from `contact_id` to `contact_involved`
