### PR TITLE
C51-356: Show Linked Cases First

### DIFF
--- a/ang/civicase/Utils.js
+++ b/ang/civicase/Utils.js
@@ -306,8 +306,7 @@
       return {
         id: caseId,
         return: caseReturnParams,
-        // Related cases by contact
-        'api.Case.getcaselist.1': {
+        'api.Case.getcaselist.relatedCasesByContact': {
           contact_id: {IN: '$value.contact_id'},
           id: {'!=': '$value.id'},
           is_deleted: 0,
@@ -315,7 +314,7 @@
           'api.Activity.get.1': allActivitiesParams
         },
         // Linked cases
-        'api.Case.getcaselist.2': {
+        'api.Case.getcaselist.linkedCases': {
           id: {IN: '$value.related_case_ids'},
           is_deleted: 0,
           return: caseListReturnParams,

--- a/ang/test/civicase/CaseDetails.spec.js
+++ b/ang/test/civicase/CaseDetails.spec.js
@@ -24,13 +24,13 @@
     beforeEach(inject(function (_$compile_, _$rootScope_, _CasesData_, _crmApi_, _$q_, _formatCase_) {
       $compile = _$compile_;
       $rootScope = _$rootScope_;
-      CasesData = _CasesData_.get();
+      CasesData = _CasesData_;
       $scope = $rootScope.$new();
       $q = _$q_;
       crmApi = _crmApi_;
       formatCase = _formatCase_;
 
-      crmApi.and.returnValue($q.resolve(_.cloneDeep(CasesData)));
+      crmApi.and.returnValue($q.resolve(CasesData.get()));
     }));
 
     describe('basic tests', function () {
@@ -71,8 +71,8 @@
     describe('pushCaseData()', function () {
       beforeEach(function () {
         compileDirective();
-        element.isolateScope().item = CasesData.values[0];
-        element.isolateScope().pushCaseData(CasesData.values[0]);
+        element.isolateScope().item = CasesData.get().values[0];
+        element.isolateScope().pushCaseData(CasesData.get().values[0]);
       });
 
       it('calculates the incomplete scheduled activities', function () {
@@ -81,6 +81,40 @@
 
       it('calculates the incomplete tasks activities', function () {
         expect(element.isolateScope().item.category_count.incomplete.task).toBe(2);
+      });
+
+      describe('Related Cases', function () {
+        describe('related cases', function () {
+          var relatedCasesByContact, linkedCases;
+
+          beforeEach(function () {
+            relatedCasesByContact = CasesData.get().values[0]['api.Case.getcaselist.relatedCasesByContact'].values;
+            linkedCases = CasesData.get().values[0]['api.Case.getcaselist.linkedCases'].values;
+          });
+
+          it('related cases are displayed', function () {
+            expect(element.isolateScope().item.relatedCases.length).toBe(relatedCasesByContact.concat(linkedCases).length);
+          });
+        });
+
+        describe('linked cases cases', function () {
+          var relatedCasesCopy, sortedList;
+
+          beforeEach(function () {
+            relatedCasesCopy = angular.copy(element.isolateScope().item.relatedCases);
+            sortedList = relatedCasesCopy.sort(function (x, y) {
+              return !!y.is_linked - !!x.is_linked;
+            });
+          });
+
+          it('linked cases are displayed first', function () {
+            expect(sortedList).toEqual(element.isolateScope().item.relatedCases);
+          });
+        });
+
+        it('shows the first page of the pager', function () {
+          expect(element.isolateScope().relatedCasesPager.num).toBe(1);
+        });
       });
       /* TODO - Rest of function needs to be unit tested */
     });
@@ -91,7 +125,7 @@
       beforeEach(function () {
         compileDirective();
         element.isolateScope().item = {};
-        element.isolateScope().item.relatedCases = CasesData.values[0];
+        element.isolateScope().item.relatedCases = CasesData.get().values[0];
         element.isolateScope().relatedCasesPager.num = 2;
         element.isolateScope().relatedCasesPager.size = 5;
       });
@@ -128,7 +162,7 @@
     });
 
     function compileDirective () {
-      $scope.viewingCaseDetails = formatCase(CasesData.values[0]);
+      $scope.viewingCaseDetails = formatCase(CasesData.get().values[0]);
       element = $compile('<div civicase-case-details="viewingCaseDetails"></div>')($scope);
       $scope.$digest();
     }

--- a/ang/test/mocks/data/cases.data.js
+++ b/ang/test/mocks/data/cases.data.js
@@ -1691,6 +1691,11 @@
       ]
     };
 
+    _.each(casesMockData.values, function (caseObj) {
+      caseObj['api.Case.getcaselist.relatedCasesByContact'].values = [angular.copy(casesMockData.values[0])];
+      caseObj['api.Case.getcaselist.linkedCases'].values = [angular.copy(casesMockData.values[1])];
+    });
+
     return {
       /**
        * Returns a list of mocked cases
@@ -1698,7 +1703,7 @@
        * @return {Array} each array contains an object with the activity data.
        */
       get: function () {
-        return _.clone(casesMockData);
+        return angular.copy(casesMockData);
       }
     };
   });

--- a/ang/test/mocks/data/cases.data.js
+++ b/ang/test/mocks/data/cases.data.js
@@ -191,8 +191,8 @@
             16: '1',
             53: '1'
           },
-          'api.Case.getcaselist.1': { 'values': [] },
-          'api.Case.getcaselist.2': { 'values': [] },
+          'api.Case.getcaselist.relatedCasesByContact': { 'values': [] },
+          'api.Case.getcaselist.linkedCases': { 'values': [] },
           'api.Activity.get.1': {
             'is_error': 0,
             'version': 3,
@@ -801,8 +801,8 @@
           'color': '#42afcb',
           'case_type': 'Housing Support',
           'selected': false,
-          'api.Case.getcaselist.1': { 'values': [] },
-          'api.Case.getcaselist.2': { 'values': [] },
+          'api.Case.getcaselist.relatedCasesByContact': { 'values': [] },
+          'api.Case.getcaselist.linkedCases': { 'values': [] },
           'api.Activity.get.1': {
             'is_error': 0,
             'version': 3,
@@ -1368,8 +1368,8 @@
           'color': '#42afcb',
           'case_type': 'Adult Day Care Referral',
           'selected': false,
-          'api.Case.getcaselist.1': { 'values': [] },
-          'api.Case.getcaselist.2': { 'values': [] },
+          'api.Case.getcaselist.relatedCasesByContact': { 'values': [] },
+          'api.Case.getcaselist.linkedCases': { 'values': [] },
           'api.Activity.get.1': {
             'is_error': 0,
             'version': 3,


### PR DESCRIPTION
## Overview
As part of this PR, the linked cases are shown first on the Other Cases block.

## Before
![2018-12-10 at 6 27 pm](https://user-images.githubusercontent.com/5058867/49734137-56c19580-fca9-11e8-911d-e9f8e2532152.png)

## After
![2018-12-10 at 6 26 pm](https://user-images.githubusercontent.com/5058867/49734083-2da10500-fca9-11e8-841e-7d8561b57b30.png)

## Technical Details
1. In `ang/civicase/CaseDetails.js`, code related to Related Cases has been moved to `prepareRelatedCases` method.
2. The following logic is added to sort the related cases by linked first.
```javascript
caseObj.relatedCases.sort(function (x, y) {
  return !!y.is_linked - !!x.is_linked;
});
```
3. API objects like `'api.Case.getcaselist.1` has been renamed to more developer friendly `'api.Case.getcaselist.relatedCasesByContact'`, so that its more readable.