### PR TITLE
C51-417: Add Case Button In Contact; Select Case Client As Configured In Webform

### DIFF
--- a/ang/civicase.ang.php
+++ b/ang/civicase.ang.php
@@ -201,13 +201,9 @@ if (isset($webformsToDisplay)) {
       if (!in_array($webform['nid'], $allowedWebforms)) {
         continue;
       }
-      $node = node_load($webform['nid']);
-      $data = $node->webform_civicrm['data'];
-      $client = 0;
-      if (isset($data['case'][1]['case'][1]['client_id'])) {
-        $clients = $data['case'][1]['case'][1]['client_id'];
-        $client = reset($clients);
-      }
+
+      $client = getClientDeltaFromWebform($webform['nid']);
+
       $items[] = array(
         'title' => $webform['title'],
         'action' => 'gotoWebform(cases[0], "' . $webform['path'] . '", '.$client.')',
@@ -238,6 +234,15 @@ $options['allowCaseLocks'] = (bool) Civi::settings()->get('civicaseAllowCaseLock
 // Retrieve civicase webform URL
 $allowCaseWebform = Civi::settings()->get('civicaseAllowCaseWebform');
 $options['newCaseWebformUrl'] = $allowCaseWebform ? Civi::settings()->get('civicaseWebformUrl') : NULL;
+$options['newCaseWebformClient'] = 'cid';
+if ($options['newCaseWebformUrl']) {
+  $path = explode('/', $options['newCaseWebformUrl']);
+  $nid = array_pop($path);
+  $client = getClientDeltaFromWebform($nid);
+  if ($client) {
+    $options['newCaseWebformClient'] = 'cid' . $client;
+  }
+}
 
 if (!function_exists('glob_recursive')) {
   /**
@@ -254,6 +259,24 @@ if (!function_exists('glob_recursive')) {
 
     return $files;
   }
+}
+
+/**
+ * Returns the contact number which is configured as client for a given webform id.
+ *
+ * @param {int} $webform_id
+ * @return int
+ */
+function getClientDeltaFromWebform($webform_id) {
+  $node = node_load($webform_id);
+  $data = $node->webform_civicrm['data'];
+  $client = 0;
+  if (isset($data['case'][1]['case'][1]['client_id'])) {
+    $clients = $data['case'][1]['case'][1]['client_id'];
+    $client = reset($clients);
+  }
+
+  return $client;
 }
 
 /**

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
@@ -11,7 +11,7 @@
     </a>
     <a ng-if="checkPerm('add cases') && newCaseWebformUrl"
        class="btn-primary btn"
-       ng-href="{{ newCaseWebformUrl | civicaseCrmUrl:{cid: contactId} }}">
+       ng-href="{{ newCaseWebformUrl | civicaseCrmUrl:{[newCaseWebformClient]: contactId} }}">
       <i class="material-icons">add_circle</i>
       {{ ts('Add case') }}
     </a>

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
@@ -26,6 +26,7 @@
     $scope.caseDetailsLoaded = false;
     $scope.contactId = Contact.getContactIDFromUrl();
     $scope.newCaseWebformUrl = CRM.civicase.newCaseWebformUrl;
+    $scope.newCaseWebformClient = CRM.civicase.newCaseWebformClient;
     $scope.casesListConfig = [
       {
         'name': 'opened',


### PR DESCRIPTION
## Overview
This PR adds support to use different case client as configured in webform. 

## Before
Previously just the 'cid' would be passed in the URL which would work only if the first contact is set as case client.

## After
Now which ever contact is set as case client in the webform, the url will be used as 'cid[client-contact]'.
So if contact 2 is set as case client in webform, the add case URL will have 'cid2=[contact_id]'.

## Technical Details
A variable called 'newCaseWebformClient' is added which will have the case client number for the webform configured. So in the webform if there are more than 1 contact and say contact 2 is set as case client, then 'newCaseWebformClient' will say 'cid2'.
Previously it will always say 'cid' and so it will only work if the case client is set to contact 1 in the webform.
In 'contact-case-tab.directive.html', '[newCaseWebformClient]' is used in place of 'cid' (notice the []). Its wrapped in [] because 'newCaseWebformClient' is a variable and we need the value of that variable as URL param name.