### PR TITLE
C51-410: Case Role Filtering

### DIFF
--- a/api/v3/Case/Getcaselist.php
+++ b/api/v3/Case/Getcaselist.php
@@ -20,25 +20,11 @@ function _civicrm_api3_case_getcaselist_spec(&$spec) {
     'type' => CRM_Utils_Type::T_INT,
   );
 
-  $spec['role_contact'] = array(
-    'title' => 'Role Contact Id',
-    'description' => '',
-    'type' => CRM_Utils_Type::T_INT,
-    'FKClassName' => 'CRM_Contact_DAO_Contact',
-    'FKApiName' => 'Contact',
-  );
-
-  $spec['role_type'] = array(
-    'title' => 'Role Type',
-    'description' => '',
-    'type' => CRM_Utils_Type::T_INT,
-  );
-
-  $spec['role_can_be_client'] = array(
-    'title' => 'Role can be client?',
-    'description' => '',
-    'type' => CRM_Utils_Type::T_BOOLEAN,
-  );
+  $spec['has_role'] = [
+    'title' => 'Case has role',
+    'description' => '{ contact, role_type, can_be_client }',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
 
   $spec['contact_is_deleted'] = array(
     'title' => 'Contact Is Deleted',

--- a/api/v3/Case/Getcaselist.php
+++ b/api/v3/Case/Getcaselist.php
@@ -20,6 +20,26 @@ function _civicrm_api3_case_getcaselist_spec(&$spec) {
     'type' => CRM_Utils_Type::T_INT,
   );
 
+  $spec['role_contact'] = array(
+    'title' => 'Role Contact Id',
+    'description' => '',
+    'type' => CRM_Utils_Type::T_INT,
+    'FKClassName' => 'CRM_Contact_DAO_Contact',
+    'FKApiName' => 'Contact',
+  );
+
+  $spec['role_type'] = array(
+    'title' => 'Role Type',
+    'description' => '',
+    'type' => CRM_Utils_Type::T_INT,
+  );
+
+  $spec['role_can_be_client'] = array(
+    'title' => 'Role can be client?',
+    'description' => '',
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+  );
+
   $spec['contact_is_deleted'] = array(
     'title' => 'Contact Is Deleted',
     'description' => 'Set FALSE to filter out cases for deleted contacts, TRUE to return only cases of deleted contacts',

--- a/api/v3/Case/Getdetails.php
+++ b/api/v3/Case/Getdetails.php
@@ -23,25 +23,11 @@ function _civicrm_api3_case_getdetails_spec(&$spec) {
     'type' => CRM_Utils_Type::T_INT,
   );
 
-  $spec['role_contact'] = array(
-    'title' => 'Role Contact Id',
-    'description' => '',
-    'type' => CRM_Utils_Type::T_INT,
-    'FKClassName' => 'CRM_Contact_DAO_Contact',
-    'FKApiName' => 'Contact',
-  );
-
-  $spec['role_type'] = array(
-    'title' => 'Role Type',
-    'description' => '',
-    'type' => CRM_Utils_Type::T_INT,
-  );
-
-  $spec['role_can_be_client'] = array(
-    'title' => 'Role can be client?',
-    'description' => '',
-    'type' => CRM_Utils_Type::T_BOOLEAN,
-  );
+  $spec['has_role'] = [
+    'title' => 'Case has role',
+    'description' => '{ contact, role_type, can_be_client }',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
 
   $spec['contact_is_deleted'] = array(
     'title' => 'Contact Is Deleted',
@@ -95,7 +81,7 @@ function civicrm_api3_case_getdetails($params) {
     $sql->where(CRM_Core_DAO::createSQLFilter('manager.id', $params['case_manager']));
   }
 
-  if (!empty($params['role_contact'])) {
+  if (!empty($params['has_role'])) {
     _civicrm_api3_case_getdetails_handle_role_filters($params, $sql);
   }
 
@@ -383,23 +369,26 @@ function _civicrm_api3_case_getdetails_extrasort(&$params) {
  * @param object $sql a reference to the SQL object.
  */
 function _civicrm_api3_case_getdetails_handle_role_filters ($params, $sql) {
-  _civicase_prepare_param_for_filtering($params, 'role_contact');
+  $hasRole = $params['has_role'];
+  $canBeAClient = !isset($hasRole['can_be_client']) || $hasRole['can_be_client'];
 
-  $roleContactFilter = CRM_Core_DAO::createSQLFilter('case_relationship.contact_id_b', $params['role_contact']);
-  $clientFilter = CRM_Core_DAO::createSQLFilter('case_client.contact_id', $params['role_contact']);
+  _civicase_prepare_param_for_filtering($hasRole, 'contact');
+
+  $roleContactFilter = CRM_Core_DAO::createSQLFilter('case_relationship.contact_id_b', $hasRole['contact']);
+  $clientFilter = CRM_Core_DAO::createSQLFilter('case_client.contact_id', $hasRole['contact']);
 
   $sql->join('case_relationship', 'LEFT JOIN civicrm_relationship AS case_relationship
     ON case_relationship.case_id = a.id');
   $sql->where('case_relationship.is_active = 1');
 
-  if (!empty($params['role_type'])) {
-    _civicase_prepare_param_for_filtering($params, 'role_type');
+  if (!empty($hasRole['role_type'])) {
+    _civicase_prepare_param_for_filtering($hasRole, 'role_type');
 
-    $roleTypeFilter = CRM_Core_DAO::createSQLFilter('case_relationship.relationship_type_id', $params['role_type']);
+    $roleTypeFilter = CRM_Core_DAO::createSQLFilter('case_relationship.relationship_type_id', $hasRole['role_type']);
     $roleContactFilter = "($roleContactFilter AND $roleTypeFilter)";
   }
 
-  if (isset($params['role_can_be_client']) && $params['role_can_be_client']) {
+  if ($canBeAClient) {
     $sql->join('case_client', 'LEFT JOIN civicrm_case_contact AS case_client
       ON case_client.case_id = a.id');
     $sql->where("$roleContactFilter OR $clientFilter");


### PR DESCRIPTION
## Overview

This PR adds support for filtering case types by the contacts that have some relationship to it.

## Scenarios

### Setup

* Contact is Betty Adams (204)
* Betty Adams is client for case 148, 149, and 150
* Betty Adams is "Homeless Services Coordinator" (id 11) for case 145
* Betty Adams is "Health Services Coordinator" (id 12) for case 6

### Contact has some relation

```js
// request:
{
  has_role: {
    contact: 204,
    can_be_client: false
  }
}

// returned cases:
6, 145
```

### Contact has a specific relation to the case

```js
// request:
{
  has_role: {
    contact: 204,
    role_type: 12,
    can_be_client: false
  }
}

// returned cases:
6
```

### Contact has some relation or is client of case

```js
// request:
{
  has_role: {
    contact: 204,
    // role_can_be_client: true (optional)
  }
}

// returned cases:
6, 145, 148, 149, 150
```

### Contact has specific relation or is client of case

```js
// request
{
  role_contact: 204,
  role_type: 12,
  // role_can_be_client: true (optional)
}

// returned cases
6, 148, 149, 150
```

### Contact is client of case
(this was already implemented)

```js
// request
{
  contact_id: 204
}

// returned cases
148, 149, 150
```

## Technical details

The existing `involved` filtering can't be used because it filters by contacts that either have a relationship to the case, or a client to the case. The problem is that we can't filter by relationship type unless the contact is a client AND has a specific relation to the case.

The `civicrm_api3_case_getdetails` action was augmented so it supports the new filters:

```php
function civicrm_api3_case_getdetails($params) {
  // ...

  if (!empty($params['role_contact'])) {
    _civicrm_api3_case_getdetails_handle_role_filters($params, $sql);
  }

  // ...
}

function _civicrm_api3_case_getdetails_handle_role_filters ($params, $sql) {
  _civicase_prepare_param_for_filtering($params, 'role_contact');

  $roleContactFilter = CRM_Core_DAO::createSQLFilter('case_relationship.contact_id_b', $params['role_contact']);
  $clientFilter = CRM_Core_DAO::createSQLFilter('case_client.contact_id', $params['role_contact']);

  $sql->join('case_relationship', 'LEFT JOIN civicrm_relationship AS case_relationship
    ON case_relationship.case_id = a.id');
  $sql->where('case_relationship.is_active = 1');

  if (!empty($params['role_type'])) {
    _civicase_prepare_param_for_filtering($params, 'role_type');

    $roleTypeFilter = CRM_Core_DAO::createSQLFilter('case_relationship.relationship_type_id', $params['role_type']);
    $roleContactFilter = "($roleContactFilter AND $roleTypeFilter)";
  }

  if (isset($params['role_can_be_client']) && $params['role_can_be_client']) {
    $sql->join('case_client', 'LEFT JOIN civicrm_case_contact AS case_client
      ON case_client.case_id = a.id');
    $sql->where("$roleContactFilter OR $clientFilter");
  } else {
    $sql->where($roleContactFilter);
  }
}
```

`_civicase_prepare_param_for_filtering` is used for converting fields from this:

```php
['paramName' => 'value']
```

To this format:

```php
['paramName' => ['=' => 'value']]
```

Because the later is the expected format when using `CRM_Core_DAO::createSQLFilter`:

```php
function _civicase_prepare_param_for_filtering (&$params, $paramName) {
  if (!is_array($params[$paramName])) {
    $params[$paramName] = [
      '=' => $params[$paramName]
    ];
  }
}
```