### PR TITLE
C51-334: Use Activity.getdayswithactivities in civicase-activities-calendar

### DIFF
--- a/ang/civicase/ActivitiesCalendar--decorator.js
+++ b/ang/civicase/ActivitiesCalendar--decorator.js
@@ -12,7 +12,7 @@
       datepicker.compile = function () {
         return function ($rootScope) {
           datepicker.link.apply(this, arguments);
-          $rootScope.$emit('uibDaypicker::compiled');
+          $rootScope.$emit('civicase::uibDaypicker::compiled');
         };
       };
 

--- a/ang/civicase/ActivitiesCalendar--decorator.js
+++ b/ang/civicase/ActivitiesCalendar--decorator.js
@@ -5,6 +5,17 @@
     $provide.decorator('uibDaypickerDirective', function ($controller, $delegate) {
       var datepicker = $delegate[0];
 
+      /**
+       * After the link function is executed, emits an event that signals
+       * that the directive is compiled and attached to the DOM
+       */
+      datepicker.compile = function () {
+        return function ($rootScope) {
+          datepicker.link.apply(this, arguments);
+          $rootScope.$emit('uibDaypicker::compiled');
+        };
+      };
+
       datepicker.controller = function ($scope, $element, dateFilter) {
         var vm = this;
 

--- a/ang/civicase/ActivitiesCalendar.js
+++ b/ang/civicase/ActivitiesCalendar.js
@@ -4,7 +4,6 @@
   module.directive('civicaseActivitiesCalendar', function ($timeout, $uibPosition) {
     return {
       scope: {
-        activities: '=',
         caseId: '=',
         refresh: '=refreshCallback'
       },
@@ -161,11 +160,6 @@
     };
 
     (function init () {
-      $scope.$watch('activities', function () {
-        $scope.selectedActivites = getSelectedActivities();
-
-        $scope.$broadcast('civicaseActivitiesCalendar::refreshDatepicker');
-      }, true);
     })();
 
     /**
@@ -173,23 +167,7 @@
      * selected date. Triggers when the calendar date changes.
      */
     $scope.onDateSelected = function () {
-      $scope.selectedActivites = getSelectedActivities();
-
-      if ($scope.selectedActivites.length) {
-        $scope.$emit('civicaseActivitiesCalendar::openActivitiesPopover');
-      }
     };
-
-    /**
-     * Returns the activities that belong to the given date.
-     *
-     * @param {Date} date
-     */
-    function getActivitiesForDate (date) {
-      return $scope.activities.filter(function (activity) {
-        return moment(activity.activity_date_time).isSame(date, 'day');
-      });
-    }
 
     /**
      * Returns the class that the given date should have depending on the status
@@ -201,60 +179,11 @@
      *   can be "day", "month", or "year".
      */
     function getDayCustomClass (params) {
-      var activities = getActivitiesForDate(params.date);
       var isInCurrentMonth = this.datepicker.activeDate.getMonth() === params.date.getMonth();
 
       if (!isInCurrentMonth && params.mode === 'day') {
         return 'invisible';
       }
-
-      if (activities.length === 0 || params.mode !== 'day') {
-        return;
-      }
-
-      if (haveAllActivitiesBeenCompleted(activities)) {
-        return 'civicase__activities-calendar__day-status civicase__activities-calendar__day-status--completed';
-      } else if (isAnyActivityOverdue(activities)) {
-        return 'civicase__activities-calendar__day-status civicase__activities-calendar__day-status--overdue';
-      } else {
-        return 'civicase__activities-calendar__day-status civicase__activities-calendar__day-status--scheduled';
-      }
-    }
-
-    /**
-     * Returns a list of selected activities for the currently selected date.
-     *
-     * @return {Array} a list of formatted activities.
-     */
-    function getSelectedActivities () {
-      return getActivitiesForDate($scope.selectedDate)
-        .map(function (activity) {
-          return formatActivity(activity, $scope.caseId);
-        });
-    }
-
-    /**
-     * Determines if all the given activities have been completed.
-     *
-     * @param {Array} activities
-     * @return {Boolean}
-     */
-    function haveAllActivitiesBeenCompleted (activities) {
-      return _.every(activities, function (activity) {
-        return _.includes(CRM.civicase.activityStatusTypes.completed, +activity.status_id);
-      });
-    }
-
-    /**
-     * Determines if at least one of the given activities is overdue.
-     *
-     * @param {Array} activities
-     * @return {Boolean}
-     */
-    function isAnyActivityOverdue (activities) {
-      return _.some(activities, function (activity) {
-        return activity.is_overdue;
-      });
     }
   }
 })(CRM.$, CRM._, angular);

--- a/ang/civicase/ActivitiesCalendar.js
+++ b/ang/civicase/ActivitiesCalendar.js
@@ -26,8 +26,8 @@
       var popoverArrow = popover.find('.arrow');
 
       (function init () {
-        $scope.$on('civicaseActivitiesCalendar::openActivitiesPopover', openActivitiesPopover);
-        $scope.$on('civicaseActivitiesCalendar::refreshDatepicker', function () {
+        $scope.$on('civicase::ActivitiesCalendar::openActivitiesPopover', openActivitiesPopover);
+        $scope.$on('civicase::ActivitiesCalendar::refreshDatepicker', function () {
           datepickerScope = datepickerScope || element.find('[uib-datepicker]').isolateScope();
 
           datepickerScope.datepicker.refreshView();
@@ -166,14 +166,14 @@
     };
 
     (function init () {
-      $rootScope.$on('uibDaypicker::compiled', function () {
+      $rootScope.$on('civicase::uibDaypicker::compiled', function () {
         loadDaysWithActivitiesIncomplete()
           .then(function () {
-            $scope.$emit('civicaseActivitiesCalendar::refreshDatepicker');
+            $scope.$emit('civicase::ActivitiesCalendar::refreshDatepicker');
           })
           .then(loadDaysWithActivitiesCompleted)
           .then(function () {
-            $scope.$emit('civicaseActivitiesCalendar::refreshDatepicker');
+            $scope.$emit('civicase::ActivitiesCalendar::refreshDatepicker');
           });
       });
     }());

--- a/ang/civicase/ActivitiesCalendar.js
+++ b/ang/civicase/ActivitiesCalendar.js
@@ -20,6 +20,7 @@
      * @param {Object} element
      */
     function civicaseActivitiesCalendarLink ($scope, element) {
+      var datepickerScope;
       var bootstrapThemeContainer = $('#bootstrap-theme');
       var popover = element.find('.activities-calendar-popover');
       var popoverArrow = popover.find('.arrow');
@@ -27,7 +28,7 @@
       (function init () {
         $scope.$on('civicaseActivitiesCalendar::openActivitiesPopover', openActivitiesPopover);
         $scope.$on('civicaseActivitiesCalendar::refreshDatepicker', function () {
-          var datepickerScope = element.find('[uib-datepicker]').isolateScope();
+          datepickerScope = datepickerScope || element.find('[uib-datepicker]').isolateScope();
 
           datepickerScope.datepicker.refreshView();
         });
@@ -149,7 +150,7 @@
 
   module.controller('civicaseActivitiesCalendarController', civicaseActivitiesCalendarController);
 
-  function civicaseActivitiesCalendarController ($scope, crmApi) {
+  function civicaseActivitiesCalendarController ($rootScope, $scope, crmApi) {
     var daysWithActivities = {};
 
     $scope.loading = false;
@@ -168,11 +169,17 @@
     (function init () {
       $scope.loading = true;
 
-      loadDaysWithActivitiesIncomplete()
-        .then(function () {
-          $scope.loading = false;
-        })
-        .then(loadDaysWithActivitiesCompleted);
+      $rootScope.$on('uibDaypicker::compiled', function () {
+        loadDaysWithActivitiesIncomplete()
+          .then(function () {
+            $scope.$emit('civicaseActivitiesCalendar::refreshDatepicker');
+            $scope.loading = false;
+          })
+          .then(loadDaysWithActivitiesCompleted)
+          .then(function () {
+            $scope.$emit('civicaseActivitiesCalendar::refreshDatepicker');
+          });
+      });
     }());
 
     /**

--- a/ang/civicase/ActivitiesCalendar.js
+++ b/ang/civicase/ActivitiesCalendar.js
@@ -153,7 +153,6 @@
   function civicaseActivitiesCalendarController ($rootScope, $scope, crmApi) {
     var daysWithActivities = {};
 
-    $scope.loading = false;
     $scope.selectedActivites = [];
     $scope.selectedDate = null;
     $scope.calendarOptions = {
@@ -167,13 +166,10 @@
     };
 
     (function init () {
-      $scope.loading = true;
-
       $rootScope.$on('uibDaypicker::compiled', function () {
         loadDaysWithActivitiesIncomplete()
           .then(function () {
             $scope.$emit('civicaseActivitiesCalendar::refreshDatepicker');
-            $scope.loading = false;
           })
           .then(loadDaysWithActivitiesCompleted)
           .then(function () {

--- a/ang/civicase/CaseDetails--tabs--summary.html
+++ b/ang/civicase/CaseDetails--tabs--summary.html
@@ -81,7 +81,6 @@
     </div>
     <div class="civicase__summary-tab-tile  panel civicase__panel-transparent-header civicase__summary-tab-tile--fixed">
       <civicase-activities-calendar
-        activities="item.allActivities"
         case-id="item.id"
         refresh-callback="refresh">
       </civicase-activities-calendar>
@@ -91,7 +90,7 @@
   <div class="clearfix civicase__summary-tab-tile-container">
     <div class="civicase__summary-tab-tile civicase__summary-tab__activity-list col-lg-6 col-md-12 panel civicase__panel-transparent-header" ng-include="'~/civicase/CaseDetails--tabs--summary--RecentCommunications.html'"></div>
     <div class="civicase__summary-tab-tile civicase__summary-tab__activity-list col-lg-6 col-md-12 panel civicase__panel-transparent-header" ng-include="'~/civicase/CaseDetails--tabs--summary--Tasks.html'"></div>
-  </div>  
+  </div>
   <!-- Other Cases -->
   <div ng-if="item && item.relatedCases.length" ng-include="'~/civicase/CaseDetails--other-cases.html'"></div>
   <!-- End - Other Cases -->

--- a/ang/test/civicase/ActivitiesCalendar.spec.js
+++ b/ang/test/civicase/ActivitiesCalendar.spec.js
@@ -19,16 +19,6 @@
       crmApi.and.returnValue($q.resolve({ values: [] }));
     }));
 
-    describe('on init', function () {
-      beforeEach(function () {
-        initController();
-      });
-
-      it('turns on the loading state', function () {
-        expect($scope.loading).toBe(true);
-      });
-    });
-
     describe('when uib-datepicker signals that it is ready', function () {
       beforeEach(function () {
         spyOn($scope, '$emit').and.callThrough();
@@ -52,10 +42,6 @@
         beforeEach(function () {
           crmApi.calls.reset();
           $scope.$digest();
-        });
-
-        it('turn off the loading state', function () {
-          expect($scope.loading).toBe(false);
         });
 
         it('loads the days with complete activities', function () {

--- a/ang/test/civicase/ActivitiesCalendar.spec.js
+++ b/ang/test/civicase/ActivitiesCalendar.spec.js
@@ -24,7 +24,7 @@
         spyOn($scope, '$emit').and.callThrough();
 
         initController();
-        $rootScope.$emit('uibDaypicker::compiled');
+        $rootScope.$emit('civicase::uibDaypicker::compiled');
       });
 
       it('starts loading the days with incomplete activities', function () {
@@ -53,7 +53,7 @@
 
         it('has triggered the datepicker refresh twice, one for each request', function () {
           _.times(2, function (i) {
-            expect($scope.$emit.calls.argsFor(i)[0]).toBe('civicaseActivitiesCalendar::refreshDatepicker');
+            expect($scope.$emit.calls.argsFor(i)[0]).toBe('civicase::ActivitiesCalendar::refreshDatepicker');
           });
         });
       });
@@ -195,7 +195,7 @@
        */
       function initControllerAndEmitDatepickerReadyEvent () {
         initController();
-        $rootScope.$emit('uibDaypicker::compiled');
+        $rootScope.$emit('civicase::uibDaypicker::compiled');
         $scope.$digest();
       }
 
@@ -264,7 +264,7 @@
         });
 
         it('does not open the activities popover', function () {
-          expect($scope.$emit).not.toHaveBeenCalledWith('civicaseActivitiesCalendar::openActivitiesPopover');
+          expect($scope.$emit).not.toHaveBeenCalledWith('civicase::ActivitiesCalendar::openActivitiesPopover');
         });
       });
     });
@@ -325,7 +325,7 @@
 
       describe('when the "open activities popover" event is emitted', function () {
         beforeEach(function () {
-          activitiesCalendar.isolateScope().$emit('civicaseActivitiesCalendar::openActivitiesPopover');
+          activitiesCalendar.isolateScope().$emit('civicase::ActivitiesCalendar::openActivitiesPopover');
           $timeout.flush();
         });
 
@@ -342,7 +342,7 @@
 
       describe('closing the popover', function () {
         beforeEach(function () {
-          activitiesCalendar.isolateScope().$emit('civicaseActivitiesCalendar::openActivitiesPopover');
+          activitiesCalendar.isolateScope().$emit('civicase::ActivitiesCalendar::openActivitiesPopover');
           $timeout.flush();
         });
 
@@ -388,7 +388,7 @@
 
             popover.width(100);
             $uibPosition.positionElements.and.returnValue(mockBodyOffset);
-            activitiesCalendar.isolateScope().$emit('civicaseActivitiesCalendar::openActivitiesPopover');
+            activitiesCalendar.isolateScope().$emit('civicase::ActivitiesCalendar::openActivitiesPopover');
             $timeout.flush();
           });
 

--- a/ang/test/civicase/ActivitiesCalendar.spec.js
+++ b/ang/test/civicase/ActivitiesCalendar.spec.js
@@ -2,18 +2,14 @@
 
 (function ($, _, moment) {
   describe('civicaseActivitiesCalendarController', function () {
-    var $controller, $scope, $rootScope, activitiesMockData,
-      dates, formatActivity, mockCaseId;
+    var $controller, $scope, $rootScope, dates, mockCaseId;
 
     beforeEach(module('civicase', 'civicase.data', 'ui.bootstrap'));
 
-    beforeEach(inject(function (_$controller_, _$rootScope_,
-      _activitiesMockData_, datesMockData, _formatActivity_) {
+    beforeEach(inject(function (_$controller_, _$rootScope_, datesMockData) {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
-      activitiesMockData = _activitiesMockData_.get();
       dates = datesMockData;
-      formatActivity = _formatActivity_;
     }));
 
     describe('calendar options', function () {
@@ -67,69 +63,9 @@
         });
       });
 
-      describe('when all the activities for the current date are completed', function () {
-        beforeEach(function () {
-          var activities = [
-            { activity_date_time: dates.today, status_id: _.sample(CRM.civicase.activityStatusTypes.completed) },
-            { activity_date_time: dates.today, status_id: _.sample(CRM.civicase.activityStatusTypes.completed) },
-            { activity_date_time: dates.today, status_id: _.sample(CRM.civicase.activityStatusTypes.completed) }
-          ];
-
-          initController(activities);
-
-          customClass = getDayCustomClass(dates.today);
-        });
-
-        it('marks the day as having completed all of its activities', function () {
-          expect(customClass).toBe('civicase__activities-calendar__day-status civicase__activities-calendar__day-status--completed');
-        });
-      });
-
-      describe('when all the activities for a given date in the past are completed', function () {
-        beforeEach(function () {
-          var activities = [
-            { activity_date_time: dates.yesterday, status_id: _.sample(CRM.civicase.activityStatusTypes.completed) },
-            { activity_date_time: dates.yesterday, status_id: _.sample(CRM.civicase.activityStatusTypes.completed) },
-            { activity_date_time: dates.yesterday, status_id: _.sample(CRM.civicase.activityStatusTypes.completed) }
-          ];
-
-          initController(activities);
-
-          customClass = getDayCustomClass(dates.yesterday);
-        });
-
-        it('marks the day as having completed all of its activities', function () {
-          expect(customClass).toBe('civicase__activities-calendar__day-status civicase__activities-calendar__day-status--completed');
-        });
-      });
-
-      describe('when all the activities for a given date in the future are completed', function () {
-        beforeEach(function () {
-          var activities = [
-            { activity_date_time: dates.tomorrow, status_id: _.sample(CRM.civicase.activityStatusTypes.completed) },
-            { activity_date_time: dates.tomorrow, status_id: _.sample(CRM.civicase.activityStatusTypes.completed) },
-            { activity_date_time: dates.tomorrow, status_id: _.sample(CRM.civicase.activityStatusTypes.completed) }
-          ];
-
-          initController(activities);
-
-          customClass = getDayCustomClass(dates.tomorrow);
-        });
-
-        it('marks the day as having completed all of its activities', function () {
-          expect(customClass).toBe('civicase__activities-calendar__day-status civicase__activities-calendar__day-status--completed');
-        });
-      });
-
       describe('when there are no activities for the given date', function () {
         beforeEach(function () {
-          var activities = [
-            { activity_date_time: dates.tomorrow },
-            { activity_date_time: dates.tomorrow },
-            { activity_date_time: dates.tomorrow }
-          ];
-
-          initController(activities);
+          initController();
 
           customClass = getDayCustomClass(dates.today);
         });
@@ -139,69 +75,9 @@
         });
       });
 
-      describe('when there is at least one activity that is overdue for a given date in the past', function () {
-        beforeEach(function () {
-          var activities = [
-            { activity_date_time: dates.yesterday, status_id: _.sample(CRM.civicase.activityStatusTypes.completed), is_overdue: false },
-            { activity_date_time: dates.yesterday, status_id: _.sample(CRM.civicase.activityStatusTypes.completed), is_overdue: false },
-            { activity_date_time: dates.yesterday, status_id: _.sample(CRM.civicase.activityStatusTypes.incomplete), is_overdue: true }
-          ];
-
-          initController(activities);
-
-          customClass = getDayCustomClass(dates.yesterday);
-        });
-
-        it('marks the day as having overdue activities', function () {
-          expect(customClass).toBe('civicase__activities-calendar__day-status civicase__activities-calendar__day-status--overdue');
-        });
-      });
-
-      describe('when there is at least one activity that is overdue for a given date in the future', function () {
-        beforeEach(function () {
-          var activities = [
-            { activity_date_time: dates.tomorrow, status_id: _.sample(CRM.civicase.activityStatusTypes.completed) },
-            { activity_date_time: dates.tomorrow, status_id: _.sample(CRM.civicase.activityStatusTypes.completed) },
-            { activity_date_time: dates.tomorrow, status_id: _.sample(CRM.civicase.activityStatusTypes.incomplete) }
-          ];
-
-          initController(activities);
-
-          customClass = getDayCustomClass(dates.tomorrow);
-        });
-
-        it('marks the day as having scheduled activities', function () {
-          expect(customClass).toBe('civicase__activities-calendar__day-status civicase__activities-calendar__day-status--scheduled');
-        });
-      });
-
-      describe('when there is at least one activity that is overdue for the current date', function () {
-        beforeEach(function () {
-          var activities = [
-            { activity_date_time: dates.today, status_id: _.sample(CRM.civicase.activityStatusTypes.completed) },
-            { activity_date_time: dates.today, status_id: _.sample(CRM.civicase.activityStatusTypes.completed) },
-            { activity_date_time: dates.today, status_id: _.sample(CRM.civicase.activityStatusTypes.incomplete) }
-          ];
-
-          initController(activities);
-
-          customClass = getDayCustomClass(dates.today);
-        });
-
-        it('marks the day as having scheduled activities', function () {
-          expect(customClass).toBe('civicase__activities-calendar__day-status civicase__activities-calendar__day-status--scheduled');
-        });
-      });
-
       describe('when the date is outside this month', function () {
         beforeEach(function () {
-          var activities = [
-            { activity_date_time: dates.tomorrow, status_id: _.sample(CRM.civicase.activityStatusTypes.completed) },
-            { activity_date_time: dates.tomorrow, status_id: _.sample(CRM.civicase.activityStatusTypes.completed) },
-            { activity_date_time: dates.tomorrow, status_id: _.sample(CRM.civicase.activityStatusTypes.incomplete) }
-          ];
-
-          initController(activities);
+          initController();
 
           customClass = getDayCustomClass(moment(dates.today).add(1, 'month').toDate());
         });
@@ -240,33 +116,6 @@
         initController();
       });
 
-      describe('when selecting a date with activities included', function () {
-        var expectedSelectedActivities;
-
-        beforeEach(function () {
-          spyOn($scope, '$emit').and.callThrough();
-
-          expectedSelectedActivities = activitiesMockData
-            .filter(function (activity) {
-              return moment(activity.activity_date_time).isSame(dates.today, 'day');
-            })
-            .map(function (activity) {
-              return formatActivity(activity, mockCaseId);
-            });
-
-          $scope.selectedDate = dates.today;
-          $scope.onDateSelected();
-        });
-
-        it('only provides the activities for the given date', function () {
-          expect($scope.selectedActivites).toEqual(expectedSelectedActivities);
-        });
-
-        it('opens the activities popover', function () {
-          expect($scope.$emit).toHaveBeenCalledWith('civicaseActivitiesCalendar::openActivitiesPopover');
-        });
-      });
-
       describe('when selecting a date with no activities included', function () {
         beforeEach(function () {
           spyOn($scope, '$emit').and.callThrough();
@@ -283,38 +132,15 @@
           expect($scope.$emit).not.toHaveBeenCalledWith('civicaseActivitiesCalendar::openActivitiesPopover');
         });
       });
-
-      describe('when the activities object is updated', function () {
-        beforeEach(function () {
-          var mockActivity = _.chain(activitiesMockData).first().clone().value();
-          mockActivity.activity_date_time = dates.nextWeek;
-          $scope.selectedDate = dates.nextWeek;
-
-          $scope.onDateSelected();
-
-          $scope.activities = [mockActivity];
-
-          $scope.$digest();
-        });
-
-        it('updates the selected activities', function () {
-          expect($scope.selectedActivites).toEqual($scope.activities);
-        });
-      });
     });
 
     /**
-     * Initializes the activities calendar component. Passes the given activities
-     * as a binding. If no activities are provided it passes an empty array.
-     *
-     * @param {Array} activities.
+     * Initializes the activities calendar component
      */
-    function initController (activities) {
+    function initController () {
       $scope = $rootScope.$new();
-      activities = activities || activitiesMockData;
       mockCaseId = _.uniqueId();
 
-      $scope.activities = activities;
       $scope.caseId = mockCaseId;
 
       $controller('civicaseActivitiesCalendarController', { $scope: $scope });
@@ -322,7 +148,7 @@
   });
 
   describe('Activities Calendar DOM Events', function () {
-    var $compile, $rootScope, $scope, $timeout, $uibPosition, activitiesMockData, activitiesCalendar, datepickerMock;
+    var $compile, $rootScope, $scope, $timeout, $uibPosition, activitiesCalendar, datepickerMock;
 
     beforeEach(module('civicase', 'civicase.data', 'civicase.templates', function ($compileProvider, $provide) {
       $uibPosition = jasmine.createSpyObj('$uibPosition', ['positionElements']);
@@ -341,11 +167,10 @@
       });
     }));
 
-    beforeEach(inject(function (_$compile_, _$rootScope_, _$timeout_, _activitiesMockData_) {
+    beforeEach(inject(function (_$compile_, _$rootScope_, _$timeout_) {
       $compile = _$compile_;
       $rootScope = _$rootScope_;
       $timeout = _$timeout_;
-      activitiesMockData = _activitiesMockData_.get();
 
       $('<div id="bootstrap-theme"></div>').appendTo('body');
     }));
@@ -453,25 +278,6 @@
       });
     });
 
-    describe('when the activities are updated', function () {
-      beforeEach(inject(function (datesMockData) {
-        var activities = [
-          { activity_date_time: datesMockData.today, status_id: _.sample(CRM.civicase.activityStatusTypes.scheduled) }
-        ];
-
-        initDirective(activities);
-        datepickerMock.refreshView.calls.reset();
-
-        $scope.activities[0].status_id = _.sample(CRM.civicase.activityStatusTypes.completed);
-
-        $scope.$digest();
-      }));
-
-      it('refreshes the datepicker so it displays the new activity statuses', function () {
-        expect(datepickerMock.refreshView).toHaveBeenCalledWith();
-      });
-    });
-
     /**
      * Appends a mock calendar table element inside the uib-datepicker element.
      */
@@ -532,11 +338,9 @@
      */
     function initDirective (activities) {
       var html = `<civicase-activities-calendar
-        activities="activities"
         refresh-callback="refresh">
       </civicase-activities-calendar>`;
       $scope = $rootScope.$new();
-      $scope.activities = activities || activitiesMockData;
       $scope.refresh = _.noop;
       activitiesCalendar = $compile(html)($scope);
 


### PR DESCRIPTION
_(Note: To reduce the scope of the tickets and PRs, the refactoring of the calendar has been split into two separate tasks, this one being the first of them. To avoid merging an incomplete calendar to `develop`, a `C51-refactor-activities-calendar` branch has been created in which the two tasks will be merged, so that the calendar will be release on `develop` only once it has been fully refactored)_

This PR utilizes the new `Activity.getdayswithactivities` endpoint (#110), to fetch the data necessary for the calendar to display the due/overdue/completed dots under each day

This is the flow:
1. The `uib-datepicker`'s link function has been decorated so that a `civicase::uibDaypicker::compiled` event is emitted when the directive has been compiled and attached to the DOM
2. The Activities Calendar controller listens for that event and, when received, it makes two requests
    1. Days with incomplete activities
    2. Days with complete activities
    ```js
    $rootScope.$on('civicase::uibDaypicker::compiled', function () {
      loadDaysWithActivitiesIncomplete()
        .then(function () {
          $scope.$emit('civicase::ActivitiesCalendar::refreshDatepicker');
        })
        .then(loadDaysWithActivitiesCompleted)
        .then(function () {
          $scope.$emit('civicase::ActivitiesCalendar::refreshDatepicker');
        });
    });
    ```
    The second request is triggered only _after_ the first one is completed. This is because, in case there is a very large number of activities for a given month (could be up to 400K), we want to deliver the critical data to the user (= days with incomplete activities) as fast as possible, and only later less important data
3. Every day returned by both response is then processed by the controller and placed in the internal `daysWithActivities` object: if a day has been returned by the first request, is marked with `{ status: 'incomplete' }`, otherwise it's marked with `{ status: 'completed' }`. If a day is returned by _both_ requests, then that date is kept marked as "incomplete"
    ```js
    function addDays (days, status) {
      days.values.reduce(function (acc, val) {
        acc[val] = acc[val] && acc[val].status === 'incomplete'
          ? acc[val]
          : { status: status };

        return acc;
      }, daysWithActivities);
    }
    ```
4. Each request, when completed, emits the `civicaseActivitiesCalendar::refreshDatepicker` event, so that the Activities Calendar's `link` function can refresh the view and show the dots
    ```js
    scope.$on('civicaseActivitiesCalendar::refreshDatepicker', function () {
      datepickerScope = datepickerScope || element.find('[uib-datepicker]').isolateScope();
      datepickerScope.datepicker.refreshView();
    });
    ```
5. The different dots are still applies by the `getDayCustomClass` function, but the logic is slightly different. For each date passed to the function by the datepicker, the function checks if there is an equivalent day stored in `daysWithActivities`. If there is, then the status assigned to the day and the current day determines which dot is applied to the day:
    ```js
    function getDayCustomClass (params) {
      var classSuffix = '';
      var day = daysWithActivities[moment(params.date).format('YYYY-MM-DD')];
      
      // ...

      if (!day || params.mode !== 'day') {
        return;
      }

      if (day.status === 'completed') {
        classSuffix = 'completed';
      } else if (moment(params.date).isSameOrAfter(moment.now())) {
        classSuffix = 'scheduled';
      } else {
        classSuffix = 'overdue';
      }

      return '<class-applied-to-days>' + classSuffix;
    }
    ```