### PR TITLE
C51-286: Autopopulate case client using hook

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/CaseClientPopulator.php
+++ b/CRM/Civicase/Hook/BuildForm/CaseClientPopulator.php
@@ -1,0 +1,35 @@
+<?php
+
+class CRM_Civicase_Hook_BuildForm_CaseClientPopulator {
+
+  /**
+   * Runs the Case Client populator hook for the Case Form. When a client id
+   * is provided as a request parameter, it adds this value to the client id
+   * field of the form.
+   *
+   * @param CRM_Core_Form $form
+   */
+  public function run(&$form) {
+    $clientId = CRM_Utils_Request::retrieve('civicase_cid', 'Positive');
+
+    if (!$this->shouldRun($form, $clientId)) {
+      return;
+    }
+
+    $form->setDefaults(['client_id' => $clientId]);
+  }
+
+  /**
+   * Determines if the hook will run. This hook is only valid for the Case form
+   * and the civicase client id parameter must be defined.
+   *
+   * @param CRM_Core_Form $form
+   * @param INT|NULL $clientId
+   */
+  public function shouldRun($form, $clientId) {
+    $isCaseForm = CRM_Case_Form_Case::class === get_class($form);
+
+    return $isCaseForm && $clientId;
+  }
+
+}

--- a/ang/civicase/ContactCaseTab.html
+++ b/ang/civicase/ContactCaseTab.html
@@ -4,7 +4,7 @@
   <div class="civicase__contact-cases-tab clearfix">
     <a ng-if="checkPerm('add cases')"
       class="btn-primary btn civicase__contact-cases-tab-add"
-      ng-href="{{ 'civicrm/case/add' | civicaseCrmUrl:{cid: contactId, reset: 1, action: 'add', context: 'standalone'} }}"
+      ng-href="{{ 'civicrm/case/add' | civicaseCrmUrl:{civicase_cid: contactId, reset: 1, action: 'add', context: 'standalone'} }}"
       crm-popup-form-success="refresh()">
       <i class="material-icons">add_circle</i>
       {{ ts('Add case') }}

--- a/civicase.php
+++ b/civicase.php
@@ -202,6 +202,14 @@ function civicase_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
  * @param CRM_Core_Form $form
  */
 function civicase_civicrm_buildForm($formName, &$form) {
+  $hooks = [
+    new CRM_Civicase_Hook_BuildForm_CaseClientPopulator(),
+  ];
+
+  foreach ($hooks as $hook) {
+    $hook->run($form);
+  }
+
   // Display category option for activity types and activity statuses
   if ($formName == 'CRM_Admin_Form_Options' && in_array($form->getVar('_gName'), array('activity_type', 'activity_status'))) {
     $options = civicrm_api3('optionValue', 'get', array(


### PR DESCRIPTION
## Overview
This PR autopopulates the case client using the BuildForm hook.

[Previously](https://github.com/compucorp/uk.co.compucorp.civicase/pull/131) we tried to autopopulate this field using the `cid` parameter, but this fail due to an error in core.

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/49933323-b2567380-fea1-11e8-95c9-904c0fcb01e0.gif)
There are two issues:
* The field is autopopulated for a single contact. This blocks users from creating a multiple contact case, unless they later edit it.
* When saving the case an error is thrown saying the field is "missing". This is an error from core.

## After
![pr-after](https://user-images.githubusercontent.com/1642119/49933451-0e20fc80-fea2-11e8-8ab2-270dfc9206c8.gif)
The field is autopopulated, it allows for multiple contacts, and can be saved correctly.

## Technical details

As mentioned before, this field was previously autopopulated in https://github.com/compucorp/uk.co.compucorp.civicase/pull/131 using only the `cid` parameter as provided by core, but this method fails when saving the form. It also does not allow multiple contacts on the field from the get go.

To fix this a new hook was implemented that runs on the `buildForm` phase, checks if the user is viewing the Case form and there's a `civicase_cid` URL get parameter defined. When all checks are correct, it sets this URL parameter as the value for the client ID:

```php
<?php

class CRM_Civicase_Hook_BuildForm_CaseClientPopulator {

  public function run(&$form) {
    $clientId = CRM_Utils_Request::retrieve('civicase_cid', 'Positive');

    if (!$this->shouldRun($form, $clientId)) {
      return;
    }

    $form->setDefaults(['client_id' => $clientId]);
  }

  public function shouldRun($form, $clientId) {
    $isCaseForm = CRM_Case_Form_Case::class === get_class($form);

    return $isCaseForm && $clientId;
  }

}

```

This hook class is then implemented in the civcase hook as follows:

```php
function civicase_civicrm_buildForm($formName, &$form) {
  $hooks = [
    new CRM_Civicase_Hook_BuildForm_CaseClientPopulator(),
  ];

  foreach ($hooks as $hook) {
    $hook->run($form);
  }

  // ...
}
```