### PR TITLE
C51-315: "View cases" link

### DIFF
--- a/ang/civicase/DashboardTab.html
+++ b/ang/civicase/DashboardTab.html
@@ -12,7 +12,6 @@
         <!-- New Cases -->
         <civicase-panel-query query="newCasesPanel.query" handlers="newCasesPanel.handlers" custom-data="newCasesPanel.custom">
           <panel-query-actions>
-            {{customData.foobar()}}
             <a class="panel-heading-control" ng-href="{{customData.viewCasesLink().url}}">
               {{customData.viewCasesLink().label}}
             </a>

--- a/ang/civicase/DashboardTab.html
+++ b/ang/civicase/DashboardTab.html
@@ -12,8 +12,8 @@
         <!-- New Cases -->
         <civicase-panel-query query="newCasesPanel.query" handlers="newCasesPanel.handlers" custom-data="newCasesPanel.custom">
           <panel-query-actions>
-            <a class="panel-heading-control" ng-href="{{customData.viewCasesLink().url}}">
-              {{customData.viewCasesLink().label}}
+            <a class="panel-heading-control" ng-href="{{customData.viewCasesLink.url}}">
+              {{customData.viewCasesLink.label}}
             </a>
           </panel-query-actions>
           <panel-query-title>

--- a/ang/civicase/DashboardTab.html
+++ b/ang/civicase/DashboardTab.html
@@ -11,6 +11,12 @@
       <div class="civicase__dashboard__tab__col civicase__dashboard__tab__col--right">
         <!-- New Cases -->
         <civicase-panel-query query="newCasesPanel.query" handlers="newCasesPanel.handlers" custom-data="newCasesPanel.custom">
+          <panel-query-actions>
+            {{customData.foobar()}}
+            <a class="panel-heading-control" ng-href="{{customData.viewCasesLink().url}}">
+              {{customData.viewCasesLink().label}}
+            </a>
+          </panel-query-actions>
           <panel-query-title>
             You have {{loading.full ? '-' : total}} new cases
           </panel-query-title>

--- a/ang/civicase/DashboardTab.js
+++ b/ang/civicase/DashboardTab.js
@@ -87,7 +87,7 @@
       custom: {
         itemName: 'cases',
         caseClick: casesCustomClick,
-        viewCasesLink: viewCasesLink
+        viewCasesLink: viewCasesLink()
       },
       query: { entity: 'Case', action: 'getcaselist', countAction: 'getdetailscount', params: getQueryParams('cases') },
       handlers: {
@@ -192,8 +192,9 @@
         }
 
         $scope.activitiesPanel.query.params = getQueryParams('activities');
-        $scope.newCasesPanel.query.params = getQueryParams('cases');
         $scope.newMilestonesPanel.query.params = getQueryParams('milestones');
+        $scope.newCasesPanel.query.params = getQueryParams('cases');
+        $scope.newCasesPanel.custom.viewCasesLink = viewCasesLink();
 
         loadCaseIds();
       });

