### PR TITLE
C51-354: Fix "See all" link of Activity Calendar

### DIFF
--- a/ang/civicase/activity/actions/directives/activity-actions.directive.html
+++ b/ang/civicase/activity/actions/directives/activity-actions.directive.html
@@ -1,5 +1,5 @@
 <li ng-if="mode === 'case-summary'">
-  <a ng-href="#{{ getActivityFeedUrl(selectedActivities[0].case_id, null, null, null, selectedActivities[0].id) }}">
+  <a ng-href="{{ getActivityFeedUrl({ caseId: selectedActivities[0].case_id, activityId: selectedActivities[0].id }) }}">
     <i class="material-icons">pageview</i> {{ ts('View in Feed') }}
   </a>
 </li>

--- a/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
+++ b/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
@@ -617,7 +617,7 @@
     function seeAllLinkUrl (date) {
       var activityFilters = getSeeMoreActivityFilters(date);
 
-      return getActivityFeedUrl({ filters: activityFilters });
+      return getActivityFeedUrl({ activityFilters: activityFilters });
     }
 
     /**

--- a/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
+++ b/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
@@ -151,7 +151,7 @@
   module.controller('civicaseActivitiesCalendarController', civicaseActivitiesCalendarController);
 
   function civicaseActivitiesCalendarController ($q, $rootScope, $route, $sce,
-    $scope, crmApi, formatActivity, ContactsCache) {
+    $scope, ContactsCache, crmApi, formatActivity, getActivityFeedUrl) {
     var ACTIVITIES_DISPLAY_LIMIT = 25;
     var DEBOUNCE_WAIT = 300;
 
@@ -318,30 +318,24 @@
     }
 
     /**
-     * Returns the querystring params for the "see more" link, so that the link
+     * Returns the activity filters params for the "see more" link, so that the link
      * sends the user to the activity feed already filtered by the given date
      *
      * @param {Date} date
      * @return {Object}
      */
