### PR TITLE
RSE-176: Add Cases Option Value

### DIFF
--- a/CRM/Civicase/Setup/CreateCasesOptionValue.php
+++ b/CRM/Civicase/Setup/CreateCasesOptionValue.php
@@ -1,0 +1,20 @@
+<?php
+
+use CRM_Core_BAO_SchemaHandler as SchemaHandler;
+
+class CRM_Civicase_Setup_CreateCasesOptionValue {
+
+  public function apply() {
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => 'case_type_categories',
+      'name' => 'Cases',
+      'label' => 'Cases',
+      'is_default' => $option['is_default'],
+      'is_active' => TRUE,
+      'is_reserved' => TRUE,
+    ]);
+
+    return TRUE;
+  }
+
+}

--- a/CRM/Civicase/Setup/CreateCasesOptionValue.php
+++ b/CRM/Civicase/Setup/CreateCasesOptionValue.php
@@ -9,7 +9,7 @@ class CRM_Civicase_Setup_CreateCasesOptionValue {
       'option_group_id' => 'case_type_categories',
       'name' => 'Cases',
       'label' => 'Cases',
-      'is_default' => $option['is_default'],
+      'is_default' => TRUE,
       'is_active' => TRUE,
       'is_reserved' => TRUE,
     ]);

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -61,6 +61,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
 
     $steps = [
       new CaseTypeCategorySupport(),
+      new CreateCasesOptionValue(),
     ];
     foreach ($steps as $step) {
       $step->apply();

--- a/CRM/Civicase/Upgrader/Steps/Step0003.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0003.php
@@ -1,0 +1,14 @@
+<?php
+
+use CRM_Civicase_Setup_CreateCasesOptionValue as CreateCasesOptionValue;
+
+class CRM_Civicase_Upgrader_Steps_Step0003 {
+
+  public function apply() {
+    $step = new CreateCasesOptionValue();
+    $step->apply();
+
+    return TRUE;
+  }
+
+}


### PR DESCRIPTION
## Overview
As part of this PR, a new Option Value called `Cases` is created part of `Case Type Categories` Option Group.

## After
![2019-07-02 at 4 01 PM](https://user-images.githubusercontent.com/5058867/60506061-a5d12580-9ce2-11e9-9d6c-efa665f58aac.jpg)

## Technical Details
Added `CRM_Civicase_Setup_CreateCasesOptionValue` class, which takes care of adding the option value, and it is reused for Upgrading and also for Installing the extension.