### PR TITLE
C51-379: Fix Affix issues

### DIFF
--- a/ang/civicase/CaseDetails.js
+++ b/ang/civicase/CaseDetails.js
@@ -387,7 +387,11 @@
             top: $casePanelBody.offset().top - bodyPadding
           }
         }).on('affixed.bs.affix', function () {
-          $caseNavigation.css('top', $toolbarDrawer.height());
+          var caseNavigationTopPosition = $toolbarDrawer.is(':visible')
+            ? $toolbarDrawer.height()
+            : bodyPadding;
+
+          $caseNavigation.css('top', caseNavigationTopPosition);
         }).on('affixed-top.bs.affix', function () {
           $caseNavigation.css('top', 'auto');
         });

--- a/ang/civicase/CaseListDirectives.js
+++ b/ang/civicase/CaseListDirectives.js
@@ -27,6 +27,7 @@
      *   attributes of directive
      */
     function civicaseStickyTableHeaderLink (scope, $el, attrs) {
+      var $toolbarDrawer = $('#toolbar');
       var $table = $el;
       var $header = $el.find('thead');
 
@@ -86,7 +87,7 @@
             .on('affixed.bs.affix', function () {
               $header.scrollLeft($table.scrollLeft()); // Bind scrolling
               $header.css('top', bodyPadding + 'px'); // Set top pos to body padding so that it don't overlap with the toolbar
-              $table.css('padding-top', $header.height() + 'px'); // Add top padding to remove the glitch when header moves out of DOM relative position
+              $toolbarDrawer.is(':visible') && $table.css('padding-top', $header.height() + 'px'); // Add top padding to remove the glitch when header moves out of DOM relative position
             })
             .on('affixed-top.bs.affix', function () {
               $header.css('top', 0); // Resets top pos when in default state

--- a/ang/test/civicase/CaseListDirectives.spec.js
+++ b/ang/test/civicase/CaseListDirectives.spec.js
@@ -13,6 +13,8 @@ describe('CaseListDirective', function () {
     }));
 
     beforeEach(function () {
+      CRM.$('body').append('<div id="toolbar" style="height: 60px"></div>');
+
       element = $compile(angular.element('<div civicase-sticky-table-header> <table><thead><th>Sample title</th><th>Sample title</th></thead></table></div>'))(scope);
     });
 
@@ -26,6 +28,8 @@ describe('CaseListDirective', function () {
 
     afterEach(function () {
       CRM.$.fn.affix = affixOriginalFunction;
+
+      CRM.$('#toolbar').remove();
     });
 
     describe('if loading is not complete and case is focused', function () {
@@ -122,6 +126,39 @@ describe('CaseListDirective', function () {
 
       it('resets the padding for top header and when the header gets back to its state', function () {
         expect(affixReturnValue.on).toHaveBeenCalledWith('affixed-top.bs.affix', jasmine.any(Function));
+      });
+    });
+
+    describe('table list padding', function () {
+      var affixEventHandler;
+
+      beforeEach(inject(function ($timeout) {
+        element.find('thead').css('height', '100px');
+        scope.$digest();
+        $timeout.flush();
+
+        affixEventHandler = affixReturnValue.on.calls.argsFor(0)[1];
+      }));
+
+      describe('when scrolling and the toolbar drawer is visible', function () {
+        beforeEach(inject(function () {
+          affixEventHandler();
+        }));
+
+        it('adds a padding to the table equal to the table header', function () {
+          expect(element.css('padding-top')).toBe(element.find('thead').css('height'));
+        });
+      });
+
+      describe('when scrolling and the toolbar drawer is not visible', function () {
+        beforeEach(function () {
+          CRM.$('#toolbar').hide();
+          affixEventHandler();
+        });
+
+        it('does not add a padding to the table', function () {
+          expect(element.css('padding-top')).toBe('');
+        });
       });
     });
   });


### PR DESCRIPTION
## Overview

## Case details tab menu
### Before
![pr-before-1](https://user-images.githubusercontent.com/1642119/50742484-4d611580-11e2-11e9-8bdd-0527a8665c06.gif)

### After
![pr-after-1](https://user-images.githubusercontent.com/1642119/50742522-bba5d800-11e2-11e9-8631-ecb8137a3c28.gif)

## Case list table header
### Before
![pr-before-2](https://user-images.githubusercontent.com/1642119/50746029-81006780-1203-11e9-9e05-2ece250633b6.gif)

### After
![pr-after-2](https://user-images.githubusercontent.com/1642119/50746092-d2a8f200-1203-11e9-98f3-4e7667609fc4.gif)

## Technical details

The main issue is that the foldable Drupal shortcut menu can be hidden and still have a height property that would be taken into consideration when calculating the offset of the different elements to be affixed.

To fix this issue we take into consideration the visibility of the Drupal shortcut menu before adding its with to the affix offset value:

```js
// for the case details:
function civicaseCaseTabAffix (scope, $el, attrs) {
  // ...

  $timeout(function () {
    $caseNavigation.affix({
      // ...
    }).on('affixed.bs.affix', function () {
      var caseNavigationTopPosition = $toolbarDrawer.is(':visible')
        ? $toolbarDrawer.height() // when open: add the Drupal menu as offset
        : bodyPadding; // when closed, calculate the offset using the case detail container padding top property

      $caseNavigation.css('top', caseNavigationTopPosition);
    }) // ...
  });
}
```

```js
// for the case list table:
function civicaseStickyTableHeaderLink (scope, $el, attrs) {
  // ...

  function computeFixPositioning () {
    $timeout(function () {
      // ...
      $header.affix({
        // ...
      })
        .on('affixed.bs.affix', function () {
          // ...
          // if the Drupal menu is visible then add padding to the table header
          $toolbarDrawer.is(':visible') && $table.css('padding-top', $header.height() + 'px');
        })
        // ...
    }, 0);
  }
}
```