--- a/ang/civicase/DashboardTab.js
+++ b/ang/civicase/DashboardTab.js
@@ -325,17 +325,19 @@
      * @return {Object}
      */
     function viewCasesQueryParams () {
-      var filterKey;
       var params = {};
 
       if ($scope.filters.caseRelationshipType !== 'all') {
         params.cf = {};
 
-        filterKey = $scope.filters.caseRelationshipType === 'is_case_manager'
-          ? 'case_manager'
-          : 'contact_id';
+        // @NOTE: The case list page expects the param's value to be
+        // inside an array (`case_filter.contact_id` already is)
+        if ($scope.filters.caseRelationshipType === 'is_case_manager') {
+          params.cf.case_manager = [$scope.activityFilters.case_filter.case_manager];
+        } else {
+          params.cf.contact_id = $scope.activityFilters.case_filter.contact_id;
+        }
 
-        params.cf[filterKey] = $scope.activityFilters.case_filter[filterKey];
         params.cf = JSON.stringify(params.cf);
       }
 

--- a/ang/civicase/DashboardTab.js
+++ b/ang/civicase/DashboardTab.js
@@ -11,7 +11,7 @@
 
   module.controller('dashboardTabController', dashboardTabController);
 
-  function dashboardTabController ($location, $rootScope, $route, $scope,
+  function dashboardTabController ($location, $rootScope, $route, $sce, $scope,
     ContactsDataService, crmApi, formatCase, formatActivity) {
     var ACTIVITIES_QUERY_PARAMS_DEFAULTS = {
       'contact_id': 'user_contact_id',
@@ -84,7 +84,11 @@
       }
     };
     $scope.newCasesPanel = {
-      custom: { itemName: 'cases', caseClick: casesCustomClick },
+      custom: {
+        itemName: 'cases',
+        caseClick: casesCustomClick,
+        viewCasesLink: viewCasesLink
+      },
       query: { entity: 'Case', action: 'getcaselist', countAction: 'getdetailscount', params: getQueryParams('cases') },
       handlers: {
         range: _.curry(rangeHandler)('start_date')('YYYY-MM-DD')(false),
@@ -284,6 +288,58 @@
       } catch (e) {
         return formattedResults;
       }
+    }
+
+    /**
+     * Returns an object representing the "view cases" link
+     *
+     * Depending on the value of the relationship type filter, both the label
+     * and the url of the link might change
+     *
+     * This function is being called directly on the view so that the object
+     * is updated automatically whenever the relationship type filter value changes
+     *
+     * @return {Object}
+     */
+    function viewCasesLink () {
+      var queryParams = viewCasesQueryParams();
+
+      return {
+        url: $sce.trustAsResourceUrl('#/case/list?' + $.param(queryParams)),
+        label: $scope.filters.caseRelationshipType === 'all'
+          ? 'View all cases'
+          : 'View all my cases'
+      };
+    }
+
+    /**
+     * Returns the query string params for the "view cases" link
+     *
+     * The only query string parameter needed by the link is
+     *   `cf.case_manager` if the relationship type filter is set on "My Cases"
+     *   `cf.contact_id` if the relationship type filter is set on "Cases I'm involved in""
+     *
+     * If the relationship type filter is set on "All Cases", then
+     * no parameter is needed
+     *
+     * @return {Object}
+     */
+    function viewCasesQueryParams () {
+      var filterKey;
+      var params = {};
+
+      if ($scope.filters.caseRelationshipType !== 'all') {
+        params.cf = {};
+
+        filterKey = $scope.filters.caseRelationshipType === 'is_case_manager'
+          ? 'case_manager'
+          : 'contact_id';
+
+        params.cf[filterKey] = $scope.activityFilters.case_filter[filterKey];
+        params.cf = JSON.stringify(params.cf);
+      }
+
+      return params;
     }
   }
 })(angular, CRM.$, CRM._, CRM.civicase.activityStatusTypes);

--- a/ang/test/civicase/ActivitiesCalendar.spec.js
+++ b/ang/test/civicase/ActivitiesCalendar.spec.js
@@ -639,7 +639,7 @@
         });
 
         url = $scope.seeAllLinkUrl(dates.yesterday);
-        queryParams = extractQueryStringParams();
+        queryParams = CRM.testUtils.extractQueryStringParams(url.$$unwrapTrustedValue());
       });
 
       it('is a trusted url', function () {
@@ -667,27 +667,6 @@
         expect(queryParams.foo).toBe(currentRouteParams.foo);
         expect(queryParams.af.bar).toBe(currentRouteParams.af.bar);
       });
