### PR TITLE
C51-411: Get case roles

### DIFF
--- a/api/v3/RelationshipType/Getcaseroles.php
+++ b/api/v3/RelationshipType/Getcaseroles.php
@@ -1,26 +1,37 @@
 <?php
 
 function _civicrm_api3_relationship_type_getcaseroles_spec(&$spec) {
-  // no specs
+  $spec = CRM_Contact_DAO_RelationshipType::fields();
 }
 
 function civicrm_api3_relationship_type_getcaseroles($params) {
-  $rolesMap = [];
+  $caseRoleNames = _civicrm_api3_relationship_type_getcaseroles_getCaseRoleNames();
+
+  $params['label_b_a'] = [ 'IN' => $caseRoleNames ];
+  $params['is_active'] = 1;
+
+  return civicrm_api3('RelationshipType', 'get', $params);
+}
+
+/**
+ * Returns a list of relationship type names that have been associated to
+ * case types
+ *
+ * @return array
+ */
+function _civicrm_api3_relationship_type_getcaseroles_getCaseRoleNames () {
+  $rolenamesMap = [];
   $caseTypes = civicrm_api3('CaseType', 'get', [
     'sequential' => 1,
     'is_active' => 1,
+    'options' => [ 'limit' => 0 ],
   ]);
 
   foreach ($caseTypes['values'] as $caseType) {
     foreach ($caseType['definition']['caseRoles'] as $role) {
-      $rolesMap[$role['name']] = true;
+      $rolenamesMap[$role['name']] = true;
     }
   }
 
-  $relationshipTypes = civicrm_api3('RelationshipType', 'get', [
-    'label_b_a' => ['IN' => array_keys($rolesMap)],
-    'is_active' => 1,
-  ]);
-
-  return $relationshipTypes;
+  return array_keys($rolenamesMap);
 }

--- a/api/v3/RelationshipType/Getcaseroles.php
+++ b/api/v3/RelationshipType/Getcaseroles.php
@@ -1,0 +1,26 @@
+<?php
+
+function _civicrm_api3_relationship_type_getcaseroles_spec(&$spec) {
+  // no specs
+}
+
+function civicrm_api3_relationship_type_getcaseroles($params) {
+  $rolesMap = [];
+  $caseTypes = civicrm_api3('CaseType', 'get', [
+    'sequential' => 1,
+    'is_active' => 1,
+  ]);
+
+  foreach ($caseTypes['values'] as $caseType) {
+    foreach ($caseType['definition']['caseRoles'] as $role) {
+      $rolesMap[$role['name']] = true;
+    }
+  }
+
+  $relationshipTypes = civicrm_api3('RelationshipType', 'get', [
+    'label_b_a' => ['IN' => array_keys($rolesMap)],
+    'is_active' => 1,
+  ]);
+
+  return $relationshipTypes;
+}


### PR DESCRIPTION
## Overview
This PR adds a new action endpoint that returns a list of relationship types that are associated to case types.

## Technical details

The relationship types associated to case types are stored in their XML definition field and only have a reference to the `label_b_a` of the relationship type, not the ID. A sample structure for a case type would be as follows:

```js
{
  id: 1,
  // ...
  definition: {
    // ...
    caseRoles: [
      { name: 'Relationship Type label b a', manger: 1, creator: 1 },
      { name: 'Another relationship type' }
    ]
  }
}
```

This action endpoint queries all active case types, stores all references to case roles, queries the relationship type entity to find those roles, and then returns them:

```php
function civicrm_api3_relationship_type_getcaseroles($params) {
  $rolesMap = [];
  $caseTypes = civicrm_api3('CaseType', 'get', [
    'sequential' => 1,
    'is_active' => 1,
  ]);

  foreach ($caseTypes['values'] as $caseType) {
    foreach ($caseType['definition']['caseRoles'] as $role) {
      $rolesMap[$role['name']] = true;
    }
  }

  $relationshipTypes = civicrm_api3('RelationshipType', 'get', [
    'label_b_a' => ['IN' => array_keys($rolesMap)],
    'is_active' => 1,
  ]);

  return $relationshipTypes;
}
```