### PR TITLE
RSE-184: Filter by Case Type Category in Manage Case

### DIFF
--- a/ang/civicase.ang.php
+++ b/ang/civicase.ang.php
@@ -1,96 +1,109 @@
 <?php
-// This file declares an Angular module which can be autoloaded
-// in CiviCRM. See also:
-// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
+
+/**
+ * @file
+ * Declares an Angular module which can be autoloaded in CiviCRM.
+ *
+ * See also:
+ * http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules.
+ */
+
+use Civi\CCase\Utils as Utils;
+
 Civi::resources()
-  ->addPermissions(array('administer CiviCase', 'administer CiviCRM',
-    'access all cases and activities', 'add cases', 'basic case information'))
+  ->addPermissions([
+    'administer CiviCase', 'administer CiviCRM',
+    'access all cases and activities', 'add cases', 'basic case information',
+  ])
   ->addScriptFile('org.civicrm.shoreditch', 'base/js/affix.js', 1000, 'html-header')
-  ->addSetting(array(
-    'config' => array(
+  ->addSetting([
+    'config' => [
       'enableComponents' => CRM_Core_Config::singleton()->enableComponents,
       'user_contact_id' => (int) CRM_Core_Session::getLoggedInContactID(),
-    ),
-  ));
-// The following changes are only relevant to the full-page app
+    ],
+  ]);
+// The following changes are only relevant to the full-page app.
 if (CRM_Utils_System::getUrlPath() == 'civicrm/case/a') {
-  // Add shoreditch custom css if not already present
-  if (!civicrm_api3('Setting', 'getvalue', array('name' => "customCSSURL"))) {
+  // Add shoreditch custom css if not already present.
+  if (!civicrm_api3('Setting', 'getvalue', ['name' => "customCSSURL"])) {
     Civi::resources()
       ->addStyleFile('org.civicrm.shoreditch', 'css/custom-civicrm.css', 99, 'html-header');
   }
   CRM_Utils_System::resetBreadCrumb();
-  $breadcrumb = array(
-    array(
+  $breadcrumb = [
+    [
       'title' => ts('Home'),
       'url' => CRM_Utils_System::url(),
-    ),
-    array(
+    ],
+    [
       'title' => ts('CiviCRM'),
       'url' => CRM_Utils_System::url('civicrm', 'reset=1'),
-    ),
-    array(
+    ],
+    [
       'title' => ts('Case Dashboard'),
       'url' => CRM_Utils_System::url('civicrm/case/a/#/case'),
-    ),
-  );
+    ],
+  ];
   CRM_Utils_System::appendBreadCrumb($breadcrumb);
 }
-$options = array(
+$options = [
   'activityTypes' => 'activity_type',
   'activityStatuses' => 'activity_status',
   'caseStatuses' => 'case_status',
   'priority' => 'priority',
   'activityCategories' => 'activity_category',
-);
+];
 foreach ($options as &$option) {
-  $result = civicrm_api3('OptionValue', 'get', array(
-    'return' => array('value', 'label', 'color', 'icon', 'name', 'grouping'),
+  $result = civicrm_api3('OptionValue', 'get', [
+    'return' => ['value', 'label', 'color', 'icon', 'name', 'grouping'],
     'option_group_id' => $option,
     'is_active' => 1,
-    'options' => array('limit' => 0, 'sort' => 'weight'),
-  ));
-  $option = array();
+    'options' => ['limit' => 0, 'sort' => 'weight'],
+  ]);
+  $option = [];
   foreach ($result['values'] as $item) {
     $key = $item['value'];
     CRM_Utils_Array::remove($item, 'id', 'value');
     $option[$key] = $item;
   }
 }
-$caseTypes = civicrm_api3('CaseType', 'get', array(
-  'return' => array('name', 'title', 'description', 'definition'),
-  'options' => array('limit' => 0, 'sort' => 'weight'),
+$caseTypes = civicrm_api3('CaseType', 'get', [
+  'return' => ['name', 'title', 'description', 'definition'],
+  'options' => ['limit' => 0, 'sort' => 'weight'],
   'is_active' => 1,
-));
+]);
 foreach ($caseTypes['values'] as &$item) {
   CRM_Utils_Array::remove($item, 'id', 'is_forkable', 'is_forked');
 }
 $options['caseTypes'] = $caseTypes['values'];
-$result = civicrm_api3('RelationshipType', 'get', array(
+$result = civicrm_api3('RelationshipType', 'get', [
   'is_active' => 1,
-  'options' => array('limit' => 0),
-));
+  'options' => ['limit' => 0],
+]);
 $options['relationshipTypes'] = $result['values'];
 $options['fileCategories'] = CRM_Civicase_FileCategory::getCategories();
-$options['activityStatusTypes'] = array(
+$options['activityStatusTypes'] = [
   'incomplete' => array_keys(\CRM_Activity_BAO_Activity::getStatusesByType(CRM_Activity_BAO_Activity::INCOMPLETE)),
   'completed' => array_keys(\CRM_Activity_BAO_Activity::getStatusesByType(CRM_Activity_BAO_Activity::COMPLETED)),
   'cancelled' => array_keys(\CRM_Activity_BAO_Activity::getStatusesByType(CRM_Activity_BAO_Activity::CANCELLED)),
-);
-$result = civicrm_api3('CustomGroup', 'get', array(
+];
+$result = civicrm_api3('CustomGroup', 'get', [
   'sequential' => 1,
-  'return' => array('extends_entity_column_value', 'title', 'extends'),
-  'extends' => array('IN' => array('Case', 'Activity')),
+  'return' => ['extends_entity_column_value', 'title', 'extends'],
+  'extends' => ['IN' => ['Case', 'Activity']],
   'is_active' => 1,
-  'options' => array('sort' => 'weight'),
-  'api.CustomField.get' => array(
+  'options' => ['sort' => 'weight'],
+  'api.CustomField.get' => [
     'is_active' => 1,
     'is_searchable' => 1,
-    'return' => array('label', 'html_type', 'data_type', 'is_search_range', 'filter', 'option_group_id'),
-    'options' => array('sort' => 'weight'),
-  ),
-));
-$options['customSearchFields'] = $options['customActivityFields'] = array();
+    'return' => [
+      'label', 'html_type', 'data_type', 'is_search_range',
+      'filter', 'option_group_id',
+    ],
+    'options' => ['sort' => 'weight'],
+  ],
+]);
+$options['customSearchFields'] = $options['customActivityFields'] = [];
 foreach ($result['values'] as $group) {
   if (!empty($group['api.CustomField.get']['values'])) {
     if ($group['extends'] == 'Case') {
@@ -98,100 +111,101 @@ foreach ($result['values'] as $group) {
         $group['caseTypes'] = CRM_Utils_Array::collect('name', array_values(array_intersect_key($caseTypes['values'], array_flip($group['extends_entity_column_value']))));
       }
       foreach ($group['api.CustomField.get']['values'] as $field) {
-        $group['fields'][] = Civi\CCase\Utils::formatCustomSearchField($field);
+        $group['fields'][] = Utils::formatCustomSearchField($field);
       }
       unset($group['api.CustomField.get']);
       $options['customSearchFields'][] = $group;
     }
     else {
       foreach ($group['api.CustomField.get']['values'] as $field) {
-        $options['customActivityFields'][] = Civi\CCase\Utils::formatCustomSearchField($field) + array('group' => $group['title']);
+        $options['customActivityFields'][] = Utils::formatCustomSearchField($field) + ['group' => $group['title']];
       }
     }
   }
 }
-// Case tags
+// Case tags.
 $options['tags'] = CRM_Core_BAO_Tag::getColorTags('civicrm_case');
-$options['tagsets'] = CRM_Utils_Array::value('values', civicrm_api3('Tag', 'get', array(
+$options['tagsets'] = CRM_Utils_Array::value('values', civicrm_api3('Tag', 'get', [
   'sequential' => 1,
-  'return' => array("id", "name"),
-  'used_for' => array('LIKE' => "%civicrm_case%"),
+  'return' => ["id", "name"],
+  'used_for' => ['LIKE' => "%civicrm_case%"],
   'is_tagset' => 1,
-)));
-// Bulk actions for case list - we put this here so it can be modified by other extensions
-$options['caseActions'] = array(
-  array(
+]));
+// Bulk actions for case list.
+// we put this here so it can be modified by other extensions.
+$options['caseActions'] = [
+  [
     'title' => ts('Change Case Status'),
     'action' => 'changeStatus(cases)',
     'icon' => 'fa-pencil-square-o',
-  ),
-  array(
+  ],
+  [
     'title' => ts('Edit Tags'),
     'action' => 'editTags(cases[0])',
     'icon' => 'fa-tags',
     'number' => 1,
-  ),
-  array(
+  ],
+  [
     'title' => ts('Print Case'),
     'action' => 'print(cases[0])',
     'number' => 1,
     'icon' => 'fa-print',
-  ),
-  array(
+  ],
+  [
     'title' => ts('Email Case Manager'),
     'action' => 'emailManagers(cases)',
     'icon' => 'fa-envelope-o',
-  ),
-  array(
+  ],
+  [
     'title' => ts('Print/Merge Document'),
     'action' => 'printMerge(cases)',
     'icon' => 'fa-file-pdf-o',
-  ),
-  array(
+  ],
+  [
     'title' => ts('Export Cases'),
     'action' => 'exportCases(cases)',
     'icon' => 'fa-file-excel-o',
-  ),
-  array(
+  ],
+  [
     'title' => ts('Link Cases'),
     'action' => 'linkCases(cases[0])',
     'number' => 1,
     'icon' => 'fa-link',
-  ),
-  array(
+  ],
+  [
     'title' => ts('Link 2 Cases'),
     'action' => 'linkCases(cases[0], cases[1])',
     'number' => 2,
     'icon' => 'fa-link',
-  ),
-);
+  ],
+];
 if (CRM_Core_Permission::check('administer CiviCase')) {
-  $options['caseActions'][] = array(
+  $options['caseActions'][] = [
     'title' => ts('Merge 2 Cases'),
     'number' => 2,
     'action' => 'mergeCases(cases)',
     'icon' => 'fa-compress',
-  );
-  $options['caseActions'][] = array(
+  ];
+  $options['caseActions'][] = [
     'title' => ts('Lock Case'),
     'action' => 'lockCases(cases[0])',
     'number' => 1,
     'icon' => 'fa-lock',
-  );
+  ];
 }
 if (CRM_Core_Permission::check('delete in CiviCase')) {
-  $options['caseActions'][] = array(
+  $options['caseActions'][] = [
     'title' => ts('Delete Case'),
     'action' => 'deleteCases(cases)',
     'icon' => 'fa-trash',
-  );
+  ];
 }
-// Add webforms with cases attached to menu
-$items = array();
+// Add webforms with cases attached to menu.
+$items = [];
 
 $webformsToDisplay = Civi::settings()->get('civi_drupal_webforms');
 if (isset($webformsToDisplay)) {
-  $allowedWebforms = array();
+  $allowedWebforms = [];
   foreach ($webformsToDisplay as $webformNode) {
     $allowedWebforms[] = $webformNode['nid'];
   }
@@ -202,26 +216,26 @@ if (isset($webformsToDisplay)) {
         continue;
       }
 
-      $client = getClientDeltaFromWebform($webform['nid']);
+      $client = get_client_delta_from_webform($webform['nid']);
 
-      $items[] = array(
+      $items[] = [
         'title' => $webform['title'],
-        'action' => 'gotoWebform(cases[0], "' . $webform['path'] . '", '.$client.')',
+        'action' => 'gotoWebform(cases[0], "' . $webform['path'] . '", ' . $client . ')',
         'icon' => 'fa-link',
-      );
+      ];
     }
-    $options['caseActions'][] = array(
+    $options['caseActions'][] = [
       'title' => ts('Webforms'),
       'action' => '',
       'icon' => 'fa-file-text-o',
       'items' => $items,
-    );
+    ];
   }
 }
 
