### PR TITLE
C51-341: Implement getdetailscount api endpoint on the front end

### DIFF
--- a/ang/civicase/CaseListTable.js
+++ b/ang/civicase/CaseListTable.js
@@ -351,7 +351,7 @@
       }
       return [
         ['Case', 'getcaselist', $.extend(true, returnCaseParams, params)],
-        ['Case', 'getcount', params]
+        ['Case', 'getdetailscount', params]
       ];
     }
 

--- a/ang/civicase/ContactCaseTab.js
+++ b/ang/civicase/ContactCaseTab.js
@@ -43,13 +43,9 @@
         'name': 'related',
         'title': 'Other cases for this contact',
         'filterParams': {
-          'case_manager': Contact.getContactIDFromUrl(),
-          'options': { // Todo: Should be removed after Fixing count API response for case list. C51-277
-            'limit': 0
-          }
+          'case_manager': Contact.getContactIDFromUrl()
         },
-        'showContactRole': true,
-        'disableLoadMore': true // Todo: Should be removed after Fixing count API response for case list. C51-277
+        'showContactRole': true
       }
     ];
 
@@ -147,7 +143,7 @@
         totalCountApi.push(params.count);
       });
 
-      // getTotalCasesCount(totalCountApi); // Todo: Uncommented after Fixing count API response for case list. C51-277
+      getTotalCasesCount(totalCountApi);
     }
 
     /**
@@ -178,7 +174,7 @@
 
       return {
         cases: ['Case', 'getcaselist', $.extend(true, returnCaseParams, filter, params)],
-        count: ['Case', 'getcount', $.extend(true, returnCaseParams, filter, params)]
+        count: ['Case', 'getdetailscount', $.extend(true, returnCaseParams, filter, params)]
       };
     }
 
@@ -241,7 +237,6 @@
         }, []);
 
         fetchContactsData(allCases);
-        $scope.totalCount = allCases.length; // Todo: Should be removed after Fixing count API response for case list. C51-277
 
         if (!$scope.selectedCase) {
           setCaseAsSelected(allCases[0]);

--- a/ang/civicase/Dashboard.js
+++ b/ang/civicase/Dashboard.js
@@ -75,8 +75,7 @@
      */
     function prepareCaseFilterOption () {
       var options = [
-        // @NOTE Disabled, see C51-277
-        // { 'text': 'My cases', 'id': 'is_case_manager' },
+        { 'text': 'My cases', 'id': 'is_case_manager' },
         { 'text': 'Cases I am involved in', 'id': 'is_involved' }
       ];
 

--- a/ang/civicase/Dashboard.js
+++ b/ang/civicase/Dashboard.js
@@ -35,7 +35,7 @@
         cf.status_id = [status];
       }
       if ($scope.myCasesOnly) {
-        cf.case_manager = [CRM.config.user_contact_id];
+        cf.case_manager = CRM.config.user_contact_id;
       }
       return '#/case/list?' + $.param({cf: JSON.stringify(cf)});
     };
