### PR TITLE
C51-340: Add Case.getdetailscount api endpoint

### DIFF
--- a/api/v3/Case/Getdetailscount.php
+++ b/api/v3/Case/Getdetailscount.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Case.getdetailscount API
+ *
+ * Provides a count of cases but properly respects filters unlike `getcount`.
+ * Please refer to C51-277 for more information.
+ *
+ * @param array $params
+ * @return array API result
+ * @throws API_Exception
+ */
+function civicrm_api3_case_getdetailscount($params) {
+  $params['options'] = CRM_Utils_Array::value('options', $params, []);
+  $params['options']['is_count'] = 1;
+
+  $casesList = civicrm_api3('Case', 'getdetails', $params);
+
+  return $casesList['values'];
+}

--- a/api/v3/Case/Getdetailscount.php
+++ b/api/v3/Case/Getdetailscount.php
@@ -4,7 +4,6 @@
  * Case.getdetailscount API
  *
  * Provides a count of cases but properly respects filters unlike `getcount`.
- * Please refer to C51-277 for more information.
  *
  * @param array $params
  * @return array API result


### PR DESCRIPTION
## Overview

This PR adds a new endpoint that counts cases properly after being filtered by special case fields like `case_manager`.

## getcount endpoint
![pr-before](https://user-images.githubusercontent.com/1642119/48443841-b8551980-e768-11e8-81c3-5ec8ea47ad89.gif)

## getdetailscount endpoint
![pr-after](https://user-images.githubusercontent.com/1642119/48443903-e9354e80-e768-11e8-9ab2-863c733951e5.gif)

## Technical details

The original `getcount` does not respect the `case_manager` filter when doing the count. This is a special filter that was added to the `getdetails` api: 
https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/api/v3/Case/Getdetails.php#L50-L57

This new endpoint allows cases to be counted using the `getdetails` api and passing the `is_count` option, which CiviCRM uses to override the query and replace it with a count using the same filters.

## Notes

Unit tests were created for this endpoint but they were failing. For more information please refer to:
https://compucorp.atlassian.net/browse/C51-340