-// Contact tasks
+// Contact tasks.
 $contactTasks = CRM_Contact_Task::permissionedTaskTitles(CRM_Core_Permission::getPermission());
-$options['contactTasks'] = array();
+$options['contactTasks'] = [];
 foreach (CRM_Contact_Task::$_tasks as $id => $value) {
   if (isset($contactTasks[$id]) && isset($value['url'])) {
     $options['contactTasks'][$id] = $value;
@@ -231,43 +245,49 @@ foreach (CRM_Contact_Task::$_tasks as $id => $value) {
 $options['allowMultipleCaseClients'] = (bool) Civi::settings()->get('civicaseAllowMultipleClients');
 $options['allowCaseLocks'] = (bool) Civi::settings()->get('civicaseAllowCaseLocks');
 
-// Retrieve civicase webform URL
+// Retrieve civicase webform URL.
 $allowCaseWebform = Civi::settings()->get('civicaseAllowCaseWebform');
 $options['newCaseWebformUrl'] = $allowCaseWebform ? Civi::settings()->get('civicaseWebformUrl') : NULL;
 $options['newCaseWebformClient'] = 'cid';
 if ($options['newCaseWebformUrl']) {
   $path = explode('/', $options['newCaseWebformUrl']);
   $nid = array_pop($path);
-  $client = getClientDeltaFromWebform($nid);
+  $client = get_client_delta_from_webform($nid);
   if ($client) {
     $options['newCaseWebformClient'] = 'cid' . $client;
   }
 }
 
 if (!function_exists('glob_recursive')) {
+
   /**
-   * Recursive Glob function
+   * Recursive Glob function.
+   *
    * Source: http://php.net/manual/en/function.glob.php#106595
-   * Does not support flag GLOB_BRACE
+   * Does not support flag GLOB_BRACE.
    */
   function glob_recursive($pattern, $flags = 0) {
     $files = glob($pattern, $flags);
 
-    foreach (glob(dirname($pattern) . '/*', GLOB_ONLYDIR|GLOB_NOSORT) as $dir) {
+    foreach (glob(dirname($pattern) . '/*', GLOB_ONLYDIR | GLOB_NOSORT) as $dir) {
       $files = array_merge($files, glob_recursive($dir . '/' . basename($pattern), $flags));
     }
 
     return $files;
   }
+
 }
 
 /**
- * Returns the contact number which is configured as client for a given webform id.
+ * Returns the contact number of the client for given webform id.
  *
- * @param {int} $webform_id
+ * @param int $webform_id
+ *   Webform id.
+ *
  * @return int
+ *   Contact Number.
  */
-function getClientDeltaFromWebform($webform_id) {
+function get_client_delta_from_webform($webform_id) {
   $node = node_load($webform_id);
   $data = $node->webform_civicrm['data'];
   $client = 0;
@@ -280,26 +300,34 @@ function getClientDeltaFromWebform($webform_id) {
 }
 
 /**
- * Get a list of JS files
+ * Get a list of JS files.
  */
-function getJSFiles () {
-  return array_merge(array(
-    'assetBuilder://visual-bundle.js', // at the moment, it's safe to include this multiple times -- deduped by resource manager
-    'ang/civicase.js'
-  ), glob_recursive(dirname(__FILE__) . '/civicase/*.js'));
+function get_js_files() {
+  return array_merge([
+    // At the moment, it's safe to include this multiple times.
+    // deduped by resource manager.
+    'assetBuilder://visual-bundle.js',
+    'ang/civicase.js',
+  ], glob_recursive(dirname(__FILE__) . '/civicase/*.js'));
 }
 
-return array(
-  'js' => getJSFiles(),
-  'css' => array(
-    'assetBuilder://visual-bundle.css', // at the moment, it's safe to include this multiple times -- deduped by resource manager
+return [
+  'js' => get_js_files(),
+  'css' => [
+    // At the moment, it's safe to include this multiple times.
+    // deduped by resource manager.
+    'assetBuilder://visual-bundle.css',
     'css/*.css',
     'ang/civicase/*.css',
-  ),
-  'partials' => array(
+  ],
+  'partials' => [
     'ang/civicase',
-  ),
+  ],
   'settings' => $options,
-  'requires' => array('crmAttachment', 'crmUi', 'crmUtil', 'ngRoute', 'angularFileUpload', 'bw.paging', 'crmRouteBinder', 'crmResource', 'ui.bootstrap', 'uibTabsetClass', 'dialogService'),
-  'basePages' => array(),
-);
+  'requires' => [
+    'crmAttachment', 'crmUi', 'crmUtil', 'ngRoute', 'angularFileUpload',
+    'bw.paging', 'crmRouteBinder', 'crmResource', 'ui.bootstrap',
+    'uibTabsetClass', 'dialogService',
+  ],
+  'basePages' => [],
+];

--- a/ang/civicase.ang.php
+++ b/ang/civicase.ang.php
@@ -10,42 +10,14 @@
 
 use Civi\CCase\Utils as Utils;
 
-Civi::resources()
-  ->addPermissions([
-    'administer CiviCase', 'administer CiviCRM',
-    'access all cases and activities', 'add cases', 'basic case information',
-  ])
-  ->addScriptFile('org.civicrm.shoreditch', 'base/js/affix.js', 1000, 'html-header')
-  ->addSetting([
-    'config' => [
-      'enableComponents' => CRM_Core_Config::singleton()->enableComponents,
-      'user_contact_id' => (int) CRM_Core_Session::getLoggedInContactID(),
-    ],
-  ]);
+load_resources();
+
 // The following changes are only relevant to the full-page app.
 if (CRM_Utils_System::getUrlPath() == 'civicrm/case/a') {
-  // Add shoreditch custom css if not already present.
-  if (!civicrm_api3('Setting', 'getvalue', ['name' => "customCSSURL"])) {
-    Civi::resources()
-      ->addStyleFile('org.civicrm.shoreditch', 'css/custom-civicrm.css', 99, 'html-header');
-  }
-  CRM_Utils_System::resetBreadCrumb();
-  $breadcrumb = [
-    [
-      'title' => ts('Home'),
-      'url' => CRM_Utils_System::url(),
-    ],
-    [
-      'title' => ts('CiviCRM'),
-      'url' => CRM_Utils_System::url('civicrm', 'reset=1'),
-    ],
-    [
-      'title' => ts('Case Dashboard'),
-      'url' => CRM_Utils_System::url('civicrm/case/a/#/case'),
-    ],
-  ];
-  CRM_Utils_System::appendBreadCrumb($breadcrumb);
+  adds_shoreditch_css();
+  update_breadcrumbs();
 }
+
 $options = [
   'activityTypes' => 'activity_type',
   'activityStatuses' => 'activity_status',
@@ -53,210 +25,18 @@ $options = [
   'priority' => 'priority',
   'activityCategories' => 'activity_category',
 ];
-foreach ($options as &$option) {
-  $result = civicrm_api3('OptionValue', 'get', [
-    'return' => ['value', 'label', 'color', 'icon', 'name', 'grouping'],
-    'option_group_id' => $option,
-    'is_active' => 1,
-    'options' => ['limit' => 0, 'sort' => 'weight'],
-  ]);
-  $option = [];
-  foreach ($result['values'] as $item) {
-    $key = $item['value'];
-    CRM_Utils_Array::remove($item, 'id', 'value');
-    $option[$key] = $item;
-  }
-}
-$caseTypes = civicrm_api3('CaseType', 'get', [
-  'return' => ['name', 'title', 'description', 'definition'],
-  'options' => ['limit' => 0, 'sort' => 'weight'],
-  'is_active' => 1,
-]);
-foreach ($caseTypes['values'] as &$item) {
-  CRM_Utils_Array::remove($item, 'id', 'is_forkable', 'is_forked');
-}
-$options['caseTypes'] = $caseTypes['values'];
-$result = civicrm_api3('RelationshipType', 'get', [
-  'is_active' => 1,
-  'options' => ['limit' => 0],
-]);
-$options['relationshipTypes'] = $result['values'];
-$options['fileCategories'] = CRM_Civicase_FileCategory::getCategories();
-$options['activityStatusTypes'] = [
-  'incomplete' => array_keys(\CRM_Activity_BAO_Activity::getStatusesByType(CRM_Activity_BAO_Activity::INCOMPLETE)),
-  'completed' => array_keys(\CRM_Activity_BAO_Activity::getStatusesByType(CRM_Activity_BAO_Activity::COMPLETED)),
-  'cancelled' => array_keys(\CRM_Activity_BAO_Activity::getStatusesByType(CRM_Activity_BAO_Activity::CANCELLED)),
-];
-$result = civicrm_api3('CustomGroup', 'get', [
-  'sequential' => 1,
-  'return' => ['extends_entity_column_value', 'title', 'extends'],
-  'extends' => ['IN' => ['Case', 'Activity']],
-  'is_active' => 1,
-  'options' => ['sort' => 'weight'],
-  'api.CustomField.get' => [
-    'is_active' => 1,
-    'is_searchable' => 1,
-    'return' => [
-      'label', 'html_type', 'data_type', 'is_search_range',
-      'filter', 'option_group_id',
-    ],
-    'options' => ['sort' => 'weight'],
-  ],
-]);
-$options['customSearchFields'] = $options['customActivityFields'] = [];
-foreach ($result['values'] as $group) {
-  if (!empty($group['api.CustomField.get']['values'])) {
-    if ($group['extends'] == 'Case') {
-      if (!empty($group['extends_entity_column_value'])) {
-        $group['caseTypes'] = CRM_Utils_Array::collect('name', array_values(array_intersect_key($caseTypes['values'], array_flip($group['extends_entity_column_value']))));
-      }
-      foreach ($group['api.CustomField.get']['values'] as $field) {
-        $group['fields'][] = Utils::formatCustomSearchField($field);
-      }
-      unset($group['api.CustomField.get']);
-      $options['customSearchFields'][] = $group;
-    }
-    else {
-      foreach ($group['api.CustomField.get']['values'] as $field) {
-        $options['customActivityFields'][] = Utils::formatCustomSearchField($field) + ['group' => $group['title']];
-      }
-    }
-  }
-}
-// Case tags.
-$options['tags'] = CRM_Core_BAO_Tag::getColorTags('civicrm_case');
-$options['tagsets'] = CRM_Utils_Array::value('values', civicrm_api3('Tag', 'get', [
-  'sequential' => 1,
-  'return' => ["id", "name"],
-  'used_for' => ['LIKE' => "%civicrm_case%"],
-  'is_tagset' => 1,
-]));
-// Bulk actions for case list.
-// we put this here so it can be modified by other extensions.
-$options['caseActions'] = [
-  [
-    'title' => ts('Change Case Status'),
-    'action' => 'changeStatus(cases)',
-    'icon' => 'fa-pencil-square-o',
-  ],
-  [
-    'title' => ts('Edit Tags'),
-    'action' => 'editTags(cases[0])',
-    'icon' => 'fa-tags',
-    'number' => 1,
-  ],
-  [
-    'title' => ts('Print Case'),
-    'action' => 'print(cases[0])',
-    'number' => 1,
-    'icon' => 'fa-print',
-  ],
-  [
-    'title' => ts('Email Case Manager'),
-    'action' => 'emailManagers(cases)',
-    'icon' => 'fa-envelope-o',
-  ],
-  [
-    'title' => ts('Print/Merge Document'),
-    'action' => 'printMerge(cases)',
-    'icon' => 'fa-file-pdf-o',
-  ],
-  [
-    'title' => ts('Export Cases'),
-    'action' => 'exportCases(cases)',
-    'icon' => 'fa-file-excel-o',
-  ],
-  [
-    'title' => ts('Link Cases'),
-    'action' => 'linkCases(cases[0])',
-    'number' => 1,
-    'icon' => 'fa-link',
-  ],
-  [
-    'title' => ts('Link 2 Cases'),
-    'action' => 'linkCases(cases[0], cases[1])',
-    'number' => 2,
-    'icon' => 'fa-link',
-  ],
-];
-if (CRM_Core_Permission::check('administer CiviCase')) {
-  $options['caseActions'][] = [
-    'title' => ts('Merge 2 Cases'),
-    'number' => 2,
-    'action' => 'mergeCases(cases)',
-    'icon' => 'fa-compress',
-  ];
-  $options['caseActions'][] = [
-    'title' => ts('Lock Case'),
-    'action' => 'lockCases(cases[0])',
-    'number' => 1,
-    'icon' => 'fa-lock',
-  ];
-}
-if (CRM_Core_Permission::check('delete in CiviCase')) {
-  $options['caseActions'][] = [
-    'title' => ts('Delete Case'),
-    'action' => 'deleteCases(cases)',
-    'icon' => 'fa-trash',
-  ];
-}
-// Add webforms with cases attached to menu.
-$items = [];
 
-$webformsToDisplay = Civi::settings()->get('civi_drupal_webforms');
-if (isset($webformsToDisplay)) {
-  $allowedWebforms = [];
-  foreach ($webformsToDisplay as $webformNode) {
-    $allowedWebforms[] = $webformNode['nid'];
-  }
-  $webforms = civicrm_api3('Case', 'getwebforms');
-  if (isset($webforms['values'])) {
-    foreach ($webforms['values'] as $webform) {
-      if (!in_array($webform['nid'], $allowedWebforms)) {
-        continue;
-      }
-
-      $client = get_client_delta_from_webform($webform['nid']);
-
-      $items[] = [
-        'title' => $webform['title'],
-        'action' => 'gotoWebform(cases[0], "' . $webform['path'] . '", ' . $client . ')',
-        'icon' => 'fa-link',
-      ];
-    }
-    $options['caseActions'][] = [
-      'title' => ts('Webforms'),
-      'action' => '',
-      'icon' => 'fa-file-text-o',
-      'items' => $items,
-    ];
-  }
-}
-
-// Contact tasks.
-$contactTasks = CRM_Contact_Task::permissionedTaskTitles(CRM_Core_Permission::getPermission());
-$options['contactTasks'] = [];
-foreach (CRM_Contact_Task::$_tasks as $id => $value) {
-  if (isset($contactTasks[$id]) && isset($value['url'])) {
-    $options['contactTasks'][$id] = $value;
-  }
-}
-// Exposed settings:
-$options['allowMultipleCaseClients'] = (bool) Civi::settings()->get('civicaseAllowMultipleClients');
-$options['allowCaseLocks'] = (bool) Civi::settings()->get('civicaseAllowCaseLocks');
-
-// Retrieve civicase webform URL.
-$allowCaseWebform = Civi::settings()->get('civicaseAllowCaseWebform');
-$options['newCaseWebformUrl'] = $allowCaseWebform ? Civi::settings()->get('civicaseWebformUrl') : NULL;
-$options['newCaseWebformClient'] = 'cid';
-if ($options['newCaseWebformUrl']) {
-  $path = explode('/', $options['newCaseWebformUrl']);
-  $nid = array_pop($path);
-  $client = get_client_delta_from_webform($nid);
-  if ($client) {
-    $options['newCaseWebformClient'] = 'cid' . $client;
-  }
-}
+set_option_values_to_js_vars($options);
+set_case_types_to_js_vars($options);
+set_relationship_types_to_js_vars($options);
+set_file_categories_to_js_vars($options);
+set_activity_status_types_to_js_vars($options);
+set_custom_fields_info_to_js_vars($options);
+set_tags_to_js_vars($options);
+set_case_actions($options);
+set_contact_tasks($options);
+expose_settings($options);
+retrieve_civicase_webform_url($options);
 
 if (!function_exists('glob_recursive')) {
 
@@ -276,6 +56,56 @@ if (!function_exists('glob_recursive')) {
     return $files;
   }
 
+}
+
+/**
+ * Loads Resources.
+ */
+function load_resources() {
+  Civi::resources()
+    ->addPermissions([
+      'administer CiviCase', 'administer CiviCRM',
+      'access all cases and activities', 'add cases', 'basic case information',
+    ])
+    ->addScriptFile('org.civicrm.shoreditch', 'base/js/affix.js', 1000, 'html-header')
+    ->addSetting([
+      'config' => [
+        'enableComponents' => CRM_Core_Config::singleton()->enableComponents,
+        'user_contact_id' => (int) CRM_Core_Session::getLoggedInContactID(),
+      ],
+    ]);
+}
+
+/**
+ * Add shoreditch custom css if not already present.
+ */
+function adds_shoreditch_css() {
+  if (!civicrm_api3('Setting', 'getvalue', ['name' => "customCSSURL"])) {
+    Civi::resources()
+      ->addStyleFile('org.civicrm.shoreditch', 'css/custom-civicrm.css', 99, 'html-header');
+  }
+}
+
+/**
+ * Update Breadcrumbs.
+ */
+function update_breadcrumbs() {
+  CRM_Utils_System::resetBreadCrumb();
+  $breadcrumb = [
+    [
+      'title' => ts('Home'),
+      'url' => CRM_Utils_System::url(),
+    ],
+    [
+      'title' => ts('CiviCRM'),
+      'url' => CRM_Utils_System::url('civicrm', 'reset=1'),
+    ],
+    [
+      'title' => ts('Case Dashboard'),
+      'url' => CRM_Utils_System::url('civicrm/case/a/#/case'),
+    ],
+  ];
+  CRM_Utils_System::appendBreadCrumb($breadcrumb);
 }
 
 /**
@@ -309,6 +139,278 @@ function get_js_files() {
     'assetBuilder://visual-bundle.js',
     'ang/civicase.js',
   ], glob_recursive(dirname(__FILE__) . '/civicase/*.js'));
+}
+
+/**
+ * Sets the case types to javascript global variable.
+ */
+function set_case_types_to_js_vars(&$options) {
+  $caseTypes = civicrm_api3('CaseType', 'get', [
+    'return' => ['name', 'title', 'description', 'definition'],
+    'options' => ['limit' => 0, 'sort' => 'weight'],
+    'is_active' => 1,
+  ]);
+  foreach ($caseTypes['values'] as &$item) {
+    CRM_Utils_Array::remove($item, 'id', 'is_forkable', 'is_forked');
+  }
+  $options['caseTypes'] = $caseTypes['values'];
+}
+
+/**
+ * Sets the relationship types to javascript global variable.
+ */
+function set_relationship_types_to_js_vars(&$options) {
+  $result = civicrm_api3('RelationshipType', 'get', [
+    'is_active' => 1,
+    'options' => ['limit' => 0],
+  ]);
+  $options['relationshipTypes'] = $result['values'];
+}
+
+/**
+ * Sets the tags and tagsets to javascript global variable.
+ */
+function set_tags_to_js_vars(&$options) {
+  $options['tags'] = CRM_Core_BAO_Tag::getColorTags('civicrm_case');
+  $options['tagsets'] = CRM_Utils_Array::value('values', civicrm_api3('Tag', 'get', [
+    'sequential' => 1,
+    'return' => ["id", "name"],
+    'used_for' => ['LIKE' => "%civicrm_case%"],
+    'is_tagset' => 1,
+  ]));
+}
+
+/**
+ * Sets the option values to javascript global variable.
+ */
+function set_option_values_to_js_vars(&$options) {
+  foreach ($options as &$option) {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'return' => ['value', 'label', 'color', 'icon', 'name', 'grouping'],
+      'option_group_id' => $option,
+      'is_active' => 1,
+      'options' => ['limit' => 0, 'sort' => 'weight'],
+    ]);
+    $option = [];
+    foreach ($result['values'] as $item) {
+      $key = $item['value'];
+      CRM_Utils_Array::remove($item, 'id', 'value');
+      $option[$key] = $item;
+    }
+  }
+}
+
+/**
+ * Sets the file categories to javascript global variable.
+ */
+function set_file_categories_to_js_vars(&$options) {
+  $options['fileCategories'] = CRM_Civicase_FileCategory::getCategories();
+}
+
+/**
+ * Sets the activity status types to javascript global variable.
+ */
+function set_activity_status_types_to_js_vars(&$options) {
+  $options['activityStatusTypes'] = [
+    'incomplete' => array_keys(\CRM_Activity_BAO_Activity::getStatusesByType(CRM_Activity_BAO_Activity::INCOMPLETE)),
+    'completed' => array_keys(\CRM_Activity_BAO_Activity::getStatusesByType(CRM_Activity_BAO_Activity::COMPLETED)),
+    'cancelled' => array_keys(\CRM_Activity_BAO_Activity::getStatusesByType(CRM_Activity_BAO_Activity::CANCELLED)),
+  ];
+}
+
+/**
+ * Sets the custom fields information to javascript global variable.
+ */
+function set_custom_fields_info_to_js_vars(&$options) {
+  $result = civicrm_api3('CustomGroup', 'get', [
+    'sequential' => 1,
+    'return' => ['extends_entity_column_value', 'title', 'extends'],
+    'extends' => ['IN' => ['Case', 'Activity']],
+    'is_active' => 1,
+    'options' => ['sort' => 'weight'],
+    'api.CustomField.get' => [
+      'is_active' => 1,
+      'is_searchable' => 1,
+      'return' => [
+        'label', 'html_type', 'data_type', 'is_search_range',
+        'filter', 'option_group_id',
+      ],
+      'options' => ['sort' => 'weight'],
+    ],
+  ]);
+  $options['customSearchFields'] = $options['customActivityFields'] = [];
+  foreach ($result['values'] as $group) {
+    if (!empty($group['api.CustomField.get']['values'])) {
+      if ($group['extends'] == 'Case') {
+        if (!empty($group['extends_entity_column_value'])) {
+          $group['caseTypes'] = CRM_Utils_Array::collect('name', array_values(array_intersect_key($caseTypes['values'], array_flip($group['extends_entity_column_value']))));
+        }
+        foreach ($group['api.CustomField.get']['values'] as $field) {
+          $group['fields'][] = Utils::formatCustomSearchField($field);
+        }
+        unset($group['api.CustomField.get']);
+        $options['customSearchFields'][] = $group;
+      }
+      else {
+        foreach ($group['api.CustomField.get']['values'] as $field) {
+          $options['customActivityFields'][] = Utils::formatCustomSearchField($field) + ['group' => $group['title']];
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Bulk actions for case list.
+ *
+ * We put this here so it can be modified by other extensions.
+ */
+function set_case_actions(&$options) {
+  $options['caseActions'] = [
+    [
+      'title' => ts('Change Case Status'),
+      'action' => 'changeStatus(cases)',
+      'icon' => 'fa-pencil-square-o',
+    ],
+    [
+      'title' => ts('Edit Tags'),
+      'action' => 'editTags(cases[0])',
+      'icon' => 'fa-tags',
+      'number' => 1,
+    ],
+    [
+      'title' => ts('Print Case'),
+      'action' => 'print(cases[0])',
+      'number' => 1,
+      'icon' => 'fa-print',
+    ],
+    [
+      'title' => ts('Email Case Manager'),
+      'action' => 'emailManagers(cases)',
+      'icon' => 'fa-envelope-o',
+    ],
+    [
+      'title' => ts('Print/Merge Document'),
+      'action' => 'printMerge(cases)',
+      'icon' => 'fa-file-pdf-o',
+    ],
+    [
+      'title' => ts('Export Cases'),
+      'action' => 'exportCases(cases)',
+      'icon' => 'fa-file-excel-o',
+    ],
+    [
+      'title' => ts('Link Cases'),
+      'action' => 'linkCases(cases[0])',
+      'number' => 1,
+      'icon' => 'fa-link',
+    ],
+    [
+      'title' => ts('Link 2 Cases'),
+      'action' => 'linkCases(cases[0], cases[1])',
+      'number' => 2,
+      'icon' => 'fa-link',
+    ],
+  ];
+  if (CRM_Core_Permission::check('administer CiviCase')) {
+    $options['caseActions'][] = [
+      'title' => ts('Merge 2 Cases'),
+      'number' => 2,
+      'action' => 'mergeCases(cases)',
+      'icon' => 'fa-compress',
+    ];
+    $options['caseActions'][] = [
+      'title' => ts('Lock Case'),
+      'action' => 'lockCases(cases[0])',
+      'number' => 1,
+      'icon' => 'fa-lock',
+    ];
+  }
+  if (CRM_Core_Permission::check('delete in CiviCase')) {
+    $options['caseActions'][] = [
+      'title' => ts('Delete Case'),
+      'action' => 'deleteCases(cases)',
+      'icon' => 'fa-trash',
+    ];
+  }
+
+  add_webforms_case_action($options);
+}
+
+/**
+ * Add webforms with cases attached to menu.
+ */
+function add_webforms_case_action(&$options) {
+  $items = [];
+
+  $webformsToDisplay = Civi::settings()->get('civi_drupal_webforms');
+  if (isset($webformsToDisplay)) {
+    $allowedWebforms = [];
+    foreach ($webformsToDisplay as $webformNode) {
+      $allowedWebforms[] = $webformNode['nid'];
+    }
+    $webforms = civicrm_api3('Case', 'getwebforms');
+    if (isset($webforms['values'])) {
+      foreach ($webforms['values'] as $webform) {
+        if (!in_array($webform['nid'], $allowedWebforms)) {
+          continue;
+        }
+
+        $client = get_client_delta_from_webform($webform['nid']);
+
+        $items[] = [
+          'title' => $webform['title'],
+          'action' => 'gotoWebform(cases[0], "' . $webform['path'] . '", ' . $client . ')',
+          'icon' => 'fa-link',
+        ];
+      }
+      $options['caseActions'][] = [
+        'title' => ts('Webforms'),
+        'action' => '',
+        'icon' => 'fa-file-text-o',
+        'items' => $items,
+      ];
+    }
+  }
+}
+
+/**
+ * Sets contact tasks.
+ */
+function set_contact_tasks(&$options) {
+  $contactTasks = CRM_Contact_Task::permissionedTaskTitles(CRM_Core_Permission::getPermission());
+  $options['contactTasks'] = [];
+  foreach (CRM_Contact_Task::$_tasks as $id => $value) {
+    if (isset($contactTasks[$id]) && isset($value['url'])) {
+      $options['contactTasks'][$id] = $value;
+    }
+  }
+}
+
+/**
+ * Expose settings.
+ */
+function expose_settings(&$options) {
+  $options['allowMultipleCaseClients'] = (bool) Civi::settings()->get('civicaseAllowMultipleClients');
+  $options['allowCaseLocks'] = (bool) Civi::settings()->get('civicaseAllowCaseLocks');
+}
+
+/**
+ * Retrieve civicase webform url.
+ */
+function retrieve_civicase_webform_url(&$options) {
+  // Retrieve civicase webform URL.
+  $allowCaseWebform = Civi::settings()->get('civicaseAllowCaseWebform');
+  $options['newCaseWebformUrl'] = $allowCaseWebform ? Civi::settings()->get('civicaseWebformUrl') : NULL;
+  $options['newCaseWebformClient'] = 'cid';
+  if ($options['newCaseWebformUrl']) {
+    $path = explode('/', $options['newCaseWebformUrl']);
+    $nid = array_pop($path);
+    $client = get_client_delta_from_webform($nid);
+    if ($client) {
+      $options['newCaseWebformClient'] = 'cid' . $client;
+    }
+  }
 }
 
 return [

--- a/ang/civicase.ang.php
+++ b/ang/civicase.ang.php
@@ -24,6 +24,7 @@ $options = [
   'caseStatuses' => 'case_status',
   'priority' => 'priority',
   'activityCategories' => 'activity_category',
+  'caseTypeCategories' => 'case_type_categories',
 ];
 
 set_option_values_to_js_vars($options);
@@ -146,7 +147,9 @@ function get_js_files() {
  */
 function set_case_types_to_js_vars(&$options) {
   $caseTypes = civicrm_api3('CaseType', 'get', [
-    'return' => ['name', 'title', 'description', 'definition'],
+    'return' => [
+      'name', 'title', 'description', 'definition', 'case_type_category',
+    ],
     'options' => ['limit' => 0, 'sort' => 'weight'],
     'is_active' => 1,
   ]);
@@ -194,7 +197,7 @@ function set_option_values_to_js_vars(&$options) {
     $option = [];
     foreach ($result['values'] as $item) {
       $key = $item['value'];
-      CRM_Utils_Array::remove($item, 'id', 'value');
+      CRM_Utils_Array::remove($item, 'id');
       $option[$key] = $item;
     }
   }

--- a/ang/civicase/case/list/directives/case-list-table.directive.js
+++ b/ang/civicase/case/list/directives/case-list-table.directive.js
@@ -319,7 +319,9 @@
       var params = {'case_type_id.is_active': 1};
       _.each(filters, function (val, filter) {
         if (val || typeof val === 'boolean') {
-          if (typeof val === 'number' || typeof val === 'boolean') {
+          if (filter === 'case_type_category') {
+            params['case_type_id.case_type_category'] = val;
+          } else if (typeof val === 'number' || typeof val === 'boolean') {
             params[filter] = val;
           } else if (typeof val === 'object' && !$.isArray(val)) {
             params[filter] = val;

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -24,47 +24,23 @@
     var ts = $scope.ts = CRM.ts('civicase');
     var caseTypes = CRM.civicase.caseTypes;
     var caseStatuses = CRM.civicase.caseStatuses;
+    var caseTypeCategories = CRM.civicase.caseTypeCategories;
     var allSearchFields = {
-      id: {
-        label: ts('Case ID'),
-        html_type: 'Number'
-      },
-      has_role: {
-        label: ts('Contact Search')
-      },
-      case_manager: {
-        label: ts('Case Manager')
-      },
-      start_date: {
-        label: ts('Start Date')
-      },
-      end_date: {
-        label: ts('End Date')
-      },
-      is_deleted: {
-        label: ts('Deleted Cases')
-      },
-      tag_id: {
-        label: ts('Tags')
-      }
+      id: { label: ts('Case ID'), html_type: 'Number' },
+      has_role: { label: ts('Contact Search') },
+      case_manager: { label: ts('Case Manager') },
+      start_date: { label: ts('Start Date') },
+      end_date: { label: ts('End Date') },
+      is_deleted: { label: ts('Deleted Cases') },
+      tag_id: { label: ts('Tags') }
     };
     var caseRelationshipConfig = [
-      {
-        'text': 'All Cases',
-        'id': 'all'
-      },
-      {
-        'text': 'My cases',
-        'id': 'is_case_manager'
-      },
-      {
-        'text': 'Cases I am involved',
-        'id': 'is_involved'
-      }
+      { 'text': 'All Cases', 'id': 'all' },
+      { 'text': 'My cases', 'id': 'is_case_manager' },
+      { 'text': 'Cases I am involved', 'id': 'is_involved' }
     ];
 
     $scope.pageTitle = '';
-    $scope.caseTypeOptions = _.map(caseTypes, mapSelectOptions);
     $scope.caseStatusOptions = _.map(caseStatuses, mapSelectOptions);
     $scope.customGroups = CRM.civicase.customSearchFields;
     $scope.caseRelationshipOptions = caseRelationshipConfig;
@@ -82,6 +58,7 @@
 
     (function init () {
       bindRouteParamsToScope();
+      setCaseTypesBasedOnCategory();
       initiateWatchers();
       initSubscribers();
       setCustomSearchFieldsAsSearchFilters();
@@ -282,6 +259,8 @@
      * Only works when dropdown is unexpanded
      */
     function filtersWatcher () {
+      setCaseTypesBasedOnCategory();
+
       if (!$scope.expanded) {
         $scope.doSearch();
       }
@@ -300,6 +279,7 @@
     function initiateWatchers () {
       $scope.$watch('expanded', expandedWatcher);
       $scope.$watch('relationshipType', relationshipTypeWatcher);
+      $scope.$watch('caseTypeCategory', setCaseTypesBasedOnCategory);
       $scope.$watchCollection('filters', filtersWatcher);
       $scope.$watchCollection('contactRoleFilter', caseRoleWatcher);
     }
@@ -342,6 +322,29 @@
         .then(function (caseRolesResponse) {
           return caseRolesResponse.values;
         });
+    }
+
+    /**
+     * Sets the Case Types Based on Case Type Category
+     */
+    function setCaseTypesBasedOnCategory () {
+      var filteredCaseTypes = caseTypes;
+
+      if ($scope.filters.case_type_category) {
+        var caseTypeCategory = _.find(caseTypeCategories, function (category) {
+          return category.name.toLowerCase() === $scope.filters.case_type_category.toLowerCase();
+        });
+      }
+
+      if ($scope.filters.case_type_category) {
+        filteredCaseTypes = _.chain(caseTypes)
+          .filter(function (caseType) {
+            return caseType.case_type_category === caseTypeCategory.value;
+          })
+          .value();
+      }
+
+      $scope.caseTypeOptions = _.map(filteredCaseTypes, mapSelectOptions);
     }
 
     /**

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -267,6 +267,28 @@
     }
 
     /**
+     * Returns case types filtered by given category
+     *
+     * @param {String} categoryName
+     * @return {Array}
+     */
+    function getCaseTypesFilteredByCategory (categoryName) {
+      var filteredCaseTypes = [];
+
+      var caseTypeCategory = _.find(caseTypeCategories, function (category) {
+        return category.name.toLowerCase() === $scope.filters.case_type_category.toLowerCase();
+      });
+
+      if (caseTypeCategory) {
+        filteredCaseTypes = _.filter(caseTypes, function (caseType) {
+          return caseType.case_type_category === caseTypeCategory.value;
+        });
+      }
+
+      return filteredCaseTypes;
+    }
+
+    /**
      * All subscribers are initiated here
      */
     function initSubscribers () {
@@ -328,21 +350,9 @@
      * Sets the Case Types Based on Case Type Category
      */
     function setCaseTypesBasedOnCategory () {
-      var filteredCaseTypes = caseTypes;
-
-      if ($scope.filters.case_type_category) {
-        var caseTypeCategory = _.find(caseTypeCategories, function (category) {
-          return category.name.toLowerCase() === $scope.filters.case_type_category.toLowerCase();
-        });
-      }
-
-      if ($scope.filters.case_type_category) {
-        filteredCaseTypes = _.chain(caseTypes)
-          .filter(function (caseType) {
-            return caseType.case_type_category === caseTypeCategory.value;
-          })
-          .value();
-      }
+      var filteredCaseTypes = $scope.filters.case_type_category
+        ? getCaseTypesFilteredByCategory($scope.filters.case_type_category)
+        : caseTypes;
 
       $scope.caseTypeOptions = _.map(filteredCaseTypes, mapSelectOptions);
     }

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -273,19 +273,17 @@
      * @return {Array}
      */
     function getCaseTypesFilteredByCategory (categoryName) {
-      var filteredCaseTypes = [];
-
       var caseTypeCategory = _.find(caseTypeCategories, function (category) {
-        return category.name.toLowerCase() === $scope.filters.case_type_category.toLowerCase();
+        return category.name.toLowerCase() === categoryName.toLowerCase();
       });
 
-      if (caseTypeCategory) {
-        filteredCaseTypes = _.filter(caseTypes, function (caseType) {
-          return caseType.case_type_category === caseTypeCategory.value;
-        });
+      if (!caseTypeCategory) {
+        return [];
       }
 
-      return filteredCaseTypes;
+      return _.filter(caseTypes, function (caseType) {
+        return caseType.case_type_category === caseTypeCategory.value;
+      });
     }
 
     /**


### PR DESCRIPTION
## Overview
As part of this PR, filtering by case type category is added to `Manage Cases` page.

## Before
![before](https://user-images.githubusercontent.com/5058867/61355930-f758e300-a892-11e9-81b2-8b7acca2aaa1.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/61356016-1788a200-a893-11e9-852e-ec7e2999d267.gif)

## Technical Details
1. Linting fixes and refactoring has been done to `civicase.ang.php`. All the code has been moved to separate small functions to make it more manageable.

**Filtering using Case Type Category**
1. Case type categories Option Values has been exposed to frontend global variable named `CRM.civicase.caseTypeCategories`.
2. The Case category value for each case type is exposed using the existing `CRM.civicase.caseTypes` global variable.
3. A new function `setCaseTypesBasedOnCategory` is created, which is called at init, and also when `filters` are changed. It checked if the `case_type_category` filter is present, and filters the `CaseTypes` for that category.
4. `case-list-table.directive.js` reads the `case_type_category` filter value which is set from `search.directive.js`, and loads the cases from the same case category into the Manage Cases Page.