-    function getSeeMoreQueryParams (date) {
+    function getSeeMoreActivityFilters (date) {
       var dateMoment = moment(date);
-      var params = _.merge({}, $route.current.params, {
-        dtab: 1,
-        af: {
-          '@moreFilters': true,
-          activity_date_time: {
-            BETWEEN: [
-              dateMoment.startOf('day').format('YYYY-MM-DD HH:mm:ss'),
-              dateMoment.endOf('day').format('YYYY-MM-DD HH:mm:ss')
-            ]
-          }
+
+      return {
+        '@moreFilters': true,
+        'activity_date_time': {
+          'BETWEEN': [
+            dateMoment.startOf('day').format('YYYY-MM-DD HH:mm:ss'),
+            dateMoment.endOf('day').format('YYYY-MM-DD HH:mm:ss')
+          ]
         }
-      });
-
-      params.af = JSON.stringify(params.af);
-
-      return params;
+      };
     }
 
     /**
@@ -621,9 +615,9 @@
      * @return {TrustedValueHolderType}
      */
     function seeAllLinkUrl (date) {
-      var urlParams = getSeeMoreQueryParams(date);
+      var activityFilters = getSeeMoreActivityFilters(date);
 
-      return $sce.trustAsResourceUrl('#/case?' + $.param(urlParams));
+      return getActivityFeedUrl({ filters: activityFilters });
     }
 
     /**

--- a/ang/civicase/activity/factories/get-activity-feed-url.factory.js
+++ b/ang/civicase/activity/factories/get-activity-feed-url.factory.js
@@ -28,7 +28,7 @@
         {},
         $route.current.params.af || {},
         activityFilters,
-        urlParams.filters || {}
+        urlParams.activityFilters || {}
       );
 
       var finalUrlParams = angular.extend({}, $route.current.params, {

--- a/ang/civicase/activity/factories/get-activity-feed-url.factory.js
+++ b/ang/civicase/activity/factories/get-activity-feed-url.factory.js
@@ -2,44 +2,59 @@
   var module = angular.module('civicase');
 
   module.factory('getActivityFeedUrl', function ($route, $location, $sce) {
-    return function (caseId, category, statusType, status, id) {
-      var af = {};
+    return function (urlParams) {
+      var activityFilters = {};
+      var baseUrl = '#/case/list?';
       var currentPath = $location.path();
 
-      caseId = parseInt(caseId, 10);
+      urlParams = urlParams || {};
+      urlParams.activityId = urlParams.activityId || 0;
 
-      if (category) {
-        af['activity_type_id.grouping'] = category;
+      if (urlParams.category) {
+        activityFilters['activity_type_id.grouping'] = urlParams.category;
       }
 
-      if (statusType) {
-        af.status_id = CRM.civicase.activityStatusTypes[statusType];
+      if (urlParams.statusType) {
+        activityFilters.status_id = CRM.civicase.activityStatusTypes[urlParams.statusType];
       }
 
-      if (status) {
-        af.status_id = [_.findKey(CRM.civicase.activityStatuses, function (statusObj) {
-          return statusObj.name === status;
+      if (urlParams.status) {
+        activityFilters.status_id = [_.findKey(CRM.civicase.activityStatuses, function (statusObj) {
+          return statusObj.name === urlParams.status;
         })];
       }
 
-      var p = {
-        caseId: caseId,
-        tab: 'activities',
-        aid: id || 0,
+      activityFilters = angular.extend(
+        {},
+        $route.current.params.af || {},
+        activityFilters,
+        urlParams.filters || {}
+      );
+
+      var p = angular.extend({}, $route.current.params, {
+        aid: urlParams.activityId,
         focus: 1,
         sx: 0,
         ai: '{"myActivities":false,"delegated":false}',
-        af: JSON.stringify(af)
-      };
-      // If we're not already viewing a case, force the id filter
+        af: JSON.stringify(activityFilters)
+      });
+
       if (currentPath !== '/case/list') {
-        p.cf = JSON.stringify({id: caseId});
+        baseUrl = '#/case?';
+        p.dtab = 1;
+
+        // If we're not already viewing a case, force the case id filter
+        p.cf = JSON.stringify({ id: urlParams.caseId });
       } else {
-        p = angular.extend({}, $route.current.params, p);
+        p.tab = 'activities';
+      }
+
+      if (urlParams.caseId) {
+        p.caseId = parseInt(urlParams.caseId, 10);
       }
 
       // The value to mark as trusted in angular context for security.
-      return $sce.trustAsResourceUrl('/case/list?' + $.param(p));
+      return $sce.trustAsResourceUrl(baseUrl + $.param(p));
     };
   });
 })(angular, CRM.$, CRM._, CRM);

--- a/ang/civicase/activity/factories/get-activity-feed-url.factory.js
+++ b/ang/civicase/activity/factories/get-activity-feed-url.factory.js
@@ -31,7 +31,7 @@
         urlParams.filters || {}
       );
 
-      var p = angular.extend({}, $route.current.params, {
+      var finalUrlParams = angular.extend({}, $route.current.params, {
         aid: urlParams.activityId,
         focus: 1,
         sx: 0,
@@ -41,20 +41,20 @@
 
       if (currentPath !== '/case/list') {
         baseUrl = '#/case?';
-        p.dtab = 1;
+        finalUrlParams.dtab = 1;
 
         // If we're not already viewing a case, force the case id filter
-        p.cf = JSON.stringify({ id: urlParams.caseId });
+        finalUrlParams.cf = JSON.stringify({ id: urlParams.caseId });
       } else {
-        p.tab = 'activities';
+        finalUrlParams.tab = 'activities';
       }
 
       if (urlParams.caseId) {
-        p.caseId = parseInt(urlParams.caseId, 10);
+        finalUrlParams.caseId = parseInt(urlParams.caseId, 10);
       }
 
       // The value to mark as trusted in angular context for security.
-      return $sce.trustAsResourceUrl(baseUrl + $.param(p));
+      return $sce.trustAsResourceUrl(baseUrl + $.param(finalUrlParams));
     };
   });
 })(angular, CRM.$, CRM._, CRM);

--- a/ang/civicase/case/card/directives/case-card-case-list.directive.html
+++ b/ang/civicase/case/card/directives/case-card-case-list.directive.html
@@ -28,7 +28,7 @@
       <span>Next Milestone: </span>
       <a class="civicase__case-card__next-milestone-date"
          ng-class="{'civicase__overdue-activity-icon': data.activity_summary.milestone[0].is_overdue}"
-         ng-href="#{{ activityFeedUrl(data.id, 'milestone', 'incomplete', null, data.activity_summary.milestone[0].id) }}"
+         ng-href="{{getActivityFeedUrl({ caseId: data.id, category: 'milestone', statusType: 'incomplete', activityId: data.activity_summary.milestone[0].id })}}"
          title="{{data.activity_summary.milestone[0].subject || data.activity_summary.milestone[0].type;}}"
       >{{ formatDate(data.activity_summary.milestone[0].activity_date_time, 'DD/MM/YYYY') }} </a>
     </div>
@@ -37,12 +37,12 @@
         <span>Tasks: </span>
         <a class="civicase__case-card__activity-count"
            ng-if="data.category_count.incomplete.task"
-           ng-href="#{{ activityFeedUrl(data.id, 'task', 'incomplete') }}"
+           ng-href="{{getActivityFeedUrl({ caseId: data.id, category: 'task', statusType: 'incomplete' })}}"
         > {{ data.category_count.incomplete.task }} </a>
         <span ng-if="data.category_count.incomplete.task && data.category_count.overdue.task" class="civicase__pipe"> | </span>
         <a class="civicase__case-card__activity-count civicase__overdue-activity-icon civicase__overdue-activity-icon--before"
            ng-if="data.category_count.overdue.task"
-           ng-href="#{{ activityFeedUrl(data.id, 'task', 'incomplete') }}"
+           ng-href="{{getActivityFeedUrl({ caseId: data.id, category: 'task', statusType: 'incomplete' })}}"
         > {{ data.category_count.overdue.task }} </a>
         <span ng-if="!data.category_count.incomplete.task && !data.category_count.overdue.task" class="civicase__case-card__activity-count civicase__case-card__activity-count--zero">0</span>
       </div>
@@ -50,12 +50,12 @@
         <span>Comms: </span>
         <a class="civicase__case-card__activity-count"
            ng-if="data.category_count.incomplete.communication"
-           ng-href="#{{ activityFeedUrl(data.id, 'communication', 'incomplete') }}"
+           ng-href="{{getActivityFeedUrl({ caseId: data.id, category: 'communication', statusType: 'incomplete' })}}"
         > {{ data.category_count.incomplete.communication }} </a>
         <span ng-if="data.category_count.incomplete.communication && data.category_count.overdue.communication" class="civicase__pipe"> | </span>
         <a class="civicase__case-card__activity-count civicase__overdue-activity-icon civicase__overdue-activity-icon--before"
            ng-if="data.category_count.overdue.communication"
-           ng-href="#{{ activityFeedUrl(data.id, 'communication', 'incomplete') }}"
+           ng-href="{{getActivityFeedUrl({ caseId: data.id, category: 'communication', statusType: 'incomplete' })}}"
         > {{ data.category_count.overdue.communication }} </a>
         <span ng-if="!data.category_count.incomplete.communication && !data.category_count.overdue.communication" class="civicase__case-card__activity-count civicase__case-card__activity-count--zero">0</span>
       </div>
@@ -63,12 +63,12 @@
         <span>Other: </span>
         <a class="civicase__case-card__activity-count"
            ng-if="data.category_count.incomplete.other"
-           ng-href="#{{ activityFeedUrl(data.id, otherCategories, 'incomplete') }}"
+           ng-href="{{getActivityFeedUrl({ caseId: data.id, category: otherCategories, statusType: 'incomplete' })}}"
         > {{ data.category_count.incomplete.other }} </a>
         <span ng-if="data.category_count.incomplete.other && data.category_count.overdue.other" class="civicase__pipe"> | </span>
         <a class="civicase__case-card__activity-count civicase__overdue-activity-icon civicase__overdue-activity-icon--before"
            ng-if="data.category_count.overdue.other"
-           ng-href="#{{ activityFeedUrl(data.id, otherCategories, 'incomplete') }}"
+           ng-href="{{getActivityFeedUrl({ caseId: data.id, category: otherCategories, statusType: 'incomplete' })}}"
         > {{ data.category_count.overdue.other }} </a>
         <span ng-if="!data.category_count.incomplete.other && !data.category_count.overdue.other" class="civicase__case-card__activity-count civicase__case-card__activity-count--zero">0</span>
       </div>

--- a/ang/civicase/case/card/directives/case-card-other-cases.directive.html
+++ b/ang/civicase/case/card/directives/case-card-other-cases.directive.html
@@ -23,7 +23,7 @@
       <span>Next Milestone: </span>
       <a class="civicase__case-card__next-milestone-date"
           ng-class="{'civicase__overdue-activity-icon': data.activity_summary.milestone[0].is_overdue}"
-          ng-href="#{{ activityFeedUrl(data.id, 'milestone', 'incomplete', null, data.activity_summary.milestone[0].id) }}"
+          ng-href="{{getActivityFeedUrl({ caseId: data.id, category: 'milestone', statusType: 'incomplete', activityId: data.activity_summary.milestone[0].id })}}"
           title="{{data.activity_summary.milestone[0].subject || data.activity_summary.milestone[0].type;}}"
       >{{ formatDate(data.activity_summary.milestone[0].activity_date_time) }} </a>
     </span>
@@ -33,12 +33,12 @@
         <span>Tasks: </span>
         <a class="civicase__case-card__activity-count"
             ng-if="data.category_count.incomplete.task"
-            ng-href="#{{ activityFeedUrl(data.id, 'task', 'incomplete') }}"
+            ng-href="{{getActivityFeedUrl({ caseId: data.id, category: 'task', statusType: 'incomplete' })}}"
         > {{ data.category_count.incomplete.task }} </a>
         <span ng-if="data.category_count.incomplete.task && data.category_count.overdue.task" class="civicase__pipe"> | </span>
         <a class="civicase__case-card__activity-count civicase__overdue-activity-icon civicase__overdue-activity-icon--before"
             ng-if="data.category_count.overdue.task"
-            ng-href="#{{ activityFeedUrl(data.id, 'task', 'incomplete') }}"
+            ng-href="{{getActivityFeedUrl({ caseId: data.id, category: 'task', statusType: 'incomplete' })}}"
         > {{ data.category_count.overdue.task }} </a>
         <span ng-if="!data.category_count.incomplete.task && !data.category_count.overdue.task" class="civicase__case-card__activity-count civicase__case-card__activity-count--zero">0</span>
       </div>
@@ -46,12 +46,12 @@
         <span>Comms: </span>
         <a class="civicase__case-card__activity-count"
             ng-if="data.category_count.incomplete.communication"
-            ng-href="#{{ activityFeedUrl(data.id, 'communication', 'incomplete') }}"
+            ng-href="{{getActivityFeedUrl({ caseId: data.id, category: 'communication', statusType: 'incomplete' })}}"
         > {{ data.category_count.incomplete.communication }} </a>
         <span ng-if="data.category_count.incomplete.communication && data.category_count.overdue.communication" class="civicase__pipe"> | </span>
         <a class="civicase__case-card__activity-count civicase__overdue-activity-icon civicase__overdue-activity-icon--before"
             ng-if="data.category_count.overdue.communication"
-            ng-href="#{{ activityFeedUrl(data.id, 'communication', 'incomplete') }}"
+            ng-href="{{getActivityFeedUrl({ caseId: data.id, category: 'communication', statusType: 'incomplete' })}}"
         > {{ data.category_count.overdue.communication }} </a>
         <span ng-if="!data.category_count.incomplete.communication && !data.category_count.overdue.communication" class="civicase__case-card__activity-count civicase__case-card__activity-count--zero">0</span>
       </div>
@@ -59,12 +59,12 @@
         <span>Other: </span>
         <a class="civicase__case-card__activity-count"
             ng-if="data.category_count.incomplete.other"
-            ng-href="#{{ activityFeedUrl(data.id, null, 'incomplete') }}"
+            ng-href="{{getActivityFeedUrl({ caseId: data.id, statusType: 'incomplete' })}}"
         > {{ data.category_count.incomplete.other }} </a>
         <span ng-if="data.category_count.incomplete.other && data.category_count.overdue.other" class="civicase__pipe"> | </span>
         <a class="civicase__case-card__activity-count civicase__overdue-activity-icon civicase__overdue-activity-icon--before"
             ng-if="data.category_count.overdue.other"
-            ng-href="#{{ activityFeedUrl(data.id, null, 'incomplete') }}"
+            ng-href="{{getActivityFeedUrl({ caseId: data.id, statusType: 'incomplete' })}}"
         > {{ data.category_count.overdue.other }} </a>
         <span ng-if="!data.category_count.incomplete.other && !data.category_count.overdue.other" class="civicase__case-card__activity-count civicase__case-card__activity-count--zero">0</span>
       </div>

--- a/ang/civicase/case/card/directives/case-card.directive.js
+++ b/ang/civicase/case/card/directives/case-card.directive.js
@@ -25,7 +25,7 @@
   });
 
   module.controller('CivicaseCaseCardController', function ($scope, getActivityFeedUrl, DateHelper) {
-    $scope.activityFeedUrl = getActivityFeedUrl;
+    $scope.getActivityFeedUrl = getActivityFeedUrl;
     $scope.formatDate = DateHelper.formatDate;
     $scope.otherCategories = _.map(_.filter(CRM.civicase.activityCategories, function (category) {
       return category.name !== 'task' && category.name !== 'communication';

--- a/ang/civicase/case/details/directives/case-details.directive.js
+++ b/ang/civicase/case/details/directives/case-details.directive.js
@@ -29,7 +29,7 @@
 
     $scope.areDetailsLoaded = false;
     $scope.relatedCasesPager = { total: 0, size: 5, num: 0, range: {} };
-    $scope.activityFeedUrl = getActivityFeedUrl;
+    $scope.getActivityFeedUrl = getActivityFeedUrl;
     $scope.bulkAllowed = BulkActions.isAllowed();
     $scope.caseTypesLength = _.size(caseTypes);
     $scope.CRM = CRM;

--- a/ang/civicase/case/details/summary-tab/case-details-summary-tab.html
+++ b/ang/civicase/case/details/summary-tab/case-details-summary-tab.html
@@ -34,7 +34,8 @@
           {{item.category_count.overdue.communication}} overdue
         </div>
       </a>
-      <a class="civicase__summary-activity-count" ng-href="{{getActivityFeedUrl({ caseId: item.id, status: 'Scheduled' })}}">
+      <a class="civicase__summary-activity-count"
+        ng-href="{{getActivityFeedUrl({ caseId: item.id, status: 'Scheduled' })}}">
         <div>{{item.category_count.scheduled.count}}</div>
         <div>Scheduled Activities</div>
         <div

--- a/ang/civicase/case/details/summary-tab/case-details-summary-tab.html
+++ b/ang/civicase/case/details/summary-tab/case-details-summary-tab.html
@@ -14,7 +14,8 @@
           <span>{{formatDate(item.modified_date, 'DD MMMM YYYY' )}}</span>
         </div>
       </div>
-      <a class="civicase__summary-activity-count" ng-href="#{{ activityFeedUrl(item.id, 'task', 'incomplete') }}">
+      <a class="civicase__summary-activity-count"
+        ng-href="{{getActivityFeedUrl({ caseId: item.id, category: 'task', statusType: 'incomplete' })}}">
         <div>{{item.category_count.incomplete.task || 0}}</div>
         <div>Open Tasks</div>
         <div
@@ -23,7 +24,8 @@
           {{item.category_count.overdue.task}} overdue
         </div>
       </a>
-      <a class="civicase__summary-activity-count" ng-href="#{{ activityFeedUrl(item.id, 'communication', 'incomplete') }}">
+      <a class="civicase__summary-activity-count"
+        ng-href="{{getActivityFeedUrl({ caseId: item.id, category: 'communication', statusType: 'incomplete' })}}">
         <div>{{item.category_count.incomplete.communication ? item.category_count.incomplete.communication : 0}}</div>
         <div>Unread Comms</div>
         <div
@@ -32,7 +34,7 @@
           {{item.category_count.overdue.communication}} overdue
         </div>
       </a>
-      <a class="civicase__summary-activity-count" ng-href="#{{ activityFeedUrl(item.id, null, null, 'Scheduled') }}">
+      <a class="civicase__summary-activity-count" ng-href="{{getActivityFeedUrl({ caseId: item.id, status: 'Scheduled' })}}">
         <div>{{item.category_count.scheduled.count}}</div>
         <div>Scheduled Activities</div>
         <div

--- a/ang/civicase/case/details/summary-tab/case-summary-recent-communications.html
+++ b/ang/civicase/case/details/summary-tab/case-summary-recent-communications.html
@@ -1,7 +1,7 @@
 <div class="panel-heading clearfix">
   <h3 class="panel-title pull-left">{{ ts('Recent Communications') }}</h3>
   <a class="pull-right"
-     ng-href="#{{ activityFeedUrl(item.id, 'communication', 'completed') }}"
+     ng-href="{{getActivityFeedUrl({ caseId: item.id, category: 'communication', statusType: 'completed' })}}"
      ng-if="item.category_count.completed.communication"
      title="{{ ts('View All') }}"
   >{{ ts('View All') }}</a>

--- a/ang/civicase/case/details/summary-tab/case-summary-tasks.html
+++ b/ang/civicase/case/details/summary-tab/case-summary-tasks.html
@@ -6,7 +6,7 @@
     <span class="civicase__case-card__activity-count civicase__overdue-activity-icon civicase__overdue-activity-icon--before" ng-if="item.category_count.overdue.task">{{item.category_count.overdue.task}} </span>
   </h3>
   <a class="pull-right"
-     ng-href="#{{ activityFeedUrl(item.id, 'task', 'completed') }}"
+     ng-href="{{ getActivityFeedUrl({ caseId: item.id, category: 'task', statusType: 'completed' }) }}"
      ng-if="item.category_count.incomplete.task"
      title="{{ ts('View All') }}"
   >{{ ts('View All') }}</a>

--- a/ang/test/civicase/activity/calendar/directives/activities-calendar.directive.spec.js
+++ b/ang/test/civicase/activity/calendar/directives/activities-calendar.directive.spec.js
@@ -2,9 +2,14 @@
 
 (function ($, _, moment) {
   describe('civicaseActivitiesCalendarController', function () {
-    var $controller, $q, $scope, $rootScope, crmApi, formatActivity, dates, mockedActivities;
+    var $controller, $q, $scope, $rootScope, $route, crmApi, formatActivity, dates,
+      mockedActivities;
 
-    beforeEach(module('civicase', 'crmUtil', 'civicase.data', 'ui.bootstrap'));
+    beforeEach(module('civicase', 'crmUtil', 'civicase.data', 'ui.bootstrap', function ($provide) {
+      $route = { current: { params: {} } };
+
+      $provide.value('$route', $route);
+    }));
 
     beforeEach(inject(function (_$controller_, _$q_, _$rootScope_, _crmApi_,
       _formatActivity_, datesMockData) {
@@ -633,10 +638,9 @@
           foo: 'foo',
           af: { bar: 'bar' }
         };
+        $route.current.params = currentRouteParams;
 
-        initController(null, {
-          '$route': { current: { params: currentRouteParams } }
-        });
+        initController(null);
 
         url = $scope.seeAllLinkUrl(dates.yesterday);
         queryParams = CRM.testUtils.extractQueryStringParams(url.$$unwrapTrustedValue());
@@ -644,6 +648,10 @@
 
       it('is a trusted url', function () {
         expect(url.$$unwrapTrustedValue).toBeDefined();
+      });
+
+      it('displays the activities from the dashboard by default', function () {
+        expect(url).toMatch(/^#\/case\?/);
       });
 
       it('redirects to the activities feed tab', function () {

--- a/ang/test/civicase/activity/factories/get-activity-feed-url.factory.spec.js
+++ b/ang/test/civicase/activity/factories/get-activity-feed-url.factory.spec.js
@@ -24,8 +24,11 @@
         activityFeedUrlObject = getActivityFeedUrlAsObject();
       });
 
-      it('returns an url pointing to the dashboard activity feed', function () {
+      it('returns a url pointing to the dashboard', function () {
         expect(activityFeedUrlObject.baseUrl).toBe('#/case');
+      });
+
+      it('it requests the activity feed tab using the dtab param', function () {
         expect(activityFeedUrlObject.params.dtab).toBe('1');
       });
     });
@@ -37,7 +40,7 @@
         activityFeedUrlObject = getActivityFeedUrlAsObject();
       });
 
-      it('returns an url pointing to the case activity feed', function () {
+      it('returns a url pointing to the case activity feed', function () {
         expect(activityFeedUrlObject.baseUrl).toBe('#/case/list');
         expect(activityFeedUrlObject.params.tab).toBe('activities');
       });

--- a/ang/test/civicase/activity/factories/get-activity-feed-url.factory.spec.js
+++ b/ang/test/civicase/activity/factories/get-activity-feed-url.factory.spec.js
@@ -1,0 +1,151 @@
+/* eslint-env jasmine */
+
+(function (_, activityStatusTypes, extractQueryStringParams) {
+  describe('getActivityFeedUrl', function () {
+    var $location, $route, $sce, activityFeedUrlObject, getActivityFeedUrl;
+
+    beforeEach(module('civicase', function ($provide) {
+      $location = jasmine.createSpyObj('$location', ['path']);
+      $route = { current: { params: {} } };
+
+      $provide.value('$location', $location);
+      $provide.value('$route', $route);
+    }));
+
+    beforeEach(inject(function (_$sce_, _getActivityFeedUrl_) {
+      $sce = _$sce_;
+      getActivityFeedUrl = _getActivityFeedUrl_;
+    }));
+
+    describe('when getting the activity feed url from the dashboard page', function () {
+      beforeEach(function () {
+        $location.path.and.returnValue('/case');
+
+        activityFeedUrlObject = getActivityFeedUrlAsObject();
+      });
+
+      it('returns an url pointing to the dashboard activity feed', function () {
+        expect(activityFeedUrlObject.baseUrl).toBe('#/case');
+        expect(activityFeedUrlObject.params.dtab).toBe('1');
+      });
+    });
+
+    describe('when getting the activity feed url from the case details page', function () {
+      beforeEach(function () {
+        $location.path.and.returnValue('/case/list');
+
+        activityFeedUrlObject = getActivityFeedUrlAsObject();
+      });
+
+      it('returns an url pointing to the case activity feed', function () {
+        expect(activityFeedUrlObject.baseUrl).toBe('#/case/list');
+        expect(activityFeedUrlObject.params.tab).toBe('activities');
+      });
+    });
+
+    describe('when passing an activity id', function () {
+      var activityId = _.uniqueId();
+
+      beforeEach(function () {
+        activityFeedUrlObject = getActivityFeedUrlAsObject({
+          activityId: activityId
+        });
+      });
+
+      it('filters activities by id', function () {
+        expect(activityFeedUrlObject.params.aid).toBe(activityId);
+      });
+    });
+
+    describe('when passing an activity category', function () {
+      var category = _.uniqueId();
+
+      beforeEach(function () {
+        activityFeedUrlObject = getActivityFeedUrlAsObject({
+          category: category
+        });
+      });
+
+      it('filter activities by category', function () {
+        expect(activityFeedUrlObject.params.af['activity_type_id.grouping']).toBe(category);
+      });
+    });
+
+    describe('when passing an activity status type', function () {
+      beforeEach(function () {
+        activityFeedUrlObject = getActivityFeedUrlAsObject({
+          statusType: 'completed'
+        });
+      });
+
+      it('filter activities by status type', function () {
+        expect(activityFeedUrlObject.params.af.status_id).toEqual(activityStatusTypes.completed);
+      });
+    });
+
+    describe('when there are activity filters in the current route', function () {
+      beforeEach(function () {
+        $route.current.params.af = { status_id: [_.uniqueId()] };
+        activityFeedUrlObject = getActivityFeedUrlAsObject();
+      });
+
+      it('preserves the current activity filters', function () {
+        expect(activityFeedUrlObject.params.af).toEqual($route.current.params.af);
+      });
+    });
+
+    describe('when requesting filters that already exist in the current route', function () {
+      beforeEach(function () {
+        $route.current.params.af = { status_id: [_.uniqueId()] };
+        activityFeedUrlObject = getActivityFeedUrlAsObject({
+          statusType: 'completed'
+        });
+      });
+
+      it('overrides the current filters with the new ones', function () {
+        expect(activityFeedUrlObject.params.af).toEqual({
+          status_id: activityStatusTypes.completed
+        });
+      });
+    });
+
+    describe('when requesting the activities for a particular case', function () {
+      var caseId = _.uniqueId();
+
+      beforeEach(function () {
+        activityFeedUrlObject = getActivityFeedUrlAsObject({
+          caseId: caseId
+        });
+      });
+
+      it('filters activities by case id', function () {
+        expect(activityFeedUrlObject.params.caseId).toBe(caseId);
+      });
+    });
+
+    /**
+     * Returns the value returned by calling `getActivityFeedUrl` and gives
+     * some extra information: the base URL, the query parameters, and the full
+     * url path.
+     *
+     * @param {Object} urlParams the urlParams to pass to the `getActivityFeedUrl` service.
+     * @return {Object} the base url, the query params, and the full url for the activity feed.
+     */
+    function getActivityFeedUrlAsObject (urlParams) {
+      var wrappedActivityFeedUrl = getActivityFeedUrl(urlParams);
+      var activityFeedUrl = $sce.valueOf(wrappedActivityFeedUrl);
+      var activityFeedParams = extractQueryStringParams(activityFeedUrl);
+      var baseUrl = activityFeedUrl.match(/^(.+)\?/)[1];
+
+      return {
+        baseUrl: baseUrl,
+        params: activityFeedParams,
+        url: activityFeedUrl
+      };
+    }
+  });
+})(
+  CRM._,
+  CRM.civicase.activityStatusTypes,
+  CRM.testUtils.extractQueryStringParams
+);

--- a/ang/test/civicase/case/card/directives/case-card.directive.spec.js
+++ b/ang/test/civicase/case/card/directives/case-card.directive.spec.js
@@ -1,9 +1,13 @@
 /* eslint-env jasmine */
 (function ($) {
   describe('civicaseCaseCard', function () {
-    var element, $compile, $rootScope, $scope, CasesData;
+    var element, $compile, $rootScope, $route, $scope, CasesData;
 
-    beforeEach(module('civicase.templates', 'civicase', 'civicase.data'));
+    beforeEach(module('civicase.templates', 'civicase', 'civicase.data', function ($provide) {
+      $route = { current: { params: {} } };
+
+      $provide.value('$route', $route);
+    }));
 
     beforeEach(inject(function (_$compile_, _$rootScope_, _CasesData_) {
       $compile = _$compile_;

--- a/ang/test/civicase/case/details/directives/case-details.directive.spec.js
+++ b/ang/test/civicase/case/details/directives/case-details.directive.spec.js
@@ -1,7 +1,8 @@
 /* eslint-env jasmine */
 (function (_) {
   describe('civicaseCaseDetails', function () {
-    var element, controller, activitiesMockData, $controller, $compile, $rootScope, $scope, $provide, crmApi, crmApiMock, $q, formatCase, CasesData, CasesUtils;
+    var element, controller, activitiesMockData, $controller, $compile, $rootScope,
+      $route, $scope, $provide, crmApi, crmApiMock, $q, formatCase, CasesData, CasesUtils;
 
     beforeEach(module('civicase.templates', 'civicase', 'civicase.data', function (_$provide_) {
       $provide = _$provide_;
@@ -12,11 +13,13 @@
     beforeEach(inject(function ($q) {
       var formatCaseMock = jasmine.createSpy('formatCase');
       crmApiMock = jasmine.createSpy('crmApi').and.returnValue($q.resolve());
+      $route = { current: { params: {} } };
 
       formatCaseMock.and.callFake(function (data) {
         return data;
       });
 
+      $provide.value('$route', $route);
       $provide.value('crmApi', crmApiMock);
       $provide.value('formatCase', formatCaseMock);
     }));

--- a/ang/test/civicase/shared/directives/popover.directive.spec.js
+++ b/ang/test/civicase/shared/directives/popover.directive.spec.js
@@ -176,8 +176,10 @@
         });
 
         it('aligns the popover arrow to the right', function () {
-          var arrowCurrentPosition = popover.find('.arrow').css('left');
-          var arrowExpectedPosition = 'calc(100% + -' + popover.find('.arrow').outerWidth() + 'px)';
+          var arrowCurrentPosition, arrowExpectedPosition, popoverWidth;
+          arrowCurrentPosition = popover.find('.arrow').css('left');
+          popoverWidth = popover.find('.arrow').outerWidth();
+          arrowExpectedPosition = `calc(-${popoverWidth}px + 100%)`;
 
           expect(arrowCurrentPosition).toBe(arrowExpectedPosition);
         });


### PR DESCRIPTION
## Overview
This PR redirects the "see all activities" link from the activity calendar on the case details so they are displayed on the activity tab for the case instead of displaying the activities on the activity tab of the dashboard.

## Before
![pr](https://user-images.githubusercontent.com/1642119/52921469-eb6df280-32ed-11e9-83c5-e53ae27b9d00.gif)
The "See All" takes the user to the activities tab on the dashboard.

## After
![pr](https://user-images.githubusercontent.com/1642119/52921405-1146c780-32ed-11e9-990f-3c4a7c67d3d3.gif)

The "See All" takes the user to the activities tab on the case.

**Note:** for both scenarios the activities limit was removed so the effect can be demonstrated more clearly.

## Technical details

The solution was to adapt the `getActivityFeedUrl` util function so it can take the user to either the case activities or the dashboard activities depending on their current section. Also, the `getActivityFeedUrl` was refactored so it uses a single object parameter instead of multiple parameter values in order to simplify passing and skipping certain parameters.

The new implementation for the `getActivityFeedUrl` looks as follows:

```js
function (urlParams) {
  var activityFilters = {};
  var baseUrl = '#/case/list?';
  var currentPath = $location.path();

  urlParams = urlParams || {};
  urlParams.activityId = urlParams.activityId || 0;

  if (urlParams.category) {
    activityFilters['activity_type_id.grouping'] = urlParams.category;
  }

  if (urlParams.statusType) {
    activityFilters.status_id = CRM.civicase.activityStatusTypes[urlParams.statusType];
  }

  if (urlParams.status) {
    activityFilters.status_id = [_.findKey(CRM.civicase.activityStatuses, function (statusObj) {
      return statusObj.name === urlParams.status;
    })];
  }

  activityFilters = angular.extend(
    {},
    $route.current.params.af || {},
    activityFilters,
    urlParams.activityFilters || {}
  );

  var finalUrlParams = angular.extend({}, $route.current.params, {
    aid: urlParams.activityId,
    focus: 1,
    sx: 0,
    ai: '{"myActivities":false,"delegated":false}',
    af: JSON.stringify(activityFilters)
  });

  if (currentPath !== '/case/list') {
    baseUrl = '#/case?';
    finalUrlParams.dtab = 1;

    // If we're not already viewing a case, force the case id filter
    finalUrlParams.cf = JSON.stringify({ id: urlParams.caseId });
  } else {
    finalUrlParams.tab = 'activities';
  }

  if (urlParams.caseId) {
    finalUrlParams.caseId = parseInt(urlParams.caseId, 10);
  }

  // The value to mark as trusted in angular context for security.
  return $sce.trustAsResourceUrl(baseUrl + $.param(finalUrlParams));
}
```

As you can see, the `baseUrl` var changes depending if the current path is `'/case/list'` or not. Also, the function now accepts a filters parameter that allows setting specific activity filters to be preselected after the user is redirected.

Since the signature of the function changed, all templates references had to change so they use the new object paramater, denoted by the `ng-href="{{ getActivityFeedUrl({ caseId: 123, activityId: 456 }); }}` changes in this PR, and also changed the name from `activityFeedUrl` to `getActivityFeedUrl`.

The actual implementation in the activity calendar then changed to this:

```js
function seeAllLinkUrl (date) {
  var urlParams = getSeeMoreActivityFilters(date);

  return getActivityFeedUrl({ filters: urlParams });
}

function getSeeMoreActivityFilters (date) {
  var dateMoment = moment(date);

  return {
    '@moreFilters': true,
    'activity_date_time': {
      'BETWEEN': [
        dateMoment.startOf('day').format('YYYY-MM-DD HH:mm:ss'),
        dateMoment.endOf('day').format('YYYY-MM-DD HH:mm:ss')
      ]
    }
  };
}
```