### PR TITLE
C51-412: Filter cases by role

### DIFF
--- a/ang/civicase/case/search/directives/search.directive.html
+++ b/ang/civicase/case/search/directives/search.directive.html
@@ -21,8 +21,18 @@
         <input class="form-control" type="number" ng-model="filters.id" />
       </div>
       <div ng-if="isEnabled('contact_id')" class="civicase__case-filter-form-elements">
-        <label>{{ ts('Client Name or Email') }}</label>
-        <input class="form-control" class="form-control" ng-list crm-entityref="{entity: 'Contact', select: {multiple: true}}" ng-model="filters.contact_id" />
+        <label>{{ ts('Contact Search') }}</label>
+        <input class="form-control" ng-list crm-entityref="{entity: 'Contact', select: {multiple: true}}" ng-model="filters.contact_id" />
+        <input class="form-control"
+          ng-list
+          ng-model="selectedContactRoleFilter"
+          crm-ui-select="{
+            allowClear: true,
+            multiple: true,
+            placeholder: 'Contact role',
+            data: contactRoleFilters
+          }"
+        />
       </div>
       <div class="civicase__case-filter-form-elements" ng-if="checkPerm('administer CiviCase') && isEnabled('is_deleted')">
         <span class="civicase__checkbox" role="checkbox" aria-checked="{{filters.is_deleted}}" tabindex="0" aria-labelledby="Deleted Cases" ng-click="toggleIsDeleted($event)" ng-keydown="toggleIsDeleted($event)">

--- a/ang/civicase/case/search/directives/search.directive.html
+++ b/ang/civicase/case/search/directives/search.directive.html
@@ -20,24 +20,29 @@
         <label >{{ ts('Case ID') }}</label>
         <input class="form-control" type="number" ng-model="filters.id" />
       </div>
-      <div ng-if="isEnabled('contact_id')" class="civicase__case-filter-form-elements">
-        <label>{{ ts('Contact Search') }}</label>
-        <input class="form-control"
-          ng-model="searchForm.selectedContacts"
-          crm-entityref="{
-            entity: 'Contact',
-            select: { multiple: true }
-          }"
-        />
-        <input class="form-control"
-          ng-model="searchForm.selectedContactRoles"
-          crm-ui-select="{
-            allowClear: true,
-            multiple: true,
-            placeholder: 'Contact role',
-            data: contactRoleFilters
-          }"
-        />
+      <div ng-if="isEnabled('contact_id')" class="civicase__case-filter-form-elements row">
+        <label class="col-sm-12">{{ ts('Contact Search') }}</label>
+        <div class="col-sm-3">
+          <input class="form-control"
+            ng-model="searchForm.selectedContacts"
+            placeholder="Contact"
+            crm-entityref="{
+              entity: 'Contact',
+              select: { multiple: true }
+            }"
+          />
+        </div>
+        <div class="col-sm-3">
+          <input class="form-control"
+            ng-model="searchForm.selectedContactRoles"
+            crm-ui-select="{
+              allowClear: true,
+              multiple: true,
+              placeholder: 'Contact role',
+              data: contactRoleFilters
+            }"
+          />
+        </div>
       </div>
       <div class="civicase__case-filter-form-elements" ng-if="checkPerm('administer CiviCase') && isEnabled('is_deleted')">
         <span class="civicase__checkbox" role="checkbox" aria-checked="{{filters.is_deleted}}" tabindex="0" aria-labelledby="Deleted Cases" ng-click="toggleIsDeleted($event)" ng-keydown="toggleIsDeleted($event)">

--- a/ang/civicase/case/search/directives/search.directive.html
+++ b/ang/civicase/case/search/directives/search.directive.html
@@ -22,10 +22,15 @@
       </div>
       <div ng-if="isEnabled('contact_id')" class="civicase__case-filter-form-elements">
         <label>{{ ts('Contact Search') }}</label>
-        <input class="form-control" ng-list crm-entityref="{entity: 'Contact', select: {multiple: true}}" ng-model="filters.contact_id" />
         <input class="form-control"
-          ng-list
-          ng-model="selectedContactRoleFilter"
+          ng-model="searchForm.selectedContacts"
+          crm-entityref="{
+            entity: 'Contact',
+            select: { multiple: true }
+          }"
+        />
+        <input class="form-control"
+          ng-model="searchForm.selectedContactRoles"
           crm-ui-select="{
             allowClear: true,
             multiple: true,

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -65,6 +65,10 @@
       { id: 'all-case-roles', text: 'All Case Roles' },
       { id: 'client', text: 'Client' }
     ];
+    var defaultSearchFormValues = {
+      selectedContacts: [],
+      selectedContactRoles: [ contactRoleFilters[0].id ]
+    };
 
     $scope.pageTitle = '';
     $scope.caseTypeOptions = _.map(caseTypes, mapSelectOptions);
@@ -75,10 +79,7 @@
     $scope.filterDescription = buildDescription();
     $scope.filters = angular.extend({}, $scope.defaults);
     $scope.contactRoleFilters = contactRoleFilters;
