### PR TITLE
RSE-110: Add custom activity actions added by other extensions.

### DIFF
--- a/ang/civicase/activity/actions/directives/activity-actions.directive.html
+++ b/ang/civicase/activity/actions/directives/activity-actions.directive.html
@@ -23,6 +23,11 @@
     <i class="material-icons">filter_none</i> {{ ts('Copy to Case') }}
   </a>
 </li>
+<li ng-repeat="link in selectedActivities[0]['api.Activity.getactionlinks']">
+  <a ng-href="{{ link.url }}" class="{{ link.class }}">
+    <i class="material-icons">filter_none</i>{{ link.name }}
+  </a>
+</li>
 <li ng-if="mode === 'case-activity-bulk-action'">
   <a href ng-click="manageTags('add', selectedActivities)">
     <i class="material-icons">add_circle</i> {{ ts('Tag - add to activities') }}

--- a/ang/civicase/activity/feed/directives/activity-feed.directive.js
+++ b/ang/civicase/activity/feed/directives/activity-feed.directive.js
@@ -368,10 +368,17 @@
         ],
         options: options
       };
+      var chainedApiParams = {
+        activity_id :'$value.id',
+        activity_type_id :'$value.activity_type_id',
+        source_record_id: '$value.source_record_id',
+        case_id :'$value.case_id'
+      };
       var params = {
         is_current_revision: 1,
         is_deleted: 0,
         is_test: 0,
+        'api.Activity.getactionlinks' : chainedApiParams,
         options: {}
       };
 

--- a/ang/civicase/activity/feed/directives/activity-feed.directive.js
+++ b/ang/civicase/activity/feed/directives/activity-feed.directive.js
@@ -368,7 +368,7 @@
         ],
         options: options
       };