@@ -55,7 +55,7 @@
      */
     function caseRelationshipTypeWatcher (newValue) {
       newValue === 'is_case_manager'
-        ? $scope.activityFilters.case_filter.case_manager = [CRM.config.user_contact_id]
+        ? $scope.activityFilters.case_filter.case_manager = CRM.config.user_contact_id
         : delete ($scope.activityFilters.case_filter.case_manager);
 
       newValue === 'is_involved'

--- a/ang/civicase/DashboardTab.js
+++ b/ang/civicase/DashboardTab.js
@@ -85,7 +85,7 @@
     };
     $scope.newCasesPanel = {
       custom: { itemName: 'cases', caseClick: casesCustomClick },
-      query: { entity: 'Case', action: 'getcaselist', params: getQueryParams('cases') },
+      query: { entity: 'Case', action: 'getcaselist', countAction: 'getdetailscount', params: getQueryParams('cases') },
       handlers: {
         range: _.curry(rangeHandler)('start_date')('YYYY-MM-DD')(false),
         results: _.curry(resultsHandler)(formatCase)('contacts')

--- a/ang/civicase/PanelQuery.js
+++ b/ang/civicase/PanelQuery.js
@@ -120,7 +120,7 @@
 
       var apiCalls = {
         get: [ $scope.query.entity, ($scope.query.action || 'get'), prepareGetParams(paramsCopy) ],
-        count: [ $scope.query.entity, 'getcount', paramsCopy ]
+        count: [ $scope.query.entity, ($scope.query.countAction || 'getcount'), paramsCopy ]
       };
 
       skipCount && (delete apiCalls.count);

--- a/ang/civicase/Search.js
+++ b/ang/civicase/Search.js
@@ -52,11 +52,10 @@
         'text': 'All Cases',
         'id': 'all'
       },
-      // @NOTE Disabled, see C51-277
-      // {
-      //   'text': 'My cases',
-      //   'id': 'is_case_manager'
-      // },
+      {
+        'text': 'My cases',
+        'id': 'is_case_manager'
+      },
       {
         'text': 'Cases I am involved',
         'id': 'is_involved'

--- a/ang/test/civicase/CaseListTable.spec.js
+++ b/ang/test/civicase/CaseListTable.spec.js
@@ -48,7 +48,7 @@
             'id': { 'LIKE': '%' + $scope.filters.id + '%' },
             'contact_is_deleted': 0
           })],
