### PR TITLE
C51-269: Add Activity.getmonthswithactivities endpoint

### DIFF
--- a/api/v3/Activity/Getmonthswithactivities.php
+++ b/api/v3/Activity/Getmonthswithactivities.php
@@ -1,0 +1,71 @@
+<?php
+use CRM_Civicase_ExtensionUtil as E;
+
+/**
+ * Activity.Getmonthswithactivities API specification
+ *
+ * @param array $spec description of fields supported by this API call
+ * 
+ * @return void
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ */
+function _civicrm_api3_activity_Getmonthswithactivities_spec(&$spec) {
+  $allowed = ['activity_date_time', 'activity_status_id', 'case_id'];
+  $all = civicrm_api3('Activity', 'getfields', array('api_action' => 'get'))['values'];
+  
+  $spec = array_filter($all, function ($name) use ($allowed) {
+    return in_array($name, $allowed);
+  }, ARRAY_FILTER_USE_KEY);
+}
+
+/**
+ * Returns list of unique [MM, YYYY] month-year pair with at least an activity
+ * 
+ * @method Activity.Getmonthswithactivities API
+ *
+ * @param array $params
+ * @return array API result with list of months
+ * @see civicrm_api3_create_success
+ * @throws API_Exception
+ */
+function civicrm_api3_activity_Getmonthswithactivities($params) {
+  try {
+      $dao = CRM_Utils_SQL_Select::from('civicrm_activity a');
+      $dao->select(['YEAR(a.activity_date_time) AS year, MONTH(a.activity_date_time) AS month']);
+
+      if (array_key_exists('activity_date_time', $params)) {
+          _civicrm_api3_activity_Getmonthswithactivities_handle_id_param($params['activity_date_time'], 'a.activity_date_time', $dao);
+      }
+
+      if (array_key_exists('activity_status_id', $params)) {
+          _civicrm_api3_activity_Getmonthswithactivities_handle_id_param($params['activity_status_id'], 'a.status_id', $dao);
+      }
+
+      if (array_key_exists('case_id', $params)) {
+          $dao->join('ca', 'INNER JOIN civicrm_case_activity AS ca ON a.id = ca.activity_id');
+          _civicrm_api3_activity_Getmonthswithactivities_handle_id_param($params['case_id'], 'ca.case_id', $dao);
+      }
+
+      $dao->groupBy('YEAR(a.activity_date_time), MONTH(a.activity_date_time) ASC');
+      $result = $dao->execute()->fetchAll();
+
+      $params['sequential'] = 1;
+
+      return civicrm_api3_create_success($result, $params, 'Activity', 'getmonthswithactivities');
+  } catch (Exception $exception) {
+    throw new API_Exception($exception->getMessage(), $exception->getCode());
+  }
+}
+
+/**
+ * Creates a WHERE clause with the given API parameter and column name
+ *
+ * @param array $param
+ * @param string $param
+ * @param CRM_Utils_SQL_Select $param
+ */
+function _civicrm_api3_activity_Getmonthswithactivities_handle_id_param($param, $column, $dao) {
+  $param = is_array($param) ? $param : array('=' => $param);
+
+  $dao->where(CRM_Core_DAO::createSQLFilter($column, $param));
+}

