### PR TITLE
C51-314: Do not display cases that have been deleted on the dashboard

### DIFF
--- a/ang/civicase/DashboardTab.js
+++ b/ang/civicase/DashboardTab.js
@@ -31,7 +31,8 @@
     };
     var CASES_QUERY_PARAMS_DEFAULTS = {
       'status_id.grouping': 'Opened',
-      'options': { 'sort': 'start_date DESC' }
+      'options': { 'sort': 'start_date DESC' },
+      'is_deleted': 0
     };
     var MILESTONES_QUERY_PARAMS_DEFAULTS = {
       'contact_id': 'user_contact_id',

--- a/ang/test/civicase/DashboardTab.spec.js
+++ b/ang/test/civicase/DashboardTab.spec.js
@@ -128,6 +128,10 @@
           expect($scope.newCasesPanel.query.params['status_id.grouping']).toBe('Opened');
         });
 
+        it('fetches cases that have not been deleted', function () {
+          expect($scope.newCasesPanel.query.params.is_deleted).toBe(0);
+        });
+
         it('sorts by start_date, descending order', function () {
           expect($scope.newCasesPanel.query.params.options.sort).toBe('start_date DESC');
         });


### PR DESCRIPTION
## Overview

This PR fixes an issue where deleted cases would be displayed on the dashboard.

## Before
![civicase dashboard all cases case 8000](https://user-images.githubusercontent.com/1642119/49587292-d2ce7d00-f939-11e8-9cd7-4796d47b08b7.png)

## After
<img width="717" alt="screen shot 2018-12-06 at 9 30 46 am" src="https://user-images.githubusercontent.com/1642119/49587214-a3b80b80-f939-11e8-8cb9-e7d64b2070ad.png">

## Technical details

The default query parameters for the case now include the `is_deleted: 0` option to skip deleted records.