### PR TITLE
CATL-1069: Fix case_manager role shown for all roles

### DIFF
--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
@@ -261,7 +261,7 @@
       role.role = relType.label_b_a;
       role.contact_type = relType.contact_type_b;
       role.contact_sub_type = relType.contact_sub_type_b;
-      role.description = (role.manager ? (ts('Case Manager.') + ' ') : '') + (relType.description || '');
+      role.description = (role.manager === '1' ? (ts('Case Manager.') + ' ') : '') + (relType.description || '');
       role.relationship_type_id = relType.id;
     }
 


### PR DESCRIPTION
## Overview
In the People tab of Case Details, the Case Manager role was shown for all relationships, even if it is not assigned.

## Before
![2019-05-15 at 6 17 PM](https://user-images.githubusercontent.com/5058867/57776648-acf5a180-773d-11e9-9e31-efb5f734e9ce.jpg)

## After
![2019-05-15 at 6 16 PM](https://user-images.githubusercontent.com/5058867/57776592-8b94b580-773d-11e9-8d57-875bffaf86e0.jpg)

## Technical Details
This was happening because the `Case.getCaseList` API, sometimes returns `0` and sometimes returns `false` for the `manager` property under contacts.

![2019-05-15 at 6 18 PM](https://user-images.githubusercontent.com/5058867/57776763-ee864c80-773d-11e9-9ebb-3b611eda447c.jpg)

That is why the code needed to be refactored to consider `0` as `false`.
`role.manager === '1'`
