### PR TITLE
C51-265: Defer loading activities

### DIFF
--- a/ang/civicase/ActivitiesCalendar.html
+++ b/ang/civicase/ActivitiesCalendar.html
@@ -7,8 +7,20 @@
     datepicker-options="calendarOptions"></div>
   <div class="popover bottom activities-calendar-popover">
     <div class="arrow"></div>
-    <div class="popover-content">
-      <div ng-repeat="activity in selectedActivites | orderBy: '-is_overdue'"
+    <div class="popover-content" ng-switch="loadingActivities">
+      <div ng-switch-when="true" class="civicase__activity-card civicase__activity-card--short">
+        <div class="panel panel-default">
+          <div class="panel-body">
+            <div class="civicase__activity-card-row" style="margin-bottom: 8px;">
+              <div class="civicase__loading-placeholder__oneline" style="width: 0.8em; font-size: 24px; margin-right: 10px;"></div>
+              <div class="civicase__loading-placeholder__oneline" style="width: 8em; font-size: 18px;"></div>
+            </div>
+            <div class="civicase__activity-card-row--file civicase__loading-placeholder__oneline" style="width: 8em; margin-bottom: 10px;"></div>
+            <div class="civicase__activity-card-row--file civicase__loading-placeholder__oneline" style="width: 5em; margin-bottom: 10px;"></div>
+          </div>
+        </div>
+      </div>
+      <div <div ng-switch-when="false" ng-repeat="activity in selectedActivites | orderBy: '-is_overdue'"
         case-activity-card="activity"
         custom-dropdown-class="civicase__activities-calendar__dropdown"
         refresh-on-checkbox-toggle="true"

--- a/ang/civicase/ActivitiesCalendar.html
+++ b/ang/civicase/ActivitiesCalendar.html
@@ -8,19 +8,8 @@
   <div class="popover bottom activities-calendar-popover">
     <div class="arrow"></div>
     <div class="popover-content" ng-switch="loadingActivities">
-      <div ng-switch-when="true" class="civicase__activity-card civicase__activity-card--short">
-        <div class="panel panel-default">
-          <div class="panel-body">
-            <div class="civicase__activity-card-row" style="margin-bottom: 8px;">
-              <div class="civicase__loading-placeholder__oneline" style="width: 0.8em; font-size: 24px; margin-right: 10px;"></div>
-              <div class="civicase__loading-placeholder__oneline" style="width: 8em; font-size: 18px;"></div>
-            </div>
-            <div class="civicase__activity-card-row--file civicase__loading-placeholder__oneline" style="width: 8em; margin-bottom: 10px;"></div>
-            <div class="civicase__activity-card-row--file civicase__loading-placeholder__oneline" style="width: 5em; margin-bottom: 10px;"></div>
-          </div>
-        </div>
-      </div>
-      <div <div ng-switch-when="false" ng-repeat="activity in selectedActivites | orderBy: '-is_overdue'"
+      <civicase-activity-card-placeholder ng-switch-when="true"></civicase-activity-card-placeholder>
+      <div ng-switch-when="false" ng-repeat="activity in selectedActivites | orderBy: '-is_overdue'"
         case-activity-card="activity"
         custom-dropdown-class="civicase__activities-calendar__dropdown"
         refresh-on-checkbox-toggle="true"

