### PR TITLE
C51-267: Load only data of currently selected month in Activities Calendar

### DIFF
--- a/ang/civicase/ActivitiesCalendar--decorator.js
+++ b/ang/civicase/ActivitiesCalendar--decorator.js
@@ -2,13 +2,20 @@
   var module = angular.module('civicase');
 
   module.config(function ($provide) {
-    $provide.decorator('uibMonthpickerDirective', function ($controller, $delegate) {
+    $provide.decorator('uibDatepickerDirective', function ($controller, $delegate) {
       var datepicker = $delegate[0];
 
       datepicker.compile = function () {
         return function ($scope) {
           datepicker.link.apply(this, arguments);
-          augmentMonthSelectMethod($scope, 'select');
+
+          // Watches for changes in the value of the currently selected date
+          // and emits an event if the month has changed
+          $scope.$watch('activeDt.date', function (newDate, oldDate) {
+            if (newDate && oldDate && (newDate.getMonth() !== oldDate.getMonth())) {
+              $scope.$emit('civicase::uibDaypicker::monthSelected', $scope.activeDt.date);
+            }
+          });
         };
       };
 
@@ -21,7 +28,6 @@
       datepicker.compile = function () {
         return function ($scope) {
           datepicker.link.apply(this, arguments);
-          augmentMonthSelectMethod($scope, 'move');
 
           // Emits an event to signal that the directive is compiled and attached
           // to the DOM, with the currently selected date passed as param
@@ -63,21 +69,4 @@
       return $delegate;
     });
   });
-
-  /**
-   * Augment the original month select method with the given name, by making it
-   * emit an event with the selected month passed as param
-   *
-   * @param {Object} $scope
-   * @param {String} methodName
-   */
-  function augmentMonthSelectMethod ($scope, methodName) {
-    var originalMethod;
-
-    originalMethod = $scope[methodName];
-    $scope[methodName] = function () {
-      originalMethod.apply(this, arguments);
-      $scope.$emit('civicase::uibDaypicker::monthSelected', $scope.activeDt.date);
-    };
-  }
 })(angular);

--- a/ang/civicase/ActivitiesCalendar.js
+++ b/ang/civicase/ActivitiesCalendar.js
@@ -169,33 +169,7 @@
       startingDay: 1
     };
 
-    /**
-     * Called when the user clicks on a day on the datepicker directive
-     *
-     * If the day has any activities on it, it loads the activities and display
-     * them in a popover
-     */
-    $scope.onDateSelected = function () {
-      var date = moment($scope.selectedDate).format('YYYY-MM-DD');
-
-      if (!daysWithActivities[date]) {
-        return;
-      }
-
-      $scope.loadingActivities = true;
-      $scope.selectedActivites = [];
-
-      $scope.$emit('civicase::ActivitiesCalendar::openActivitiesPopover');
-
-      loadActivitiesOfDate(date)
-        .then(function (activities) {
-          loadContactsOfActivities(activities)
-            .then(function () {
-              $scope.selectedActivites = activities;
-              $scope.loadingActivities = false;
-            });
-        });
-    };
+    $scope.onDateSelected = onDateSelected;
 
     (function init () {
       createDebouncedLoad();
@@ -499,6 +473,34 @@
 
       return loadDaysWithActivities(status, date)
         .then(_.curryRight(updateDaysList)('incomplete'));
+    }
+
+    /**
+     * Called when the user clicks on a day on the datepicker directive
+     *
+     * If the day has any activities on it, it loads the activities and display
+     * them in a popover
+     */
+    function onDateSelected () {
+      var date = moment($scope.selectedDate).format('YYYY-MM-DD');
+
+      if (!daysWithActivities[date]) {
+        return;
+      }
+
+      $scope.loadingActivities = true;
+      $scope.selectedActivites = [];
+
+      $scope.$emit('civicase::ActivitiesCalendar::openActivitiesPopover');
+
+      loadActivitiesOfDate(date)
+        .then(function (activities) {
+          loadContactsOfActivities(activities)
+            .then(function () {
+              $scope.selectedActivites = activities;
+              $scope.loadingActivities = false;
+            });
+        });
     }
 
     /**

--- a/ang/civicase/ActivitiesCalendar.js
+++ b/ang/civicase/ActivitiesCalendar.js
@@ -343,8 +343,12 @@
 
     /**
      * Entry point of the load logic
+     *
+     * @param {Boolean} [useCache=true]
      */
-    function load () {
+    function load (useCache) {
+      useCache = useCache !== false;
+
       $scope.loadingDays = true;
 
       // @NOTE The user could be switching to different dates (in particular, months)
@@ -357,7 +361,11 @@
       // This is also the reason why `date` has to be passed all the way down
       // to the `loadDaysWithActivities` function
       (function (date) {
-        loadDaysWithActivitiesIncomplete(date)
+        if (useCache && daysWithActivities[moment(date).format('YYYY-MM')]) {
+          return $q.resolve();
+        }
+
+        return loadDaysWithActivitiesIncomplete(date)
           .then(function () {
             $scope.$emit('civicase::ActivitiesCalendar::refreshDatepicker');
           })
@@ -366,11 +374,11 @@
           })
           .then(function () {
             $scope.$emit('civicase::ActivitiesCalendar::refreshDatepicker');
-          })
-          .then(function () {
-            $scope.loadingDays = false;
           });
-      }(selectedDate));
+      }(selectedDate))
+        .then(function () {
+          $scope.loadingDays = false;
+        });
     }
 
     /**
@@ -553,7 +561,7 @@
         });
       });
 
-      load();
+      load(false);
     }
 
     /**

--- a/ang/civicase/ActivitiesCalendar.js
+++ b/ang/civicase/ActivitiesCalendar.js
@@ -368,7 +368,7 @@
       // This is also the reason why `date` has to be passed all the way down
       // to the `loadDaysWithActivities` function
       (function (date) {
-        if (useCache && daysWithActivities[moment(date).format('YYYY-MM')]) {
+        if (useCache && daysWithActivities[getYearMonth(date)]) {
           return $q.resolve();
         }
 
@@ -555,11 +555,11 @@
      * performs two type of data reset
      *
      * hard reset: all months except the one of the currently selected date get
-     * delete directly from the internal cache
+     * deleted directly from the internal cache
      *
      * soft reset: the month of the currently selected date is not deleted, but
      * its days are marked to be flushed (deleted) later, in case they won't get
-     * by the next API requests
+     * returned anymore by the next API requests
      *
      * The soft reset avoids removing all the dots at once before even making the
      * API requests, making for a smoother UI experience
@@ -581,7 +581,7 @@
     }
 
     /**
-     * Stores the currently selected date on the datepicker (as a Moment)
+     * Stores the date currently selected on the datepicker
      * and triggers the load logic (debounced, if specified)
      *
      * @param {Date} selectedDate

--- a/ang/civicase/ActivitiesCalendar.js
+++ b/ang/civicase/ActivitiesCalendar.js
@@ -353,8 +353,8 @@
      *
      * @param {Boolean} [useCache=true]
      */
