### PR TITLE
RSE-227: Modify Add Case Page To Show Custom Fields For Case Categories

### DIFF
--- a/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
+++ b/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
@@ -1,0 +1,30 @@
+<?php
+
+class CRM_Civicase_Hook_Helper_CaseTypeCategory {
+
+  /**
+   * Returns the case category for a case.
+   *
+   * @param int $caseTypeId
+   *
+   * @return int|null
+   */
+  public function getCategory($caseTypeId) {
+    $caseCategory = NULL;
+
+    if (empty($caseTypeId)) {
+      return $caseCategory;
+    }
+
+    $result = civicrm_api3('CaseType', 'getsingle', [
+      'return' => ['case_type_category'],
+      'id' => $caseTypeId,
+    ]);
+
+    if (!empty($result['case_type_category'])) {
+      $caseCategory = $result['case_type_category'];
+    }
+
+    return $caseCategory;
+  }
+}

--- a/CRM/Civicase/Hook/PostProcess/CaseCategoryCustomFieldsSaver.php
+++ b/CRM/Civicase/Hook/PostProcess/CaseCategoryCustomFieldsSaver.php
@@ -1,0 +1,48 @@
+<?php
+
+class CRM_Civicase_Hook_PostProcess_CaseCategoryCustomFieldsSaver {
+
+  /**
+   * Saves/Processes the Case category custom field values for the Case.
+   *
+   * @param string $formName
+   * @param CRM_Core_Form $form
+   */
+  public function run($formName, &$form) {
+    if (!$this->shouldRun($formName)) {
+      return;
+    }
+
+    $this->processCaseCategoryCustomFieldValues($form);
+  }
+
+  /**
+   * Caves the case category custom field values for the case.
+   *
+   * @param CRM_Core_Form $form
+   */
+  private function processCaseCategoryCustomFieldValues($form) {
+    $values = $form->_submitValues;
+    $customFieldValues = CRM_Core_BAO_CustomField::postProcess(
+      $values,
+      NULL,
+      'CaseCategory'
+    );
+
+    $caseTableName = CRM_Case_BAO_Case::getTableName();
+    if ($customFieldValues) {
+      CRM_Core_BAO_CustomValueTable::store($customFieldValues, $caseTableName, $form->_caseId);
+    }
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * @param string $formName
+   *
+   * @return bool
+   */
+  private function shouldRun($formName) {
+    return $formName == CRM_Case_Form_Case::class;
+  }
+}

--- a/CRM/Civicase/Hook/PreProcess/CaseCategoryCustomFieldsAdder.php
+++ b/CRM/Civicase/Hook/PreProcess/CaseCategoryCustomFieldsAdder.php
@@ -1,0 +1,47 @@
+<?php
+
+use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+
+class CRM_Civicase_Hook_PreProcess_CaseCategoryCustomFieldsAdder {
+
+  /**
+   * Adds the Case category custom field values for the Case Type
+   *
+   * @param string $formName
+   * @param CRM_Core_Form $form
+   */
+  public function run($formName, &$form) {
+    if (!$this->shouldRun($formName, $form)) {
+      return;
+    }
+
+    $this->addCaseCategoryCustomFields($form);
+  }
+
+  /**
+   * Determines if the hook will run. Will run if the form is the custom data type
+   * form and of type case. The form is responsible for adding custom fields for
+   * a case type.
+   *
+   * @param string $formName
+   * @param CRM_Core_Form $form
+   *
+   * @return bool
+   */
+  private function shouldRun($formName, &$form) {
+    return $formName == CRM_Custom_Form_CustomDataByType::class && $form->_type == 'Case';
+  }
+
+  /**
+   * Adds the custom fields for the case category of the case to the form.
+   *
+   * @param CRM_Core_Form $form
+   */
+  private function addCaseCategoryCustomFields(&$form) {
+    $form->_type = 'CaseCategory';
+    $caseTypeCategoryHelper = new CaseTypeCategoryHelper();
+    $caseCategoryId = $caseTypeCategoryHelper->getCategory($form->_subType);
+    CRM_Custom_Form_CustomData::setGroupTree($form, $caseCategoryId, $form->_groupID, $form->_onlySubtype);
+    $form->_type = 'Case';
+  }
+}

--- a/CRM/Civicase/Hook/PreProcess/CaseCategoryCustomFieldsSetDefaultValues.php
+++ b/CRM/Civicase/Hook/PreProcess/CaseCategoryCustomFieldsSetDefaultValues.php
@@ -1,0 +1,65 @@
+<?php
+
+use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+
+class CRM_Civicase_Hook_PreProcess_CaseCategoryCustomFieldsSetDefaultValues {
+
+  /**
+   * Sets the case category custom fields values in cache so that these values will be set as defaults
+   * when reloading the add case form or if the case form fails validation.
+   *
+   *
+   * @param string $formName
+   * @param CRM_Core_Form $form
+   */
+  public function run($formName, &$form) {
+    if (!$this->shouldRun($formName, $form)) {
+      return;
+    }
+
+    $this->setDefaultValuesForCaseCategoryCustomFields($form);
+  }
+
+  /**
+   * This function processes and sets default values for the case category custom fields. These
+   * values are stored in the cache and pre-poluoated on the Add case form particularly for situations
+   * where a case is being added and the form fails validation. Without this function the default values
+   * set for the Case Category custom fields will not be preserved and user will need to re-enter those
+   * values all over again.
+   *
+   * @param CRM_Core_Form $form
+   */
+  private function setDefaultValuesForCaseCategoryCustomFields($form) {
+    $caseTypeId = CRM_Utils_Array::value('case_type_id', CRM_Utils_Request::exportValues(), $form->_caseTypeId);
+    $caseTypeCategoryHelper = new CaseTypeCategoryHelper();
+    $caseCategoryId = $caseTypeCategoryHelper->getCategory($caseTypeId);
+
+    //hidden_custom will not be empty when custom field is being edited.
+    if (!$caseCategoryId || empty($_POST['hidden_custom'])) {
+      return;
+    }
+
+    $qfKey = $form->get_template_vars('qfKey');
+    $beforeCachedCustomDataValues = CRM_Core_BAO_Cache::getItem('custom data', $qfKey);
+    CRM_Custom_Form_CustomData::preProcess($form, NULL, $caseCategoryId, 1, 'CaseCategory');
+    $afterCachedCustomDataValues = CRM_Core_BAO_Cache::getItem('custom data', $qfKey);
+
+    //We need to do this because the cached data for the custom values will be overwritten with new values for
+    //Case category custom fields If we don't merge both data together.
+    if ($beforeCachedCustomDataValues != $afterCachedCustomDataValues) {
+      $combinedCachedCustomDataValues = array_merge($beforeCachedCustomDataValues, $afterCachedCustomDataValues);
+      CRM_Core_BAO_Cache::setItem($combinedCachedCustomDataValues, 'custom data', $qfKey);
+    }
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * @param string $formName
+   *
+   * @return bool
+   */
+  private function shouldRun($formName) {
+    return $formName == CRM_Case_Form_Case::class;
+  }
+}

--- a/CRM/Civicase/Setup/AddCaseCategoryCgExtendsValue.php
+++ b/CRM/Civicase/Setup/AddCaseCategoryCgExtendsValue.php
@@ -1,0 +1,23 @@
+<?php
+
+
+class CRM_Civicase_Setup_AddCaseCategoryCgExtendsValue {
+
+  /**
+   * Add the CaseCategory as a valid Entity that a custom group can extend.
+   *
+   * @return bool
+   */
+  public function apply() {
+    $caseCategoryLabel = 'CaseCategory';
+
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => 'cg_extend_objects',
+      'name' => 'civicrm_case_type',
+      'label' => $caseCategoryLabel,
+      'value' => $caseCategoryLabel,
+      'is_active' => TRUE,
+      'is_reserved' => TRUE,
+    ]);
+  }
+}

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -2,6 +2,7 @@
 
 use CRM_Civicase_Setup_CaseTypeCategorySupport as CaseTypeCategorySupport;
 use CRM_Civicase_Setup_CreateCasesOptionValue as CreateCasesOptionValue;
