### PR TITLE
C51-390: Refactor Gulpfile.js and adds list all screens to be covered under backstopJS to the readme file

### DIFF
--- a/gulp-tasks/backstopjs.js
+++ b/gulp-tasks/backstopjs.js
@@ -1,6 +1,6 @@
 /**
  * @file
- * This file contains functional configurations for setting up backstopJS test suite
+ * Contains functional configurations for setting up backstopJS test suite
  */
 
 'use strict';

--- a/gulp-tasks/backstopjs.js
+++ b/gulp-tasks/backstopjs.js
@@ -1,3 +1,10 @@
+/**
+ * @file
+ * This file contains functional configurations for setting up backstopJS test suite
+ */
+
+'use strict';
+
 var _ = require('lodash');
 var argv = require('yargs').argv;
 var backstopjs = require('backstopjs');

--- a/gulp-tasks/karma-unit-test.js
+++ b/gulp-tasks/karma-unit-test.js
@@ -1,6 +1,6 @@
 /**
  * @file
- * This file contains function for karma tests gulp task
+ * Exports Gulp "test" task
  */
 
 'use strict';

--- a/gulp-tasks/sass-sync.js
+++ b/gulp-tasks/sass-sync.js
@@ -1,9 +1,7 @@
 /**
  * @file
- * This file contains function for sass:sync gulp task
+ * Exports Gulp "sass:sync" task
  */
-
-'use strict';
 
 var civicrmScssRoot = require('civicrm-scssroot')();
 

--- a/gulp-tasks/sass-sync.js
+++ b/gulp-tasks/sass-sync.js
@@ -1,0 +1,12 @@
+/**
+ * @file
+ * This file contains function for sass:sync gulp task
+ */
+
+'use strict';
+
+var civicrmScssRoot = require('civicrm-scssroot')();
+
+module.exports = function () {
+  civicrmScssRoot.updateSync();
+};

--- a/gulp-tasks/sass.js
+++ b/gulp-tasks/sass.js
@@ -1,0 +1,65 @@
+/**
+ * @file
+ * This file contains function for sass gulp task
+ *
+ * The gulp task compiles and minifies scss/civicase.scss file into css/civicase.min.css.
+ * Also prefix the output css selector with `#bootstrap-theme` selector except the output.
+ * selector starts from either `body`, `page-civicrm-case` or `.___outside-namespace` classes.
+ */
+
+'use strict';
+
+var autoprefixer = require('gulp-autoprefixer');
+var bulk = require('gulp-sass-bulk-import');
+var civicrmScssRoot = require('civicrm-scssroot')();
+var cssmin = require('gulp-cssmin');
+var gulp = require('gulp');
+var postcss = require('gulp-postcss');
+var postcssDiscardDuplicates = require('postcss-discard-duplicates');
+var postcssPrefix = require('postcss-prefix-selector');
+var rename = require('gulp-rename');
+var sass = require('gulp-sass');
+var stripCssComments = require('gulp-strip-css-comments');
+var sourcemaps = require('gulp-sourcemaps');
+var transformSelectors = require('gulp-transform-selectors');
+
+var bootstrapNamespace = '#bootstrap-theme';
+var outsideNamespaceRegExp = /^\.___outside-namespace/;
+
+function sassTask () {
+  return gulp.src('scss/civicase.scss')
+    .pipe(bulk())
+    .pipe(sourcemaps.init())
+    .pipe(autoprefixer({
+      browsers: ['last 2 versions'],
+      cascade: false
+    }))
+    .pipe(sass({
+      outputStyle: 'compressed',
+      includePaths: civicrmScssRoot.getPath(),
+      precision: 10
+    }).on('error', sass.logError))
+    .pipe(stripCssComments({ preserve: false }))
+    .pipe(postcss([postcssPrefix({
+      prefix: bootstrapNamespace + ' ',
+      exclude: [/^body/, /page-civicrm-case/, outsideNamespaceRegExp]
+    }), postcssDiscardDuplicates]))
+    .pipe(transformSelectors(removeOutsideNamespaceMarker, { splitOnCommas: true }))
+    .pipe(cssmin({ sourceMap: true }))
+    .pipe(rename({ suffix: '.min' }))
+    .pipe(sourcemaps.write('.'))
+    .pipe(gulp.dest('css/'));
+}
+
+/**
+ * Deletes the special class that was used as marker for styles that should
+ * not be nested inside the bootstrap namespace from the given selector
+ *
+ * @param  {String} selector
+ * @return {String}
+ */
+function removeOutsideNamespaceMarker (selector) {
+  return selector.replace(outsideNamespaceRegExp, '');
+}
+
+module.exports = sassTask;