-    $scope.searchForm = {
-      selectedContacts: [],
-      selectedContactRoles: [ contactRoleFilters[0].id ]
-    };
+    $scope.searchForm = _.cloneDeep({}, defaultSearchFormValues);
 
     (function init () {
       bindRouteParamsToScope();
@@ -163,6 +164,7 @@
     function bindRouteParamsToScope () {
       $scope.$bindToRoute({expr: 'expanded', param: 'sx', format: 'bool', default: false});
       $scope.$bindToRoute({expr: 'filters', param: 'cf', default: {}});
+      $scope.$bindToRoute({expr: 'searchForm', param: 'searchForm', default: defaultSearchFormValues});
     }
 
     /**

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -61,14 +61,6 @@
         'id': 'is_involved'
       }
     ];
-    var contactRoleFilters = [
-      { id: 'all-case-roles', text: 'All Case Roles' },
-      { id: 'client', text: 'Client' }
-    ];
-    var defaultSearchFormValues = {
-      selectedContacts: [],
-      selectedContactRoles: [ contactRoleFilters[0].id ]
-    };
 
     $scope.pageTitle = '';
     $scope.caseTypeOptions = _.map(caseTypes, mapSelectOptions);
@@ -78,8 +70,14 @@
     $scope.checkPerm = CRM.checkPerm;
     $scope.filterDescription = buildDescription();
     $scope.filters = angular.extend({}, $scope.defaults);
-    $scope.contactRoleFilters = contactRoleFilters;
-    $scope.searchForm = _.cloneDeep({}, defaultSearchFormValues);
+    $scope.contactRoleFilters = [
+      { id: 'all-case-roles', text: 'All Case Roles' },
+      { id: 'client', text: 'Client' }
+    ];
+    $scope.searchForm = {
+      selectedContacts: [],
+      selectedContactRoles: [ 'all-case-roles' ]
+    };
 
     (function init () {
       bindRouteParamsToScope();
@@ -164,7 +162,7 @@
     function bindRouteParamsToScope () {
       $scope.$bindToRoute({expr: 'expanded', param: 'sx', format: 'bool', default: false});
       $scope.$bindToRoute({expr: 'filters', param: 'cf', default: {}});
-      $scope.$bindToRoute({expr: 'searchForm', param: 'searchForm', default: defaultSearchFormValues});
+      $scope.$bindToRoute({expr: 'searchForm', param: 'searchForm', default: $scope.searchForm});
     }
 
     /**

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -18,7 +18,8 @@
   /**
    * Controller Function for civicase-search directive
    */
-  module.controller('civicaseSearchController', function ($scope, $rootScope, $timeout, crmApi) {
+  module.controller('civicaseSearchController', function ($scope, $rootScope, $timeout,
+    crmApi, getSelect2Value) {
     // The ts() functions help load strings for this module.
     var ts = $scope.ts = CRM.ts('civicase');
     var caseTypes = CRM.civicase.caseTypes;
@@ -214,8 +215,8 @@
      */
     function caseRoleWatcher () {
       var filters = $scope.filters;
-      var selectedContacts = getSelect2ValueAsArray($scope.searchForm.selectedContacts);
-      var selectedContactRoles = getSelect2ValueAsArray($scope.searchForm.selectedContactRoles);
+      var selectedContacts = getSelect2Value($scope.searchForm.selectedContacts);
+      var selectedContactRoles = getSelect2Value($scope.searchForm.selectedContactRoles);
       var hasAllCaseRolesSelected = selectedContactRoles.indexOf('all-case-roles') >= 0;
       var hasClientSelected = selectedContactRoles.indexOf('client') >= 0;
       var caseRoleIds = _.filter(selectedContactRoles, function (roleId) {
@@ -275,19 +276,6 @@
       if (!$scope.expanded) {
         $scope.doSearch();
       }
-    }
-
-    /**
-     * Returns Select2 values as arrays. Select2 returns a single selected value
-     * as an array, but multiple values as a string separated by comas.
-     *
-     * @param {Array|String} value the value as provided by Select2.
-     * @return {Array}
-     */
-    function getSelect2ValueAsArray (value) {
-      return _.isArray(value)
-        ? value
-        : value.split(',');
     }
 
     /**

--- a/ang/civicase/shared/factories/get-select2-value.factory.js
+++ b/ang/civicase/shared/factories/get-select2-value.factory.js
@@ -1,0 +1,20 @@
+(function (angular, $, _, CRM) {
+  var module = angular.module('civicase');
+
+  module.factory('getSelect2Value', function () {
+    return getSelect2Value;
+  });
+
+  /**
+   * Returns Select2 values as arrays. Select2 returns a single selected value
+   * as an array, but multiple values as a string separated by comas.
+   *
+   * @param {Array|String} value the value as provided by Select2.
+   * @return {Array}
+   */
+  function getSelect2Value (value) {
+    return _.isArray(value)
+      ? value
+      : value.split(',');
+  }
+})(angular, CRM.$, CRM._, CRM);

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -1,15 +1,23 @@
 /* eslint-env jasmine */
 (function ($) {
   describe('civicaseSearch', function () {
-    var $controller, $rootScope, $scope, CaseFilters, affixOriginalFunction, offsetOriginalFunction, originalDoSearch, orginalParentScope, affixReturnValue, originalBindToRoute;
+    var $controller, $rootScope, $scope, CaseFilters, crmApi, affixOriginalFunction,
+      offsetOriginalFunction, originalDoSearch, orginalParentScope, affixReturnValue,
+      originalBindToRoute;
 
-    beforeEach(module('civicase.templates', 'civicase', 'civicase.data'));
+    beforeEach(module('civicase.templates', 'civicase', 'civicase.data', function ($provide) {
+      crmApi = jasmine.createSpy('crmApi');
 
-    beforeEach(inject(function (_$controller_, _$rootScope_, _CaseFilters_) {
+      $provide.value('crmApi', crmApi);
+    }));
+
+    beforeEach(inject(function (_$controller_, $q, _$rootScope_, _CaseFilters_) {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       $scope = $rootScope.$new();
       CaseFilters = _CaseFilters_;
+
+      crmApi.and.returnValue($q.resolve({ values: [] }));
     }));
 
     beforeEach(function () {

--- a/ang/test/civicase/contact/directives/contact-icon.directive.spec.js
+++ b/ang/test/civicase/contact/directives/contact-icon.directive.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env jasmine */
 
 (function (_) {
-  fdescribe('ContactPopoverContent', function () {
+  describe('ContactPopoverContent', function () {
     var $controller, $rootScope, $scope, contactsDataServiceMock;
     var expectedContactIcon = 'Individual';
 


### PR DESCRIPTION
## Overview

This PR modifies the the case search. The client search was changed to a contact search that allows users to filter cases by contact clients or roles. 

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/54352944-292e1480-4629-11e9-9618-6caf8c12b306.png)

## After
![pr](https://user-images.githubusercontent.com/1642119/54358583-1f131280-4637-11e9-8eee-04f71b278c4c.gif)


## Technical details

The filter implements `crm-ui-select`, the format for the options looks as follows:

```js
    $scope.contactRoleFilters = [
      { id: 'all-case-roles', text: 'All Case Roles' },
      { id: 'client', text: 'Client' }
      // sample of options added later:
      { id: 12, text: 'Health Service Coordinator' }
    ];
```

The "All Case Roles" and "Client" options are provided as soon as the component is rendered, but the specifics role options are fetched asynchronously:

```js
    (function init () {
      // ...
      requestCaseRoles().then(addCaseRolesToContactRoleFilters);
    }());

    function requestCaseRoles () {
      return crmApi('RelationshipType', 'getcaseroles', {
        options: { limit: 0 }
      })
        .then(function (caseRolesResponse) {
          return caseRolesResponse.values;
        });
    }

    function addCaseRolesToContactRoleFilters (caseRoles) {
      _.chain(caseRoles)
        .sortBy('label_b_a')
        .forEach(function (caseRole) {
          $scope.contactRoleFilters.push({
            id: caseRole.id,
            text: caseRole.label_b_a
          });
        })
        .value();
    }
```

The selected contacts and roles are stored in a `searchForm` object instead of `filters` because the final filters look different than the values originally provided by the `crm-ui-select`. When the select values changes the transformations are done so the data is passed to `filters` in the expected format:

```js
    function initiateWatchers () {
      // ...
      $scope.$watchCollection('searchForm', caseRoleWatcher);
    }

    function caseRoleWatcher () {
      var filters = $scope.filters;
      var selectedContacts = getSelect2Value($scope.searchForm.selectedContacts);
      var selectedContactRoles = getSelect2Value($scope.searchForm.selectedContactRoles);
      var hasAllCaseRolesSelected = selectedContactRoles.indexOf('all-case-roles') >= 0;
      var hasClientSelected = selectedContactRoles.indexOf('client') >= 0;
      var caseRoleIds = _.filter(selectedContactRoles, function (roleId) {
        return parseInt(roleId, 10);
      });

      // skips the role filter if there are no contacts selected:
      if (!selectedContacts.length) {
        delete filters.has_role;

        return;
      }

      filters.has_role = {
        contact: { IN: selectedContacts },
        can_be_client: true
      };

      // removes any reference to the `contact_id` since this filter can be used for clients:
      delete filters.contact_id;

      if (caseRoleIds.length) {
        filters.has_role.role_type = { IN: caseRoleIds };
      }

      // if filtering by a specific role then it sets the `can_be_client` filter to false:
      if (!hasAllCaseRolesSelected && !hasClientSelected) {
        filters.has_role.can_be_client = false;
      }
    }
```

## Tests

Tests have been skipped for now because there was no time to complete the task, add tests, and be on time for the release. Tests will be added after merging the ticket to develop.