+use CRM_Civicase_Setup_AddCaseCategoryCgExtendsValue as AddCaseCategoryCgExtendsValue;
 
 /**
  * Collection of upgrade steps.
@@ -63,6 +64,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     $steps = [
       new CaseTypeCategorySupport(),
       new CreateCasesOptionValue(),
+      new AddCaseCategoryCgExtendsValue(),
     ];
     foreach ($steps as $step) {
       $step->apply();

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -443,7 +443,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
   public function enqueuePendingRevisions(CRM_Queue_Queue $queue) {
     $currentRevisionNum = (int) $this->getCurrentRevision();
     foreach ($this->getRevisions() as $revisionNum => $revisionClass) {
-      if ($revisionNum < $currentRevisionNum) {
+      if ($revisionNum <= $currentRevisionNum) {
         continue;
       }
       $tsParams = [1 => $this->extensionName, 2 => $revisionNum];

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_Civicase_Setup_CaseTypeCategorySupport as CaseTypeCategorySupport;
+use CRM_Civicase_Setup_CreateCasesOptionValue as CreateCasesOptionValue;
 
 /**
  * Collection of upgrade steps.

--- a/CRM/Civicase/Upgrader/Steps/Step0004.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0004.php
@@ -1,0 +1,18 @@
+<?php
+
+use CRM_Civicase_Setup_AddCaseCategoryCgExtendsValue as AddCaseCategoryCgExtendsValue;
+
+class CRM_Civicase_Upgrader_Steps_Step0004 {
+
+  /**
+   * Add the CaseCategory as a valid Entity that a custom group can extend.
+   *
+   * @return bool
+   */
+  public function apply() {
+    $step = new AddCaseCategoryCgExtendsValue();
+    $step->apply();
+
+    return TRUE;
+  }
+}

