### PR TITLE
C51-286: Auto populate contact

### DIFF
--- a/ang/civicase/ContactCaseTab.html
+++ b/ang/civicase/ContactCaseTab.html
@@ -4,7 +4,7 @@
   <div class="civicase__contact-cases-tab clearfix">
     <a ng-if="checkPerm('add cases')"
       class="btn-primary btn civicase__contact-cases-tab-add"
-      ng-href="{{ 'civicrm/case/add' | civicaseCrmUrl:{reset: 1, action: 'add', context: 'standalone'} }}"
+      ng-href="{{ 'civicrm/case/add' | civicaseCrmUrl:{cid: contactId, reset: 1, action: 'add', context: 'standalone'} }}"
       crm-popup-form-success="refresh()">
       <i class="material-icons">add_circle</i>
       {{ ts('Add case') }}

--- a/ang/civicase/ContactCaseTab.js
+++ b/ang/civicase/ContactCaseTab.js
@@ -4,11 +4,13 @@
   module.directive('civicaseContactCaseTab', function () {
     return {
       restrict: 'EA',
-      controller: CivicaseContactCaseTabController,
+      controller: 'CivicaseContactCaseTabController',
       templateUrl: '~/civicase/ContactCaseTab.html',
       scope: {}
     };
   });
+
+  module.controller('CivicaseContactCaseTabController', CivicaseContactCaseTabController);
 
   function CivicaseContactCaseTabController ($scope, crmApi, formatCase, Contact, ContactsDataService) {
     var commonConfigs = {
@@ -22,13 +24,14 @@
     };
 
     $scope.caseDetailsLoaded = false;
+    $scope.contactId = Contact.getContactIDFromUrl();
     $scope.casesListConfig = [
       {
         'name': 'opened',
         'title': 'Open Cases',
         'filterParams': {
           'status_id.grouping': 'Opened',
-          'contact_id': Contact.getContactIDFromUrl()
+          'contact_id': $scope.contactId
         },
         'showContactRole': false
       }, {
@@ -36,14 +39,14 @@
         'title': 'Resolved cases',
         'filterParams': {
           'status_id.grouping': 'Closed',
-          'contact_id': Contact.getContactIDFromUrl()
+          'contact_id': $scope.contactId
         },
         'showContactRole': false
       }, {
         'name': 'related',
         'title': 'Other cases for this contact',
         'filterParams': {
-          'case_manager': Contact.getContactIDFromUrl()
+          'case_manager': $scope.contactId
         },
         'showContactRole': true
       }
@@ -186,7 +189,7 @@
      */
     function getContactRole (caseObj) {
       var contact = _.find(caseObj.contacts, {
-        contact_id: Contact.getContactIDFromUrl()
+        contact_id: $scope.contactId
       });
 
       return contact ? contact.role : 'No Role Associated';

--- a/ang/test/civicase/ActivityFeed.spec.js
+++ b/ang/test/civicase/ActivityFeed.spec.js
@@ -140,7 +140,12 @@
       describe('when the activity details panel is iniliased with window already scrolled', function () {
         beforeEach(function () {
           compileDirective({isAffixedOnInit: true});
+
           $activityDetailsPanel = element.find('.civicase__activity-panel');
+        });
+
+        afterEach(function () {
+          removeTestDomElements();
         });
 
         it('sets the top positioning', function () {

--- a/ang/test/civicase/ContactCaseTab.spec.js
+++ b/ang/test/civicase/ContactCaseTab.spec.js
@@ -1,1 +1,40 @@
-// Todo write unit tests for ContactCaseTab.js
+/* eslint-env jasmine */
+
+(function (_) {
+  fdescribe('Contact Case Tab', function () {
+    var $controller, $rootScope, $scope, mockContactId, mockContactService;
+
+    beforeEach(module('civicase', function ($provide) {
+      mockContactService = jasmine.createSpyObj('Contact', ['getContactIDFromUrl']);
+
+      $provide.value('Contact', mockContactService);
+    }));
+
+    beforeEach(inject(function (_$controller_, _$rootScope_) {
+      $controller = _$controller_;
+      $rootScope = _$rootScope_;
+    }));
+
+    beforeEach(function () {
+      mockContactId = _.uniqueId();
+
+      mockContactService.getContactIDFromUrl.and.returnValue(mockContactId);
+      initController();
+    });
+
+    describe('on init', function () {
+      it('stores the contact id extracted from the URL', function () {
+        expect($scope.contactId).toBe(mockContactId);
+      });
+    });
+
+    /**
+     * Initializes the contact case tab controller.
+     */
+    function initController () {
+      $scope = $rootScope.$new();
+
+      $controller('CivicaseContactCaseTabController', { $scope: $scope });
+    }
+  });
+})(CRM._);

--- a/ang/test/civicase/ContactCaseTab.spec.js
+++ b/ang/test/civicase/ContactCaseTab.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env jasmine */
 
 (function (_) {
-  fdescribe('Contact Case Tab', function () {
+  describe('Contact Case Tab', function () {
     var $controller, $rootScope, $scope, mockContactId, mockContactService;
 
     beforeEach(module('civicase', function ($provide) {


### PR DESCRIPTION
## Overview
This PR automatically selects the current contact when creating a new case from the contact's case tab.

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/49486454-e7652500-f814-11e8-9fe1-1cb99861fddf.gif)


## After
![pr-after](https://user-images.githubusercontent.com/1642119/49486411-b684f000-f814-11e8-9642-d81d32c44995.gif)

## Technical details

The solution was simple: to pass the `cid` (contact id) parameter to the form URL:

```html
<a ng-href="{{ 'civicrm/case/add' | civicaseCrmUrl:{cid: contactId, reset: 1, action: 'add', context: 'standalone'} }}">
```

The contact ID is provided by ` Contact.getContactIDFromUrl()`:

```js
$scope.contactId = Contact.getContactIDFromUrl();
```

Since this value is constant all other instances of `Contact.getContactIDFromUrl()` were replaced by `$scope.contactId`. 