--- a/gulp-tasks/sass.js
+++ b/gulp-tasks/sass.js
@@ -1,10 +1,6 @@
 /**
  * @file
- * This file contains function for sass gulp task
- *
- * The gulp task compiles and minifies scss/civicase.scss file into css/civicase.min.css.
- * Also prefix the output css selector with `#bootstrap-theme` selector except the output.
- * selector starts from either `body`, `page-civicrm-case` or `.___outside-namespace` classes.
+ * Exports Gulp "sass" task
  */
 
 'use strict';
@@ -23,9 +19,14 @@ var stripCssComments = require('gulp-strip-css-comments');
 var sourcemaps = require('gulp-sourcemaps');
 var transformSelectors = require('gulp-transform-selectors');
 
-var bootstrapNamespace = '#bootstrap-theme';
-var outsideNamespaceRegExp = /^\.___outside-namespace/;
+var BOOTSTRAP_NAMESPACE = '#bootstrap-theme';
+var OUTSIDE_NAMESPACE_REGEX = /^\.___outside-namespace/;
 
+/*
+ * The gulp task compiles and minifies scss/civicase.scss file into css/civicase.min.css.
+ * Also prefix the output css selector with `#bootstrap-theme` selector except the output.
+ * selector starts from either `body`, `page-civicrm-case` or `.___outside-namespace` classes.
+ */
 function sassTask () {
   return gulp.src('scss/civicase.scss')
     .pipe(bulk())
@@ -41,8 +42,8 @@ function sassTask () {
     }).on('error', sass.logError))
     .pipe(stripCssComments({ preserve: false }))
     .pipe(postcss([postcssPrefix({
-      prefix: bootstrapNamespace + ' ',
-      exclude: [/^body/, /page-civicrm-case/, outsideNamespaceRegExp]
+      prefix: BOOTSTRAP_NAMESPACE + ' ',
+      exclude: [/^body/, /page-civicrm-case/, OUTSIDE_NAMESPACE_REGEX]
     }), postcssDiscardDuplicates]))
     .pipe(transformSelectors(removeOutsideNamespaceMarker, { splitOnCommas: true }))
     .pipe(cssmin({ sourceMap: true }))