--- a/api/v3/Activity/Getmonthswithactivities.php
+++ b/api/v3/Activity/Getmonthswithactivities.php
@@ -26,32 +26,30 @@ function _civicrm_api3_activity_Getmonthswithactivities_spec(&$spec) {
  */
 function civicrm_api3_activity_Getmonthswithactivities($params)
 {
-    $result = civicrm_api3('Activity', 'get', array_merge($params, [
-      'sequential' => 1,
-      'return' => 'activity_date_time',
-      'options' => ['limit' => 0],
-    ]));
+  $result = civicrm_api3('Activity', 'get', array_merge($params, [
+    'sequential' => 1,
+    'return' => 'activity_date_time',
+    'options' => ['limit' => 0],
+  ]));
 
-    if (!boolval($result['is_error'])) {
-      $grouped_activity_dates = array();
-      $grouped_activity_dates_indexes = array();
-      $index = 0;
-
-      foreach($result['values'] as $activity_date_time) {
-        list($activity_year, $activity_month) = explode('-', $activity_date_time['activity_date_time']);
-        
-        if (!isset($grouped_activity_dates_indexes[$activity_month . $activity_year])) {
-          $grouped_activity_dates_indexes[$activity_month . $activity_year] = $index;
-          $index++;
-          $grouped_activity_dates[] = array(
-            'year' => $activity_year,
-            'month' => $activity_month,
-          );
-        }
-      }
-
-      return civicrm_api3_create_success($grouped_activity_dates, $params, 'Activity', 'getmonthswithactivities');
-    }
-
+  if (boolval($result['is_error'])) {
     return civicrm_api3_create_error($result['error_message'], $params);
+  }
+  
+  $grouped_activity_dates = [];
+  $grouped_activity_dates_indexes = [];
+
+  foreach($result['values'] as $activity_date_time) {
+    list($activity_year, $activity_month) = explode('-', $activity_date_time['activity_date_time']);
+    
+    if (!isset($grouped_activity_dates_indexes[$activity_month . $activity_year])) {
+      $grouped_activity_dates_indexes[$activity_month . $activity_year] = true;
+      $grouped_activity_dates[] = array(
+        'year' => $activity_year,
+        'month' => $activity_month,
+      );
+    }
+  }
+
+  return civicrm_api3_create_success($grouped_activity_dates, $params, 'Activity', 'getmonthswithactivities');
 }

--- a/api/v3/Activity/Getmonthswithactivities.php
+++ b/api/v3/Activity/Getmonthswithactivities.php
@@ -29,32 +29,28 @@ function _civicrm_api3_activity_Getmonthswithactivities_spec(&$spec) {
  * @throws API_Exception
  */
 function civicrm_api3_activity_Getmonthswithactivities($params) {
-  try {
-      $dao = CRM_Utils_SQL_Select::from('civicrm_activity a');
-      $dao->select(['YEAR(a.activity_date_time) AS year, MONTH(a.activity_date_time) AS month']);
+  $dao = CRM_Utils_SQL_Select::from('civicrm_activity a');
+  $dao->select(['YEAR(a.activity_date_time) AS year, MONTH(a.activity_date_time) AS month']);
 
-      if (array_key_exists('activity_date_time', $params)) {
-          _civicrm_api3_activity_Getmonthswithactivities_handle_id_param($params['activity_date_time'], 'a.activity_date_time', $dao);
-      }
-
-      if (array_key_exists('activity_status_id', $params)) {
-          _civicrm_api3_activity_Getmonthswithactivities_handle_id_param($params['activity_status_id'], 'a.status_id', $dao);
-      }
-
-      if (array_key_exists('case_id', $params)) {
-          $dao->join('ca', 'INNER JOIN civicrm_case_activity AS ca ON a.id = ca.activity_id');
-          _civicrm_api3_activity_Getmonthswithactivities_handle_id_param($params['case_id'], 'ca.case_id', $dao);
-      }
-
-      $dao->groupBy('YEAR(a.activity_date_time), MONTH(a.activity_date_time) ASC');
-      $result = $dao->execute()->fetchAll();
-
-      $params['sequential'] = 1;
-
-      return civicrm_api3_create_success($result, $params, 'Activity', 'getmonthswithactivities');
-  } catch (Exception $exception) {
-    throw new API_Exception($exception->getMessage(), $exception->getCode());
+  if (array_key_exists('activity_date_time', $params)) {
+      _civicrm_api3_activity_Getmonthswithactivities_handle_id_param($params['activity_date_time'], 'a.activity_date_time', $dao);
   }
+
+  if (array_key_exists('activity_status_id', $params)) {
+      _civicrm_api3_activity_Getmonthswithactivities_handle_id_param($params['activity_status_id'], 'a.status_id', $dao);
+  }
+
+  if (array_key_exists('case_id', $params)) {
+      $dao->join('ca', 'INNER JOIN civicrm_case_activity AS ca ON a.id = ca.activity_id');
+      _civicrm_api3_activity_Getmonthswithactivities_handle_id_param($params['case_id'], 'ca.case_id', $dao);
+  }
+
+  $dao->groupBy('YEAR(a.activity_date_time), MONTH(a.activity_date_time) ASC');
+  $result = $dao->execute()->fetchAll();
+
+  $params['sequential'] = 1;
+
+  return civicrm_api3_create_success($result, $params, 'Activity', 'getmonthswithactivities');
 }
 
 /**

--- a/civicase.civix.php
+++ b/civicase.civix.php
@@ -443,22 +443,3 @@ function _civicase_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) 
     $metaDataFolders[] = $settingsDir;
   }
 }
-
-/**
- * (Delegated) Implements hook_civicrm_entityTypes().
- *
- * Find any *.entityType.php files, merge their content, and return.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
- */
-
-function _civicase_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, array (
-    'CRM_Civicase_DAO_CaseContactLock' => 
-    array (
-      'name' => 'CaseContactLock',
-      'class' => 'CRM_Civicase_DAO_CaseContactLock',
-      'table' => 'civicase_contactlock',
-    ),
-  ));
-}

--- a/civicase.civix.php
+++ b/civicase.civix.php
@@ -443,3 +443,22 @@ function _civicase_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) 
     $metaDataFolders[] = $settingsDir;
   }
 }