-    function load (useCache) {
-      useCache = useCache !== false;
+    function load (options) {
+      options = _.defaults({}, options, { useCache: true });
 
       $scope.loadingDays = true;
 
@@ -368,7 +368,7 @@
       // This is also the reason why `date` has to be passed all the way down
       // to the `loadDaysWithActivities` function
       (function (date) {
-        if (useCache && daysWithActivities[getYearMonth(date)]) {
+        if (options.useCache && daysWithActivities[getYearMonth(date)]) {
           return $q.resolve();
         }
 
@@ -469,19 +469,19 @@
      * The days are returned in an object containing also the year+month they
      * belong to, so that they can be properly grouped in the internal list of days
      *
-     * @param {*} status
      * @param {Date} date
+     * @param {*} status
      * @return {Promise}
      */
-    function loadDaysWithActivities (status, date) {
+    function loadDaysWithActivities (date, status) {
       var params = {};
       var dateMoment = moment(date);
 
       params.status_id = status;
       params.activity_date_time = {
         BETWEEN: [
-          dateMoment.startOf('month').format('YYYY-MM-DD') + ' 00:00:00',
-          dateMoment.endOf('month').format('YYYY-MM-DD') + ' 23:59:59'
+          dateMoment.startOf('month').format('YYYY-MM-DD HH:mm:ss'),
+          dateMoment.endOf('month').format('YYYY-MM-DD HH:mm:ss')
         ]
       };
 
@@ -507,7 +507,7 @@
     function loadDaysWithActivitiesCompleted (date) {
       var status = CRM.civicase.activityStatusTypes.completed[0];
 
-      return loadDaysWithActivities(status, date)
+      return loadDaysWithActivities(date, status)
         .then(_.curryRight(updateDaysList)(date)('completed'));
     }
 
@@ -520,7 +520,7 @@
     function loadDaysWithActivitiesIncomplete (date) {
       var status = { 'IN': CRM.civicase.activityStatusTypes.incomplete };
 
-      return loadDaysWithActivities(status, date)
+      return loadDaysWithActivities(date, status)
         .then(_.curryRight(updateDaysList)(date)('incomplete'));
     }
 
@@ -577,7 +577,7 @@
         }
       });
 
-      load(false);
+      load({ useCache: false });
     }
 
     /**

--- a/ang/civicase/ActivitiesCalendar.js
+++ b/ang/civicase/ActivitiesCalendar.js
@@ -198,14 +198,7 @@
     };
 
     (function init () {
-      debouncedLoad = _.debounce(function () {
-        var args = arguments;
-
-        $scope.$apply(function () {
-          load.apply(null, args);
-        });
-      }, DEBOUNCE_WAIT);
-
+      createDebouncedLoad();
       initListeners();
       initWatchers();
     }());
@@ -235,6 +228,20 @@
 
         return acc;
       }, daysWithActivities);
+    }
+
+    /**
+     * Creates a debounced version of the `load` function
+     */
+    function createDebouncedLoad () {
+      debouncedLoad = _.debounce(function () {
+        var args = arguments;
+
+        // Execute the function as part of the digest cycle
+        $scope.$apply(function () {
+          load.apply(null, args);
+        });
+      }, DEBOUNCE_WAIT);
     }
 
     /**

--- a/ang/civicase/ActivitiesCalendar.js
+++ b/ang/civicase/ActivitiesCalendar.js
@@ -153,6 +153,7 @@
   function civicaseActivitiesCalendarController ($q, $rootScope, $scope, crmApi,
     formatActivity, ContactsDataService) {
     var daysWithActivities = {};
+    var selectedMoment = null;
 
     $scope.loadingDays = false;
     $scope.loadingActivities = false;
@@ -303,7 +304,10 @@
      * Initializes the controller's listeners
      */
     function initListeners () {
-      $rootScope.$on('civicase::uibDaypicker::compiled', load);
+      $rootScope.$on('civicase::uibDaypicker::compiled', function (__, selectDate) {
+        selectedMoment = moment(selectDate);
+        load();
+      });
       $rootScope.$on('civicase::ActivitiesCalendar::reload', reload);
     }
 
@@ -407,7 +411,8 @@
     }
 
     /**
-     * Loads the dates with at least an activity with the given status(es)
+     * Loads the dates within the currently selected month (if any is selected)
+     * with at least an activity with the given status(es)
      *
      * @param {*} statusParam
      * @return {Promise}
@@ -416,6 +421,15 @@
       var params = {};
 
       params.status_id = statusParam;
+
+      if (selectedMoment) {
+        params.activity_date_time = {
+          BETWEEN: [
+            selectedMoment.startOf('month').format('YYYY-MM-DD') + ' 00:00:00',
+            selectedMoment.endOf('month').format('YYYY-MM-DD') + ' 23:59:59'
+          ]
+        };
+      }
 
       if ($scope.caseId) {
         params.case_id = getCaseIdApiParam();

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -222,7 +222,7 @@
      * It triggers a full reload if the panel's name is passed with the event
      *
      * @param {Object} $event
-     * @para§m {String/Array} name
+     * @param {String/Array} name
      */
     function reloadEventHandler ($event, name) {
       var refresh = _.isArray(name)

--- a/ang/test/civicase/ActivitiesCalendar.spec.js
+++ b/ang/test/civicase/ActivitiesCalendar.spec.js
@@ -21,16 +21,23 @@
     }));
 
     describe('when uib-datepicker signals that it is ready', function () {
+      var endOfMonth, startOfMonth;
       beforeEach(function () {
+        startOfMonth = moment(dates.today).startOf('month').format('YYYY-MM-DD');
+        endOfMonth = moment(dates.today).endOf('month').format('YYYY-MM-DD');
+
         spyOn($scope, '$emit').and.callThrough();
 
         initController();
-        $rootScope.$emit('civicase::uibDaypicker::compiled');
+        $rootScope.$emit('civicase::uibDaypicker::compiled', dates.today);
       });
 
-      it('starts loading the days with incomplete activities', function () {
+      it('loads the days with incomplete activities of the currently selected month', function () {
         expect(crmApi).toHaveBeenCalledWith('Activity', 'getdayswithactivities', jasmine.objectContaining({
-          status_id: { 'IN': CRM.civicase.activityStatusTypes.incomplete }
+          status_id: { 'IN': CRM.civicase.activityStatusTypes.incomplete },
+          activity_date_time: {
+            'BETWEEN': [startOfMonth + ' 00:00:00', endOfMonth + ' 23:59:59']
+          }
         }));
       });
 
@@ -44,9 +51,12 @@
           $scope.$digest();
         });
 
-        it('loads the days with complete activities', function () {
+        it('loads the days with complete activities of the currently selected month', function () {
           expect(crmApi).toHaveBeenCalledWith('Activity', 'getdayswithactivities', jasmine.objectContaining({
-            status_id: CRM.civicase.activityStatusTypes.completed[0]
+            status_id: CRM.civicase.activityStatusTypes.completed[0],
+            activity_date_time: {
+              'BETWEEN': [startOfMonth + ' 00:00:00', endOfMonth + ' 23:59:59']
+            }
           }));
         });
 

--- a/ang/test/civicase/ActivitiesCalendar.spec.js
+++ b/ang/test/civicase/ActivitiesCalendar.spec.js
@@ -545,16 +545,16 @@
     });
 
     describe('when the date picker selects a month', function () {
-      var allArgs, endOfMonth, selectedMoment, startOfMonth;
+      var allArgs, endOfMonth, nextMonth, startOfMonth;
 
       beforeEach(function () {
-        selectedMoment = moment();
-        startOfMonth = selectedMoment.startOf('month').format('YYYY-MM-DD');
-        endOfMonth = selectedMoment.endOf('month').format('YYYY-MM-DD');
+        nextMonth = moment(dates.today).add(1, 'month');
+        startOfMonth = nextMonth.startOf('month').format('YYYY-MM-DD');
+        endOfMonth = nextMonth.endOf('month').format('YYYY-MM-DD');
 
         initControllerAndEmitDatepickerReadyEvent();
         crmApi.calls.reset();
-        $rootScope.$emit('civicase::uibDaypicker::monthSelected', selectedMoment.toDate());
+        $rootScope.$emit('civicase::uibDaypicker::monthSelected', nextMonth.toDate());
         $scope.$digest();
 
         allArgs = crmApi.calls.allArgs();

--- a/ang/test/civicase/ActivitiesCalendar.spec.js
+++ b/ang/test/civicase/ActivitiesCalendar.spec.js
@@ -22,6 +22,7 @@
 
     describe('when uib-datepicker signals that it is ready', function () {
       var endOfMonth, startOfMonth;
+
       beforeEach(function () {
         startOfMonth = moment(dates.today).startOf('month').format('YYYY-MM-DD');
         endOfMonth = moment(dates.today).endOf('month').format('YYYY-MM-DD');
@@ -540,6 +541,54 @@
 
       it('triggers a full reload', function () {
         expect(crmApi.calls.count()).toBe(2);
+      });
+    });
+
+    describe('when the date picker selects a month', function () {
+      var allArgs, endOfMonth, selectedMoment, startOfMonth;
+
+      beforeEach(function () {
+        selectedMoment = moment();
+        startOfMonth = selectedMoment.startOf('month').format('YYYY-MM-DD');
+        endOfMonth = selectedMoment.endOf('month').format('YYYY-MM-DD');
+
+        initControllerAndEmitDatepickerReadyEvent();
+        crmApi.calls.reset();
+        $rootScope.$emit('civicase::uibDaypicker::monthSelected', selectedMoment.toDate());
+        $scope.$digest();
+
+        allArgs = crmApi.calls.allArgs();
+      });
+
+      // @NOTE: the function that loads the data when a new month is selected
+      // is debounced to avoid flooding, and as such can't be tested normally
+      // The use of `done` and `setTimeout` is necessary for jasmine to
+      // wait the next tick loop before testing the assertions
+
+      it('does not invoke the load function before 300ms', function (done) {
+        setTimeout(function () {
+          expect(crmApi).not.toHaveBeenCalled();
+          done();
+        }, 290);
+      });
+
+      it('invokes the load function after 300ms', function (done) {
+        setTimeout(function () {
+          expect(crmApi).toHaveBeenCalled();
+          done();
+        }, 300);
+      });
+
+      it('loads the days with activities of the month of the selected date', function (done) {
+        setTimeout(function () {
+          expect(crmApi.calls.count()).toBe(2);
+          allArgs.forEach(function (args) {
+            expect(args[2].activity_date_time).toEqual({
+              'BETWEEN': [startOfMonth + ' 00:00:00', endOfMonth + ' 23:59:59']
+            });
+          });
+          done();
+        }, 300);
       });
     });
 


### PR DESCRIPTION
This PR adds the ability for the calendar to load only a month's worth of data at a time, in order to improve performance in case of large numbers of cases and/or activities. Additionally the data is cached, so that the component doesn't make api requests for months the user already previously selected 

![month-load](https://user-images.githubusercontent.com/6400898/48632939-7b845f00-e9c2-11e8-9397-39321f279b4b.gif)

The loading functionality is debounced with a wait time of `300`ms, so that the user doesn't flood the API when switching quickly between months.

**Debounce off**
![debounce-off](https://user-images.githubusercontent.com/6400898/48633027-b1c1de80-e9c2-11e8-96eb-3b773ddf259d.gif)

**Debounce on**
![debounce-on](https://user-images.githubusercontent.com/6400898/48633028-b1c1de80-e9c2-11e8-9f48-0c1e77b9586b.gif)

