### PR TITLE
C51-401: Fix has_roles logic

### DIFF
--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -237,7 +237,8 @@
 
       filters.has_role = {
         contact: { IN: selectedContacts },
-        can_be_client: true
+        can_be_client: true,
+        all_case_roles_selected: hasAllCaseRolesSelected
       };
 
       delete filters.contact_id;


### PR DESCRIPTION
## Overview
Searching For "Client" Role displays results of all roles for the specified Contact

## Technical Discussion
Previously, when `can_be_client` was true, we were applying the `other roles` filter. This was resulting in returning all cases where the selected contact has any role, instead of just being the client.

```php
 if ($canBeAClient) {
    _civicrm_api3_case_getdetails_join_client($roleSubQuery, $hasRole);
     // the following lines should be applied only when the other roles than client is selected. or all case roles has been selected.
    _civicrm_api3_case_getdetails_join_relationships($roleSubQuery, $hasRole, [
      'joinType' => 'LEFT JOIN',
    ]);
    $roleSubQuery->where('case_relationship.case_id IS NOT NULL
      OR case_client.case_id IS NOT NULL');
} 
```

To fix this, a new param `all_case_roles_selected ` has been sent from frontend, which is true when All Case Roles are selected from dropdown.
And the code has been changed in the following way
```php
if ($canBeAClient) {
  _civicrm_api3_case_getdetails_join_client($roleSubQuery, $hasRole);

  if ($hasOtherRolesThanClient || $isAllCaseRolesTrue) {
    _civicrm_api3_case_getdetails_join_relationships($roleSubQuery, $hasRole, [
      'joinType' => 'LEFT JOIN',
    ]);

    $roleSubQuery->where('case_relationship.case_id IS NOT NULL
      OR case_client.case_id IS NOT NULL');
  } else {
    $roleSubQuery->where('case_client.case_id IS NOT NULL');
  }
} 
```