--- a/civicase.php
+++ b/civicase.php
@@ -664,6 +664,8 @@ function civicase_civicrm_preProcess($formName, &$form) {
     $hook->run($formName, $form);
   }
 
+  # TODO: We need to move this function into it's own class and implement as above.
+
   if ($formName == 'CRM_Admin_Form_Setting_Case') {
     $settings = $form->getVar('_settings');
     $settings['civicaseAllowCaseLocks'] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;

--- a/civicase.php
+++ b/civicase.php
@@ -419,6 +419,14 @@ function civicase_civicrm_validateForm($formName, &$fields, &$files, &$form, &$e
  * Implements hook_civicrm_postProcess().
  */
 function civicase_civicrm_postProcess($formName, &$form) {
+  $hooks = [
+    new CRM_Civicase_Hook_PostProcess_CaseCategoryCustomFieldsSaver(),
+  ];
+
+  foreach ($hooks as $hook) {
+    $hook->run($formName, $form);
+  }
+
   if (!empty($form->civicase_reload)) {
     $api = civicrm_api3('Case', 'getdetails', array('check_permissions' => 1) + $form->civicase_reload);
     $form->ajaxResponse['civicase_reload'] = $api['values'];
@@ -647,6 +655,15 @@ function civicase_civicrm_permission_check($permission, &$granted) {
  * Implements hook_civicrm_preProcess().
  */
 function civicase_civicrm_preProcess($formName, &$form) {
+  $hooks = [
+    new CRM_Civicase_Hook_PreProcess_CaseCategoryCustomFieldsAdder(),
+    new CRM_Civicase_Hook_PreProcess_CaseCategoryCustomFieldsSetDefaultValues(),
+  ];
+
+  foreach ($hooks as $hook) {
+    $hook->run($formName, $form);
+  }
+
   if ($formName == 'CRM_Admin_Form_Setting_Case') {
     $settings = $form->getVar('_settings');
     $settings['civicaseAllowCaseLocks'] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;


### PR DESCRIPTION
## Overview
This PR modifies the Add case page at `civicrm/case/add` to include custom fields for a case type category. 

## Before
This functionality does not exist.

## After
The Case category custom fields are added.
![CaseCategoryFields](https://user-images.githubusercontent.com/6951813/61235226-e8f0b700-a72c-11e9-9f2e-9b71ea14cab1.gif)


## Technical Details
- When fetching Case Type Custom fields to be added to the Add Case form, an additional check is added via a hook to check if the case type belongs to a case category that has custom fields. If there is, the custom fields are added as part of the custom fields set to be displayed on the form.
A function was added to the `CRM_Civicase_Hook_PreProcess_CaseCategoryCustomFieldsAdder` t take care of this
```php
  private function addCaseCategoryCustomFields(&$form) {
    $form->_type = 'CaseCategory';
    $caseTypeCategoryHelper = new CaseTypeCategoryHelper();
    $caseCategoryId = $caseTypeCategoryHelper->getCategory($form->_subType);
    CRM_Custom_Form_CustomData::setGroupTree($form, $caseCategoryId, $form->_groupID, $form->_onlySubtype);
    $form->_type = 'Case';
  }

```

- The post process hook is also invoked to save the Case category Custom field values for a new Case just added.
- When a Case form is saved and there are validation errors, the values previously entered for the Case Category custom fields were lost. The following function was added in PreProcess hook function for the Case Form class to fix the issue. It turned out that the cache is saved using the Case form qfkey and the Case Category custom fields values need to be saved in the cache too and also preserving the old values for the caches so that it does not get overrriden.

```php
  private function setDefaultValuesForCaseCategoryCustomFields($form) {
    $caseTypeId = CRM_Utils_Array::value('case_type_id', CRM_Utils_Request::exportValues(), $form->_caseTypeId);
    $caseTypeCategoryHelper = new CaseTypeCategoryHelper();
    $caseCategoryId = $caseTypeCategoryHelper->getCategory($caseTypeId);

    //hidden_custom will not be empty when custom field is being edited.
    if (!$caseCategoryId || empty($_POST['hidden_custom'])) {
      return;
    }

    $qfKey = $form->get_template_vars('qfKey');
    $beforeCachedCustomDataValues = CRM_Core_BAO_Cache::getItem('custom data', $qfKey);
    CRM_Custom_Form_CustomData::preProcess($form, NULL, $caseCategoryId, 1, 'CaseCategory');
    $afterCachedCustomDataValues = CRM_Core_BAO_Cache::getItem('custom data', $qfKey);

    //We need to do this because the cached data for the custom values will be overwritten with new values for
    //Case category custom fields If we don't merge both data together.
    if ($beforeCachedCustomDataValues != $afterCachedCustomDataValues) {
      $combinedCachedCustomDataValues = array_merge($beforeCachedCustomDataValues, $afterCachedCustomDataValues);
      CRM_Core_BAO_Cache::setItem($combinedCachedCustomDataValues, 'custom data', $qfKey);
    }
  }
```