### PR TITLE
C51-387: Hide Activity Types when Exceeding max instance

### DIFF
--- a/ang/civicase/activity/directives/add-activity-menu.directive.js
+++ b/ang/civicase/activity/directives/add-activity-menu.directive.js
@@ -64,7 +64,9 @@
         if (exclude.indexOf(actSpec.name) < 0) {
           var actTypeId = _.findKey(civicase.activityTypes, {name: actSpec.name});
 
-          ret.push($.extend({id: actTypeId}, civicase.activityTypes[actTypeId]));
+          if (!actSpec.max_instances || !activityCount[actTypeId] || (actSpec.max_instances < activityCount[actTypeId])) {
+            ret.push($.extend({id: actTypeId}, civicase.activityTypes[actTypeId]));
+          }
         }
       });
 

--- a/ang/civicase/activity/directives/add-activity-menu.directive.js
+++ b/ang/civicase/activity/directives/add-activity-menu.directive.js
@@ -57,7 +57,7 @@
         if (exclude.indexOf(actSpec.name) < 0) {
           var actTypeId = _.findKey(civicase.activityTypes, {name: actSpec.name});
 
-          if (!actSpec.max_instances || !activityCount[actTypeId] || (actSpec.max_instances >= parseInt(activityCount[actTypeId]))) {
+          if (!actSpec.max_instances || !activityCount[actTypeId] || (actSpec.max_instances > parseInt(activityCount[actTypeId]))) {
             ret.push($.extend({id: actTypeId}, civicase.activityTypes[actTypeId]));
           }
         }

--- a/ang/civicase/activity/directives/add-activity-menu.directive.js
+++ b/ang/civicase/activity/directives/add-activity-menu.directive.js
@@ -24,14 +24,7 @@
         $scope.availableActivityTypes = getAvailableActivityTypes(
           $scope.case.activity_count, definition);
       } else {
-        $scope.$watch('case.definition', function (definition) {
-          if (!definition) {
-            return;
-          }
-
-          $scope.availableActivityTypes = getAvailableActivityTypes(
-            $scope.case.activity_count, definition);
-        });
+        initWatchers();
       }
     })();
 
@@ -64,7 +57,7 @@
         if (exclude.indexOf(actSpec.name) < 0) {
           var actTypeId = _.findKey(civicase.activityTypes, {name: actSpec.name});
 
-          if (!actSpec.max_instances || !activityCount[actTypeId] || (actSpec.max_instances < activityCount[actTypeId])) {
+          if (!actSpec.max_instances || !activityCount[actTypeId] || (actSpec.max_instances >= parseInt(activityCount[actTypeId]))) {
             ret.push($.extend({id: actTypeId}, civicase.activityTypes[actTypeId]));
           }
         }
@@ -83,6 +76,25 @@
       }
 
       return _.sortBy(ret, 'label');
+    }
+
+    /**
+     * Initialise watchers
+     */
+    function initWatchers () {
+      $scope.$watch('case.definition', function (definition) {
+        if (!definition) {
+          return;
+        }
+
+        $scope.availableActivityTypes = getAvailableActivityTypes(
+          $scope.case.activity_count, definition);
+      });
+
+      $scope.$watch('case.allActivities', function () {
+        $scope.availableActivityTypes = getAvailableActivityTypes(
+          $scope.case.activity_count, $scope.case.definition);
+      });
     }
 
     /**

--- a/ang/test/civicase/activity/directives/add-activity-menu.directive.spec.js
+++ b/ang/test/civicase/activity/directives/add-activity-menu.directive.spec.js
@@ -41,6 +41,36 @@
         });
       });
 
+      describe('activity menu', function () {
+        var activityTypeWithMaxInstance, activityTypeExceedingMaxInstanceIsHidden;
+
+        beforeEach(function () {
+          var activityTypes = CRM.civicase.caseTypes[1].definition.activityTypes;
+          activityTypeWithMaxInstance = activityTypes.find(function (activity) {
+            return activity.max_instances;
+          });
+          var actTypeId = _.findKey(CRM.civicase.activityTypes, {
+            name: activityTypeWithMaxInstance.name
+          });
+          var mockCase = {
+            case_type_id: 1,
+            allActivities: [
+              { id: _.uniqueId(), activity_type_id: actTypeId }
+            ]
+          };
+
+          initController(mockCase);
+
+          activityTypeExceedingMaxInstanceIsHidden = !_.find($scope.availableActivityTypes, function (activityType) {
+            return activityType.name === activityTypeWithMaxInstance.name;
+          });
+        });
+
+        it('hides activity types exceeding max instance', function () {
+          expect(activityTypeExceedingMaxInstanceIsHidden).toBe(true);
+        });
+      });
+
       /**
        * Initializes the add activity menu controller.
        *


### PR DESCRIPTION
## Overview
As part of this PR, Activity Types exceeding max_instance are hidden from "Add New Menu".
Issue reported in Github: https://github.com/compucorp/uk.co.compucorp.civicase/issues/151

## Before
![before](https://user-images.githubusercontent.com/5058867/51471141-e6c02800-1d9b-11e9-8655-765b29612eed.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/51471181-00fa0600-1d9c-11e9-952a-d5d074ecb2e7.gif)

## Technical Details
The original issue reported is a Core Issue, but this problem was not present in old civicase, because we hid all activity types exceeding max_instance. Hence the same fix needs to be applied to current version.

This functionality got broken when copying code from old civicase to new. 
So the following line is added back
https://github.com/compucorp/uk.co.compucorp.civicase/blob/78a35c1f90fa0f5aa0e1e530f1f97278ab24a0e8/ang/civicase/View.js#L94

However, there was a bug in the old logic, 
`actSpec.max_instances < activityCount[actTypeId]`
but the `activityCount[actTypeId]` should be less than `actSpec.max_instances` in order for it to hide. It has been corrected.