### PR TITLE
C51-371: Bug Fixes for Case Report Bulk Action

### DIFF
--- a/CRM/Civicase/XMLProcessor/Report.php
+++ b/CRM/Civicase/XMLProcessor/Report.php
@@ -144,15 +144,21 @@ AND    ac.case_id = %1
   }
 
   /**
-   * Redact Case Relationship Fields
+   * Process Case Relationship Fields
    *
    * @param CRM_Civicase_XMLProcessor_Report $report
+   * @param array $caseRoles
    * @param array $caseRelationships
+   * @param boolean $isRedact
    */
-  private function redactCaseRelationshipFields($report, &$caseRelationships) {
+  private static function processCaseRelationshipFields(&$report, &$caseRoles, &$caseRelationships, $isRedact) {
     foreach ($caseRelationships as $key => & $value) {
       if (!empty($caseRoles[$value['relation_type']])) {
         unset($caseRoles[$value['relation_type']]);
+      }
+
+      if (!$isRedact) {
+        continue;
       }
 
       if (!array_key_exists($value['name'], $report->_redactionStringRules)) {
@@ -190,7 +196,7 @@ AND    ac.case_id = %1
    * @param CRM_Civicase_XMLProcessor_Report $report
    * @param array $caseRoles
    */
-  private function redactCaseClientFields (&$report, &$caseRoles) {
+  private static function redactCaseClientFields (&$report, &$caseRoles) {
     foreach ($caseRoles['client'] as &$client) {
       if (!array_key_exists(CRM_Utils_Array::value('sort_name', $client), $report->_redactionStringRules)) {
 
@@ -227,9 +233,11 @@ AND    ac.case_id = %1
    *
    * @param CRM_Civicase_XMLProcessor_Report $report
    * @param array $relClient
+   * @param array $caseRelationships
    * @param array $otherRelationships
+   * @param boolean $isRedact
    */
-  private function processClientRelationshipFields ($report, &$relClient, &$otherRelationships, $isRedact) {
+  private static function processClientRelationshipFields (&$report, &$relClient, $caseRelationships, &$otherRelationships, $isRedact) {
     foreach ($relClient as $r) {
       if ($isRedact) {
         if (!array_key_exists($r['name'], $report->_redactionStringRules)) {
@@ -272,7 +280,7 @@ AND    ac.case_id = %1
    * @param CRM_Civicase_XMLProcessor_Report $report
    * @param array $relGlobal
    */
-  private function redactGlobalRelationshipFields ($report, &$relGlobal) {
+  private static function redactGlobalRelationshipFields (&$report, &$relGlobal) {
     foreach ($relGlobal as & $r) {
       if (!array_key_exists($r['sort_name'], $report->_redactionStringRules)) {
         $report->_redactionStringRules = CRM_Utils_Array::crmArrayMerge($report->_redactionStringRules,
@@ -344,12 +352,12 @@ AND    ac.case_id = %1
     $relGlobal = CRM_Case_BAO_Case::getGlobalContacts($globalGroupInfo);
 
     if ($isRedact) {
-      CRM_Civicase_XMLProcessor_Report::redactCaseRelationshipFields($report, $caseRelationships);
       CRM_Civicase_XMLProcessor_Report::redactCaseClientFields($report, $caseRoles);
       CRM_Civicase_XMLProcessor_Report::redactGlobalRelationshipFields($report, $relGlobal);
     }
 
-    CRM_Civicase_XMLProcessor_Report::processClientRelationshipFields($report, $relClient, $otherRelationships, $isRedact);
+    CRM_Civicase_XMLProcessor_Report::processCaseRelationshipFields($report, $caseRoles, $caseRelationships, $isRedact);
+    CRM_Civicase_XMLProcessor_Report::processClientRelationshipFields($report, $relClient, $caseRelationships, $otherRelationships, $isRedact);
 
     // Retrieve custom values for cases.
     $customValues = CRM_Core_BAO_CustomValueTable::getEntityValues($caseID, 'Case');

--- a/CRM/Civicase/XMLProcessor/Report.php
+++ b/CRM/Civicase/XMLProcessor/Report.php
@@ -85,7 +85,7 @@ AND    ac.case_id = %1
     $template->assign_by_ref('case', $case);
 
     if ($params['include_activities'] == 1) {
-      $template->assign('includeActivities', '');
+      $template->assign('includeActivities', 'All');
     }
     else {
       $template->assign('includeActivities', 'Missing activities only');


### PR DESCRIPTION
## Overview
This PR fixes the the following two bugs related to the Case Report Bulk Action

## Problem 1
Non-Assigned roles are displayed on reports generated using Bulk Actions.

### Before
![2019-01-03 at 1 39 pm](https://user-images.githubusercontent.com/5058867/50628194-fd255180-0f5c-11e9-96ff-3def3777c400.png)

### After
![2019-01-03 at 1 38 pm](https://user-images.githubusercontent.com/5058867/50628177-ec74db80-0f5c-11e9-9c09-96b95d8dae0e.png)

### Technical Details
While refactoring `Report.php`(https://github.com/compucorp/uk.co.compucorp.civicase/commit/5428f4d4a29118cfcb4ad945c903923b8215ff93#diff-ea1f1b04ff56d2e2a233049eddae8d21), some of the things were missed
1. `$caseRoles` and `$isRedact` parameter was not passed to `redactCaseRelationshipFields`. Also the following code should have run irrespective of the value of `$isRedact`.
Now those are added and the function is renamed to `processCaseRelationshipFields`.

2. Also `processClientRelationshipFields` method was missing the `$caseRelationships` param, which is fixed.


## Problem 2
Past Activities are not displayed on report generated using Bulk Actions.

### Before
![2019-01-03 at 1 45 pm](https://user-images.githubusercontent.com/5058867/50628380-e7fcf280-0f5d-11e9-9216-f92f0984c811.png)
(Number of activities are printed for the purpose of screenshot)

### After
![2019-01-03 at 1 46 pm](https://user-images.githubusercontent.com/5058867/50628415-0236d080-0f5e-11e9-9456-fe9b735b6bca.png)

### Technical Details
By mistake, when copying the `getCaseReport` method, the following line was wrongly copied, which is fixed
https://github.com/compucorp/uk.co.compucorp.civicase/pull/142/commits/99b5492917da9a7a5d59639c1050572a8806951b#diff-ea1f1b04ff56d2e2a233049eddae8d21R88