+
+/**
+ * (Delegated) Implements hook_civicrm_entityTypes().
+ *
+ * Find any *.entityType.php files, merge their content, and return.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
+ */
+
+function _civicase_civix_civicrm_entityTypes(&$entityTypes) {
+  $entityTypes = array_merge($entityTypes, array (
+    'CRM_Civicase_DAO_CaseContactLock' => 
+    array (
+      'name' => 'CaseContactLock',
+      'class' => 'CRM_Civicase_DAO_CaseContactLock',
+      'table' => 'civicase_contactlock',
+    ),
+  ));
+}

--- a/tests/phpunit/BaseHeadlessTest.php
+++ b/tests/phpunit/BaseHeadlessTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+abstract class BaseHeadlessTest extends PHPUnit_Framework_TestCase implements HeadlessInterface, TransactionalInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+}

--- a/tests/phpunit/api/v3/Activity/GetmonthswithactivitiesTest.php
+++ b/tests/phpunit/api/v3/Activity/GetmonthswithactivitiesTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Activity.Getmonthswithactivities API Test Case
+ * This is a generic test class implemented with PHPUnit.
+ * @group headless
+ */
+class api_v3_Activity_GetmonthswithactivitiesTest extends \PHPUnit_Framework_TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  /**
+   * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+   * See: https://github.com/civicrm/org.civicrm.testapalooza/blob/master/civi-test.md
+   */
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  /**
+   * The setup() method is executed before the test is executed (optional).
+   */
+  public function setUp() {
+    parent::setUp();
+  }
+
+  /**
+   * The tearDown() method is executed after the test was executed (optional)
+   * This can be used for cleanup.
+   */
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+  /**
+   * Simple example test case.
+   *
+   * Note how the function name begins with the word "test".
+   */
+  public function testApiExample() {
+    $result = civicrm_api3('Activity', 'Getmonthswithactivities', array('magicword' => 'sesame'));
+    $this->assertEquals('Twelve', $result['values'][12]['name']);
+  }
+
+}

--- a/tests/phpunit/api/v3/Activity/GetmonthswithactivitiesTest.php
+++ b/tests/phpunit/api/v3/Activity/GetmonthswithactivitiesTest.php
@@ -22,21 +22,6 @@ class api_v3_Activity_GetmonthswithactivitiesTest extends \PHPUnit_Framework_Tes
   }
 
   /**
-   * The setup() method is executed before the test is executed (optional).
-   */
-  public function setUp() {
-    parent::setUp();
-  }
-
-  /**
-   * The tearDown() method is executed after the test was executed (optional)
-   * This can be used for cleanup.
-   */
-  public function tearDown() {
-    parent::tearDown();
-  }
-
-  /**
    * Simple example test case.
    *
    * Note how the function name begins with the word "test".

--- a/tests/phpunit/api/v3/Activity/GetmonthswithactivitiesTest.php
+++ b/tests/phpunit/api/v3/Activity/GetmonthswithactivitiesTest.php
@@ -9,25 +9,18 @@ use Civi\Test\TransactionalInterface;
  * This is a generic test class implemented with PHPUnit.
  * @group headless
  */
-class api_v3_Activity_GetmonthswithactivitiesTest extends \PHPUnit_Framework_TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+class api_v3_Activity_GetmonthswithactivitiesTest extends BaseHeadlessTest {
 
   /**
-   * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
-   * See: https://github.com/civicrm/org.civicrm.testapalooza/blob/master/civi-test.md
-   */
-  public function setUpHeadless() {
-    return \Civi\Test::headless()
-      ->installMe(__DIR__)
-      ->apply();
-  }
-
-  /**
-   * Simple example test case.
-   *
-   * Note how the function name begins with the word "test".
+   * Test function to return expected data model.
    */
   public function testApiExample() {
-    $result = civicrm_api3('Activity', 'Getmonthswithactivities', array('magicword' => 'sesame'));
+    $result = civicrm_api3('Activity', 'Getmonthswithactivities')['values'];
+    $this->assetInternalType('array', $result);
+
+    $first = $result[0];
+    $this->assertArrayHasKey('year', $first);
+    $this->assertArrayHasKey('month', $first);
     $this->assertEquals('Twelve', $result['values'][12]['name']);
   }
 


### PR DESCRIPTION
The PR adds `Activity.getmonthswithactivities` endpoint which returns a list of the map of unique `month` and `year` with at least one activity. The endpoint supports all the parameters that `Activity.get` does.

Sample response
```json
[
        {
            "year": "2009",
            "month": "1"
        },
        {
            "year": "2009",
            "month": "10"
        },
        {
            "year": "2010",
            "month": "3"
        },
        {
            "year": "2015",
            "month": "5"
        },
        {
            "year": "2015",
            "month": "12"
        },
        {
            "year": "2016",
            "month": "12"
        },
        {
            "year": "2017",
            "month": "1"
        },
        {
            "year": "2017",
            "month": "10"
        },
        {
            "year": "2017",
            "month": "11"
        },
        {
            "year": "2017",
            "month": "12"
        },
        {
            "year": "2018",
            "month": "11"
        }
]
```