### PR TITLE
C51-418: Configurable 'New Case' button

### DIFF
--- a/ang/civicase/dashboard/directives/dashboard.directive.html
+++ b/ang/civicase/dashboard/directives/dashboard.directive.html
@@ -27,10 +27,15 @@
             class="form-control civicase__dashboard__relation-filter"
             crm-ui-select="{allowClear: false, multiple: false, data: caseRelationshipOptions}"
             ng-model="filters.caseRelationshipType" />
-          <a ng-if="checkPerm('add cases')"
+          <a ng-if="checkPerm('add cases')  && !newCaseWebformUrl"
             ng-href="{{ url('civicrm/case/add', {reset: 1, action: 'add', context: 'standalone'}) }}"
             class="btn btn-primary crm-popup civicase__dashboard__add-case"
             crm-popup-form-success="refresh()">
+            <i class="material-icons">add_circle</i>{{ ts('Add Case') }}
+          </a>
+          <a ng-if="checkPerm('add cases') && newCaseWebformUrl"
+             ng-href="{{ newCaseWebformUrl | civicaseCrmUrl }}"
+             class="btn btn-primary civicase__dashboard__add-case">
             <i class="material-icons">add_circle</i>{{ ts('Add Case') }}
           </a>
         </div>

--- a/ang/civicase/dashboard/directives/dashboard.directive.js
+++ b/ang/civicase/dashboard/directives/dashboard.directive.js
@@ -19,6 +19,7 @@
     $scope.activityFilters = {
       case_filter: {'case_type_id.is_active': 1, contact_is_deleted: 0}
     };
+    $scope.newCaseWebformUrl = CRM.civicase.newCaseWebformUrl;
 
     (function init () {
       bindRouteParamsToScope();


### PR DESCRIPTION
## Overview
 #197  adds a way to allow the Add case URL to be configurable. This PR allows the New Case on the navigation menu and the Add case button on Case dashboard to use this functionality. If an alternate add new case URL is set, the new URL is used rather than the default behaviour for these menus.

<img width="1281" alt="CiviCase Dashboard - All Cases  mastercore 2019-04-29 14-26-14" src="https://user-images.githubusercontent.com/6951813/56899253-ec0fcb80-6a8a-11e9-96b6-d389f7a4d917.png">
<img width="1275" alt="CiviCase Dashboard - All Cases  mastercore 2019-04-29 14-26-49" src="https://user-images.githubusercontent.com/6951813/56899255-eca86200-6a8a-11e9-80cd-32fb67e3dabb.png">

## Before
The new case on navigation and the Add Case button on the cases dashboard is not configurable

## After
![civicaseAddwebform2](https://user-images.githubusercontent.com/6951813/56899419-4c067200-6a8b-11e9-8fa1-4722fddf3470.gif)

