### PR TITLE
C51-222: Remove Client name from Edit Activity modal

### DIFF
--- a/ang/civicase/case/details/directives/case-details.directive.js
+++ b/ang/civicase/case/details/directives/case-details.directive.js
@@ -207,7 +207,6 @@
       return CRM.url('civicrm/case/activity', {
         action: 'update',
         reset: 1,
-        cid: $scope.item.client[0].contact_id,
         caseid: $scope.item.id,
         id: id,
         civicase_reload: $scope.caseGetParams()


### PR DESCRIPTION
## Overview
In the PR https://github.com/compucorp/uk.co.compucorp.civicase/pull/157, the client name removal was not done when Editing an Activity. It has been fixed in this PR.

## Before
![2019-01-22 at 2 30 pm](https://user-images.githubusercontent.com/5058867/51523734-4ed14580-1e52-11e9-8b0d-d1af86f93236.png)

## After
![2019-01-22 at 2 31 pm](https://user-images.githubusercontent.com/5058867/51523762-5db7f800-1e52-11e9-9e7d-4dbe01d3143c.png)