@@ -59,7 +60,7 @@ function sassTask () {
  * @return {String}
  */
 function removeOutsideNamespaceMarker (selector) {
-  return selector.replace(outsideNamespaceRegExp, '');
+  return selector.replace(OUTSIDE_NAMESPACE_REGEX, '');
 }
 
 module.exports = sassTask;

--- a/gulp-tasks/test.js
+++ b/gulp-tasks/test.js
@@ -1,0 +1,16 @@
+/**
+ * @file
+ * This file contains function for karma tests gulp task
+ */
+
+'use strict';
+
+var karma = require('karma');
+var path = require('path');
+
+module.exports = function (done) {
+  new karma.Server({
+    configFile: path.resolve(__dirname, '../ang/test/karma.conf.js'),
+    singleRun: true
+  }, done).start();
+};

--- a/gulp-tasks/watch.js
+++ b/gulp-tasks/watch.js
@@ -1,0 +1,15 @@
+/**
+ * @file
+ * This file contains function for watch gulp task
+ */
+
+'use strict';
+
+var gulp = require('gulp');
+var civicrmScssRoot = require('civicrm-scssroot')();
+
+module.exports = function () {
+  gulp.watch('scss/**/*.scss', ['sass']);
+  gulp.watch(['ang/**/*.js', '!ang/test/karma.conf.js'], ['test']);
+  gulp.watch(civicrmScssRoot.getWatchList(), ['sass']);
+};

--- a/gulp-tasks/watch.js
+++ b/gulp-tasks/watch.js
@@ -1,6 +1,6 @@
 /**
  * @file
- * This file contains function for watch gulp task
+ * Exports Gulp "watch" task
  */
 
 'use strict';
@@ -10,6 +10,6 @@ var civicrmScssRoot = require('civicrm-scssroot')();
 
 module.exports = function () {
   gulp.watch('scss/**/*.scss', ['sass']);
-  gulp.watch(['ang/**/*.js', '!ang/test/karma.conf.js'], ['test']);
   gulp.watch(civicrmScssRoot.getWatchList(), ['sass']);
+  gulp.watch(['ang/**/*.js', '!ang/test/karma.conf.js'], ['test']);
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,18 +1,17 @@
 /**
  * @file
- * This file contains gulp configurations for setting up SASS with feature of
- * importing Shoreditch Partials and minifying the css file to .min.css
+ * Contains gulp tasks for the application
  *
- * Tasks
- * default : Runs sass and test task
- * sass:sync : Compiles civicase.scss under scss folder to CSS counterpart
- * sass: Compiles civicase.scss under scss folder to CSS counterpart
- * test: Runs Karma unit tests
- * backstopjs:reference: For creating reference screenshots
- * backstopjs:test: For creating test screenshots and matching them
- * backstopjs:openReport: For opening reports in the browser
- * backstopjs:approve: Approving reports
- * watch: Watches for scss and js file changes and run sass task
+ * Available Tasks
+ * default
+ * sass:sync
+ * sass
+ * test
+ * backstopjs
+ * backstopjs
+ * backstopjs
+ * backstopjs
+ * watch
  */
 
 'use strict';
@@ -22,35 +21,40 @@ var gulp = require('gulp');
 var backstopJSTask = require('./gulp-tasks/backstopjs.js');
 var sassTask = require('./gulp-tasks/sass.js');
 var sassSyncTask = require('./gulp-tasks/sass-sync.js');
-var testTask = require('./gulp-tasks/test.js');
+var testTask = require('./gulp-tasks/karma-unit-test.js');
 var watchTask = require('./gulp-tasks/watch.js');
 
 /**
- * The gulp task updates and sync the scssRoot paths
+ * Updates and sync the scssRoot paths
  */
 gulp.task('sass:sync', sassSyncTask);
 
 /**
- * Gulp sass task
+ * Compiles civicase.scss under scss folder to CSS counterpart
  */
 gulp.task('sass', ['sass:sync'], sassTask);
 
 /**
- * Gulp unit tests task
+ * Runs Karma unit tests
  */
 gulp.task('test', testTask);
 
 /**
- * Gulp watch task
+ * Watches for scss and js file changes and run sass task and karma unit tests
  */
 gulp.task('watch', watchTask);
 
 /**
- * Gulp backstop tasks
+ * BackstopJS task
+ *
+ * backstopjs:reference: Creates reference screenshots
+ * backstopjs:test: Creates test screenshots and matching them
+ * backstopjs:openReport: Opens reports in the browser
+ * backstopjs:approve: Approves reports
  */
 ['reference', 'test', 'openReport', 'approve'].map(backstopJSTask);
 
 /**
- * Gulp default task
+ * Runs sass and test task
  */
 gulp.task('default', ['sass', 'test']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,10 +7,10 @@
  * sass:sync
  * sass
  * test
- * backstopjs
- * backstopjs
- * backstopjs
- * backstopjs
+ * backstopjs:reference
+ * backstopjs:test
+ * backstopjs:openReport
+ * backstopjs:approve
  * watch
  */
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,109 +4,53 @@
  * importing Shoreditch Partials and minifying the css file to .min.css
  *
  * Tasks
- * default : Runs SASS task
+ * default : Runs sass and test task
+ * sass:sync : Compiles civicase.scss under scss folder to CSS counterpart
  * sass: Compiles civicase.scss under scss folder to CSS counterpart
- * watch: Watches for scss file changes and run sass task
+ * test: Runs Karma unit tests
+ * backstopjs:reference: For creating reference screenshots
+ * backstopjs:test: For creating test screenshots and matching them
+ * backstopjs:openReport: For opening reports in the browser
+ * backstopjs:approve: Approving reports
+ * watch: Watches for scss and js file changes and run sass task
  */
+
 'use strict';
 
-var autoprefixer = require('gulp-autoprefixer');
-var bulk = require('gulp-sass-bulk-import');
-var civicrmScssRoot = require('civicrm-scssroot')();
-var cssmin = require('gulp-cssmin');
 var gulp = require('gulp');
-var karma = require('karma');
-var path = require('path');
-var postcss = require('gulp-postcss');
-var postcssDiscardDuplicates = require('postcss-discard-duplicates');
-var postcssPrefix = require('postcss-prefix-selector');
-var rename = require('gulp-rename');
-var sass = require('gulp-sass');
-var stripCssComments = require('gulp-strip-css-comments');
-var sourcemaps = require('gulp-sourcemaps');
-var transformSelectors = require('gulp-transform-selectors');
+
 var backstopJSTask = require('./gulp-tasks/backstopjs.js');
-
-var bootstrapNamespace = '#bootstrap-theme';
-var outsideNamespaceRegExp = /^\.___outside-namespace/;
-
-/**
-  * The gulp task updates and sync the scssRoot paths
-  */
-gulp.task('sass:sync', () => {
-  civicrmScssRoot.updateSync();
-});
+var sassTask = require('./gulp-tasks/sass.js');
+var sassSyncTask = require('./gulp-tasks/sass-sync.js');
+var testTask = require('./gulp-tasks/test.js');
+var watchTask = require('./gulp-tasks/watch.js');
 
 /**
- * The gulp task compiles and minifies scss/civicase.scss file into css/civicase.min.css.
- * Also prefix the output css selector with `#bootstrap-theme` selector except the output.
- * selector starts from either `body`, `page-civicrm-case` or `.___outside-namespace` classes.
+ * The gulp task updates and sync the scssRoot paths
  */
-gulp.task('sass', ['sass:sync'], function () {
-  return gulp.src('scss/civicase.scss')
-    .pipe(bulk())
-    .pipe(sourcemaps.init())
-    .pipe(autoprefixer({
-      browsers: ['last 2 versions'],
-      cascade: false
-    }))
-    .pipe(sass({
-      outputStyle: 'compressed',
-      includePaths: civicrmScssRoot.getPath(),
-      precision: 10
-    }).on('error', sass.logError))
-    .pipe(stripCssComments({ preserve: false }))
-    .pipe(postcss([postcssPrefix({
-      prefix: bootstrapNamespace + ' ',
-      exclude: [/^body/, /page-civicrm-case/, outsideNamespaceRegExp]
-    }), postcssDiscardDuplicates]))
-    .pipe(transformSelectors(removeOutsideNamespaceMarker, { splitOnCommas: true }))
-    .pipe(cssmin({ sourceMap: true }))
-    .pipe(rename({ suffix: '.min' }))
-    .pipe(sourcemaps.write('.'))
-    .pipe(gulp.dest('css/'));
-});
+gulp.task('sass:sync', sassSyncTask);
 
 /**
- * Watch task
+ * Gulp sass task
  */
-gulp.task('watch', function () {
-  gulp.watch('scss/**/*.scss', ['sass']);
-  gulp.watch(['ang/**/*.js', '!ang/test/karma.conf.js'], ['test']);
-  gulp.watch(civicrmScssRoot.getWatchList(), ['sass']);
-});
+gulp.task('sass', ['sass:sync'], sassTask);
 
 /**
- * Default task
+ * Gulp unit tests task
+ */
+gulp.task('test', testTask);
+
+/**
+ * Gulp watch task
+ */
+gulp.task('watch', watchTask);
+
+/**
+ * Gulp backstop tasks
+ */
+['reference', 'test', 'openReport', 'approve'].map(backstopJSTask);
+
+/**
+ * Gulp default task
  */
 gulp.task('default', ['sass', 'test']);
-
-/**
- * Deletes the special class that was used as marker for styles that should
- * not be nested inside the bootstrap namespace from the given selector
- *
- * @param  {String} selector
- * @return {String}
- */
-function removeOutsideNamespaceMarker (selector) {
-  return selector.replace(outsideNamespaceRegExp, '');
-}
-
-/**
- * Runs the unit tests
- */
-gulp.task('test', function (done) {
-  new karma.Server({
-    configFile: path.resolve(__dirname, 'ang/test/karma.conf.js'),
-    singleRun: true
-  }, done).start();
-});
-
-/**
-  * Gulp backstop tasks
-  * 'backstopjs:reference': For creating reference screenshots
-  * 'backstopjs:test': For creating test screenshots and matching them
-  * 'backstopjs:openReport': For opening reports in the browser
-  * 'backstopjs:approve': Approving reports
-  */
-['reference', 'test', 'openReport', 'approve'].map(backstopJSTask);

--- a/tests/backstop_data/Readme.md
+++ b/tests/backstop_data/Readme.md
@@ -1,0 +1,58 @@
+# Covered Screens
+The backstop test suite for Civicase 5.1 extension covers following screens
+
+## Dashboard
+- [ ] Dashboard Main screen - With overview table expanded and tooltip visible on one of the titles
+- [ ] Dashboard Overview table with gear icon opened
+- [ ] Dashboard Main screen - with loading screens
+- [ ] Dashboard Main screen - Calendar - Acitivity card
+- [ ] Dashboard Main screen  - Empty State
+
+## Activities Feed Panel
+- [ ] Activities Feed Panel - Main screen
+- [ ] Activities Feed Panel - Loading screen
+- [ ] Activities Feed Panel - Bulk action Checkbox enabled and one checkbox checked, and bulk action dropdown opened
+- [ ] Activities Feed Panel - Load more state
+- [ ] Activities Feed Panel -  filter dropdowns
+- [ ] Activities Feed Panel - with one filter enabled
+- [ ] Activities Feed Panel - one activity selected
+- [ ] Activities Feed Panel - Activity card menu on case overview
+- [ ] Activities Feed Panel - Empty State
+- [ ] Activities Feed Panel - Detail - Edit state
+- [ ] Activities Feed Panel - Detail - Delete state
+- [ ] Activities Feed Panel - Under Manage Cases
+- [ ] Activities Feed Panel - Under Contact Page
+
+## Manage Cases Screens
+- [ ] Manage Cases List - Main screen
+- [ ] Manage Cases List - Other Criterion filter button
+- [ ] Manage Cases List - Loading screen
+- [ ] Manage Cases List - selected case
+- [ ] Manage Cases List - Case Overview - with drawer closed
+- [ ] Manage Cases List - Case Overview - Empty States
+- [ ] Manage Cases List - Case Overview - with calendar activity opened
+- [ ] Manage Cases List - Case Overview - Loading
+- [ ] Manage Cases List - Case Overview - Edit custom Data
+- [ ] Manage Cases List - Case Overview - Add new - Open the popup
+- [ ] Manage Cases List - People - Case Roles
+- [ ] Manage Cases List - People - Case Roles - Loading
+- [ ] Manage Cases List - People - Other Relationships
+- [ ] Manage Cases List - People - Other Relationships - Loading
+- [ ] Manage Cases List - Files
+- [ ] Manage Cases List - Files - Loading
+- [ ] Manage Cases List - Files - Upload files - *Skip this if is hard to implement*
+
+## Contact Page
+- [ ] Contact Page - Case Tab
+- [ ] Contact Page - Case Tab - Loading screen
+- [ ] Contact Page - Case Tab - Loading more results icon (When clicked on load more
+
+## Modals
+- [ ] Modals - Contact Popover Modal
+- [ ] Modals - + 1 Contact Popover Modal
+- [ ] Modals - Dashboard Main screen - Calendar - Acitivity card
+- [ ] Modals - Status popup for activity details
+- [ ] Modals - Manage Cases - Next Activity - card menu
+- [ ] Modals - Manage Cases - Case Detail - Actions Menu
+- [ ] Modals - Manage Cases - Case Detail - Actions Menu - Edit Tags
+- [ ] Modals - Manage Cases List - Files - menu actions

--- a/tests/backstop_data/Readme.md
+++ b/tests/backstop_data/Readme.md
@@ -48,9 +48,8 @@ The backstop test suite for Civicase 5.1 extension covers following screens
 - [ ] Contact Page - Case Tab - Loading more results icon (When clicked on load more
 
 ## Modals
-- [ ] Modals - Contact Popover Modal
-- [ ] Modals - + 1 Contact Popover Modal
-- [ ] Modals - Dashboard Main screen - Calendar - Acitivity card
+- [ ] Modals - Contact Popover
+- [ ] Modals - Additional Contacts Popover
 - [ ] Modals - Status popup for activity details
 - [ ] Modals - Manage Cases - Next Activity - card menu
 - [ ] Modals - Manage Cases - Case Detail - Actions Menu


### PR DESCRIPTION
## Overview
This PR 
* Refactors Gulpfile.js and break the gulp tasks to their corresponding files in `gulp-tasks` folder
* List all the screens to be covered under backstopJS test suite

## Before/After
No visual changes are brought by the PR

## List of all screens
![list of all screens](https://user-images.githubusercontent.com/3340537/51605961-89aca980-1f36-11e9-872f-04472f95ff33.png)

## Technical Details
* All the related gulp tasks function are extracted from main `Gulpfile.js` and moved in their corresponding js files in `gulp-tasks` folder. Now the gulpfile.js only calls the `gulp.tasks` functions
```js

/**
 * The gulp task updates and sync the scssRoot paths
 */
gulp.task('sass:sync', sassSyncTask);

/**
 * Gulp sass task
 */
gulp.task('sass', ['sass:sync'], sassTask);

/**
 * Gulp unit tests task
 */
gulp.task('test', testTask);

/**
 * Gulp watch task
 */
gulp.task('watch', watchTask);

/**
 * Gulp backstop tasks
 */
['reference', 'test', 'openReport', 'approve'].map(backstopJSTask);

/**
 * Gulp default task
 */
gulp.task('default', ['sass', 'test']);
```