### PR TITLE
RSE-32: Create Case Type Category field

### DIFF
--- a/CRM/Civicase/Setup/CaseTypeCategorySupport.php
+++ b/CRM/Civicase/Setup/CaseTypeCategorySupport.php
@@ -1,0 +1,39 @@
+<?php
+
+use CRM_Core_BAO_SchemaHandler as SchemaHandler;
+
+class CRM_Civicase_Setup_CaseTypeCategorySupport {
+
+  public function apply() {
+    $this->addCaseCategoryDBColumn();
+    $this->createCaseCategoryOptionGroup();
+
+    return TRUE;
+  }
+
+  /**
+   * Add Case Type Category Column to the Case Type table
+   */
+  private function addCaseCategoryDBColumn () {
+    $caseTypeTable = CRM_Case_BAO_CaseType::getTableName();
+    $caseCategoryColumnName = 'case_type_category';
+
+    if (!SchemaHandler::checkIfFieldExists($caseTypeTable, $caseCategoryColumnName)) {
+      CRM_Core_DAO::executeQuery("
+        ALTER TABLE {$caseTypeTable}
+        ADD COLUMN {$caseCategoryColumnName} INT(10)");
+    }
+  }
+
+  /**
+   * Create Case Type Category option group
+   */
+  private function createCaseCategoryOptionGroup () {
+    CRM_Core_BAO_OptionGroup::ensureOptionGroupExists([
+      'name' => 'case_type_categories',
+      'title' => ts('Case Type Categories'),
+      'is_reserved' => 1,
+    ]);
+  }
+
+}

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_Civicase_Setup_CaseTypeCategorySupport as CaseTypeCategorySupport;
+
 /**
  * Collection of upgrade steps.
  */
@@ -55,55 +57,14 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
       ));
     }
 
-    // Create activity types
-    $this->addOptionValue(array(
-      'option_group_id' => 'activity_type',
-      'label' => ts('Alert'),
-      'name' => 'Alert',
-      'grouping' => 'alert',
-      'is_reserved' => 0,
-      'description' => ts('Alerts to display in cases'),
-      'component_id' => 'CiviCase',
-      'icon' => 'fa-exclamation',
-    ));
-    $this->addOptionValue(array(
-      'option_group_id' => 'activity_type',
-      'label' => ts('File Upload'),
-      'name' => 'File Upload',
-      // 'grouping' => '',
-      'is_reserved' => 0,
-      'description' => ts('Add files to a case'),
-      'component_id' => 'CiviCase',
-      'icon' => 'fa-file',
-    ));
-    $this->addOptionValue(array(
-      'option_group_id' => 'activity_type',
-      'label' => ts('Remove Client From Case'),
-      'name' => 'Remove Client From Case',
-      'grouping' => 'system',
-      'is_reserved' => 0,
-      'description' => ts('Client removed from multi-client case'),
-      'component_id' => 'CiviCase',
-      'icon' => 'fa-user-times',
-    ));
+    $this->addAllOptionValues();
 
