### PR TITLE
C51-414: Refactor role filter into a sub query

### DIFF
--- a/api/v3/Case/Getdetailscount.php
+++ b/api/v3/Case/Getdetailscount.php
@@ -11,16 +11,12 @@
  */
 function civicrm_api3_case_getdetailscount($params) {
   $params['options'] = CRM_Utils_Array::value('options', $params, []);
+  $params['options']['is_count'] = 1;
 
   // Remove unnecesary parameters:
   unset($params['return'], $params['sequential']);
 
-  // There is issue in the core with using $params['options']['is_count'] = 1;
-  // It does not remove the duplicate results created by LEFT JOIN.
-  $params['return'] = ['id'];
-  $params['options']['limit'] = 0;
-
   $casesList = civicrm_api3('Case', 'getdetails', $params);
 
-  return $casesList['count'];
+  return $casesList['values'];
 }


### PR DESCRIPTION
## Overview
The role filter introduced in #183 has been refactored in order to fix an issue with where the case count was not correct.

## Technical details

The temporary fix introduced in #187 was reverted back.

The query for filtering cases by roles was refactored into a subquery. The advantage of this approach is that the `GROUP BY` statement can be avoided by the main query and moved into the subquery. The train of thought of the subquery goes as follows:

1. Selects case id from the case table.
2. If the role can either be of a "manager" or a client, ir `LEFT JOIN`s the `case_client` and `relationships` table.
3. If the role is only for manager it `JOIN`s to the `relationships` table.
4. Groups the subquery by case id to avoid duplicates.

```php
function _civicrm_api3_case_getdetails_handle_role_filters ($sql, $params) {
  $hasRole = $params['has_role'];
  $canBeAClient = !isset($hasRole['can_be_client']) || $hasRole['can_be_client'];
  $roleSubQuery = new CRM_Utils_SQL_Select('civicrm_case');

  $roleSubQuery->select('civicrm_case.id');
  $roleSubQuery->groupBy('civicrm_case.id');

  if ($canBeAClient) {
    _civicrm_api3_case_getdetails_join_client($roleSubQuery, $hasRole);
    _civicrm_api3_case_getdetails_join_relationships($roleSubQuery, $hasRole, [
      'joinType' => 'LEFT JOIN',
    ]);
    $roleSubQuery->where('case_relationship.case_id IS NOT NULL
      OR case_client.case_id IS NOT NULL');
  } else {
    _civicrm_api3_case_getdetails_join_relationships($roleSubQuery, $hasRole, [
      'joinType' => 'JOIN',
    ]);
  }

  $roleSubQueryString = $roleSubQuery->toSql();

  $sql->join('case_roles', "
    JOIN ($roleSubQueryString) AS case_roles
    ON case_roles.id = a.id
  ");
}

function _civicrm_api3_case_getdetails_join_client ($sql, $params) {
  _civicase_prepare_param_for_filtering($params, 'contact');

  $contactFilter = CRM_Core_DAO::createSQLFilter('case_client.contact_id', $params['contact']);

  $sql->join('case_client', "
    LEFT JOIN civicrm_case_contact AS case_client
    ON case_client.case_id = civicrm_case.id
    AND $contactFilter
  ");
}

function _civicrm_api3_case_getdetails_join_relationships ($sql, $params, $options = []) {
  _civicase_prepare_param_for_filtering($params, 'contact');

  $contactFilter = CRM_Core_DAO::createSQLFilter('case_relationship.contact_id_b', $params['contact']);
  $joinClause = "
    {$options['joinType']} civicrm_relationship AS case_relationship
    ON case_relationship.case_id = civicrm_case.id
    AND case_relationship.is_active = 1
    AND $contactFilter
  ";

  if(!empty($params['role_type'])) {
    _civicase_prepare_param_for_filtering($params, 'role_type');

    $roleTypeFilter = CRM_Core_DAO::createSQLFilter('case_relationship.relationship_type_id', $params['role_type']);
    $joinClause .= "AND $roleTypeFilter";
  }

  $sql->join('civicrm_relationship', $joinClause);
}
```