### PR TITLE
CATL-1083: Remove Duplicate Activity Duration Field

### DIFF
--- a/CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+++ b/CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
@@ -103,18 +103,10 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
         ],
       ],
       'duration' => [
-        'title' => ts('Duration (sum for all contacts)'),
-        'type' => CRM_Utils_Type::T_INT,
-        'statistics' => [
-          'sum' => ts('Total Duration'),
-        ],
-        'is_fields' => TRUE,
-      ],
-      'duration_each' => [
-        'title' => ts('Duration (for each contact)'),
+        'title' => ts('Activity Duration'),
         'name' => 'duration',
-        'type' => CRM_Utils_Type::T_INT,
         'is_fields' => TRUE,
+        'is_filters' => TRUE,
       ],
       'details' => [
         'title' => ts('Activity Details'),


### PR DESCRIPTION
## Overview
The Activity duration fields labels are confusing and both fields seems to be doing the same thing when used in the reports. This PR removes one of the fields and renames the labels properly for easy comprehension.