-    // Create activity statuses
-    $this->addOptionValue(array(
-      'option_group_id' => 'activity_status',
-      'label' => ts('Unread'),
-      'name' => 'Unread',
-      'grouping' => 'communication',
-      'is_reserved' => 0,
-      'color' => '#d9534f',
-    ));
-    $this->addOptionValue(array(
-      'option_group_id' => 'activity_status',
-      'label' => ts('Draft'),
-      'name' => 'Draft',
-      'grouping' => 'communication',
-      'is_reserved' => 0,
-      'color' => '#c2cfd8',
-    ));
+    $steps = [
+      new CaseTypeCategorySupport(),
+    ];
+    foreach ($steps as $step) {
+      $step->apply();
+    }
 
     // Set grouping for existing statuses
     $allowedStatuses = array(
@@ -300,6 +261,61 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
   }
 
   /**
+   * Adds all the necessary Option Values
+   */
+  private function addAllOptionValues () {
+    // Create activity types
+    $this->addOptionValue(array(
+      'option_group_id' => 'activity_type',
+      'label' => ts('Alert'),
+      'name' => 'Alert',
+      'grouping' => 'alert',
+      'is_reserved' => 0,
+      'description' => ts('Alerts to display in cases'),
+      'component_id' => 'CiviCase',
+      'icon' => 'fa-exclamation',
+    ));
+    $this->addOptionValue(array(
+      'option_group_id' => 'activity_type',
+      'label' => ts('File Upload'),
+      'name' => 'File Upload',
+      // 'grouping' => '',
+      'is_reserved' => 0,
+      'description' => ts('Add files to a case'),
+      'component_id' => 'CiviCase',
+      'icon' => 'fa-file',
+    ));
+    $this->addOptionValue(array(
+      'option_group_id' => 'activity_type',
+      'label' => ts('Remove Client From Case'),
+      'name' => 'Remove Client From Case',
+      'grouping' => 'system',
+      'is_reserved' => 0,
+      'description' => ts('Client removed from multi-client case'),
+      'component_id' => 'CiviCase',
+      'icon' => 'fa-user-times',
+    ));
+
+    // Create activity statuses
+    $this->addOptionValue(array(
+      'option_group_id' => 'activity_status',
+      'label' => ts('Unread'),
+      'name' => 'Unread',
+      'grouping' => 'communication',
+      'is_reserved' => 0,
+      'color' => '#d9534f',
+    ));
+    $this->addOptionValue(array(
+      'option_group_id' => 'activity_status',
+      'label' => ts('Draft'),
+      'name' => 'Draft',
+      'grouping' => 'communication',
+      'is_reserved' => 0,
+      'color' => '#c2cfd8',
+    ));
+  }
+
+  /**
    * @param array $menuItem
    */
   public function addNav($menuItem) {
@@ -484,7 +500,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
   /**
    * Gets the PEAR style classname from an upgrader file
    *
-   * @param $file
+   * @param string $file
    *
    * @return string
    */

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -203,7 +203,8 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
         'api.OptionValue.delete' => array(),
       ));
     }
-    catch (Exception $e) {}
+    catch (Exception $e) {
+    }
     try {
       civicrm_api3('OptionGroup', 'get', array(
         'return' => array('id'),
@@ -211,7 +212,8 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
         'api.OptionGroup.delete' => array(),
       ));
     }
-    catch (Exception $e) {}
+    catch (Exception $e) {
+    }
     // Delete unused activity types
     foreach (array('File', 'Alert') as $type) {
       try {
@@ -227,7 +229,8 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
           ));
         }
       }
-      catch (Exception $e) {}
+      catch (Exception $e) {
+      }
     }
     // Delete unused activity statuses
     foreach (array('Unread', 'Draft') as $status) {
@@ -244,7 +247,8 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
           ));
         }
       }
-      catch (Exception $e) {}
+      catch (Exception $e) {
+      }
     }
 
     $this->removeNav('Manage Cases');
