### PR TITLE
C51-333: Add Activity.getdayswithactivities endpoint

### DIFF
--- a/api/v3/Activity/Getdayswithactivities.php
+++ b/api/v3/Activity/Getdayswithactivities.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Activity.getdayswithactivities API specification
+ *
+ * @param array $spec description of fields supported by this API call
+ * @return void
+ */
+function _civicrm_api3_activity_getdayswithactivities_spec(&$spec) {
+  $allowed = ['activity_date_time', 'activity_status_id', 'case_id'];
+  $all = civicrm_api3('Activity', 'getfields', array('api_action' => 'get'))['values'];
+
+  $spec = array_filter($all, function ($name) use ($allowed) {
+    return in_array($name, $allowed);
+  }, ARRAY_FILTER_USE_KEY);
+}
+
+/**
+ * Returns list of unique YYYY-MM-DD dates with at least an activity
+ *
+ * @param array $params
+ *   Prameters to be passed to API call to obtain activities list
+ *
+ * @return array
+ *   API result with the list of days
+ */
+function civicrm_api3_activity_getdayswithactivities($params) {
+  $query = CRM_Utils_SQL_Select::from('civicrm_activity a');
+  $query->select(['a.activity_date_time']);
+
+  if (!empty($params['activity_date_time'])) {
+    _civicrm_api3_activity_getdayswithactivities_handle_id_param($params['activity_date_time'], 'a.activity_date_time', $query);
+  }
+
+  if (!empty($params['activity_status_id'])) {
+    _civicrm_api3_activity_getdayswithactivities_handle_id_param($params['activity_status_id'], 'a.status_id', $query);
+  }
+
+  if (!empty($params['case_id'])) {
+    $query->join('ca', "INNER JOIN civicrm_case_activity AS ca ON a.id = ca.activity_id");
+    _civicrm_api3_activity_getdayswithactivities_handle_id_param($params['case_id'], 'ca.case_id', $query);
+  }
+
+  $query->groupBy('a.activity_date_time');
+  $result = $query->execute()->fetchAll();
+
+  $uniqueDates = array_unique(array_map(function ($row) {
+    return explode(' ', $row['activity_date_time'])[0];
+  }, $result));
+
+  $params['sequential'] = 1;
+
+  return civicrm_api3_create_success($uniqueDates, $params, 'Activity', 'getdayswithactivities');
+}
+
+
+/**
+ * Creates a WHERE clause with th given API parameter and column name
+ *
+ * @param array $param
+ * @param string $param
+ * @param CRM_Utils_SQL_Select $param
+ */
+function _civicrm_api3_activity_getdayswithactivities_handle_id_param($param, $column, $query) {
+  $param = is_array($param) ? $param : array('=' => $param);
+
+  $query->where(CRM_Core_DAO::createSQLFilter($column, $param));
+}

--- a/api/v3/Activity/Getdayswithactivities.php
+++ b/api/v3/Activity/Getdayswithactivities.php
@@ -4,6 +4,7 @@
  * Activity.getdayswithactivities API specification
  *
  * @param array $spec description of fields supported by this API call
+ *
  * @return void
  */
 function _civicrm_api3_activity_getdayswithactivities_spec(&$spec) {
@@ -18,8 +19,7 @@ function _civicrm_api3_activity_getdayswithactivities_spec(&$spec) {
 /**
  * Returns list of unique YYYY-MM-DD dates with at least an activity
  *
- * @param array $params
- *   Prameters to be passed to API call to obtain activities list
+ * @param array $params parameters to be passed to API call to obtain activities list
  *
  * @return array
  *   API result with the list of days
@@ -55,7 +55,7 @@ function civicrm_api3_activity_getdayswithactivities($params) {
 
 
 /**
- * Creates a WHERE clause with th given API parameter and column name
+ * Creates a WHERE clause with the given API parameter and column name
  *
  * @param array $param
  * @param string $param


### PR DESCRIPTION
This PR adds a `getdayswithactivities` to the `Activity` entity. The endpoint is used to get the list of _unique_ YYYY-MM-DD dates that have at least one activity.

It supports the following parameters:
* `activity_date_time` 
* `activity_status_id`
* `case_id`

Example of a response:
```json
{
  "is_error": 0,
  "version": 3,
  "count": 534,
  "values": [
    "2008-01-10",
    "2008-02-01",
    "2008-02-05",
    "2008-03-05",
    "2008-03-11"
  ]
}
```