### PR TITLE
C51-392: Add screens for activity panel feed and add some utility functions

### DIFF
--- a/tests/backstop_data/Readme.md
+++ b/tests/backstop_data/Readme.md
@@ -5,6 +5,9 @@
 
 * The current calendar month has at least one day with some activities
 
+## Contact Section
+* Make sure the civicase is installed with demo data and should have a contact name "Betty Adams" and have some activities for the contact
+
 ---
 
 # Covered Screens

--- a/tests/backstop_data/Readme.md
+++ b/tests/backstop_data/Readme.md
@@ -6,7 +6,7 @@
 * The current calendar month has at least one day with some activities
 
 ## Contact Section
-* Make sure the civicase is installed with demo data and should have a contact name "Betty Adams" and have some activities for the contact
+* Make sure the civicase is installed with demo data and should have a contact name "Betty Adams" and at least have one activity for the contact.
 
 ---
 
@@ -26,7 +26,7 @@ The backstop test suite for Civicase 5.1 extension covers following screens
 - [ ] Activities Feed Panel - Loading screen
 - [ ] Activities Feed Panel - Bulk action Checkbox enabled and one checkbox checked, and bulk action dropdown opened
 - [ ] Activities Feed Panel - Load more state
-- [ ] Activities Feed Panel -  filter dropdowns
+- [ ] Activities Feed Panel - filter dropdowns
 - [ ] Activities Feed Panel - with one filter enabled
 - [ ] Activities Feed Panel - one activity selected
 - [ ] Activities Feed Panel - Activity card menu on case overview

--- a/tests/backstop_data/backstop.tpl.json
+++ b/tests/backstop_data/backstop.tpl.json
@@ -2,8 +2,8 @@
   "id": "Civicase 5.1",
   "viewports": [{
     "name": "desktop",
-    "width": 1920,
-    "height": 3000
+    "width": 1680,
+    "height": 1050
   }],
   "onBeforeScript": "on-before.js",
   "onReadyScript": "on-ready.js",

--- a/tests/backstop_data/engine_scripts/puppet/activity-feed-panel/activity-detail.js
+++ b/tests/backstop_data/engine_scripts/puppet/activity-feed-panel/activity-detail.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const Utility = require('./../utility.js');
+
+module.exports = async (page, scenario, vp) => {
+  const utility = new Utility(page, scenario, vp);
+
+  await utility.waitForAngular();
+  await utility.waitForLoadingComplete();
+  await page.click('.civicase__activity-feed__list .civicase__activity-card:not(.civicase__activity-card--draft)');
+  await page.waitFor('.blockUI.blockOverlay', { hidden: true });
+};

--- a/tests/backstop_data/engine_scripts/puppet/activity-feed-panel/activity-detail.js
+++ b/tests/backstop_data/engine_scripts/puppet/activity-feed-panel/activity-detail.js
@@ -7,6 +7,6 @@ module.exports = async (page, scenario, vp) => {
 
   await utility.waitForAngular();
   await utility.waitForLoadingComplete();
-  await page.click('.civicase__activity-feed__list .civicase__activity-card:not(.civicase__activity-card--draft)');
+  await page.click('.civicase__activity-feed__list .civicase__activity-card');
   await page.waitFor('.blockUI.blockOverlay', { hidden: true });
 };

--- a/tests/backstop_data/engine_scripts/puppet/activity-feed-panel/activity-edit-details.js
+++ b/tests/backstop_data/engine_scripts/puppet/activity-feed-panel/activity-edit-details.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const Utility = require('./../utility.js');
+
+module.exports = async (page, scenario, vp) => {
+  const utility = new Utility(page, scenario, vp);
+  const viewPortOverride = Object.assign(page.viewport(), {height: 800});
+
+  await page.setViewport(viewPortOverride);
+
+  await require('./activity-detail.js')(page, scenario, vp);
+  await page.click('.civicase__activity-feed__body__details .edit.button');
+  await page.waitFor('.blockUI.blockOverlay', { hidden: true });
+  await utility.openAllAccordions();
+};

