### PR TITLE
C51-197: Hiding end-date filter when status is not in 'Resolved' cases

### DIFF
--- a/ang/civicase/Search.html
+++ b/ang/civicase/Search.html
@@ -34,8 +34,8 @@
         <label>{{ ts('Case Start Date') }}</label>
         <civicase-ui-date-range date-range="filters.start_date"></civicase-ui-date-range>
       </div>
-      <div  ng-if="isEnabled('end_date')" class="civicase__case-filter-form-elements">
-        <label> {{ ts('Case End Date') }}</label>
+      <div  ng-if="isEnabled('end_date') && filters.status_id.indexOf('Closed') > -1" class="civicase__case-filter-form-elements">
+        <label> {{ ts('Case End Date') }} </label>
         <civicase-ui-date-range date-range="filters.end_date"></civicase-ui-date-range>
       </div>
       <div class="civicase__case-filter-form-elements">


### PR DESCRIPTION
## Overview
 Hiding End Date filter when status filter is not resolved, and showing only when one of the status filter is resolved.

## Description
By default the case list shows all open cases, so filtering open cases with end date is kind of useless and will not shows any cases. Obviously, because an open case can't have an end date.
So, showing end date filter only when filtered cases status is `Resolved`.

## Before 
![c51- 197 - before](https://user-images.githubusercontent.com/3340537/47789832-a96b7180-dd3b-11e8-9caa-40a8ce7c764a.gif)


## After
![c51- 197 - after](https://user-images.githubusercontent.com/3340537/47789854-bc7e4180-dd3b-11e8-915a-b6e21fdb5799.gif)