-          ['Case', 'getcount', jasmine.objectContaining({
+          ['Case', 'getdetailscount', jasmine.objectContaining({
             'case_type_id.is_active': 1,
             'id': { 'LIKE': '%' + $scope.filters.id + '%' },
             'contact_is_deleted': 0

--- a/ang/test/civicase/Dashboard.spec.js
+++ b/ang/test/civicase/Dashboard.spec.js
@@ -57,7 +57,7 @@
 
         it('filters the cases and activties where the user is the manager', function () {
           expect($scope.activityFilters.case_filter).toEqual(jasmine.objectContaining({
-            case_manager: [ CRM.config.user_contact_id ]
+            case_manager: CRM.config.user_contact_id
           }));
         });
       });

--- a/ang/test/civicase/Dashboard.spec.js
+++ b/ang/test/civicase/Dashboard.spec.js
@@ -25,8 +25,7 @@
 
         it('shows the `All Cases` filter option', function () {
           expect($scope.caseRelationshipOptions).toEqual([
-            // @NOTE Disabled, see C51-277
-            // { 'text': 'My cases', 'id': 'is_case_manager' },
+            { 'text': 'My cases', 'id': 'is_case_manager' },
             { 'text': 'Cases I am involved in', 'id': 'is_involved' },
             { 'text': 'All Cases', 'id': 'all' }
           ]);
@@ -41,8 +40,7 @@
 
         it('does not show the `All Cases` filter option', function () {
           expect($scope.caseRelationshipOptions).toEqual([
-            // @NOTE Disabled, see C51-277
-            // { 'text': 'My cases', 'id': 'is_case_manager' },
+            { 'text': 'My cases', 'id': 'is_case_manager' },
             { 'text': 'Cases I am involved in', 'id': 'is_involved' }
           ]);
         });

--- a/ang/test/civicase/PanelQuery.spec.js
+++ b/ang/test/civicase/PanelQuery.spec.js
@@ -393,6 +393,25 @@
         it('stores the count', function () {
           expect(panelQueryScope.total).toEqual(NO_OF_RESULTS);
         });
+
+        describe('when the count action is provided', function () {
+          var action;
+
+          beforeEach(function () {
+            $scope.queryData.countAction = 'customcountaction';
+
+            crmApi.calls.reset();
+            compileDirective();
+
+            requests = crmApi.calls.argsFor(0)[0];
+            request = requests[Object.keys(requests)[1]];
+            action = request[1];
+          });
+
+          it('gets the count using the provided count action', function () {
+            expect(action).toBe($scope.queryData.countAction);
+          });
+        });
       });
     });
 

--- a/api/v3/Case/Getdetailscount.php
+++ b/api/v3/Case/Getdetailscount.php
@@ -14,8 +14,7 @@ function civicrm_api3_case_getdetailscount($params) {
   $params['options']['is_count'] = 1;
 
   // Remove unnecesary parameters:
-  unset($params['return']);
-  unset($params['sequential']);
+  unset($params['return'], $params['sequential']);
 
   $casesList = civicrm_api3('Case', 'getdetails', $params);
 

--- a/api/v3/Case/Getdetailscount.php
+++ b/api/v3/Case/Getdetailscount.php
@@ -13,6 +13,10 @@ function civicrm_api3_case_getdetailscount($params) {
   $params['options'] = CRM_Utils_Array::value('options', $params, []);
   $params['options']['is_count'] = 1;
 
+  // Remove unnecesary parameters:
+  unset($params['return']);
+  unset($params['sequential']);
+
   $casesList = civicrm_api3('Case', 'getdetails', $params);
 
   return $casesList['values'];


### PR DESCRIPTION
## Overview

This PR replaces the `getcount` api endpoint with the new `getdetailscount` introduced in https://github.com/compucorp/uk.co.compucorp.civicase/pull/117

This new endpoint allows for properly counting the results for cases filtered by their manager or contacts involved in the case.

## Case Manager
### Before
<img width="1264" alt="screen shot 2018-11-19 at 8 59 38 am" src="https://user-images.githubusercontent.com/1642119/48709166-15265900-ebdb-11e8-81c0-547941f3cd41.png">

Notice these two things:
* The "My Cases" search filter, and
* The pagination list

The contact only has 1 case assigned to them, but the pagination displays more records than what it should.

### After
<img width="1267" alt="screen shot 2018-11-19 at 9 14 07 am" src="https://user-images.githubusercontent.com/1642119/48709322-8108c180-ebdb-11e8-9a79-2ce05fd18da0.png">
The pagination now works properly. When there's only 1 page, the pagination is not displayed.

## Contacts case tab

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/48776912-8cc1ba00-eca7-11e8-8f28-098f48679ddb.gif)


## After
![pr-after](https://user-images.githubusercontent.com/1642119/48776874-69970a80-eca7-11e8-8e75-14799ef420ef.gif)

## Dashboard

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/48841881-243b1180-ed69-11e8-8efc-779d85d115d4.gif)

## After
![pr-after](https://user-images.githubusercontent.com/1642119/48841508-03be8780-ed68-11e8-9adb-7f67985d1372.gif)



## Technical details

* `Case.getcount` was replaced with `Case.getdetailscount`.
* Code that was added as a temporary fix for C51-277 was removed.
* Code that was commented out as a temporary fix for C51-277 was added back.

### getdetailscount fixes
The `getdetailscount` breaks given one of the following conditions:

* Pass the `sequential` parameter to the api
* Include the `activity_summary` in the `return` parameter and pass it to the api

When `sequential` is provided, the results are these:
```json
{
    "error_message": "Could not interpret return values from function.",
    "is_error": 1
}
```
Since the sequential parameter should not change the response of the api it was removed.

When the `activity_summary` is added to the `return` parameter` it will throw the following error:
```json
{
    "is_error": 1,
    "error_message": "invalid criteria for IN"
}
```
The problem is that when requesting the `activity_summary` the `getdetails` action would try to make extra requests to fetch a summary of activities for each case. Since the `return` parameter should not modify the response's count it was also removed.

### Dashboard

Apart from adding back the "My Case" filter, the way the filter was provided to the API was changed as well as it was not working properly because the contact ID was being provided using an array:
```js
$scope.activityFilters.case_filter.case_manager = [CRM.config.user_contact_id]
```
<img width="780" alt="screen shot 2018-11-21 at 8 42 55 am" src="https://user-images.githubusercontent.com/1642119/48842025-8dbb2000-ed69-11e8-8078-e9660b46e362.png">
This is returning all cases for the week instead of returning the cases for the current logged in user.

The endpoint does not recognize the filter when an array is given. When an array is given it will ignore the filter and return all cases regardless of the manager.

To properly get cases for a particular manger, one can either pass the contact id directly `case_manager: 202`, or wrap it in an IN statement: `case_manager: { IN: [202] }`.