--- a/ang/civicase/ActivitiesCalendar.js
+++ b/ang/civicase/ActivitiesCalendar.js
@@ -165,76 +165,6 @@
     };
 
     /**
-     * Loads via the api all the activities of the current case, filtered by
-     * the given query params
-     *
-     * @param {Object} params
-     * @return {Promise} resolves to {Array}
-     */
-    function loadActivities (params) {
-      return crmApi('Activity', 'get', _.defaults(params, {
-        'return': [
-          'subject', 'details', 'activity_type_id', 'status_id',
-          'source_contact_name', 'target_contact_name', 'assignee_contact_name',
-          'activity_date_time', 'is_star', 'original_id', 'tag_id.name', 'tag_id.description',
-          'tag_id.color', 'file_id', 'is_overdue', 'case_id', 'priority_id',
-          'case_id.case_type_id', 'case_id.status_id', 'case_id.contacts'
-        ],
-        'case_id.id': $scope.caseId,
-        sequential: 1,
-        options: {
-          limit: 0
-        }
-      }))
-        .then(function (result) {
-          return result.values;
-        });
-    }
-
-    /**
-     * Loads the activities of the given date. It checks if the activities are
-     * already cached before making an API request
-     *
-     * @param {String} date YYYY-MM-DD
-     * @return {Promise} resolves to {Array}
-     */
-    function loadActivitiesOfDate (date) {
-      var day = daysWithActivities[date];
-
-      if (day.activities.length) {
-        return $q.resolve(day.activities);
-      }
-
-      return loadActivities({
-        activity_date_time: {
-          BETWEEN: [ date + ' 00:00:00', date + ' 23:59:59' ]
-        }
-      })
-        .then(function (activities) {
-          day.activities = activities.map(formatActivity);
-
-          return day.activities;
-        });
-    }
-
-    /**
-     * Load the data of all the contacts referenced by the given activities
-     *
-     * @param {Array} activities
-     */
-    function loadContactsOfActivities (activities) {
-      var contactIds = _(activities).pluck('case_id.contacts').flatten().pluck('contact_id').value();
-
-      // The try/catch block is necessary because the service does not
-      // return a Promise if it doesn't find any new contacts to fetch
-      try {
-        return ContactsDataService.add(contactIds);
-      } catch (e) {
-        return $q.resolve();
-      }
-    }
-
-    /**
      * Called when the user clicks on a day on the datepicker directive
      *
      * If the day has any activities on it, it loads the activities and display
@@ -325,6 +255,76 @@
       }
 
       return 'civicase__activities-calendar__day-status civicase__activities-calendar__day-status--' + classSuffix;
+    }
+
+    /**
+     * Loads via the api all the activities of the current case, filtered by
+     * the given query params
+     *
+     * @param {Object} params
+     * @return {Promise} resolves to {Array}
+     */
+    function loadActivities (params) {
+      return crmApi('Activity', 'get', _.defaults(params, {
+        'return': [
+          'subject', 'details', 'activity_type_id', 'status_id',
+          'source_contact_name', 'target_contact_name', 'assignee_contact_name',
+          'activity_date_time', 'is_star', 'original_id', 'tag_id.name', 'tag_id.description',
+          'tag_id.color', 'file_id', 'is_overdue', 'case_id', 'priority_id',
+          'case_id.case_type_id', 'case_id.status_id', 'case_id.contacts'
+        ],
+        'case_id.id': $scope.caseId,
+        sequential: 1,
+        options: {
+          limit: 0
+        }
+      }))
+        .then(function (result) {
+          return result.values;
+        });
+    }
+
+    /**
+     * Loads the activities of the given date. It checks if the activities are
+     * already cached before making an API request
+     *
+     * @param {String} date YYYY-MM-DD
+     * @return {Promise} resolves to {Array}
+     */
+    function loadActivitiesOfDate (date) {
+      var day = daysWithActivities[date];
+
+      if (day.activities.length) {
+        return $q.resolve(day.activities);
+      }
+
+      return loadActivities({
+        activity_date_time: {
+          BETWEEN: [ date + ' 00:00:00', date + ' 23:59:59' ]
+        }
+      })
+        .then(function (activities) {
+          day.activities = activities.map(formatActivity);
+
+          return day.activities;
+        });
+    }
+
+    /**
+     * Load the data of all the contacts referenced by the given activities
+     *
+     * @param {Array} activities
+     */
+    function loadContactsOfActivities (activities) {
+      var contactIds = _(activities).pluck('case_id.contacts').flatten().pluck('contact_id').value();
+
+      // The try/catch block is necessary because the service does not
+      // return a Promise if it doesn't find any new contacts to fetch
+      try {
+        return ContactsDataService.add(contactIds);
+      } catch (e) {
+        return $q.resolve();
+      }
     }
 
     /**

--- a/ang/civicase/ActivityCardPlaceholder.html
+++ b/ang/civicase/ActivityCardPlaceholder.html
@@ -4,6 +4,7 @@
       <div class="civicase__activity-card-row" style="margin-bottom: 8px;">
         <div class="civicase__loading-placeholder__oneline" style="width: 0.8em; font-size: 24px; margin-right: 10px;"></div>
         <div class="civicase__loading-placeholder__oneline" style="width: 8em; font-size: 18px;"></div>
+        <div class="civicase__activity__right-container civicase__loading-placeholder__oneline" style="width: 3em;"></div>
       </div>
       <div class="civicase__activity-card-row--file civicase__loading-placeholder__oneline" style="width: 8em; margin-bottom: 10px;"></div>
       <div class="civicase__activity-card-row--file civicase__loading-placeholder__oneline" style="width: 5em; margin-bottom: 10px;"></div>

--- a/ang/civicase/ActivityCardPlaceholder.html
+++ b/ang/civicase/ActivityCardPlaceholder.html
@@ -1,0 +1,12 @@
+<div class="civicase__activity-card civicase__activity-card--short">
+  <div class="panel panel-default">
+    <div class="panel-body">
+      <div class="civicase__activity-card-row" style="margin-bottom: 8px;">
+        <div class="civicase__loading-placeholder__oneline" style="width: 0.8em; font-size: 24px; margin-right: 10px;"></div>
+        <div class="civicase__loading-placeholder__oneline" style="width: 8em; font-size: 18px;"></div>
+      </div>
+      <div class="civicase__activity-card-row--file civicase__loading-placeholder__oneline" style="width: 8em; margin-bottom: 10px;"></div>
+      <div class="civicase__activity-card-row--file civicase__loading-placeholder__oneline" style="width: 5em; margin-bottom: 10px;"></div>
+    </div>
+  </div>
+</div>

--- a/ang/civicase/ActivityCardPlaceholder.js
+++ b/ang/civicase/ActivityCardPlaceholder.js
@@ -1,0 +1,10 @@
+(function (angular) {
+  var module = angular.module('civicase');
+
+  module.directive('civicaseActivityCardPlaceholder', function ($timeout, $uibPosition) {
+    return {
+      templateUrl: '~/civicase/ActivityCardPlaceholder.html',
+      restrict: 'E'
+    };
+  });
+}(angular));

--- a/ang/civicase/ActivityCardPlaceholder.js
+++ b/ang/civicase/ActivityCardPlaceholder.js
@@ -1,7 +1,7 @@
 (function (angular) {
   var module = angular.module('civicase');
 
-  module.directive('civicaseActivityCardPlaceholder', function ($timeout, $uibPosition) {
+  module.directive('civicaseActivityCardPlaceholder', function () {
     return {
       templateUrl: '~/civicase/ActivityCardPlaceholder.html',
       restrict: 'E'

--- a/ang/civicase/CaseDetails.js
+++ b/ang/civicase/CaseDetails.js
@@ -16,7 +16,7 @@
 
   module.controller('civicaseCaseDetailsController', civicaseCaseDetailsController);
 
-  function civicaseCaseDetailsController ($location, $scope, BulkActions, crmApi, formatActivity, formatCase, getActivityFeedUrl, getCaseQueryParams, $route, $timeout) {
+  function civicaseCaseDetailsController ($location, $rootScope, $scope, BulkActions, crmApi, formatActivity, formatCase, getActivityFeedUrl, getCaseQueryParams, $route, $timeout) {
     // The ts() and hs() functions help load strings for this module.
     // TODO: Move the common logic into a common controller (based on the usage of ContactCaseTabCaseDetails)
     var ts = $scope.ts = CRM.ts('civicase');
@@ -144,7 +144,9 @@
         _.assign($scope.item, formatCaseDetails(data));
         countScheduledActivities();
         $scope.allowedCaseStatuses = getAllowedCaseStatuses($scope.item.definition);
+
         $scope.$broadcast('updateCaseData');
+        $rootScope.$emit('civicase::ActivitiesCalendar::reload');
       }
     };
 

--- a/ang/civicase/CaseDetails.js
+++ b/ang/civicase/CaseDetails.js
@@ -16,7 +16,7 @@
 
   module.controller('civicaseCaseDetailsController', civicaseCaseDetailsController);
 
-  function civicaseCaseDetailsController ($location, $rootScope, $scope, BulkActions, crmApi, formatActivity, formatCase, getActivityFeedUrl, getCaseQueryParams, $route, $timeout) {
+  function civicaseCaseDetailsController ($location, $scope, BulkActions, crmApi, formatActivity, formatCase, getActivityFeedUrl, getCaseQueryParams, $route, $timeout) {
     // The ts() and hs() functions help load strings for this module.
     // TODO: Move the common logic into a common controller (based on the usage of ContactCaseTabCaseDetails)
     var ts = $scope.ts = CRM.ts('civicase');
@@ -146,7 +146,7 @@
         $scope.allowedCaseStatuses = getAllowedCaseStatuses($scope.item.definition);
 
         $scope.$broadcast('updateCaseData');
-        $rootScope.$emit('civicase::ActivitiesCalendar::reload');
+        $scope.$emit('civicase::ActivitiesCalendar::reload');
       }
     };
 

--- a/ang/test/civicase/ActivitiesCalendar.spec.js
+++ b/ang/test/civicase/ActivitiesCalendar.spec.js
@@ -191,16 +191,6 @@
       });
 
       /**
-       * initializes the controller and simulates the event that the
-       * decorated uib-datepicker sends when it's compiled and attached to the DOM
-       */
-      function initControllerAndEmitDatepickerReadyEvent () {
-        initController();
-        $rootScope.$emit('civicase::uibDaypicker::compiled');
-        $scope.$digest();
-      }
-
-      /**
        * Simulates a call from the date picker to the `customClass` method.
        * Even if the method is passed from a particular instance, the method
        * gets bound to the date picker, which allows access to some of its internal
@@ -383,6 +373,19 @@
       }
     });
 
+    describe('refresh listener', function () {
+      beforeEach(function () {
+        initControllerAndEmitDatepickerReadyEvent();
+        crmApi.calls.reset();
+        $rootScope.$emit('civicase::ActivitiesCalendar::reload');
+        $scope.$digest();
+      });
+
+      it('triggers a full reload', function () {
+        expect(crmApi.calls.count()).toBe(2);
+      });
+    });
+
     /**
      * It returns the given date as part of the response of
      * the Activity.getdayswithactivities endpoint call for the given status type
@@ -413,6 +416,16 @@
       $scope.caseId = _.uniqueId();
 
       $controller('civicaseActivitiesCalendarController', { $scope: $scope });
+    }
+
+    /**
+     * initializes the controller and simulates the event that the
+     * decorated uib-datepicker sends when it's compiled and attached to the DOM
+     */
+    function initControllerAndEmitDatepickerReadyEvent () {
+      initController();
+      $rootScope.$emit('civicase::uibDaypicker::compiled');
+      $scope.$digest();
     }
   });
 

