### PR TITLE
RSE-181:  Filter Available Case Types By Category Value In URL On Add Case Form

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/CaseClientPopulator.php
+++ b/CRM/Civicase/Hook/BuildForm/CaseClientPopulator.php
@@ -9,7 +9,7 @@ class CRM_Civicase_Hook_BuildForm_CaseClientPopulator {
    *
    * @param CRM_Core_Form $form
    */
-  public function run(&$form) {
+  public function run(CRM_Core_Form &$form, $formName) {
     $clientId = CRM_Utils_Request::retrieve('civicase_cid', 'Positive');
 
     if (!$this->shouldRun($form, $clientId)) {

--- a/CRM/Civicase/Hook/BuildForm/CaseClientPopulator.php
+++ b/CRM/Civicase/Hook/BuildForm/CaseClientPopulator.php
@@ -1,13 +1,21 @@
 <?php
 
+/**
+ * CRM_Civicase_Hook_BuildForm_CaseClientPopulator class.
+ */
 class CRM_Civicase_Hook_BuildForm_CaseClientPopulator {
 
   /**
-   * Runs the Case Client populator hook for the Case Form. When a client id
-   * is provided as a request parameter, it adds this value to the client id
-   * field of the form.
+   * Runs the Case Client populator hook for the Case Form.
+   *
+   * When a client id is provided as a request parameter,
+   *
+   * It adds this value to the client id field of the form.
    *
    * @param CRM_Core_Form $form
+   *   Form object class.
+   * @param string $formName
+   *   Form name.
    */
   public function run(CRM_Core_Form &$form, $formName) {
     $clientId = CRM_Utils_Request::retrieve('civicase_cid', 'Positive');
@@ -20,13 +28,18 @@ class CRM_Civicase_Hook_BuildForm_CaseClientPopulator {
   }
 
   /**
-   * Determines if the hook will run. This hook is only valid for the Case form
-   * and the civicase client id parameter must be defined.
+   * Determines if the hook will run.
+   *
+   * This hook is only valid for the Case form.
+   *
+   * The civicase client id parameter must be defined.
    *
    * @param CRM_Core_Form $form
-   * @param INT|NULL $clientId
+   *   Form class.
+   * @param INT|null $clientId
+   *   Case Client ID.
    */
-  public function shouldRun($form, $clientId) {
+  public function shouldRun(CRM_Core_Form $form, $clientId) {
     $isCaseForm = CRM_Case_Form_Case::class === get_class($form);
 
     return $isCaseForm && $clientId;

--- a/CRM/Civicase/Hook/BuildForm/FilterCaseTypeByCategory.php
+++ b/CRM/Civicase/Hook/BuildForm/FilterCaseTypeByCategory.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * CRM_Civicase_Hook_BuildForm_FilterCaseTypeByCategory class.
+ */
+class CRM_Civicase_Hook_BuildForm_FilterCaseTypeByCategory {
+
+  /**
+   * Filters the options for the case type select element based on the category.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   * @param string $formName
+   *   Form Name.
+   */
+  public function run(CRM_Core_Form &$form, $formName) {
+    $caseCategoryName = CRM_Utils_Request::retrieve('category', 'String');
+    if (!$this->shouldRun($formName, $caseCategoryName)) {
+      return;
+    }
+
+    $this->filterCaseTypeOptionValues($form, $caseCategoryName);
+  }
+
+  /**
+   * Filters the options for the case type select element based on the category.
+   *
+   * @param CRM_Core_Form $form
+   *   Form class object.
+   * @param string $caseCategoryName
+   *   Case category name.
+   */
+  private function filterCaseTypeOptionValues(CRM_Core_Form $form, $caseCategoryName) {
+    $caseTypesInCategory = $this->getCaseTypesForCategory($caseCategoryName);
+
+    if (!$caseTypesInCategory) {
+      return;
+    }
+
+    $caseTypeIdElement = &$form->getElement('case_type_id');
+    $options = $caseTypeIdElement->_options;
+
+    foreach ($options as $key => $option) {
+      $optionValue = $option['attr']['value'];
+      if (!in_array($optionValue, $caseTypesInCategory) && $optionValue) {
+        unset($options[$key]);
+      }
+    }
+
+    $caseTypeIdElement->_options = $options;
+  }
+
+  /**
+   * Returns the case type ids for a case type category.
+   *
+   * @param string $caseCategoryName
+   *   Case category name.
+   *
+   * @return array|null
+   *   The case type id's e.g [1, 2, 3]
+   */
+  private function getCaseTypesForCategory($caseCategoryName) {
+    try {
+      $result = civicrm_api3('CaseType', 'get', [
+        'return' => ['id'],
+        'case_type_category' => $caseCategoryName,
+      ]);
+
+      if ($result['count'] == 0) {
+        return NULL;
+      }
+
+      return array_column($result['values'], 'id');
+    }
+    catch (Exception $e) {
+    }
+
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * @param string $formName
+   *   Form name.
+   * @param string $caseCategoryName
+   *   Case category name.
+   *
+   * @return bool
+   *   returns a boolean to determine if hook will run or not.
+   */
+  private function shouldRun($formName, $caseCategoryName) {
+    $isCaseForm = $formName == CRM_Case_Form_Case::class;
+
+    return $isCaseForm && $caseCategoryName;
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * @file
+ * Extension file.
+ */
+
+use Civi\Angular\AngularLoader;
+
 require_once 'civicase.civix.php';
 
 /**
@@ -18,30 +25,30 @@ function civicase_civicrm_tabset($tabsetName, &$tabs, $context) {
         if ($tab['id'] === 'case') {
           $caseTabPresent = TRUE;
           $useAng = TRUE;
-          $tab['url'] = CRM_Utils_System::url('civicrm/case/contact-case-tab', array(
+          $tab['url'] = CRM_Utils_System::url('civicrm/case/contact-case-tab', [
             'cid' => $context['contact_id'],
-          ));
+          ]);
         }
         if ($tab['id'] === 'activity') {
           $useAng = TRUE;
-          $tab['url'] = CRM_Utils_System::url('civicrm/case/contact-act-tab', array(
+          $tab['url'] = CRM_Utils_System::url('civicrm/case/contact-act-tab', [
             'cid' => $context['contact_id'],
-          ));
+          ]);
         }
       }
 
       if (!$caseTabPresent && CRM_Core_Permission::check('basic case information')) {
         $useAng = TRUE;
-        $tabs[] = array(
+        $tabs[] = [
           'id' => 'case',
-          'url' => CRM_Utils_System::url('civicrm/case/contact-case-tab', array(
+          'url' => CRM_Utils_System::url('civicrm/case/contact-case-tab', [
             'cid' => $context['contact_id'],
-          )),
+          ]),
           'title' => ts('Cases'),
           'weight' => 20,
           'count' => CRM_Contact_BAO_Contact::getCountComponent('case', $context['contact_id']),
           'class' => 'livePage',
-        );
+        ];
       }
 
       break;
@@ -49,9 +56,9 @@ function civicase_civicrm_tabset($tabsetName, &$tabs, $context) {
   }
 
   if ($useAng) {
-    $loader = new \Civi\Angular\AngularLoader();
+    $loader = new AngularLoader();
     $loader->setPageName('civicrm/case/a');
-    $loader->setModules(array('civicase'));
+    $loader->setModules(['civicase']);
     $loader->load();
   }
 }
@@ -69,7 +76,7 @@ function civicase_civicrm_config(&$config) {
   }
   Civi::$statics[__FUNCTION__] = 1;
 
-  Civi::dispatcher()->addListener('civi.api.prepare', array('CRM_Civicase_ActivityFilter', 'onPrepare'), 10);
+  Civi::dispatcher()->addListener('civi.api.prepare', ['CRM_Civicase_ActivityFilter', 'onPrepare'], 10);
 }
 
 /**
@@ -207,49 +214,53 @@ function civicase_civicrm_buildForm($formName, &$form) {
     $hook->run($form, $formName);
   }
 
-  // Display category option for activity types and activity statuses
-  if ($formName == 'CRM_Admin_Form_Options' && in_array($form->getVar('_gName'), array('activity_type', 'activity_status'))) {
-    $options = civicrm_api3('optionValue', 'get', array(
+  // Display category option for activity types and activity statuses.
+  if ($formName == 'CRM_Admin_Form_Options' && in_array($form->getVar('_gName'), ['activity_type', 'activity_status'])) {
+    $options = civicrm_api3('optionValue', 'get', [
       'option_group_id' => 'activity_category',
       'is_active' => 1,
-      'options' => array('limit' => 0, 'sort' => 'weight'),
-    ));
-    $opts = array();
+      'options' => ['limit' => 0, 'sort' => 'weight'],
+    ]);
+    $opts = [];
     if ($form->getVar('_gName') == 'activity_status') {
       $placeholder = ts('All');
-      // Activity status can also apply to uncategorized activities
-      $opts[] = array(
+      // Activity status can also apply to uncategorized activities.
+      $opts[] = [
         'id' => 'none',
         'text' => ts('Uncategorized'),
-      );
+      ];
     }
     else {
       $placeholder = ts('Uncategorized');
     }
     foreach ($options['values'] as $opt) {
-      $opts[] = array(
+      $opts[] = [
         'id' => $opt['name'],
         'text' => $opt['label'],
-      );
+      ];
     }
-    $form->add('select2', 'grouping', ts('Activity Category'), $opts, FALSE, array('class' => 'crm-select2', 'multiple' => TRUE, 'placeholder' => $placeholder));
+    $form->add('select2', 'grouping', ts('Activity Category'), $opts, FALSE, [
+      'class' => 'crm-select2',
+      'multiple' => TRUE,
+      'placeholder' => $placeholder,
+    ]);
   }
-  // Only show relevant statuses when editing an activity
+  // Only show relevant statuses when editing an activity.
   if (is_a($form, 'CRM_Activity_Form_Activity') && $form->_action & (CRM_Core_Action::ADD + CRM_Core_Action::UPDATE)) {
     if (!empty($form->_activityTypeId) && $form->elementExists('status_id')) {
       $el = $form->getElement('status_id');
-      $cat = civicrm_api3('OptionValue', 'getsingle', array(
+      $cat = civicrm_api3('OptionValue', 'getsingle', [
         'return' => 'grouping',
         'option_group_id' => "activity_type",
         'value' => $form->_activityTypeId,
-      ));
-      $cat = !empty($cat['grouping']) ? explode(',', $cat['grouping']) : array('none');
-      $options = civicrm_api3('OptionValue', 'get', array(
-        'return' => array('label', 'value', 'grouping'),
+      ]);
+      $cat = !empty($cat['grouping']) ? explode(',', $cat['grouping']) : ['none'];
+      $options = civicrm_api3('OptionValue', 'get', [
+        'return' => ['label', 'value', 'grouping'],
         'option_group_id' => "activity_status",
-        'options' => array('limit' => 0, 'sort' => 'weight'),
-      ));
-      $newOptions = $el->_options = array();
+        'options' => ['limit' => 0, 'sort' => 'weight'],
+      ]);
+      $newOptions = $el->_options = [];
       $newOptions[''] = ts('- select -');
       foreach ($options['values'] as $option) {
         if (empty($option['grouping']) || array_intersect($cat, explode(',', $option['grouping']))) {
@@ -259,21 +270,21 @@ function civicase_civicrm_buildForm($formName, &$form) {
       $el->loadArray($newOptions);
     }
   }
-  // If js requests a refresh of case data pass that request along
+  // If js requests a refresh of case data pass that request along.
   if (!empty($_REQUEST['civicase_reload'])) {
     $form->civicase_reload = json_decode($_REQUEST['civicase_reload'], TRUE);
   }
-  // Add save draft button to Communication activities
-  $specialForms = array('CRM_Contact_Form_Task_PDF', 'CRM_Contact_Form_Task_Email');
-  $specialTypes = array('Print PDF Letter', 'Email');
+  // Add save draft button to Communication activities.
+  $specialForms = ['CRM_Contact_Form_Task_PDF', 'CRM_Contact_Form_Task_Email'];
+  $specialTypes = ['Print PDF Letter', 'Email'];
   if (is_a($form, 'CRM_Activity_Form_Activity') || in_array($formName, $specialForms)) {
     $activityTypeId = $form->getVar('_activityTypeId');
     if ($activityTypeId) {
-      $activityType = civicrm_api3('OptionValue', 'getvalue', array(
+      $activityType = civicrm_api3('OptionValue', 'getvalue', [
         'return' => "name",
         'option_group_id' => "activity_type",
         'value' => $activityTypeId,
-      ));
+      ]);
     }
     else {
       $activityType = $formName == 'CRM_Contact_Form_Task_PDF' ? 'Print PDF Letter' : 'Email';
@@ -281,33 +292,37 @@ function civicase_civicrm_buildForm($formName, &$form) {
     $id = $form->getVar('_activityId');
     $status = NULL;
     if ($id) {
-      $status = civicrm_api3('Activity', 'getsingle', array('id' => $id, 'return' => 'status_id.name'));
+      $status = civicrm_api3('Activity', 'getsingle', ['id' => $id, 'return' => 'status_id.name']);
       $status = $status['status_id.name'];
     }
-    $checkParams = array('option_group_id' => 'activity_type', 'grouping' => array('LIKE' => '%communication%'), 'value' => $activityTypeId);
+    $checkParams = [
+      'option_group_id' => 'activity_type',
+      'grouping' => ['LIKE' => '%communication%'],
+      'value' => $activityTypeId,
+    ];
     if (in_array($activityType, $specialTypes) || ($activityTypeId && civicrm_api3('OptionValue', 'getcount', $checkParams))) {
       if ($form->_action & (CRM_Core_Action::ADD + CRM_Core_Action::UPDATE)) {
         $buttonGroup = $form->getElement('buttons');
         $buttons = $buttonGroup->getElements();
-        $buttons[] = $form->createElement('submit', $form->getButtonName('refresh'), ts('Save Draft'), array(
+        $buttons[] = $form->createElement('submit', $form->getButtonName('refresh'), ts('Save Draft'), [
           'crm-icon' => 'fa-pencil-square-o',
           'class' => 'crm-form-submit',
-        ));
+        ]);
         $buttonGroup->setElements($buttons);
         $form->addGroup($buttons, 'buttons');
-        $form->setDefaults(array('status_id' => 2));
+        $form->setDefaults(['status_id' => 2]);
       }
       if ($status == 'Draft' && ($form->_action & CRM_Core_Action::VIEW)) {
         if (in_array($activityType, $specialTypes)) {
           $atype = $activityType == 'Email' ? 'email' : 'pdf';
-          $caseId = civicrm_api3('Activity', 'getsingle', array('id' => $id, 'return' => 'case_id'));
-          $composeUrl = CRM_Utils_System::url("civicrm/activity/$atype/add", array(
+          $caseId = civicrm_api3('Activity', 'getsingle', ['id' => $id, 'return' => 'case_id']);
+          $composeUrl = CRM_Utils_System::url("civicrm/activity/$atype/add", [
             'action' => 'add',
             'reset' => 1,
             'caseId' => $caseId['case_id'][0],
             'context' => 'standalone',
             'draft_id' => $id,
-          ));
+          ]);
           $buttonMarkup = '<a class="button" href="' . $composeUrl . '"><i class="crm-i fa-pencil-square-o"></i> &nbsp;' . ts('Continue Editing') . '</a>';
           $form->assign('activityTypeDescription', $buttonMarkup);
         }
@@ -316,26 +331,34 @@ function civicase_civicrm_buildForm($formName, &$form) {
         }
       }
     }
-    // Form email/print activities, set defaults from the original draft activity (which will be deleted on submit)
+    // Form email/print activities, set defaults from the original draft
+    // activity (which will be deleted on submit)
     if (in_array($formName, $specialForms) && !empty($_GET['draft_id'])) {
-      $draft = civicrm_api3('Activity', 'get', array('id' => $_GET['draft_id'], 'check_permissions' => TRUE, 'sequential' => TRUE));
+      $draft = civicrm_api3('Activity', 'get', [
+        'id' => $_GET['draft_id'],
+        'check_permissions' => TRUE,
+        'sequential' => TRUE,
+      ]);
       $form->setVar('_activityId', $_GET['draft_id']);
       if (isset($draft['values'][0])) {
         $draft = $draft['values'][0];
         if (in_array($formName, $specialForms)) {
           $draft['html_message'] = CRM_Utils_Array::value('details', $draft);
         }
-        // Set defaults for to email addresses
+        // Set defaults for to email addresses.
         if ($formName == 'CRM_Contact_Form_Task_Email') {
-          $cids = CRM_Utils_Array::value('target_contact_id', civicrm_api3('Activity', 'getsingle', array('id' => $draft['id'], 'return' => 'target_contact_id')));
+          $cids = CRM_Utils_Array::value('target_contact_id', civicrm_api3('Activity', 'getsingle', ['id' => $draft['id'], 'return' => 'target_contact_id']));
           if ($cids) {
-            $toContacts = civicrm_api3('Contact', 'get', array('id' => array('IN' => $cids), 'return' => array('email', 'sort_name')));
-            $toArray = array();
+            $toContacts = civicrm_api3('Contact', 'get', [
+              'id' => ['IN' => $cids],
+              'return' => ['email', 'sort_name'],
+            ]);
+            $toArray = [];
             foreach ($toContacts['values'] as $cid => $contact) {
-              $toArray[] = array(
+              $toArray[] = [
                 'text' => '"' . $contact['sort_name'] . '" <' . $contact['email'] . '>',
                 'id' => "$cid::{$contact['email']}",
-              );
+              ];
             }
             $form->assign('toContact', json_encode($toArray));
           }
@@ -353,7 +376,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterContent/
  */
-function civicase_civicrm_alterContent (&$content, $context, $templateName, $form) {
+function civicase_civicrm_alterContent(&$content, $context, $templateName, $form) {
   $isViewingTheCaseAdminForm = get_class($form) === CRM_Admin_Form_Setting_Case::class;
 
   if (!$isViewingTheCaseAdminForm) {
@@ -374,8 +397,9 @@ function civicase_civicrm_alterContent (&$content, $context, $templateName, $for
  */
 function civicase_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
   // Save draft feature
-  // The validate stage provides an opportunity to bypass normal form processing, save the draft & return early
-  $specialForms = array('CRM_Contact_Form_Task_PDF', 'CRM_Contact_Form_Task_Email');
+  // The validate stage provides an opportunity to bypass normal
+  // form processing, save the draft & return early.
+  $specialForms = ['CRM_Contact_Form_Task_PDF', 'CRM_Contact_Form_Task_Email'];
   if (is_a($form, 'CRM_Activity_Form_Activity') || in_array($formName, $specialForms)) {
     if (array_key_exists($form->getButtonName('refresh'), $fields['buttons'])) {
       $activityType = $form->getVar('_activityTypeId');
@@ -383,12 +407,12 @@ function civicase_civicrm_validateForm($formName, &$fields, &$files, &$form, &$e
       if (!$activityType) {
         $activityType = $formName == 'CRM_Contact_Form_Task_PDF' ? 'Print PDF Letter' : 'Email';
       }
-      $params = array(
+      $params = [
         'activity_type_id' => $activityType,
         'status_id' => 'Draft',
         'case_id' => $caseId,
         'id' => $form->getVar('_activityId'),
-      );
+      ];
       if (in_array($formName, $specialForms)) {
         $params['details'] = CRM_Utils_Array::value('html_message', $fields);
       }
@@ -404,9 +428,9 @@ function civicase_civicrm_validateForm($formName, &$fields, &$files, &$form, &$e
       $session->pushUserContext($url);
       CRM_Core_Session::setStatus('Activity saved as a draft', ts('Saved'), 'success');
       if (CRM_Utils_Array::value('snippet', $_GET) === 'json') {
-        $response = array();
+        $response = [];
         if (!empty($form->civicase_reload)) {
-          $api = civicrm_api3('Case', 'getdetails', array('check_permissions' => 1) + $form->civicase_reload);
+          $api = civicrm_api3('Case', 'getdetails', ['check_permissions' => 1] + $form->civicase_reload);
           $response['civicase_reload'] = $api['values'];
         }
         CRM_Core_Page_AJAX::returnJsonResponse($response);
@@ -429,16 +453,16 @@ function civicase_civicrm_postProcess($formName, &$form) {
   }
 
   if (!empty($form->civicase_reload)) {
-    $api = civicrm_api3('Case', 'getdetails', array('check_permissions' => 1) + $form->civicase_reload);
+    $api = civicrm_api3('Case', 'getdetails', ['check_permissions' => 1] + $form->civicase_reload);
     $form->ajaxResponse['civicase_reload'] = $api['values'];
   }
   // When emailing/printing - delete draft.
-  $specialForms = array('CRM_Contact_Form_Task_PDF', 'CRM_Contact_Form_Task_Email');
+  $specialForms = ['CRM_Contact_Form_Task_PDF', 'CRM_Contact_Form_Task_Email'];
   if (in_array($formName, $specialForms)) {
     $urlParams = parse_url(htmlspecialchars_decode($form->controller->_entryURL), PHP_URL_QUERY);
     parse_str($urlParams, $urlParams);
     if (!empty($urlParams['draft_id'])) {
-      civicrm_api3('Activity', 'delete', array('id' => $urlParams['draft_id']));
+      civicrm_api3('Activity', 'delete', ['id' => $urlParams['draft_id']]);
     }
   }
 }
@@ -447,10 +471,10 @@ function civicase_civicrm_postProcess($formName, &$form) {
  * Implements hook_civicrm_permission().
  */
 function civicase_civicrm_permission(&$permissions) {
-  $permissions['basic case information'] = array(
+  $permissions['basic case information'] = [
     'Civicase: basic case information',
     ts('Allows a user to view only basic information of cases.'),
-  );
+  ];
 }
 
 /**
@@ -468,34 +492,34 @@ function civicase_civicrm_apiWrappers(&$wrappers, $apiRequest) {
  * @link https://docs.civicrm.org/dev/en/master/hooks/hook_civicrm_alterAPIPermissions/
  */
 function civicase_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
-  $permissions['case']['getfiles'] = array(
-    array('access my cases and activities', 'access all cases and activities'),
+  $permissions['case']['getfiles'] = [
+    ['access my cases and activities', 'access all cases and activities'],
     'access uploaded files',
-  );
+  ];
 
-  $permissions['case']['get'] = array(
-    array(
+  $permissions['case']['get'] = [
+    [
       'access my cases and activities',
       'access all cases and activities',
       'basic case information',
-    ),
-  );
+    ],
+  ];
 
-  $permissions['case']['getcount'] = array(
-    array(
+  $permissions['case']['getcount'] = [
+    [
       'access my cases and activities',
       'access all cases and activities',
       'basic case information',
-    ),
-  );
+    ],
+  ];
 
-  $permissions['case_type']['get'] = $permissions['casetype']['getcount'] = array(
-    array(
+  $permissions['case_type']['get'] = $permissions['casetype']['getcount'] = [
+    [
       'access my cases and activities',
       'access all cases and activities',
       'basic case information',
-    ),
-  );
+    ],
+  ];
 }
 
 /**
@@ -505,13 +529,12 @@ function civicase_civicrm_pageRun(&$page) {
   if ($page instanceof CRM_Case_Page_Tab) {
     // OLD: http://localhost/civicrm/contact/view/case?reset=1&action=view&cid=129&id=51
     // NEW: http://localhost/civicrm/case/a/#/case/list?sf=contact_id.sort_name&sd=ASC&focus=0&cf=%7B%7D&caseId=51&tab=summary&sx=0
-
     $caseId = CRM_Utils_Request::retrieve('id', 'Positive');
     if ($caseId) {
-      $case = civicrm_api3('Case', 'getsingle', array(
+      $case = civicrm_api3('Case', 'getsingle', [
         'id' => $caseId,
-        'return' => array('case_type_id.name', 'status_id.name'),
-      ));
+        'return' => ['case_type_id.name', 'status_id.name'],
+      ]);
       $url = CRM_Utils_System::url('civicrm/case/a/', NULL, TRUE,
         "/case/list?sf=id&sd=DESC&caseId={$caseId}&cf=%7B%22status_id%22:%5B%22{$case['status_id.name']}%22%5D,%22case_type_id%22:%5B%22{$case['case_type_id.name']}%22%5D%7D",
         FALSE);
@@ -524,7 +547,7 @@ function civicase_civicrm_pageRun(&$page) {
     CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicase', 'packages/moment.min.js');
   }
 
-  // Adds simplescrollbarjs
+  // Adds simplescrollbarjs.
   if ($page instanceof CRM_Civicase_Page_CaseAngular) {
     CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicase', 'packages/simplebar.min.js');
     CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.civicase', 'packages/simplebar.min.css', 1000, 'html-header');
@@ -550,21 +573,21 @@ function civicase_civicrm_navigationMenu(&$menu) {
    * @var array
    *   Array(string $oldUrl => string $newUrl).
    */
-  $rewriteMap = array(
+  $rewriteMap = [
     'civicrm/case?reset=1' => 'civicrm/case/a/#/case',
     'civicrm/case/search?reset=1' => 'civicrm/case/a/#/case/list?sx=1',
-  );
+  ];
 
-  _civicase_menu_walk($menu, function(&$item) use ($rewriteMap) {
+  _civicase_menu_walk($menu, function (&$item) use ($rewriteMap) {
     if (isset($item['url']) && isset($rewriteMap[$item['url']])) {
       $item['url'] = $rewriteMap[$item['url']];
     }
   });
 
-  // add new menu item
-  // Check that our item doesn't already exist
-  $menu_item_search = array('url' => 'civicrm/case/webforms');
-  $menu_items = array();
+  // Add new menu item
+  // Check that our item doesn't already exist.
+  $menu_item_search = ['url' => 'civicrm/case/webforms'];
+  $menu_items = [];
   CRM_Core_BAO_Navigation::retrieve($menu_item_search, $menu_items);
 
   if (!empty($menu_items)) {
@@ -575,11 +598,11 @@ function civicase_civicrm_navigationMenu(&$menu) {
   if (is_int($navId)) {
     $navId++;
   }
-  // Find the Civicase menu
+  // Find the Civicase menu.
   $caseID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'CiviCase', 'id', 'name');
   $administerID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Administer', 'id', 'name');
-  $menu[$administerID]['child'][$caseID]['child'][$navId] = array(
-    'attributes' => array(
+  $menu[$administerID]['child'][$caseID]['child'][$navId] = [
+    'attributes' => [
       'label' => ts('CiviCase Webforms'),
       'name' => 'CiviCase Webforms',
       'url' => 'civicrm/case/webforms',
@@ -589,8 +612,8 @@ function civicase_civicrm_navigationMenu(&$menu) {
       'parentID' => $caseID,
       'navID' => $navId,
       'active' => 1,
-    ),
-  );
+    ],
+  ];
 }
 
 /**
@@ -601,7 +624,7 @@ function civicase_civicrm_navigationMenu(&$menu) {
  * @param callable $callback
  *   Function(&$item).
  */
-function _civicase_menu_walk(&$menu, $callback) {
+function _civicase_menu_walk(array &$menu, callable $callback) {
   foreach (array_keys($menu) as $key) {
     if (isset($menu[$key]['attributes'])) {
       $callback($menu[$key]['attributes']);
@@ -626,11 +649,11 @@ function civicase_civicrm_selectWhereClause($entity, &$clauses) {
  * Implements hook_civicrm_entityTypes().
  */
 function civicase_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes[] = array(
+  $entityTypes[] = [
     'name'  => 'CaseContactLock',
     'class' => 'CRM_Civicase_DAO_CaseContactLock',
     'table' => 'civicase_contactlock',
-  );
+  ];
 
   _civicase_add_case_category_case_type_entity($entityTypes);
 }
@@ -665,8 +688,8 @@ function civicase_civicrm_preProcess($formName, &$form) {
     $hook->run($formName, $form);
   }
 
-  # TODO: We need to move this function into it's own class and implement as above.
-
+  // TODO: We need to move this function into it's own class
+  // and implement as above.
   if ($formName == 'CRM_Admin_Form_Setting_Case') {
     $settings = $form->getVar('_settings');
     $settings['civicaseAllowCaseLocks'] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;
@@ -678,11 +701,12 @@ function civicase_civicrm_preProcess($formName, &$form) {
 }
 
 /**
- * Adds Case Type Category field to the Case Type entity DAO
+ * Adds Case Type Category field to the Case Type entity DAO.
  *
- * @param Array $entityTypes
+ * @param array $entityTypes
+ *   Entity types array.
  */
-function _civicase_add_case_category_case_type_entity (&$entityTypes) {
+function _civicase_add_case_category_case_type_entity(array &$entityTypes) {
   $entityTypes['CRM_Case_DAO_CaseType']['fields_callback'][] = function ($class, &$fields) {
     $fields['case_type_category'] = [
       'name' => 'case_type_category',

--- a/civicase.php
+++ b/civicase.php
@@ -200,10 +200,11 @@ function civicase_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
 function civicase_civicrm_buildForm($formName, &$form) {
   $hooks = [
     new CRM_Civicase_Hook_BuildForm_CaseClientPopulator(),
+    new CRM_Civicase_Hook_BuildForm_FilterCaseTypeByCategory(),
   ];
 
   foreach ($hooks as $hook) {
-    $hook->run($form);
+    $hook->run($form, $formName);
   }
 
   // Display category option for activity types and activity statuses

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -7,5 +7,8 @@
     <!-- Hence the following rules are excluded -->
     <exclude name="Drupal.NamingConventions.ValidClassName.NoUnderscores"/>
     <exclude name="Drupal.Classes.ClassFileName.NoMatch"/>
+    <!--Drupal expects function names like civicase_civicrm_pre_process but civi can have-->
+    <!--civicase_civicrm_preProcess which is valid for civi.-->
+    <exclude name="Drupal.NamingConventions.ValidFunctionName.InvalidName"/>
   </rule>
 </ruleset>


### PR DESCRIPTION
## Overview
This PR filters the case type select field on an Add Case form when a category option is provided in the URL. The case types is filtered to contain only Case Types that belong to the specified category.
For example a URL `http://local.buildkit/civicrm/case/add?reset=1&action=add&category=prospecting` will filter the Case types field to return only case types related to the Prospecting case category.

## Before
Functionality was not present

## After
Functionality is added.

![CaseTypeFilter](https://user-images.githubusercontent.com/6951813/61316497-068b5280-a7f9-11e9-9d89-58fa5e77bbc5.gif)


## Technical Details
The `hook_buildForm` was used to fetch the options for this case type field and these options were modified depending on the category value in the URL.

```php
  private function filterCaseTypeOptionValues(CRM_Core_Form $form, $caseCategoryName) {
    $caseTypesInCategory = $this->getCaseTypesForCategory($caseCategoryName);

    if (!$caseTypesInCategory) {
      return;
    }

    $caseTypeIdElement = &$form->getElement('case_type_id');
    $options = $caseTypeIdElement->_options;

    foreach ($options as $key => $option) {
      $optionValue = $option['attr']['value'];
      if (!in_array($optionValue, $caseTypesInCategory) && $optionValue) {
        unset($options[$key]);
      }
    }

    $caseTypeIdElement->_options = $options;
  }
```
