### PR TITLE
C51-320: Hide delegated activities from "My Activities"

### DIFF
--- a/CRM/Civicase/Activity/ContactActivitiesSelector.php
+++ b/CRM/Civicase/Activity/ContactActivitiesSelector.php
@@ -86,13 +86,13 @@ class CRM_Civicase_Activity_ContactActivitiesSelector {
    * the requested one. It also updates the activities count in order to reflect the
    * new value.
    *
-   * @param array $activites
+   * @param array $activities
    * @param array $params
    * @return array
    */
   private function filterOutActivitiesNotBelongingToContact(&$activities, $params) {
     $activities['values'] = array_filter($activities['values'], function ($activity) use ($params) {
-      $hasNoAssignee = !isset($activity['assignee_contact_id']) || empty($activity['assignee_contact_id']);
+      $hasNoAssignee = empty($activity['assignee_contact_id']);
       $isContactAssignedToActivity = in_array($params['contact_id'], $activity['assignee_contact_id']);
 
       return $hasNoAssignee || $isContactAssignedToActivity;
@@ -104,9 +104,8 @@ class CRM_Civicase_Activity_ContactActivitiesSelector {
   /**
    * Paginates the activity records according to the limit and offset params.
    *
-   * @param array $activites
+   * @param array $activities
    * @param array $params
-   * @return array
    */
   private function paginateActivityRecords(&$activities, $params) {
     $options = CRM_Utils_Array::value('options', $params, []);
@@ -117,4 +116,5 @@ class CRM_Civicase_Activity_ContactActivitiesSelector {
     $activities['values'] = array_slice($activities['values'], $offset, $limit);
     $activities['count'] = count($activities['values']);
   }
+
 }

--- a/CRM/Civicase/Activity/ContactActivitiesSelector.php
+++ b/CRM/Civicase/Activity/ContactActivitiesSelector.php
@@ -15,6 +15,8 @@ class CRM_Civicase_Activity_ContactActivitiesSelector {
   public function getActivitiesForContact($params) {
     $newParams = $this->getParamsWithoutOffsetsAndLimits($params);
 
+    $this->addAssigneeContactIdToReturnParams($newParams);
+
     $activities = civicrm_api3('Activity', 'get', $newParams);
 
     if ($activities['error']) {
@@ -40,6 +42,21 @@ class CRM_Civicase_Activity_ContactActivitiesSelector {
     $params['options'] = $options;
 
     return $params;
+  }
+
+  /**
+   * Adds the `assignee_contact_id` field to the return parameter. This field
+   * is necesary in order to properly filter the activities for the contact and
+   * remove activities that have been delegated to someone else.
+   *
+   * @param array $params
+   */
+  private function addAssigneeContactIdToReturnParams(&$params) {
+    $return = (array) CRM_Utils_Array::value('return', $params, []);
+    $return[] = 'assignee_contact_id';
+    $return = array_unique($return);
+    $return = implode(',', $return);
+    $params['return'] = $return;
   }
 
   /**

--- a/CRM/Civicase/Activity/ContactActivitiesSelector.php
+++ b/CRM/Civicase/Activity/ContactActivitiesSelector.php
@@ -1,0 +1,79 @@
+<?php
+
+class CRM_Civicase_Activity_ContactActivitiesSelector {
+
+  const API_DEFAULT_LIMIT = 25;
+
+  /**
+   * Get the activities for a given contact. The contact must be either the creator,
+   * the client, or be one of the assignees for the activity. Also, the activity should
+   * not be assigned to someone else unless the contact is also an assignee.
+   *
+   * @param array
+   * @return array
+   */
+  public function getActivitiesForContact($params) {
+    $newParams = $this->getParamsWithoutOffsetsAndLimits($params);
+
+    $activities = civicrm_api3('Activity', 'get', $newParams);
+
+    if ($activities['error']) {
+      return $activities;
+    }
+
+    $this->filterOutActivitiesNotBelongingToContact($activities, $newParams);
+    $this->paginateActivityRecords($activities, $params);
+
+    return $activities;
+  }
+
+  /**
+   * Returns the original parameters, but without any offsets or limits.
+   *
+   * @param array $params
+   * @return array
+   */
+  private function getParamsWithoutOffsetsAndLimits($params) {
+    $options = CRM_Utils_Array::value('options', $params, []);
+    $options['limit'] = 0;
+    $options['offset'] = 0;
+    $params['options'] = $options;
+
+    return $params;
+  }
+
+  /**
+   * Removes any activities that have been assigned to another contact other than
+   * the requested one. It also updates the activities count in order to reflect the
+   * new value.
+   *
+   * @param array $activites
+   * @param array $params
+   * @return array
+   */
+  private function filterOutActivitiesNotBelongingToContact(&$activities, $params) {
+    $activities['values'] = array_filter($activities['values'], function ($activity) use ($params) {
+      $hasNoAssignee = !isset($activity['assignee_contact_id']) || empty($activity['assignee_contact_id']);
+      $isContactAssignedToActivity = in_array($params['contact_id'], $activity['assignee_contact_id']);
+
+      return $hasNoAssignee || $isContactAssignedToActivity;
+    });
+
+    $activities['count'] = count($activities['values']);
+  }
+
+  /**
+   * Paginates the activity records according to the limit and offset params.
+   *
+   * @param array $activites
+   * @param array $params
+   * @return array
+   */
+  private function paginateActivityRecords(&$activities, $params) {
+    $options = CRM_Utils_Array::value('options', $params, []);
+    $limit = CRM_Utils_Array::value('limit', $options, self::API_DEFAULT_LIMIT);
+    $offset = CRM_Utils_Array::value('offset', $options, 0);
+
+    $activities['values'] = array_slice($activities['values'], $offset, $limit);
+  }
+}

--- a/CRM/Civicase/Activity/ContactActivitiesSelector.php
+++ b/CRM/Civicase/Activity/ContactActivitiesSelector.php
@@ -5,28 +5,50 @@ class CRM_Civicase_Activity_ContactActivitiesSelector {
   const API_DEFAULT_LIMIT = 25;
 
   /**
-   * Get the activities for a given contact. The contact must be either the creator,
+   * Returns all the activities for a given contact. The contact must be either the creator,
    * the client, or be one of the assignees for the activity. Also, the activity should
    * not be assigned to someone else unless the contact is also an assignee.
    *
-   * @param array
+   * @param array $params
    * @return array
    */
-  public function getActivitiesForContact($params) {
+  public function getAllActivitiesForContact($params) {
     $newParams = $this->getParamsWithoutOffsetsAndLimits($params);
 
     $this->addAssigneeContactIdToReturnParams($newParams);
 
     $activities = civicrm_api3('Activity', 'get', $newParams);
 
-    if ($activities['error']) {
-      return $activities;
-    }
-
     $this->filterOutActivitiesNotBelongingToContact($activities, $newParams);
+
+    return $activities;
+  }
+
+  /**
+   * Returns paginated activities for the given contact using the limit and offset
+   * options.
+   *
+   * @param array $params
+   * @return array
+   */
+  public function getPaginatedActivitiesForContact($params) {
+    $activities = $this->getAllActivitiesForContact($params);
+
     $this->paginateActivityRecords($activities, $params);
 
     return $activities;
+  }
+
+  /**
+   * Returns the number of activities for the given contact.
+   *
+   * @param array $params
+   * @return int
+   */
+  public function getActivitiesForContactCount($params) {
+    $activities = $this->getAllActivitiesForContact($params);
+
+    return $activities['count'];
   }
 
   /**
@@ -93,5 +115,6 @@ class CRM_Civicase_Activity_ContactActivitiesSelector {
     $limit = $limit === 0 ? NULL : $limit;
 
     $activities['values'] = array_slice($activities['values'], $offset, $limit);
+    $activities['count'] = count($activities['values']);
   }
 }

--- a/CRM/Civicase/Activity/ContactActivitiesSelector.php
+++ b/CRM/Civicase/Activity/ContactActivitiesSelector.php
@@ -90,6 +90,7 @@ class CRM_Civicase_Activity_ContactActivitiesSelector {
     $options = CRM_Utils_Array::value('options', $params, []);
     $limit = CRM_Utils_Array::value('limit', $options, self::API_DEFAULT_LIMIT);
     $offset = CRM_Utils_Array::value('offset', $options, 0);
+    $limit = $limit === 0 ? NULL : $limit;
 
     $activities['values'] = array_slice($activities['values'], $offset, $limit);
   }

--- a/ang/civicase/ActivityFeed.js
+++ b/ang/civicase/ActivityFeed.js
@@ -264,6 +264,9 @@
      * @return {Promise}
      */
     function loadActivities () {
+      var apiAction = $scope.filters['@involvingContact'] === 'myActivities'
+        ? 'getcontactactivities'
+        : 'get';
       var returnParams = {
         sequential: 1,
         return: [
@@ -316,8 +319,8 @@
       }
 
       return crmApi({
-        acts: ['Activity', 'get', $.extend(true, returnParams, params)],
-        all: ['Activity', 'get', $.extend(true, {
+        acts: ['Activity', apiAction, $.extend(true, returnParams, params)],
+        all: ['Activity', apiAction, $.extend(true, {
           sequential: 1,
           return: ['id'],
           options: { limit: 0 }}, params)] // all activities, also used to get count

--- a/ang/civicase/ActivityFeed.js
+++ b/ang/civicase/ActivityFeed.js
@@ -259,7 +259,13 @@
     }
 
     /**
-     * Load activities
+     * Load activities.
+     *
+     * Note: When the filter is set to "My Activities" the action
+     * used is `getcontactactivities` instead of `get` since this action
+     * properly returns activities that belong to the contact, but have not
+     * been delegated to someone else. This query can't be replicated using
+     * api params hence the need for a specialized action.
      *
      * @return {Promise}
      */

--- a/ang/civicase/DashboardTab.js
+++ b/ang/civicase/DashboardTab.js
@@ -59,7 +59,12 @@
     $scope.caseIds = null;
     $scope.activitiesPanel = {
       name: 'activities',
-      query: { entity: 'Activity', params: getQueryParams('activities') },
+      query: {
+        entity: 'Activity',
+        action: 'getcontactactivities',
+        countAction: 'getcontactactivitiescount',
+        params: getQueryParams('activities')
+      },
       custom: {
         itemName: 'activities',
         involvementFilter: { '@involvingContact': 'myActivities' },
@@ -72,7 +77,12 @@
     };
     $scope.newMilestonesPanel = {
       name: 'milestones',
-      query: { entity: 'Activity', params: getQueryParams('milestones') },
+      query: {
+        entity: 'Activity',
+        action: 'getcontactactivities',
+        countAction: 'getcontactactivitiescount',
+        params: getQueryParams('milestones')
+      },
       custom: {
         itemName: 'milestones',
         involvementFilter: { '@involvingContact': 'myActivities' },
@@ -207,6 +217,7 @@
           return;
         }
 
+        updatePanelQueryActions($scope.newMilestonesPanel);
         $rootScope.$broadcast(
           'civicaseActivityFeed.query',
           $scope.newMilestonesPanel.custom.involvementFilter,
@@ -220,6 +231,7 @@
           return;
         }
 
+        updatePanelQueryActions($scope.activitiesPanel);
         $rootScope.$broadcast(
           'civicaseActivityFeed.query',
           $scope.activitiesPanel.custom.involvementFilter,
@@ -278,7 +290,6 @@
       // Flattened list of all the contact ids of all the contacts of all the cases
       var contactIds = _(results).pluck(contactsProp).flatten().pluck('contact_id').uniq().value();
       var formattedResults = results.map(formatFn);
-
       // The try/catch block is necessary because the service does not
       // return a Promise if it doesn't find any new contacts to fetch
       try {
@@ -289,6 +300,21 @@
       } catch (e) {
         return formattedResults;
       }
+    }
+
+    /**
+     * Updates the action and count action for the given panel query data depending on the selected filter.
+     * When filtering by "My Activities" the action is "getcontactactivities" and "getcontactactivitiescount",
+     * otherwise it's "get" and "getcount".
+     *
+     * @param {Object} panelQueryData
+     */
+    function updatePanelQueryActions (panelQueryData) {
+      var defaultActions = { action: 'get', countAction: 'getcount' };
+      var myActivityActions = { action: 'getcontactactivities', countAction: 'getcontactactivitiescount' };
+      var isRequestingMyActivities = panelQueryData.custom.involvementFilter['@involvingContact'] === 'myActivities';
+
+      $.extend(panelQueryData.query, isRequestingMyActivities ? myActivityActions : defaultActions);
     }
 
     /**

--- a/ang/test/civicase/ActivityFeed.spec.js
+++ b/ang/test/civicase/ActivityFeed.spec.js
@@ -38,14 +38,17 @@
       }));
 
       describe('loadActivities', function () {
+        beforeEach(function () {
+          crmApi.and.returnValue($q.resolve({acts: {}}));
+          initController();
+          $scope.filters.activitySet = CaseTypes.get()['1'].definition.activitySets[0].name;
+          $scope.filters.activity_type_id = '5';
+        });
+
         describe('when filtered by activity set and activity id', function () {
           var expectedActivityTypeIDs = [];
 
           beforeEach(function () {
-            crmApi.and.returnValue($q.resolve({acts: {}}));
-            initController();
-            $scope.filters.activitySet = CaseTypes.get()['1'].definition.activitySets[0].name;
-            $scope.filters.activity_type_id = '5';
             $scope.$digest();
 
             _.each(CaseTypes.get()['1'].definition.activitySets[0].activityTypes, function (activityTypeFromSet) {
@@ -56,9 +59,31 @@
             expectedActivityTypeIDs.push($scope.filters.activity_type_id);
           });
 
+          it('requests the activities using the "get" api action', function () {
+            expect(crmApi).toHaveBeenCalledWith({
+              acts: ['Activity', 'get', jasmine.any(Object)],
+              all: ['Activity', 'get', jasmine.any(Object)]
+            });
+          });
+
           it('filters by the activities of the selected activity set and the activity id', function () {
             var args = crmApi.calls.mostRecent().args[0].acts[2].activity_type_id;
             expect(args).toEqual({ IN: expectedActivityTypeIDs });
+          });
+        });
+
+        describe('when filtered by "My Activities"', function () {
+          beforeEach(function () {
+            $scope.filters['@involvingContact'] = 'myActivities';
+
+            $scope.$digest();
+          });
+
+          it('requests the activities using the "get contact activities" api action', function () {
+            expect(crmApi).toHaveBeenCalledWith({
+              acts: ['Activity', 'getcontactactivities', jasmine.any(Object)],
+              all: ['Activity', 'getcontactactivities', jasmine.any(Object)]
+            });
           });
         });
       });
@@ -140,7 +165,12 @@
       describe('when the activity details panel is iniliased with window already scrolled', function () {
         beforeEach(function () {
           compileDirective({isAffixedOnInit: true});
+
           $activityDetailsPanel = element.find('.civicase__activity-panel');
+        });
+
+        afterEach(function () {
+          removeTestDomElements();
         });
 
         it('sets the top positioning', function () {

--- a/ang/test/civicase/DashboardTab.spec.js
+++ b/ang/test/civicase/DashboardTab.spec.js
@@ -361,8 +361,12 @@
           expect($scope.newMilestonesPanel.query.entity).toBe('Activity');
         });
 
-        it('does not call a custom endpoint', function () {
-          expect($scope.newMilestonesPanel.query.action).not.toBeDefined();
+        it('queries the `get contact activities` action by default', function () {
+          expect($scope.newMilestonesPanel.query.action).toBe('getcontactactivities');
+        });
+
+        it('counts using the `get contact activities count` action by default', function () {
+          expect($scope.newMilestonesPanel.query.countAction).toBe('getcontactactivitiescount');
         });
 
         it('adds the params defined in the relationship filter', function () {
@@ -509,6 +513,14 @@
               $scope.$digest();
             });
 
+            it('sets the query action to "get"', function () {
+              expect($scope.newMilestonesPanel.query.action).toBe('get');
+            });
+
+            it('sets the count query action to "get count"', function () {
+              expect($scope.newMilestonesPanel.query.countAction).toBe('getcount');
+            });
+
             it('broadcasts a "civicaseActivityFeed.query" event', function () {
               expect($rootScope.$broadcast).toHaveBeenCalledWith(
                 'civicaseActivityFeed.query',
@@ -516,6 +528,21 @@
                 $scope.newMilestonesPanel.query.params,
                 true
               );
+            });
+          });
+
+          describe('when it changes to "my activities"', function () {
+            beforeEach(function () {
+              $scope.newMilestonesPanel.custom.involvementFilter = { '@involvingContact': 'myActivities' };
+              $scope.$digest();
+            });
+
+            it('sets the query action to "get contact activities"', function () {
+              expect($scope.newMilestonesPanel.query.action).toBe('getcontactactivities');
+            });
+
+            it('sets the count query action to "get contact activities count"', function () {
+              expect($scope.newMilestonesPanel.query.countAction).toBe('getcontactactivitiescount');
             });
           });
         });
@@ -588,8 +615,12 @@
           expect($scope.activitiesPanel.query.entity).toBe('Activity');
         });
 
-        it('does not call a custom endpoint', function () {
-          expect($scope.activitiesPanel.query.action).not.toBeDefined();
+        it('queries the `get contact activities` action by default', function () {
+          expect($scope.activitiesPanel.query.action).toBe('getcontactactivities');
+        });
+
+        it('counts using the `get contact activities count` action by default', function () {
+          expect($scope.activitiesPanel.query.countAction).toBe('getcontactactivitiescount');
         });
 
         it('adds the params defined in the relationship filter', function () {
@@ -736,6 +767,14 @@
               $scope.$digest();
             });
 
+            it('sets the query action to "get"', function () {
+              expect($scope.activitiesPanel.query.action).toBe('get');
+            });
+
+            it('sets the count query action to "get count"', function () {
+              expect($scope.activitiesPanel.query.countAction).toBe('getcount');
+            });
+
             it('broadcasts a "civicaseActivityFeed.query" event', function () {
               expect($rootScope.$broadcast).toHaveBeenCalledWith(
                 'civicaseActivityFeed.query',
@@ -743,6 +782,21 @@
                 $scope.activitiesPanel.query.params,
                 true
               );
+            });
+          });
+
+          describe('when it changes to "my activities"', function () {
+            beforeEach(function () {
+              $scope.activitiesPanel.custom.involvementFilter = { '@involvingContact': 'myActivities' };
+              $scope.$digest();
+            });
+
+            it('sets the query action to "get contact activities"', function () {
+              expect($scope.activitiesPanel.query.action).toBe('getcontactactivities');
+            });
+
+            it('sets the count query action to "get contact activities count"', function () {
+              expect($scope.activitiesPanel.query.countAction).toBe('getcontactactivitiescount');
             });
           });
         });

--- a/api/v3/Activity/Getcontactactivities.php
+++ b/api/v3/Activity/Getcontactactivities.php
@@ -9,7 +9,6 @@
 function _civicrm_api3_activity_getcontactactivities_spec(&$params) {
   _civicrm_api3_activity_get_spec($params);
 
-  $params['case_id']['api.required'] = TRUE;
   $params['contact_id']['api.required'] = TRUE;
   $params['return'] = [
     'api.required' => TRUE,
@@ -19,7 +18,6 @@ function _civicrm_api3_activity_getcontactactivities_spec(&$params) {
     'description' => 'The "assignee_contact_id" field is required for this action.',
   ];
 }
-
 /**
  * Returns the activities for the given contact, limited to a specific case.
  *
@@ -28,5 +26,5 @@ function _civicrm_api3_activity_getcontactactivities_spec(&$params) {
 function civicrm_api3_activity_getcontactactivities ($params) {
   $contactActivitySelector = new CRM_Civicase_Activity_ContactActivitiesSelector();
 
-  return $contactActivitySelector->getActivitiesForContact($params);
+  return $contactActivitySelector->getPaginatedActivitiesForContact($params);
 }

--- a/api/v3/Activity/Getcontactactivities.php
+++ b/api/v3/Activity/Getcontactactivities.php
@@ -20,10 +20,13 @@ function _civicrm_api3_activity_getcontactactivities_spec(&$params) {
 }
 /**
  * Returns the activities for the given contact, limited to a specific case.
+ * This action is needed because the default "get" action does not filter out
+ * activities that have been deletaged to another contact and can't be queried
+ * using the API since the condition is too complex for it.
  *
  * @param array $params
  */
-function civicrm_api3_activity_getcontactactivities ($params) {
+function civicrm_api3_activity_getcontactactivities($params) {
   $contactActivitySelector = new CRM_Civicase_Activity_ContactActivitiesSelector();
 
   return $contactActivitySelector->getPaginatedActivitiesForContact($params);

--- a/api/v3/Activity/Getcontactactivities.php
+++ b/api/v3/Activity/Getcontactactivities.php
@@ -21,7 +21,7 @@ function _civicrm_api3_activity_getcontactactivities_spec(&$params) {
 /**
  * Returns the activities for the given contact, limited to a specific case.
  * This action is needed because the default "get" action does not filter out
- * activities that have been deletaged to another contact and can't be queried
+ * activities that have been delegated to another contact and can't be queried
  * using the API since the condition is too complex for it.
  *
  * @param array $params

--- a/api/v3/Activity/Getcontactactivities.php
+++ b/api/v3/Activity/Getcontactactivities.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Defines the fields for the "getcontactactivities" action api.
+ * The case id, contact id, and return fields are set to be required.
+ *
+ * @param array $params
+ */
+function _civicrm_api3_activity_getcontactactivities_spec(&$params) {
+  _civicrm_api3_activity_get_spec($params);
+
+  $params['case_id']['api.required'] = TRUE;
+  $params['contact_id']['api.required'] = TRUE;
+  $params['return'] = [
+    'api.required' => TRUE,
+    'api.default' => "assignee_contact_id",
+    'name' => 'return',
+    'title' => 'Return fields',
+    'description' => 'The "assignee_contact_id" field is required for this action.',
+  ];
+}
+
+/**
+ * Returns the activities for the given contact, limited to a specific case.
+ *
+ * @param array $params
+ */
+function civicrm_api3_activity_getcontactactivities ($params) {
+  $contactActivitySelector = new CRM_Civicase_Activity_ContactActivitiesSelector();
+
+  return $contactActivitySelector->getActivitiesForContact($params);
+}

--- a/api/v3/Activity/Getcontactactivitiescount.php
+++ b/api/v3/Activity/Getcontactactivitiescount.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Returns the activity count for the given contact.
+ *
+ * @param array $params
+ */
+function civicrm_api3_activity_getcontactactivitiescount($params) {
+  $contactActivitySelector = new CRM_Civicase_Activity_ContactActivitiesSelector();
+
+  return $contactActivitySelector->getActivitiesForContactCount($params);
+}

--- a/api/v3/Activity/Getcontactactivitiescount.php
+++ b/api/v3/Activity/Getcontactactivitiescount.php
@@ -3,6 +3,7 @@
 /**
  * Returns the activity count for the given contact.
  *
+ * @see civicrm_api3_activity_getcontactactivities
  * @param array $params
  */
 function civicrm_api3_activity_getcontactactivitiescount($params) {


### PR DESCRIPTION
## Overview

This PR hides the activities from "My Activities" that have been delegated to other contacts.

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/49742454-f57cd080-fc6e-11e8-877d-0142ae3732c2.gif)
**Note:** The "Medical Evaluation" activity was assigned to another contact so it should not be visible in "My Activities" tab.

## After
![pr-after](https://user-images.githubusercontent.com/1642119/49750579-b60baf80-fc81-11e8-9b43-13ffbdff24e6.gif)

## Technical details

### Contact Activity Selector endpoint
In order to hide the activities that have been delegated to another contact we needed to create a new endpoint that would query the activities for the contact and filter out the delegated ones manually. The reason for this is because the query to exclude these activities is quite complex and not supported by the API:

```sql
WHERE contact_id = 123
AND (contact_id IN assignee_contact_id
OR assignee_contact_id IS NULL)
```

Since the `assignee_contact_id` is a foreign field, working with NULL is not supported.

The implementation for the new service is as follows:

```php
<?php

class CRM_Civicase_Activity_ContactActivitiesSelector {

  const API_DEFAULT_LIMIT = 25;

  public function getActivitiesForContact($params) {
    $newParams = $this->getParamsWithoutOffsetsAndLimits($params);

    $this->addAssigneeContactIdToReturnParams($newParams);

    $activities = civicrm_api3('Activity', 'get', $newParams);

    if ($activities['error']) {
      return $activities;
    }

    $this->filterOutActivitiesNotBelongingToContact($activities, $newParams);
    $this->paginateActivityRecords($activities, $params);

    return $activities;
  }

  private function getParamsWithoutOffsetsAndLimits($params) {
    $options = CRM_Utils_Array::value('options', $params, []);
    $options['limit'] = 0;
    $options['offset'] = 0;
    $params['options'] = $options;

    return $params;
  }

  private function addAssigneeContactIdToReturnParams(&$params) {
    $return = (array) CRM_Utils_Array::value('return', $params, []);
    $return[] = 'assignee_contact_id';
    $return = array_unique($return);
    $return = implode(',', $return);
    $params['return'] = $return;
  }

  private function filterOutActivitiesNotBelongingToContact(&$activities, $params) {
    $activities['values'] = array_filter($activities['values'], function ($activity) use ($params) {
      $hasNoAssignee = !isset($activity['assignee_contact_id']) || empty($activity['assignee_contact_id']);
      $isContactAssignedToActivity = in_array($params['contact_id'], $activity['assignee_contact_id']);

      return $hasNoAssignee || $isContactAssignedToActivity;
    });

    $activities['count'] = count($activities['values']);
  }

  private function paginateActivityRecords(&$activities, $params) {
    $options = CRM_Utils_Array::value('options', $params, []);
    $limit = CRM_Utils_Array::value('limit', $options, self::API_DEFAULT_LIMIT);
    $offset = CRM_Utils_Array::value('offset', $options, 0);
    $limit = $limit === 0 ? NULL : $limit;

    $activities['values'] = array_slice($activities['values'], $offset, $limit);
  }
}

```

The flow of the service is as follows:

1. It removes the limits and offsets from the original request parameters.
2. It adds the `assignee_contact_id` field to the return list since this field is important to determine which activities have been delegated.
3. It requests all activities using the original request parameters, but without limits or offsets.
4. It removes activities that have been delegated to other users.
5. It paginates the records manually after they have been fetched.


This service was implemented as an Activity action:

```php
<?php
function civicrm_api3_activity_getcontactactivities ($params) {
  $contactActivitySelector = new CRM_Civicase_Activity_ContactActivitiesSelector();

  return $contactActivitySelector->getActivitiesForContact($params);
}

function _civicrm_api3_activity_getcontactactivities_spec(&$params) {
  _civicrm_api3_activity_get_spec($params);

  $params['case_id']['api.required'] = TRUE;
  $params['contact_id']['api.required'] = TRUE;
  $params['return'] = [
    'api.required' => TRUE,
    'api.default' => "assignee_contact_id",
    'name' => 'return',
    'title' => 'Return fields',
    'description' => 'The "assignee_contact_id" field is required for this action.',
  ];
}
```

The spec "extends" from the original `get` action since it should support the same parameters. In order to limit the amount of activity records to be filtered the case and contact id are required. The return is also required so it includes the `assignee_contact_id` field.

### Front end changes

The front-end changes were fairly simple:

when the `involvingContact` is set to `myActivities` the action is changed to `getcontactactivities`, otherwise it uses the normal `get` action:

```js
function loadActivities () {
  var apiAction = $scope.filters['@involvingContact'] === 'myActivities'
    ? 'getcontactactivities'
    : 'get';

  // ...

  return crmApi({
    acts: ['Activity', apiAction, ...],
    all: ['Activity', apiAction, ...]
  });
}
```
