### PR TITLE
C51-403: Standalone activity modal form

### DIFF
--- a/ang/civicase/activity/card/directives/activity-card.directive.js
+++ b/ang/civicase/activity/card/directives/activity-card.directive.js
@@ -94,11 +94,15 @@
      * @param {object} activity
      */
     $scope.viewInPopup = function ($event, activity) {
+      var activityFormUrl = activity.case_id
+        ? 'civicrm/case/activity'
+        : 'civicrm/activity';
+
       if ($event && $($event.target).is('a, a *, input, button, button *')) {
         return;
       }
 
-      CRM.loadForm(CRM.url('civicrm/case/activity', {
+      CRM.loadForm(CRM.url(activityFormUrl, {
         action: 'update',
         id: activity.id,
         caseid: activity.case_id,

--- a/ang/civicase/activity/card/directives/activity-card.directive.js
+++ b/ang/civicase/activity/card/directives/activity-card.directive.js
@@ -94,22 +94,26 @@
      * @param {object} activity
      */
     $scope.viewInPopup = function ($event, activity) {
-      var activityFormUrl = activity.case_id
-        ? 'civicrm/case/activity'
-        : 'civicrm/activity';
+      var activityFormUrl = 'civicrm/activity';
+      var activityFormParams = {
+        action: 'update',
+        id: activity.id,
+        reset: 1
+      };
 
       if ($event && $($event.target).is('a, a *, input, button, button *')) {
         return;
       }
 
-      CRM.loadForm(CRM.url(activityFormUrl, {
-        action: 'update',
-        id: activity.id,
-        caseid: activity.case_id,
-        reset: 1
-      })).on('crmFormSuccess', function () {
-        $scope.refresh();
-      });
+      if (activity.case_id) {
+        activityFormUrl = 'civicrm/case/activity';
+        activityFormParams.caseid = activity.case_id;
+      }
+
+      CRM.loadForm(CRM.url(activityFormUrl, activityFormParams))
+        .on('crmFormSuccess', function () {
+          $scope.refresh();
+        });
     };
 
     /**

--- a/ang/test/civicase/activity/card/directives/activity-card.directive.spec.js
+++ b/ang/test/civicase/activity/card/directives/activity-card.directive.spec.js
@@ -60,6 +60,23 @@
         expect(loadFormSpy.on).toHaveBeenCalledWith('crmFormSuccess', jasmine.any(Function));
       });
 
+      describe('when editing an standalone activity', function () {
+        beforeEach(function () {
+          activity = activitiesMockData.get()[0];
+
+          delete activity.case_id;
+          activityCard.isolateScope().viewInPopup(null, activity);
+        });
+
+        it('opens the standalone activity modal form', function () {
+          expect(CRM.url).toHaveBeenCalledWith('civicrm/activity', jasmine.objectContaining({
+            action: 'update',
+            id: activity.id,
+            reset: 1
+          }));
+        });
+      });
+
       describe('when activity is saved', function () {
         beforeEach(function () {
           crmFormSuccessCallback();


### PR DESCRIPTION
## Overview
This PR implements opening the standalone activity modal form for activities that don't belong to a particular case.

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/53532346-eae31200-3acc-11e9-9877-7d9bd75f145e.gif)
**Note:** The standalone activity breaks because it's opening the civicase form and it does not have all the data that is required by said form.

## After
![pr-after](https://user-images.githubusercontent.com/1642119/53532180-4eb90b00-3acc-11e9-8b19-997e631de2f4.gif)

**Note:** The first activity is standalone, the second one belongs to a particular case.

## Technical details

The civicase or standalone forms are displayed depending if the `case_id` property of the activity is defined or not. To accomplish this the activity card directive:

```js
    $scope.viewInPopup = function ($event, activity) {
      var activityFormUrl = activity.case_id
        ? 'civicrm/case/activity'
        : 'civicrm/activity';

      // ...

      CRM.loadForm(CRM.url(activityFormUrl, {
        // ...
      }));

      // ...
    };
```