@@ -310,6 +314,8 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
   /**
    * @param string $name
    *   The name of the item in `civicrm_navigation`.
+   * @param boolean $isActive
+   *   Whether to enable/disable the nav
    */
   protected function toggleNav($name, $isActive) {
     CRM_Core_DAO::executeQuery("UPDATE `civicrm_navigation` SET is_active = %2 WHERE name IN (%1)", array(
@@ -408,66 +414,19 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
   }
 
   /**
-   * Example: Run a couple simple queries.
-   *
-   * @return TRUE on success
-   * @throws Exception
-   *
-  public function upgrade_4200() {
-    $this->ctx->log->info('Applying update 4200');
-    CRM_Core_DAO::executeQuery('UPDATE foo SET bar = "whiz"');
-    CRM_Core_DAO::executeQuery('DELETE FROM bang WHERE willy = wonka(2)');
-    return TRUE;
-  } // */
+   * Adds "Case Type Categories" field to the `civicrm_case_type` table
+   */
+  public function upgrade_0002() {
+    CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_case_type
+      ADD COLUMN case_type_category INT(10)');
 
+    CRM_Core_BAO_OptionGroup::ensureOptionGroupExists([
+      'name' => 'case_type_categories',
+      'title' => ts('Case Type Categories'),
+      'is_reserved' => 1,
+    ]);
 
-  /**
-   * Example: Run a slow upgrade process by breaking it up into smaller chunk.
-   *
-   * @return TRUE on success
-   * @throws Exception
-  public function upgrade_4202() {
-    $this->ctx->log->info('Planning update 4202'); // PEAR Log interface
-
-    $this->addTask(ts('Process first step'), 'processPart1', $arg1, $arg2);
-    $this->addTask(ts('Process second step'), 'processPart2', $arg3, $arg4);
-    $this->addTask(ts('Process second step'), 'processPart3', $arg5);
     return TRUE;
   }
-  public function processPart1($arg1, $arg2) { sleep(10); return TRUE; }
-  public function processPart2($arg3, $arg4) { sleep(10); return TRUE; }
-  public function processPart3($arg5) { sleep(10); return TRUE; }
-  // */
-
-
-  /**
-   * Example: Run an upgrade with a query that touches many (potentially
-   * millions) of records by breaking it up into smaller chunks.
-   *
-   * @return TRUE on success
-   * @throws Exception
-  public function upgrade_4203() {
-    $this->ctx->log->info('Planning update 4203'); // PEAR Log interface
-
-    $minId = CRM_Core_DAO::singleValueQuery('SELECT coalesce(min(id),0) FROM civicrm_contribution');
-    $maxId = CRM_Core_DAO::singleValueQuery('SELECT coalesce(max(id),0) FROM civicrm_contribution');
-    for ($startId = $minId; $startId <= $maxId; $startId += self::BATCH_SIZE) {
-      $endId = $startId + self::BATCH_SIZE - 1;
-      $title = ts('Upgrade Batch (%1 => %2)', array(
-        1 => $startId,
-        2 => $endId,
-      ));
-      $sql = '
-        UPDATE civicrm_contribution SET foobar = whiz(wonky()+wanker)
-        WHERE id BETWEEN %1 and %2
-      ';
-      $params = array(
-        1 => array($startId, 'Integer'),
-        2 => array($endId, 'Integer'),
-      );
-      $this->addTask($title, 'executeSql', $sql, $params);
-    }
-    return TRUE;
-  } // */
 
 }

--- a/CRM/Civicase/Upgrader/Steps/Step0001.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0001.php
@@ -1,0 +1,10 @@
+<?php
+
+class CRM_Civicase_Upgrader_Steps_Step0001 {
+  public function apply() {
+    $upgrader = CRM_Civicase_Upgrader_Base::instance();
+    $upgrader->executeSqlFile('sql/auto_install.sql');
+
+    return TRUE;
+  }
+}

--- a/CRM/Civicase/Upgrader/Steps/Step0002.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0002.php
@@ -1,29 +1,14 @@
 <?php
 
+use CRM_Civicase_Setup_CaseTypeCategorySupport as CaseTypeCategorySupport;
+
 class CRM_Civicase_Upgrader_Steps_Step0002 {
+
   public function apply() {
-    $this->addCaseCategoryDBField();
-    $this->createCaseCategoryOptionGroup();
+    $step = new CaseTypeCategorySupport();
+    $step->apply();
 
     return TRUE;
   }
 
-  /**
-   * Add Case Type Category Field to the Case Type table
-   */
-  private function addCaseCategoryDBField () {
-    CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_case_type
-    ADD COLUMN case_type_category INT(10)');
-  }
-
-  /**
-   * Create Case Type Category option group
-   */
-  private function createCaseCategoryOptionGroup () {
-    CRM_Core_BAO_OptionGroup::ensureOptionGroupExists([
-      'name' => 'case_type_categories',
-      'title' => ts('Case Type Categories'),
-      'is_reserved' => 1,
-    ]);
-  }
 }

--- a/CRM/Civicase/Upgrader/Steps/Step0002.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0002.php
@@ -1,0 +1,29 @@
+<?php
+
+class CRM_Civicase_Upgrader_Steps_Step0002 {
+  public function apply() {
+    $this->addCaseCategoryDBField();
+    $this->createCaseCategoryOptionGroup();
+
+    return TRUE;
+  }
+
+  /**
+   * Add Case Type Category Field to the Case Type table
+   */
+  private function addCaseCategoryDBField () {
+    CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_case_type
+    ADD COLUMN case_type_category INT(10)');
+  }
+
+  /**
+   * Create Case Type Category option group
+   */
+  private function createCaseCategoryOptionGroup () {
+    CRM_Core_BAO_OptionGroup::ensureOptionGroupExists([
+      'name' => 'case_type_categories',
+      'title' => ts('Case Type Categories'),
+      'is_reserved' => 1,
+    ]);
+  }
+}

--- a/civicase.php
+++ b/civicase.php
@@ -90,7 +90,6 @@ function civicase_civicrm_install() {
   _civicase_civix_civicrm_install();
 }
 
-
 /**
  * Implements hook_civicrm_postInstall().
  *
@@ -197,9 +196,6 @@ function civicase_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
 
 /**
  * Implements hook_civicrm_buildForm().
- *
- * @param string $formName
- * @param CRM_Core_Form $form
  */
 function civicase_civicrm_buildForm($formName, &$form) {
   $hooks = [
@@ -351,6 +347,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
 
 /**
  * Implements hook_civicrm_alterContent().
+ *
  * Adds extra settings fields to the Civicase Admin Settings form.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterContent/
@@ -373,12 +370,6 @@ function civicase_civicrm_alterContent (&$content, $context, $templateName, $for
 
 /**
  * Implements hook_civicrm_validateForm().
- *
- * @param string $formName
- * @param array $fields
- * @param array $files
- * @param CRM_Core_Form $form
- * @param array $errors
  */
 function civicase_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
   // Save draft feature
@@ -426,9 +417,6 @@ function civicase_civicrm_validateForm($formName, &$fields, &$files, &$form, &$e
 
 /**
  * Implements hook_civicrm_postProcess().
- * @param string $formName
- * @param CRM_Core_Form $form
- * @throws \CiviCRM_API3_Exception
  */
 function civicase_civicrm_postProcess($formName, &$form) {
   if (!empty($form->civicase_reload)) {
@@ -447,20 +435,17 @@ function civicase_civicrm_postProcess($formName, &$form) {
 }
 
 /**
- * Implements hook_civicrm_permission()
- *
- * @param array $permissions
- *   Array of permissions defined on extensions
+ * Implements hook_civicrm_permission().
  */
 function civicase_civicrm_permission(&$permissions) {
   $permissions['basic case information'] = array(
     'Civicase: basic case information',
-    ts('Allows a user to view only basic information of cases.')
+    ts('Allows a user to view only basic information of cases.'),
   );
 }
 
 /**
- * Implements hook_civicrm_apiWrappers
+ * Implements hook_civicrm_apiWrappers().
  */
 function civicase_civicrm_apiWrappers(&$wrappers, $apiRequest) {
   if ($apiRequest['entity'] == 'Case') {
@@ -484,7 +469,7 @@ function civicase_civicrm_alterAPIPermissions($entity, $action, &$params, &$perm
       'access my cases and activities',
       'access all cases and activities',
       'basic case information',
-    )
+    ),
   );
 
   $permissions['case']['getcount'] = array(
@@ -492,7 +477,7 @@ function civicase_civicrm_alterAPIPermissions($entity, $action, &$params, &$perm
       'access my cases and activities',
       'access all cases and activities',
       'basic case information',
-    )
+    ),
   );
 
   $permissions['case_type']['get'] = $permissions['casetype']['getcount'] = array(
@@ -500,7 +485,7 @@ function civicase_civicrm_alterAPIPermissions($entity, $action, &$params, &$perm
       'access my cases and activities',
       'access all cases and activities',
       'basic case information',
-    )
+    ),
   );
 }
 
@@ -531,7 +516,7 @@ function civicase_civicrm_pageRun(&$page) {
   }
 
   // Adds simplescrollbarjs
-  if ($page instanceof CRM_Civicase_Page_CaseAngular ) {
+  if ($page instanceof CRM_Civicase_Page_CaseAngular) {
     CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicase', 'packages/simplebar.min.js');
     CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.civicase', 'packages/simplebar.min.css', 1000, 'html-header');
   }
@@ -573,19 +558,19 @@ function civicase_civicrm_navigationMenu(&$menu) {
   $menu_items = array();
   CRM_Core_BAO_Navigation::retrieve($menu_item_search, $menu_items);
 
-  if ( ! empty($menu_items) ) {
+  if (!empty($menu_items)) {
     return;
   }
 
   $navId = CRM_Core_DAO::singleValueQuery("SELECT max(id) FROM civicrm_navigation");
-  if (is_integer($navId)) {
+  if (is_int($navId)) {
     $navId++;
   }
   // Find the Civicase menu
   $caseID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'CiviCase', 'id', 'name');
   $administerID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Administer', 'id', 'name');
   $menu[$administerID]['child'][$caseID]['child'][$navId] = array(
-    'attributes' => array (
+    'attributes' => array(
       'label' => ts('CiviCase Webforms'),
       'name' => 'CiviCase Webforms',
       'url' => 'civicrm/case/webforms',
@@ -594,7 +579,7 @@ function civicase_civicrm_navigationMenu(&$menu) {
       'separator' => 1,
       'parentID' => $caseID,
       'navID' => $navId,
-      'active' => 1
+      'active' => 1,
     ),
   );
 }
@@ -637,6 +622,8 @@ function civicase_civicrm_entityTypes(&$entityTypes) {
     'class' => 'CRM_Civicase_DAO_CaseContactLock',
     'table' => 'civicase_contactlock',
   );
+
+  _civicase_update_case_type_entity($entityTypes);
 }
 
 /**
@@ -668,4 +655,33 @@ function civicase_civicrm_preProcess($formName, &$form) {
 
     $form->setVar('_settings', $settings);
   }
+}
+
+/**
+ * Adds Case Type Category field to the Case Type entity DAO
+ *
+ * @param Array $entityTypes
+ */
+function _civicase_update_case_type_entity (&$entityTypes) {
+  $entityTypes['CRM_Case_DAO_CaseType']['fields_callback'][] = function ($class, &$fields) {
+    $fields['case_type_category'] = [
+      'name' => 'case_type_category',
+      'type' => CRM_Utils_Type::T_INT,
+      'title' => ts('Case Type Category'),
+      'description' => ts('FK to a civicrm_option_value (case_type_categories)'),
+      'required' => FALSE,
+      'where' => 'civicrm_case_type.case_type_category',
+      'table_name' => 'civicrm_case_type',
+      'entity' => 'CaseType',
+      'bao' => 'CRM_Case_BAO_CaseType',
+      'localizable' => 1,
+      'html' => [
+        'type' => 'Select',
+      ],
+      'pseudoconstant' => [
+        'optionGroupName' => 'case_type_categories',
+        'optionEditPath' => 'civicrm/admin/options/case_type_categories',
+      ],
+    ];
+  };
 }

--- a/civicase.php
+++ b/civicase.php
@@ -623,7 +623,7 @@ function civicase_civicrm_entityTypes(&$entityTypes) {
     'table' => 'civicase_contactlock',
   );
 
-  _civicase_update_case_type_entity($entityTypes);
+  _civicase_add_case_category_case_type_entity($entityTypes);
 }
 
 /**
@@ -662,7 +662,7 @@ function civicase_civicrm_preProcess($formName, &$form) {
  *
  * @param Array $entityTypes
  */
-function _civicase_update_case_type_entity (&$entityTypes) {
+function _civicase_add_case_category_case_type_entity (&$entityTypes) {
   $entityTypes['CRM_Case_DAO_CaseType']['fields_callback'][] = function ($class, &$fields) {
     $fields['case_type_category'] = [
       'name' => 'case_type_category',

--- a/sql/auto_install.sql
+++ b/sql/auto_install.sql
@@ -15,12 +15,3 @@ CREATE TABLE `civicase_contactlock` (
   CONSTRAINT FK_civicase_contactlock_case_id FOREIGN KEY (`case_id`) REFERENCES `civicrm_case`(`id`) ON DELETE CASCADE,
   CONSTRAINT FK_civicase_contactlock_contact_id FOREIGN KEY (`contact_id`) REFERENCES `civicrm_contact`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci;
-
--- /*******************************************************
--- *
--- * case_type_category
--- *
--- * This new column, stores the case type category
--- *
--- *******************************************************/
-ALTER TABLE `civicrm_case_type` ADD COLUMN `case_type_category` INT(10);

--- a/sql/auto_install.sql
+++ b/sql/auto_install.sql
@@ -15,3 +15,12 @@ CREATE TABLE `civicase_contactlock` (
   CONSTRAINT FK_civicase_contactlock_case_id FOREIGN KEY (`case_id`) REFERENCES `civicrm_case`(`id`) ON DELETE CASCADE,
   CONSTRAINT FK_civicase_contactlock_contact_id FOREIGN KEY (`contact_id`) REFERENCES `civicrm_contact`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci;
+
+-- /*******************************************************
+-- *
+-- * case_type_category
+-- *
+-- * This new column, stores the case type category
+-- *
+-- *******************************************************/
+ALTER TABLE `civicrm_case_type` ADD COLUMN `case_type_category` INT(10);

--- a/sql/auto_uninstall.sql
+++ b/sql/auto_uninstall.sql
@@ -1,1 +1,3 @@
 DROP TABLE IF EXISTS `civicase_contactlock`;
+
+ALTER TABLE `civicrm_case_type` DROP COLUMN `case_type_category`;


### PR DESCRIPTION
## Overview
As part of this PR, the Case Type Category field is added to Civicase.

## Before
![civicrm_case_type-before](https://user-images.githubusercontent.com/5058867/60432538-2ed35880-9c20-11e9-8119-4330700d376e.jpeg)

## After
Field is Added
![2019-07-01 at 4 49 PM](https://user-images.githubusercontent.com/5058867/60432608-4ca0bd80-9c20-11e9-80bb-73e0f4910b62.jpg)

Option Group is created
![2019-07-01 at 4 50 PM](https://user-images.githubusercontent.com/5058867/60432623-56c2bc00-9c20-11e9-9569-79cec81addd6.jpg)

## Technical Details
**Upgrader**
Support for adding upgraders in individual files has been added.

A new upgrader has been added which adds a new field `case_type_category` to `civicrm_case_type` table. 
Also it adds a new Option Group called `Case Type Categories`.

**hook_civicrm_entityTypes**
A new function `_civicase_update_case_type_entity` is added, which adds the `case_type_category` field to the `CaseType` DAO.

## Comments
`civilint` fixes has been made to the touched files. But there will be a discussion with Davi regarding this, and once finalised, `civilint`(or any other linter) will be added as part of pre commit hooks.