-      var chainedApiParams = {
+      var getActionLinksParams = {
         activity_id :'$value.id',
         activity_type_id :'$value.activity_type_id',
         source_record_id: '$value.source_record_id',
@@ -378,7 +378,7 @@
         is_current_revision: 1,
         is_deleted: 0,
         is_test: 0,
-        'api.Activity.getactionlinks' : chainedApiParams,
+        'api.Activity.getactionlinks' : getActionLinksParams,
         options: {}
       };
 

--- a/api/v3/Activity/GetActionLinks.php
+++ b/api/v3/Activity/GetActionLinks.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Activity.GetActionLinks API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec description of fields supported by this API call
+ * @return void
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ */
+function _civicrm_api3_activity_GetActionLinks_spec(&$spec) {
+  $spec['activity_type_id']['api.required'] = 1;
+  $spec['source_record_id']['api.required'] = 1;
+  $spec['activity_id']['api.required'] = 1;
+  $spec['case_id']['api.required'] = 0;
+}
+
+/**
+ * Activity.GetActionLinks API
+ * This API returns the activity action links for an activity record.
+ * Basically it adds the action links added by core plus the action links
+ * added by various extensions via hooks. Action links differ per activity
+ * as some logic may determine which links are available for a particular activity.
+ *
+ * @param array $params
+ *
+ * @return array
+ */
+function civicrm_api3_activity_GetActionLinks($params) {
+  return _civicrm_api3_activity_getActivityActionLinks($params);
+}
+
+/**
+ * Returns activity links for the activity ID in the params.
+ *
+ * @param array $params
+ *
+ * @return array
+ */
+function _civicrm_api3_activity_getActivityActionLinks($params) {
+  $actionLinks = CRM_Activity_Selector_Activity::actionLinks(
+    CRM_Utils_Array::value('activity_type_id', $params),
+    CRM_Utils_Array::value('source_record_id', $params),
+    FALSE,
+    CRM_Utils_Array::value('activity_id', $params)
+  );
+
+  $actionMask = array_sum(array_keys($actionLinks));
+
+  $seqLinks = array();
+  foreach ($actionLinks as $bit => $link) {
+    $link['bit'] = $bit;
+    $seqLinks[] = $link;
+  }
+
+  $values = array(
+    'id' => $params['activity_id'],
+    'cid' => CRM_Core_Session::getLoggedInContactID(),
+    'cxt' => '',
+    'caseid' => CRM_Utils_Array::value('case_id', $params),
+  );
+
+  //Invoke hook links for activity tab rows.
+  CRM_Utils_Hook::links(
+    'activity.tab.row',
+    'Activity',
+    $params['activity_id'],
+    $seqLinks,
+    $actionMask,
+    $values
+  );
+
+ return  _civicrm_api3_activity_GetActionLinks_processLinks($seqLinks);
+}
+
+/**
+ * Process activity links
+ *
+ * @param array $activityActionLinks
+ *
+ * @return array
+ */
+function _civicrm_api3_activity_GetActionLinks_processLinks($activityActionLinks) {
+  foreach($activityActionLinks as $id => $link) {
+
+    //remove action links already added by civicase
+    if (in_array($link['name'], ['Delete', 'File on Case', 'Edit'])) {
+      unset($activityActionLinks[$id]);
+      continue;
+    }
+
+    //format link URL
+    if (isset($link['qs']) && !CRM_Utils_System::isNull($link['qs'])) {
+      $urlPath = CRM_Utils_System::url(CRM_Core_Action::replace($link['url'], $values),
+        CRM_Core_Action::replace($link['qs'], $values), FALSE, NULL, TRUE
+      );
+    }
+    else {
+      $urlPath = CRM_Utils_Array::value('url', $link, '#');
+    }
+
+    $activityActionLinks[$id]['url'] = $urlPath;
+
+    // Add link classes
+    $classes = 'action-item';
+    if (isset($link['ref'])) {
+      $classes .= ' ' . strtolower($link['ref']);
+    }
+
+    if (isset($link['class'])) {
+      $className = is_array($link['class']) ? implode(' ', $link['class']) : $link['class'];
+      $classes .= ' ' . strtolower($className);
+    }
+
+    $activityActionLinks[$id]['class'] = $classes;
+  }
+
+  return $activityActionLinks;
+}

--- a/api/v3/Activity/GetActionLinks.php
+++ b/api/v3/Activity/GetActionLinks.php
@@ -1,5 +1,7 @@
 <?php
 
+const ACTIONS_DEFINED_BY_CIVICASE = ['Delete', 'File on Case', 'Edit'];
+
 /**
  * Activity.GetActionLinks API specification (optional)
  * This is used for documentation and validation.
@@ -47,18 +49,18 @@ function _civicrm_api3_activity_getActivityActionLinks($params) {
 
   $actionMask = array_sum(array_keys($actionLinks));
 
-  $seqLinks = array();
+  $seqLinks = [];
   foreach ($actionLinks as $bit => $link) {
     $link['bit'] = $bit;
     $seqLinks[] = $link;
   }
 
-  $values = array(
+  $values = [
     'id' => $params['activity_id'],
     'cid' => CRM_Core_Session::getLoggedInContactID(),
     'cxt' => '',
     'caseid' => CRM_Utils_Array::value('case_id', $params),
-  );
+  ];
 
   //Invoke hook links for activity tab rows.
   CRM_Utils_Hook::links(
@@ -84,7 +86,7 @@ function _civicrm_api3_activity_GetActionLinks_processLinks($activityActionLinks
   foreach($activityActionLinks as $id => $link) {
 
     //remove action links already added by civicase
-    if (in_array($link['name'], ['Delete', 'File on Case', 'Edit'])) {
+    if (in_array($link['name'], ACTIONS_DEFINED_BY_CIVICASE )) {
       unset($activityActionLinks[$id]);
       continue;
     }


### PR DESCRIPTION
## Overview
After installing the civicase extension, activity action links added by custom extensions and even some core extension like Contributions are not taken into account and only default links shows up for all activity types.

## Before
The activity action links displayed in the activity tab for a contact for each activity is a set of hardcoded pre-defined links.

<img width="1280" alt="adminexample com  mastercore 2019-04-23 11-09-27" src="https://user-images.githubusercontent.com/6951813/56574874-393bfb00-65bc-11e9-97ab-a1d861ad8abf.png">


## After
The activity action links for an activity may be different from that of another activity as it is determined by some logic executed in the hook_civicrm_links implemented by each extension.

I did some investigations on how Civi adds the activity action links for an activity record [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Activity/BAO/Activity.php#L2604-L2626) and extracted the relevant function to an API action so that the links can be fetched when fetching an activity record alongside.

<img width="1280" alt="adminexample com  mastercore 2019-04-23 11-06-32" src="https://user-images.githubusercontent.com/6951813/56574909-4eb12500-65bc-11e9-9063-87b002564ab8.png">
<img width="1274" alt="adminexample com  mastercore 2019-04-23 11-04-47" src="https://user-images.githubusercontent.com/6951813/56574910-4eb12500-65bc-11e9-9134-9b8d05952695.png">

## Technical Details
A new API action Activity.GetActionLinks as added that allows action links to be fetched with activity via chained API calls
```php
     var chainedApiParams = {
        activity_id :'$value.id',
        activity_type_id :'$value.activity_type_id',
        source_record_id: '$value.source_record_id',
        case_id :'$value.case_id'
      };
      var params = {
        is_current_revision: 1,
        is_deleted: 0,
        is_test: 0,
        'api.Activity.getactionlinks' : chainedApiParams,
        options: {}
      };

  CRM.api3('Activity', 'get', params)
```
In the angular html template responsible for displaying the action links, the following code was added.

```php
<li ng-repeat="link in selectedActivities[0]['api.Activity.getactionlinks']">
  <a ng-href="{{ link.url }}" class="{{ link.class }}">
    <i class="material-icons">filter_none</i>{{ link.name }}
  </a>
</li>
```

## Comment
Even though activity actions added by core and custom extensions are now added dynamically, there is a peculiar issue to Purchase Order extension, Contribution and I guess some other extensions that modify the view action to display a custom view rather than the default activity view. I was able to add the view action for a Purchase Order activity type but clicking on the activity still opens up the default activity view which is not possible before installing the extension. 

<img width="1294" alt="adminexample com  mastercore 2019-04-23 11-09-49" src="https://user-images.githubusercontent.com/6951813/56575183-01818300-65bd-11e9-803c-a714cc92e1fa.png">
