### PR TITLE
C51-360: Update case stats on case filters change

### DIFF
--- a/CRM/Civicase/APIHelpers/CasesByContactInvolved.php
+++ b/CRM/Civicase/APIHelpers/CasesByContactInvolved.php
@@ -1,0 +1,22 @@
+<?php
+
+class CRM_Civicase_APIHelpers_CasesByContactInvolved {
+  /**
+   * Adds joins and conditions to the given query in order to filter cases by
+   * contact involvement.
+   *
+   * @param CRM_Utils_SQL_Select $query the SQL object reference.
+   * @param Int|Array $contactInvolved the ID of the contact related to the case.
+   */
+  static function filter($query, $contactInvolved) {
+    if (!is_array($contactInvolved)) {
+      $contactInvolved = ['=' => $contactInvolved];
+    }
+
+    $caseClient = CRM_Core_DAO::createSQLFilter('contact_id', $contactInvolved);
+    $nonCaseClient = CRM_Core_DAO::createSQLFilter('involved.id', $contactInvolved);
+
+    \Civi\CCase\Utils::joinOnRelationship($query, 'involved');
+    $query->where("a.id IN (SELECT case_id FROM civicrm_case_contact WHERE ($nonCaseClient OR $caseClient))");
+  }
+}

--- a/CRM/Civicase/APIHelpers/CasesByContactInvolved.php
+++ b/CRM/Civicase/APIHelpers/CasesByContactInvolved.php
@@ -5,10 +5,12 @@ class CRM_Civicase_APIHelpers_CasesByContactInvolved {
    * Adds joins and conditions to the given query in order to filter cases by
    * contact involvement.
    *
-   * @param CRM_Utils_SQL_Select $query the SQL object reference.
-   * @param Int|Array $contactInvolved the ID of the contact related to the case.
+   * @param CRM_Utils_SQL_Select $query
+   *   The SQL object reference.
+   * @param Int|Array $contactInvolved
+   *   The ID of the contact related to the case.
    */
-  static function filter($query, $contactInvolved) {
+  public static function filter($query, $contactInvolved) {
     if (!is_array($contactInvolved)) {
       $contactInvolved = ['=' => $contactInvolved];
     }

--- a/CRM/Civicase/APIHelpers/CasesByManager.php
+++ b/CRM/Civicase/APIHelpers/CasesByManager.php
@@ -5,10 +5,12 @@ class CRM_Civicase_APIHelpers_CasesByManager {
    * Adds joins and conditions to the given query in order to filter cases by
    * manager.
    *
-   * @param CRM_Utils_SQL_Select $query the SQL object reference.
-   * @param Int|Array $caseManager the ID of the case manager.
+   * @param CRM_Utils_SQL_Select $query
+   *   The SQL object reference.
+   * @param Int|Array $caseManager
+   *   The ID of the case manager.
    */
-  static function filter($query, $caseManager) {
+  public static function filter($query, $caseManager) {
     if (!is_array($caseManager)) {
       $caseManager = ['=' => $caseManager];
     }

--- a/CRM/Civicase/APIHelpers/CasesByManager.php
+++ b/CRM/Civicase/APIHelpers/CasesByManager.php
@@ -1,0 +1,19 @@
+<?php
+
+class CRM_Civicase_APIHelpers_CasesByManager {
+  /**
+   * Adds joins and conditions to the given query in order to filter cases by
+   * manager.
+   *
+   * @param CRM_Utils_SQL_Select $query the SQL object reference.
+   * @param Int|Array $caseManager the ID of the case manager.
+   */
+  static function filter($query, $caseManager) {
+    if (!is_array($caseManager)) {
+      $caseManager = ['=' => $caseManager];
+    }
+
+    \Civi\CCase\Utils::joinOnRelationship($query, 'manager');
+    $query->where(CRM_Core_DAO::createSQLFilter('manager.id', $caseManager));
+  }
+}

--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -7,7 +7,9 @@
       replace: true,
       templateUrl: '~/civicase/case/directives/case-overview.directive.html',
       controller: civicaseCaseOverviewController,
-      scope: {},
+      scope: {
+        caseFilter: '<'
+      },
       link: civicaseCaseOverviewLink
     };
 
@@ -54,8 +56,8 @@
         $scope.showBreakdown = false;
       }
 
+      $scope.$watch('caseFilter', loadStatsData, true);
       loadHiddenCaseStatuses();
-      loadStatsData();
     }());
 
     /**
@@ -131,7 +133,7 @@
     function loadStatsData () {
       var apiCalls = [];
 
-      apiCalls.push(['Case', 'getstats', {}]);
+      apiCalls.push(['Case', 'getstats', $scope.caseFilter || {}]);
       crmApi(apiCalls).then(function (response) {
         $scope.summaryData = response[0].values;
       });

--- a/ang/civicase/dashboard/directives/dashboard-tab.directive.html
+++ b/ang/civicase/dashboard/directives/dashboard-tab.directive.html
@@ -1,6 +1,8 @@
 <div class="civicase__dashboard__tab">
   <div class="civicase__dashboard__tab__top">
-    <civicase-case-overview></civicase-case-overview>
+    <civicase-case-overview
+      case-filter="activityFilters.case_filter"
+    ></civicase-case-overview>
   </div>
   <div class="civicase__dashboard__tab__main">
     <div class="civicase__dashboard__tab__col-wrapper">

--- a/api/v3/Case/Getstats.php
+++ b/api/v3/Case/Getstats.php
@@ -7,6 +7,16 @@
  * @return void
  */
 function _civicrm_api3_case_getstats_spec(&$spec) {
+  $spec['case_manager'] = array(
+    'title' => 'Case Manager',
+    'description' => 'Contact id of the case manager',
+    'type' => CRM_Utils_Type::T_INT,
+  );
+  $spec['contact_involved'] = array(
+    'title' => 'Contact Involved',
+    'description' => 'Id of the contact involved as case roles',
+    'type' => CRM_Utils_Type::T_INT,
+  );
   $spec['my_cases'] = array(
     'title' => 'My Cases',
     'description' => 'Limit stats to only my cases',
@@ -30,6 +40,14 @@ function civicrm_api3_case_getstats($params) {
   if (!empty($params['my_cases'])) {
     \Civi\CCase\Utils::joinOnRelationship($query, 'manager');
     $query->where('manager.id = ' . CRM_Core_Session::getLoggedInContactID());
+  }
+
+  if (!empty($params['case_manager'])) {
+    CRM_Civicase_APIHelpers_CasesByManager::filter($query, $params['case_manager']);
+  }
+
+  if (!empty($params['contact_involved'])) {
+    CRM_Civicase_APIHelpers_CasesByContactInvolved::filter($query, $params['contact_involved']);
   }
 
   $query->groupBy('a.case_type_id, a.status_id');

--- a/api/v3/Case/Getstats.php
+++ b/api/v3/Case/Getstats.php
@@ -26,10 +26,12 @@ function _civicrm_api3_case_getstats_spec(&$spec) {
 function civicrm_api3_case_getstats($params) {
   $query = CRM_Utils_SQL_Select::from('civicrm_case a');
   $query->select(array('a.case_type_id as case_type_id, a.status_id as status_id, COUNT(a.id) as count'));
+
   if (!empty($params['my_cases'])) {
-    \Civi\CCase\Utils::joinOnRelationship($sql, 'manager');
+    \Civi\CCase\Utils::joinOnRelationship($query, 'manager');
     $query->where('manager.id = ' . CRM_Core_Session::getLoggedInContactID());
   }
+
   $query->groupBy('a.case_type_id, a.status_id');
   if (!empty($params['check_permissions'])) {
     $permClauses = array_filter(CRM_Case_BAO_Case::getSelectWhereClause('a'));


### PR DESCRIPTION
## Overview
This PR automatically refreshes the case stats every time the case filters change.

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/61095347-1bdf3600-a421-11e9-8500-3c6437405ed9.gif)


## After
![pr-after](https://user-images.githubusercontent.com/1642119/61095315-eaff0100-a420-11e9-96b3-8663228880c0.gif)

## Technical details
The `Getstats` action had a regression issue introduced by https://github.com/compucorp/uk.co.compucorp.civicase/commit/6829b1a644ef778a62b8c1532041b27364977c23#diff-7e05760a6cb00db1b09138c9665389dfL30

As you can see, the new code is referencing the `$sql` variable when it meant to reference `$query`. This was fixed.

The `Getstats` API action only had filters to get stat data for the current logged in user, but it was missing filters for for an arbitrary manager, or an involved contact. The code from the `Getcasedetails` action was extracted into two helper classes:

```php
<?php
class CRM_Civicase_APIHelpers_CasesByManager {

  static function filter($query, $caseManager) {
    if (!is_array($caseManager)) {
      $caseManager = ['=' => $caseManager];
    }
    \Civi\CCase\Utils::joinOnRelationship($query, 'manager');
    $query->where(CRM_Core_DAO::createSQLFilter('manager.id', $caseManager));
  }
}
```

```php
<?php
class CRM_Civicase_APIHelpers_CasesByContactInvolved {
  static function filter($query, $contactInvolved) {
    if (!is_array($contactInvolved)) {
      $contactInvolved = ['=' => $contactInvolved];
    }
    $caseClient = CRM_Core_DAO::createSQLFilter('contact_id', $contactInvolved);
    $nonCaseClient = CRM_Core_DAO::createSQLFilter('involved.id', $contactInvolved);
    \Civi\CCase\Utils::joinOnRelationship($query, 'involved');
    $query->where("a.id IN (SELECT case_id FROM civicrm_case_contact WHERE ($nonCaseClient OR $caseClient))");
  }
}
```

These helpers were then implemented in both `Getcasedetails` and `Getstats` similarly to the following code:

```php
if (!empty($params['case_manager'])) {
  CRM_Civicase_APIHelpers_CasesByManager::filter($query, $params['case_manager']);
}

if (!empty($params['contact_involved'])) {
  CRM_Civicase_APIHelpers_CasesByContactInvolved::filter($query, $params['contact_involved']);
}
```

In the FE, the `case-overview` directive now accepts a `case-filter` parameter which is passed down to the `Getstats` action and also calls the action endpoint each time the values changes:

```js
(function init () {
  // init sequence ...
  $scope.$watch('caseFilter', loadStatsData, true);
}());

// ...

function loadStatsData () {
  var apiCalls = [];

  apiCalls.push(['Case', 'getstats', $scope.caseFilter || {}]); // here
  crmApi(apiCalls).then(function (response) {
    $scope.summaryData = response[0].values;
  });
}
```

## Comments

Manual tests were conduced to make sure everything that changed works as it should.