--- a/ang/test/civicase/DashboardTab.spec.js
+++ b/ang/test/civicase/DashboardTab.spec.js
@@ -1,8 +1,7 @@
 /* eslint-env jasmine */
 (function ($, _, moment) {
   describe('dashboardTabController', function () {
-    var $controller, $rootScope, $scope, formatActivity, formatActivityMock,
-      formatCase, formatCaseMock;
+    var $controller, $rootScope, $scope, formatActivity, formatCase;
 
     beforeEach(module('civicase.templates', 'civicase', 'crmUtil'));
     beforeEach(inject(function (_$controller_, _$rootScope_, _formatActivity_, _formatCase_) {
@@ -17,7 +16,6 @@
         case_filter: { foo: 'foo' }
       };
 
-      mockFormatFunctions();
       initController();
     }));
 
@@ -76,7 +74,7 @@
             });
 
             it('calls the formatCase service on each result item', function () {
-              expect(formatCaseMock.calls.count()).toBe(mockedResults.length);
+              expect(formatCase.calls.count()).toBe(mockedResults.length);
             });
 
             it('calls ContactsDataService.add() with a duplicate-free list of the results\'s contacts', function () {
@@ -266,7 +264,7 @@
             });
 
             it('calls the formatCase service on each result item', function () {
-              expect(formatActivityMock.calls.count()).toBe(mockedResults.length);
+              expect(formatActivity.calls.count()).toBe(mockedResults.length);
             });
 
             it('calls ContactsDataService.add() with a duplicate-free list of the results\'s contacts', function () {
@@ -459,7 +457,7 @@
             });
 
             it('calls the formatCase service on each result item', function () {
-              expect(formatActivityMock.calls.count()).toBe(mockedResults.length);
+              expect(formatActivity.calls.count()).toBe(mockedResults.length);
             });
 
             it('calls ContactsDataService.add() with a duplicate-free list of the results\'s contacts', function () {
@@ -571,9 +569,7 @@
      */
     function initController () {
       $controller('dashboardTabController', {
-        $scope: $scope,
-        formatActivity: formatActivityMock,
-        formatCase: formatCaseMock
+        $scope: $scope
       });
       $scope.$digest();
     }
@@ -616,21 +612,6 @@
       var end = now.endOf(range).format(format);
 
       return [start, end];
-    }
-
-    /**
-     * Mocks the formatActivity and formatCase functions
-     */
-    function mockFormatFunctions () {
-      formatActivityMock = jasmine.createSpy(formatActivity)
-        .and.callFake(function (activity) {
-          return activity;
-        });
-
-      formatCaseMock = jasmine.createSpy(formatCase)
-        .and.callFake(function (caseObj) {
-          return caseObj;
-        });
     }
 
     /**

--- a/ang/test/mocks/services/formatActivity.mock.js
+++ b/ang/test/mocks/services/formatActivity.mock.js
@@ -1,0 +1,14 @@
+/* eslint-env jasmine */
+
+(function () {
+  var module = angular.module('civicase');
+
+  module.factory('formatActivity', function () {
+    return jasmine.createSpy('formatActivity')
+      .and.callFake(function (activity) {
+        activity.category = [];
+
+        return activity;
+      });
+  });
+})();

--- a/ang/test/mocks/services/formatCase.mock.js
+++ b/ang/test/mocks/services/formatCase.mock.js
@@ -1,0 +1,12 @@
+/* eslint-env jasmine */
+
+(function () {
+  var module = angular.module('civicase');
+
+  module.factory('formatCase', function () {
+    return jasmine.createSpy('formatCase')
+      .and.callFake(function (caseObj) {
+        return caseObj;
+      });
+  });
+})();


### PR DESCRIPTION
This PR add the deferred loading of activities to the calendar, in order to improve performance.

Before, the calendar would receive the full list of activities, which it would use to both display the dots under days with activities, and also to display the list of a day's activities when the user clicked on that day.

With #111, now the calendar doesn't receive the full list of activities anymore, but calls a new api endpoint that returns the list of days with any activities, which the calendar uses to display the dots.

The list of activities of a given day needs then to be fetched on-demand, when the user clicks on a day. The list is then cached as to avoid unnecessary api calls if the user clicks on a day he previously clicked on

![calendar-open](https://user-images.githubusercontent.com/6400898/48342326-a2aff900-e66f-11e8-9e36-e29739e30672.gif)

Moreover, the calendar needed now a new way to refresh itself whenever an activity is added/modified/deleted. Before this was quite easy, as the calendar as said above held the whole list of activities, so [watching](https://github.com/compucorp/uk.co.compucorp.civicase/blob/242bd22647f8c01f9c0817ef3eb73e6b72467aa0/ang/civicase/ActivitiesCalendar.js#L164-L168) that list was enough to know when to refresh itself
```js
$scope.$watch('activities', function () {
  $scope.selectedActivites = getSelectedActivities();

  $scope.$broadcast('civicaseActivitiesCalendar::refreshDatepicker');
}, true);
```

Given that that list of activities is not available to the calendar anymore, the calendar will now refresh itself whenever a `civicase::ActivitiesCalendar::reload` event will be sent. In the case of the Case Details page in particular (currently the only page where the calendar is used), the event will be triggered in the `pushCaseData` method, which is the method called by any activity's create/update/delete action 
```js
// ActivitiesCalendar.js
(function init () {
  $rootScope.$on('civicase::ActivitiesCalendar::reload', reload);
}());
```
```js
// CaseDetails.js
$scope.pushCaseData = function (data) {
  if ($scope.item && data.id === $scope.item.id) {
    $rootScope.$emit('civicase::ActivitiesCalendar::reload');
  }
}
```
![calendar-refresh](https://user-images.githubusercontent.com/6400898/48342620-721c8f00-e670-11e8-9a08-d2dc8d0c38af.gif)

## Technical details
A new directive has been added: `civicase-activity-card-placeholder`, which is a simple controller-less directive that allows the activity card placeholder to be reuse (right now it seems most if not all of the placeholders are simply copy&pasted wherever needed)

The placeholder is being used in the calendar, and it's displayed whenever the activities of the day the users has selected are being loaded (see gifs above)
```html
<div class="popover-content" ng-switch="loadingActivities">
  <civicase-activity-card-placeholder ng-switch-when="true"></civicase-activity-card-placeholder>
  <div ng-switch-when="false" ng-repeat="activity in selectedActivites" case-activity-card="activity"></div>
</div>
```