-
-      /**
-       * Given the "see all" link url, it extracts the querystring parameters,
-       * making sure to decode the value of the `af` property (given that the value
-       * is an encoded JSON object)
-       *
-       * return {Object}
-       */
-      function extractQueryStringParams () {
-        var paramsCouples = url.$$unwrapTrustedValue().split('?')[1].split('&');
-
-        return paramsCouples.reduce(function (acc, couple) {
-          var coupleKeyVal = couple.split('=');
-
-          acc[coupleKeyVal[0]] = coupleKeyVal[0] === 'af'
-            ? JSON.parse(decodeURIComponent(coupleKeyVal[1]))
-            : coupleKeyVal[1];
-
-          return acc;
-        }, {});
-      }
     });
 
     /**

--- a/ang/test/civicase/DashboardTab.spec.js
+++ b/ang/test/civicase/DashboardTab.spec.js
@@ -237,6 +237,78 @@
             });
           });
         });
+
+        describe('view cases link', function () {
+          var linkProps, queryParams;
+
+          it('is defined', function () {
+            expect($scope.newCasesPanel.custom.viewCasesLink).toBeDefined();
+          });
+
+          it('returns a label for the link', function () {
+            expect($scope.newCasesPanel.custom.viewCasesLink().label).toBeDefined();
+          });
+
+          it('returns a trusted url for the link', function () {
+            var url = $scope.newCasesPanel.custom.viewCasesLink().url;
+
+            expect(url).toBeDefined();
+            expect(url.$$unwrapTrustedValue).toBeDefined();
+          });
+
+          describe('when the relationship type filter is: My cases', function () {
+            beforeEach(function () {
+              $scope.filters.caseRelationshipType = 'is_case_manager';
+              $scope.activityFilters.case_filter.case_manager = [20];
+
+              linkProps = $scope.newCasesPanel.custom.viewCasesLink();
+              queryParams = CRM.testUtils.extractQueryStringParams(linkProps.url.$$unwrapTrustedValue());
+            });
+
+            it('sets "View all my cases" as label', function () {
+              expect(linkProps.label).toBe('View all my cases');
+            });
+
+            it('passes the correct filter to the manage cases page', function () {
+              expect(queryParams.cf.case_manager).toEqual($scope.activityFilters.case_filter.case_manager);
+            });
+          });
+
+          describe('when the relationship type filter is: Cases I\'m involved with', function () {
+            beforeEach(function () {
+              $scope.filters.caseRelationshipType = 'is_involved';
+              $scope.activityFilters.case_filter.contact_id = [20];
+
+              linkProps = $scope.newCasesPanel.custom.viewCasesLink();
+              queryParams = CRM.testUtils.extractQueryStringParams(linkProps.url.$$unwrapTrustedValue());
+            });
+
+            it('sets "View all my cases" as label', function () {
+              expect(linkProps.label).toBe('View all my cases');
+            });
+
+            it('passes the correct filter to the manage cases page', function () {
+              expect(queryParams.cf.contact_id).toEqual($scope.activityFilters.case_filter.contact_id);
+            });
+          });
+
+          describe('when the relationship type filter is: All Cases', function () {
+            beforeEach(function () {
+              $scope.filters.caseRelationshipType = 'all';
+
+              linkProps = $scope.newCasesPanel.custom.viewCasesLink();
+              queryParams = CRM.testUtils.extractQueryStringParams(linkProps.url.$$unwrapTrustedValue());
+            });
+
+            it('sets "View all cases" as label', function () {
+              expect(linkProps.label).toBe('View all cases');
+            });
+
+            it('passes the correct filter to the manage cases page', function () {
+              expect(queryParams.cf).not.toBeDefined();
+            });
+          });
+        });
       });
 
       describe('when the relationship type changes', function () {

--- a/ang/test/civicase/DashboardTab.spec.js
+++ b/ang/test/civicase/DashboardTab.spec.js
@@ -249,12 +249,12 @@
             expect($scope.newCasesPanel.custom.viewCasesLink).toBeDefined();
           });
 
-          it('returns a label for the link', function () {
-            expect($scope.newCasesPanel.custom.viewCasesLink().label).toBeDefined();
+          it('contains a label for the link', function () {
+            expect($scope.newCasesPanel.custom.viewCasesLink.label).toBeDefined();
           });
 
-          it('returns a trusted url for the link', function () {
-            var url = $scope.newCasesPanel.custom.viewCasesLink().url;
+          it('contains a trusted url for the link', function () {
+            var url = $scope.newCasesPanel.custom.viewCasesLink.url;
 
             expect(url).toBeDefined();
             expect(url.$$unwrapTrustedValue).toBeDefined();
@@ -264,8 +264,9 @@
             beforeEach(function () {
               $scope.filters.caseRelationshipType = 'is_case_manager';
               $scope.activityFilters.case_filter.case_manager = userId;
+              $scope.$digest();
 
-              linkProps = $scope.newCasesPanel.custom.viewCasesLink();
+              linkProps = $scope.newCasesPanel.custom.viewCasesLink;
               queryParams = CRM.testUtils.extractQueryStringParams(linkProps.url.$$unwrapTrustedValue());
             });
 
@@ -282,8 +283,9 @@
             beforeEach(function () {
               $scope.filters.caseRelationshipType = 'is_involved';
               $scope.activityFilters.case_filter.contact_id = [userId];
+              $scope.$digest();
 
-              linkProps = $scope.newCasesPanel.custom.viewCasesLink();
+              linkProps = $scope.newCasesPanel.custom.viewCasesLink;
               queryParams = CRM.testUtils.extractQueryStringParams(linkProps.url.$$unwrapTrustedValue());
             });
 
@@ -299,8 +301,9 @@
           describe('when the relationship type filter is: All Cases', function () {
             beforeEach(function () {
               $scope.filters.caseRelationshipType = 'all';
+              $scope.$digest();
 
-              linkProps = $scope.newCasesPanel.custom.viewCasesLink();
+              linkProps = $scope.newCasesPanel.custom.viewCasesLink;
               queryParams = CRM.testUtils.extractQueryStringParams(linkProps.url.$$unwrapTrustedValue());
             });
 

--- a/ang/test/civicase/DashboardTab.spec.js
+++ b/ang/test/civicase/DashboardTab.spec.js
@@ -239,7 +239,11 @@
         });
 
         describe('view cases link', function () {
-          var linkProps, queryParams;
+          var linkProps, queryParams, userId;
+
+          beforeEach(function () {
+            userId = 20;
+          });
 
           it('is defined', function () {
             expect($scope.newCasesPanel.custom.viewCasesLink).toBeDefined();
@@ -259,7 +263,7 @@
           describe('when the relationship type filter is: My cases', function () {
             beforeEach(function () {
               $scope.filters.caseRelationshipType = 'is_case_manager';
-              $scope.activityFilters.case_filter.case_manager = [20];
+              $scope.activityFilters.case_filter.case_manager = userId;
 
               linkProps = $scope.newCasesPanel.custom.viewCasesLink();
               queryParams = CRM.testUtils.extractQueryStringParams(linkProps.url.$$unwrapTrustedValue());
@@ -270,14 +274,14 @@
             });
 
             it('passes the correct filter to the manage cases page', function () {
-              expect(queryParams.cf.case_manager).toEqual($scope.activityFilters.case_filter.case_manager);
+              expect(queryParams.cf.case_manager).toEqual([userId]);
             });
           });
 
           describe('when the relationship type filter is: Cases I\'m involved with', function () {
             beforeEach(function () {
               $scope.filters.caseRelationshipType = 'is_involved';
-              $scope.activityFilters.case_filter.contact_id = [20];
+              $scope.activityFilters.case_filter.contact_id = [userId];
 
               linkProps = $scope.newCasesPanel.custom.viewCasesLink();
               queryParams = CRM.testUtils.extractQueryStringParams(linkProps.url.$$unwrapTrustedValue());
@@ -288,7 +292,7 @@
             });
 
             it('passes the correct filter to the manage cases page', function () {
-              expect(queryParams.cf.contact_id).toEqual($scope.activityFilters.case_filter.contact_id);
+              expect(queryParams.cf.contact_id).toEqual([userId]);
             });
           });
 

--- a/ang/test/global.js
+++ b/ang/test/global.js
@@ -23,7 +23,15 @@
      * @return {Object}
      */
     extractQueryStringParams: function (url) {
-      var paramsCouples = url.split('?')[1].split('&');
+      var queryString, paramsCouples;
+
+      queryString = url.split('?')[1];
+
+      if (!queryString) {
+        return {};
+      }
+
+      paramsCouples = queryString.split('&');
 
       return paramsCouples.reduce(function (acc, couple) {
         var coupleKeyVal = couple.split('=');

--- a/ang/test/global.js
+++ b/ang/test/global.js
@@ -11,4 +11,29 @@
 
   CRM.loadForm = jasmine.createSpy('loadForm');
   CRM.url = jasmine.createSpy('url');
+
+  // Common utility functions for tests
+  CRM.testUtils = {
+
+    /**
+     * Given a full url, it extracts the querystring parameters, making sure
+     * to decode and parse any value that is an encoded JSON object
+     *
+     * @param {String} url
+     * @return {Object}
+     */
+    extractQueryStringParams: function (url) {
+      var paramsCouples = url.split('?')[1].split('&');
+
+      return paramsCouples.reduce(function (acc, couple) {
+        var coupleKeyVal = couple.split('=');
+
+        acc[coupleKeyVal[0]] = coupleKeyVal[1].match(/^%7B.+%7D/)
+          ? JSON.parse(decodeURIComponent(coupleKeyVal[1]))
+          : coupleKeyVal[1];
+
+        return acc;
+      }, {});
+    }
+  };
 }(CRM));


### PR DESCRIPTION
This PR adds a "View cases" link in the "new cases" block in the dashboard, that will redirect the user to the "Manage Cases" page.

The link will change both label and query string params depending on the current value of the "case relationship" filter:

![link-label](https://user-images.githubusercontent.com/6400898/48951442-e1329700-ef3e-11e8-896b-c3fd8585b790.gif)

When the filter is on "All Cases":
![all](https://user-images.githubusercontent.com/6400898/48951614-82b9e880-ef3f-11e8-8ef7-743c1f7d91aa.gif)


When the filter is on "My cases":
![my](https://user-images.githubusercontent.com/6400898/48951617-83527f00-ef3f-11e8-81d8-5f054c33dae3.gif)


When the filter is on "Cases I'm involved in":
![involved](https://user-images.githubusercontent.com/6400898/48951616-82b9e880-ef3f-11e8-8507-b732e039616f.gif)

### Technical details
#### Link's function
The link is generated every time `$scope.filters.caseRelationshipType` changes

```js
function initWatchers () {
  $scope.$watchCollection('filters.caseRelationshipType', function (newType, oldType) {
    // ...
    $scope.newCasesPanel.query.params = getQueryParams('cases');
    $scope.newCasesPanel.custom.viewCasesLink = viewCasesLink();
  });
}
```

The link's query string parameters are generated on the fly by the function. The only parameter needed by the "Manage Cases" page is
```js
cf.case_manager = [<some-id>]
```
when filtering by "My cases", and
```js
cf.contact_id = [<some-id>]
```
when filtering by "Cases I'm involved in"

Unfortunately the "Manage Cases" page expect `<some-id>` to be in an array, thus the following
```js
function viewCasesQueryParams () {
  // ...
  // @NOTE: The case list page expects the param's value to be
  // inside an array (`case_filter.contact_id` already is)
  if ($scope.filters.caseRelationshipType === 'is_case_manager') {
    params.cf.case_manager = [$scope.activityFilters.case_filter.case_manager];
  } else {
    params.cf.contact_id = $scope.activityFilters.case_filter.contact_id;
  }
  // ...
}
```

### Common "extract query string params" function for tests
In #122 I added a [`extractQueryStringParams`](https://github.com/compucorp/uk.co.compucorp.civicase/pull/122/files#diff-970f14a1d58c0dac604e68d861b1216dR678) function, used for running some assertions in the tests of the Activities Calendar.

Now the same function was required for testing the link, so I moved it in the `globals.js` file, under `CRM.testUtils`
```js
(function (CRM) {
  CRM.civicase = {};
  CRM.angular = { requires: {} };
  // ...

  // Common utility functions for tests
  CRM.testUtils = {
    extractQueryStringParams: function (url) {
    // ...
    }
  }
}(CRM));
```
(I could not find any better place for it, given that this seems to be the first common function in the test suite)