--- a/tests/backstop_data/engine_scripts/puppet/activity-feed-panel/activity-edit-details.js
+++ b/tests/backstop_data/engine_scripts/puppet/activity-feed-panel/activity-edit-details.js
@@ -4,7 +4,8 @@ const Utility = require('./../utility.js');
 
 module.exports = async (page, scenario, vp) => {
   const utility = new Utility(page, scenario, vp);
-  const viewPortOverride = Object.assign(page.viewport(), {height: 800});
+  // We override the height of the viewport so the Edit button is visible
+  const viewPortOverride = Object.assign(page.viewport(), { height: 800 });
 
   await page.setViewport(viewPortOverride);
 

--- a/tests/backstop_data/engine_scripts/puppet/activity-feed-panel/bulk-actions.js
+++ b/tests/backstop_data/engine_scripts/puppet/activity-feed-panel/bulk-actions.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const Utility = require('./../utility.js');
+
+module.exports = async (page, scenario, vp) => {
+  const utility = new Utility(page, scenario, vp);
+
+  await utility.waitForAngular();
+  await utility.waitForLoadingComplete();
+  await page.click('.civicase__bulkactions-checkbox-toggle');
+  await page.waitFor(300);
+  await page.click('.civicase__checkbox--bulk-action');
+};

--- a/tests/backstop_data/engine_scripts/puppet/activity-feed-panel/bulk-actions.js
+++ b/tests/backstop_data/engine_scripts/puppet/activity-feed-panel/bulk-actions.js
@@ -8,6 +8,7 @@ module.exports = async (page, scenario, vp) => {
   await utility.waitForAngular();
   await utility.waitForLoadingComplete();
   await page.click('.civicase__bulkactions-checkbox-toggle');
+  // this waits for the animation to finish before continue:
   await page.waitFor(300);
   await page.click('.civicase__checkbox--bulk-action');
 };

--- a/tests/backstop_data/engine_scripts/puppet/activity-feed-panel/on-contact-page.js
+++ b/tests/backstop_data/engine_scripts/puppet/activity-feed-panel/on-contact-page.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const Utility = require('./../utility.js');
+
+module.exports = async (page, scenario, vp) => {
+  const utility = new Utility(page, scenario, vp);
+
+  await require('./../contacts/contact-dashboard.js')(page, scenario, vp);
+
+  await page.click('.ui-tabs-anchor[title="Activities"]');
+  await page.waitFor('.blockUI.blockOverlay', { hidden: true });
+  await page.waitForSelector('#civicaseActivitiesTab #bootstrap-theme .civicase__activity-feed');
+  await utility.waitForLoadingComplete();
+};

--- a/tests/backstop_data/engine_scripts/puppet/activity-feed-panel/on-manage-cases.js
+++ b/tests/backstop_data/engine_scripts/puppet/activity-feed-panel/on-manage-cases.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const Utility = require('./../utility.js');
+
+module.exports = async (page, scenario, vp) => {
+  const utility = new Utility(page, scenario, vp);
+
+  await require('./../manage-cases/select-case.js')(page, scenario, vp);
+
+  await page.click('.civicase__case-body_tab > li:nth-child(2) a');
+  await utility.waitForLoadingComplete();
+};

--- a/tests/backstop_data/engine_scripts/puppet/contacts/contact-dashboard.js
+++ b/tests/backstop_data/engine_scripts/puppet/contacts/contact-dashboard.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const Utility = require('./../utility.js');
+
+module.exports = async (page, scenario, vp) => {
+  const utility = new Utility(page, scenario, vp);
+
+  await page.type('#sort_name', 'Betty Adams');
+  await utility.clickAndWaitForNavigation('#_qf_Basic_refresh');
+  await utility.clickAndWaitForNavigation('.crm-search-results a[title="View Contact Details"]');
+};

--- a/tests/backstop_data/engine_scripts/puppet/manage-cases/select-case.js
+++ b/tests/backstop_data/engine_scripts/puppet/manage-cases/select-case.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const Utility = require('./../utility.js');
+
+module.exports = async (page, scenario, vp) => {
+  const utility = new Utility(page, scenario, vp);
+
+  await utility.waitForAngular();
+  await utility.waitForLoadingComplete('.civicase__case-list-panel');
+  // Evaluating the click using browser native click function
+  // pupetter is faling to click on the correct div (Opening a random screen)
+  await page.evaluate(() => {
+    document.querySelector('.civicase__case-list-table tbody tr:first-child .civicase__case-card').click();
+  });
+  await utility.waitForLoadingComplete();
+};

--- a/tests/backstop_data/engine_scripts/puppet/mouse-events-helper.js
+++ b/tests/backstop_data/engine_scripts/puppet/mouse-events-helper.js
@@ -29,8 +29,7 @@ async function hoverSelectorAction (page, scenario, viewport) {
   const utility = new Utility(page, scenario, viewport);
 
   for (const hoverSelector of hoverSelectors) {
-    await page.waitFor(hoverSelector);
-    await page.hover(hoverSelector);
+    await utility.waitForAndHover(clickSelectorIndex);
 
     if (scenario.waitForAjaxComplete) {
       await utility.waitForLoadingComplete();
@@ -50,8 +49,7 @@ async function clickSelectorAction (page, scenario, viewport) {
   const utility = new Utility(page, scenario, viewport);
 
   for (const clickSelector of clickSelectors) {
-    await page.waitFor(clickSelector);
-    await page.click(clickSelector);
+    await utility.waitForAndClick(clickSelectorIndex);
 
     if (scenario.waitForAjaxComplete) {
       await utility.waitForLoadingComplete();

--- a/tests/backstop_data/engine_scripts/puppet/mouse-events-helper.js
+++ b/tests/backstop_data/engine_scripts/puppet/mouse-events-helper.js
@@ -29,7 +29,7 @@ async function hoverSelectorAction (page, scenario, viewport) {
   const utility = new Utility(page, scenario, viewport);
 
   for (const hoverSelector of hoverSelectors) {
-    await utility.waitForAndHover(clickSelectorIndex);
+    await utility.waitForAndHover(hoverSelector);
 
     if (scenario.waitForAjaxComplete) {
       await utility.waitForLoadingComplete();
@@ -49,7 +49,7 @@ async function clickSelectorAction (page, scenario, viewport) {
   const utility = new Utility(page, scenario, viewport);
 
   for (const clickSelector of clickSelectors) {
-    await utility.waitForAndClick(clickSelectorIndex);
+    await utility.waitForAndClick(clickSelector);
 
     if (scenario.waitForAjaxComplete) {
       await utility.waitForLoadingComplete();

--- a/tests/backstop_data/engine_scripts/puppet/utility.js
+++ b/tests/backstop_data/engine_scripts/puppet/utility.js
@@ -8,6 +8,161 @@ module.exports = class CrmPage {
   }
 
   /**
+   * Waits and clicks every element that matches the target selector.
+   *
+   * @param {String} selector - the css selector of the target elements to
+   * click.
+   */
+  async clickAll (selector) {
+    await this.waitForSelectorAndEvaluate(selector, selector => {
+      document.querySelectorAll(selector).forEach(element => element.click());
+    });
+  }
+
+  /**
+   * Waits for the Navigation to happens after some link (selector) is clicked.
+   *
+   * @param {String} selector - the css selector for the element to click and wait for navigation.
+   */
+  async clickAndWaitForNavigation (selector) {
+    await this.engine.waitForSelector(selector);
+    await Promise.all([
+      this.engine.click(selector),
+      this.engine.waitForNavigation()
+    ]);
+    await this.cleanups();
+  }
+
+  async cleanups () {
+    await this.waitForWYSIWYG();
+    await this.waitForDatePicker();
+  }
+
+  /**
+   * Clones UIB Popover popup DOM node
+   */
+  async cloneUibPopover () {
+    await this.engine.evaluate(() => {
+      let uibPopover = document.querySelector('div[uib-popover-popup]');
+      const uibPopoverClone = uibPopover.cloneNode(true);
+
+      // Insert the new node before the reference node
+      uibPopover.parentNode.insertBefore(uibPopoverClone, uibPopover.nextSibling);
+    });
+  }
+
+  /**
+   * Checks if element is visible on screen
+   * @param {String} selector - the css selector for the element to checkfor
+   */
+  async isElementVisible (selector) {
+    return this.engine.evaluate((selector) => {
+      const e = document.querySelector(selector);
+
+      if (!e) {
+        return false;
+      }
+
+      const style = window.getComputedStyle(e);
+
+      return style && style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0' && e.offsetHeight > 0;
+    }, selector);
+  }
+
+  /**
+   * Opens all the accordions on the page
+   * Logic - to make sure that Accordion dont toggle (open and then close) multiple times, the code checks for the class
+   * 'backstop-all-accordions-open' and if not added (which won't be added initially) it excutes the open logic and adds a class
+   * preventing future toggling.
+   */
+  async openAllAccordions () {
+    const isSubAccordionExist = !!(await this.engine.$('.collapsible-title'));
+
+    // Clicking all accordion headers
+    await this.clickAll('div.crm-accordion-wrapper.collapsed > div');
+
+    if (isSubAccordionExist) {
+      await this.clickAll('.collapsible-title');
+    }
+
+    try {
+      await this.engine.waitFor('.blockUI.blockOverlay', { hidden: true });
+      // wait for reedjustment of the modal after ajax content load after opening accordion
+      await this.engine.waitFor(300);
+    } catch (e) {
+      console.log('Loaders still visible and timeout reached!');
+    }
+
+    await this.cleanups();
+  }
+
+  /**
+   * Waits for Angular to load by checking #bootstrap-theme element
+   */
+  async waitForAngular () {
+    await this.engine.waitForSelector('#bootstrap-theme');
+  }
+
+  /**
+   * Waits for all the loading placeholders to vanish
+   *
+   * @param {String} parentSelector
+   *  - for contextual loading checks
+   */
+  async waitForLoadingComplete (parentSelector) {
+    const timeout = 100000;
+    parentSelector = parentSelector !== undefined ? parentSelector + ' ' : '';
+
+    await this.engine.waitFor((parentSelector) => {
+      const allLoadingElements = document.querySelectorAll(parentSelector + 'div[class*="civicase__loading-placeholder"]');
+
+      return allLoadingElements.length === 0;
+    }, {timeout: timeout}, parentSelector);
+  }
+
+  /**
+   * Waits for a selector before clicking
+   *
+   * @param {String} selector
+   */
+  async waitForAndClick (selector) {
+    await this.engine.waitFor(selector);
+    await this.engine.click(selector);
+  }
+
+  /**
+   * Waits for a selector before hovering
+   *
+   * @param {String} selector
+   */
+  async waitForAndHover (selector) {
+    await this.engine.waitFor(selector);
+    await this.engine.hover(selector);
+  }
+
+  /**
+   * Waits for the date picker to be visible on the page
+   */
+  async waitForDatePicker () {
+    const hasDatepicker = await this.isElementVisible('.hasDatepicker');
+
+    if (hasDatepicker) {
+      this.engine.waitForSelector('.fa-calendar');
+    }
+  }
+
+  /**
+   * Waits for the WYSIWYG to be visible on the page
+   */
+  async waitForWYSIWYG () {
+    const isWysiwygVisible = await this.isElementVisible('.crm-form-wysiwyg');
+
+    if (isWysiwygVisible) {
+      await this.engine.waitFor('.cke .cke_contents', { visible: true });
+    }
+  }
+
+  /**
    * Waits for the selector to be clearly visible on the screen.
    *
    * @param {String} selector - the css selector of the target elements to
@@ -22,33 +177,19 @@ module.exports = class CrmPage {
   }
 
   /**
-   * Waits for Angular to load by checking #bootstrap-theme element
+   * Waits for an element and then evaluates a function on the browser.
+   *
+   * @param {String} selector - the css selector for the element to wait
+   * @param {Function} fn - the callback function to be executed in
+   * the browser after the target element is ready.
+   * for.
    */
-  async waitForAngular () {
-    await this.engine.waitForSelector('#bootstrap-theme');
-  }
-
-  /**
-   * Waits for all the loading placeholders to vanish
-   */
-  async waitForLoadingComplete () {
-    await this.engine.waitFor(() => {
-      const allLoadingElements = document.querySelectorAll('div[class*="civicase__loading-placeholder"]');
-
-      return allLoadingElements.length === 0;
-    });
-  }
-
-  /**
-   * Clones UIB Popover popup DOM node
-   */
-  async cloneUibPopover () {
-    await this.engine.evaluate(() => {
-      let uibPopover = document.querySelector('div[uib-popover-popup]');
-      const uibPopoverClone = uibPopover.cloneNode(true);
-
-      // Insert the new node before the reference node
-      uibPopover.parentNode.insertBefore(uibPopoverClone, uibPopover.nextSibling);
-    });
+  async waitForSelectorAndEvaluate (selector, fn) {
+    try {
+      await this.engine.waitFor(selector, { timeout: 8000 });
+      await this.engine.evaluate(fn, selector);
+    } catch (e) {
+      console.log('Selector "' + selector + '" not found');
+    }
   }
 };

--- a/tests/backstop_data/engine_scripts/puppet/utility.js
+++ b/tests/backstop_data/engine_scripts/puppet/utility.js
@@ -53,7 +53,9 @@ module.exports = class CrmPage {
 
   /**
    * Checks if element is visible on screen
+   *
    * @param {String} selector - the css selector for the element to checkfor
+   * @return {Boolean}
    */
   async isElementVisible (selector) {
     return this.engine.evaluate((selector) => {

--- a/tests/backstop_data/scenarios/activity-feed-panel.json
+++ b/tests/backstop_data/scenarios/activity-feed-panel.json
@@ -1,0 +1,60 @@
+{
+  "scenarios": [{
+    "label": "Activity Feed Panel - Main Section",
+    "url": "{url}/civicrm/case/a/#/case?dtab=1"
+  },
+  {
+    "label": "Activity Feed Panel - Bulk Actions",
+    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "onReadyScript": "activity-feed-panel/bulk-actions.js"
+  },
+  {
+    "label": "Activity Feed Panel - Loading State",
+    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "captureLoadingScreen": true
+  },
+  {
+    "label": "Activity Feed Panel - Load more clicked",
+    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "clickSelector": ".civicase__activity-feed-pager__more .btn"
+  },
+  {
+    "label": "Activity Feed Panel - Selected Filter",
+    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "clickSelectors": [
+      ".civicase__activity-filter__more",
+      ".civicase__activity-filter__contact"
+    ]
+  },
+  {
+    "label": "Activity Feed Panel - Activity Details - Select Activity",
+    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "onReadyScript": "activity-feed-panel/activity-detail.js"
+  },
+  {
+    "label": "Activity Feed Panel - Activity Details - Selected Activity - Details",
+    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "onReadyScript": "activity-feed-panel/activity-detail.js",
+    "selectors": [".CRM_Activity_Form_Activity"]
+  },
+  {
+    "label": "Activity Feed Panel - Activity Card Menu",
+    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "clickSelector": ".civicase__activity-feed__list:first-child .civicase__activity-card .civicase__activity-card-menu"
+  },
+  {
+    "label": "Activity Feed Panel - Activity Details - Edit Activity",
+    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "onReadyScript": "activity-feed-panel/activity-edit-details.js"
+  },
+  {
+    "label": "Activity Feed Panel - On Manage Cases",
+    "url": "{url}/civicrm/case/a/#/case/list",
+    "onReadyScript": "activity-feed-panel/on-manage-cases.js"
+  },
+  {
+    "label": "Activity Feed Panel - On Contact Page",
+    "url": "{url}/civicrm/contact/search?reset=1",
+    "onReadyScript": "activity-feed-panel/on-contact-page.js"
+  }]
+}


### PR DESCRIPTION
## Overview
This PR covers backstopJS screens for Activity Panel feeds 

## Covered Screens
* Activity Feed Panel - Main Section
  ![civicase51_activity_feed_panel_-_main_section_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/51745568-433b8400-20c9-11e9-9dbd-307409112eb5.png)
* Activity Feed Panel - Bulk Actions
 ![civicase51_activity_feed_panel_-_bulk_actions_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/51745564-42a2ed80-20c9-11e9-8c45-cd11a9e20bb3.png)
* Activity Feed Panel - Loading State
  ![civicase51_activity_feed_panel_-_loading_state_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/51745567-433b8400-20c9-11e9-82f9-ecc1ecaa494f.png)
* Activity Feed Panel - Load more clicked
 ![civicase51_activity_feed_panel_-_load_more_clicked_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/51745565-42a2ed80-20c9-11e9-8543-0979840610f2.png)
* Activity Feed Panel - Selected Filter
  ![civicase51_activity_feed_panel_-_selected_filter_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/51745571-43d41a80-20c9-11e9-9d38-e80d546c0ccd.png)
* Activity Feed Panel - Activity Details - Select Activity
  ![civicase51_activity_feed_panel_-_activity_details_-_select_activity_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/51745562-420a5700-20c9-11e9-989f-187b0ffd943c.png)
* Activity Feed Panel - Activity Details - Selected Activity - Details
  ![civicase51_activity_feed_panel_-_activity_details_-_selected_activity_-_details_0_crm_activity_form_activity_0_desktop](https://user-images.githubusercontent.com/3340537/51745563-42a2ed80-20c9-11e9-9a26-482534f6a584.png)
* Activity Feed Panel - Activity Card Menu
  ![civicase51_activity_feed_panel_-_activity_card_menu_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/51745559-420a5700-20c9-11e9-9f8f-eb7801ca0a59.png)
* Activity Feed Panel - Activity Details - Edit Activity
  ![civicase51_activity_feed_panel_-_activity_details_-_edit_activity_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/51745561-420a5700-20c9-11e9-86b7-e41227c6fca3.png)
* Activity Feed Panel - On Manage Cases
  ![civicase51_activity_feed_panel_-_on_manage_cases_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/51745570-43d41a80-20c9-11e9-831a-69a5716a0bb1.png)
* Activity Feed Panel - On Contact Page
  ![civicase51_activity_feed_panel_-_on_contact_page_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/51745569-433b8400-20c9-11e9-99a9-98f40212c6e2.png)
## Technical Details
* Updates viewport dimensions from random big values to sensible values (1660x1050)
* Updates `waitForLoadingComplete ` function to takes on a parameter so that loading screen can be checked on the micro level (by filtering the placeholder elements)
* For `activity-edit-details.js`, if we make the height of the viewport too large the `Edit` button was not being visible. So to fix it we set the viewport height to sensible `800` px
* To open all accordions in the activity edit form, we had to import the `openAllAccordions` function from https://github.com/compucorp/backstopjs-config/blob/master/backstop_data/engine_scripts/puppet/page-objects/crm-page.js and its related functions too.