### PR TITLE
C51-360: Fix Get relationship by case role bug

### DIFF
--- a/Civi/CCase/Utils.php
+++ b/Civi/CCase/Utils.php
@@ -14,26 +14,26 @@ class Utils {
    *   [caseTypeId => relationshipTypeId]
    */
   public static function getRelationshipTypesListByCaseRole($roleName) {
-    $ret = array();
-    $caseTypes = civicrm_api3('CaseType', 'get', array(
-      'options' => array('limit' => 0),
-      'return' => array('name', 'definition'),
-    ));
-    $relationshipTypes = civicrm_api3('RelationshipType', 'get', array(
-      'options' => array('limit' => 0),
-      'return' => array('name_b_a', 'name_a_b'),
-    ));
+    $ret = [];
+    $caseTypes = civicrm_api3('CaseType', 'get', [
+      'options' => ['limit' => 0],
+      'return' => ['name', 'definition'],
+    ]);
+    $relationshipTypes = civicrm_api3('RelationshipType', 'get', [
+      'options' => ['limit' => 0],
+      'return' => ['name_b_a', 'name_a_b'],
+    ]);
     $relationshipTypes = $relationshipTypes['values'];
 
     foreach ($caseTypes['values'] as $caseType) {
-      $caseTypeToCaseRolesList = array();
+      $caseTypeToCaseRolesList = [];
 
       foreach ($caseType['definition']['caseRoles'] as $role) {
         if ($roleName == 'involved' || !empty($role[$roleName])) {
-          foreach ($relationshipTypes as $key => $value) {
-            if ($value['name_b_a'] == $role['name']
-              || $value['name_a_b'] == $role['name']) {
-              $caseTypeToCaseRolesList[] = $value['id'];
+          foreach ($relationshipTypes as  $relationshipType) {
+            if ($relationshipType['name_b_a'] == $role['name']
+              || $relationshipType['name_a_b'] == $role['name']) {
+              $caseTypeToCaseRolesList[] = $relationshipType['id'];
             }
           }
         }

--- a/Civi/CCase/Utils.php
+++ b/Civi/CCase/Utils.php
@@ -21,18 +21,20 @@ class Utils {
     ));
     $relationshipTypes = civicrm_api3('RelationshipType', 'get', array(
       'options' => array('limit' => 0),
-      'return' => array('name_b_a'),
+      'return' => array('name_b_a', 'name_a_b'),
     ));
-    $relationshipTypes = \CRM_Utils_Array::rekey($relationshipTypes['values'], 'name_b_a');
+    $relationshipTypes = $relationshipTypes['values'];
 
     foreach ($caseTypes['values'] as $caseType) {
       $caseTypeToCaseRolesList = array();
+
       foreach ($caseType['definition']['caseRoles'] as $role) {
-        if ($roleName == 'involved') {
-          $caseTypeToCaseRolesList[] =  $relationshipTypes[$role['name']]['id'];
-        } else {
-          if (!empty($role[$roleName])) {
-            $caseTypeToCaseRolesList[] = $relationshipTypes[$role['name']]['id'];
+        if ($roleName == 'involved' || !empty($role[$roleName])) {
+          foreach ($relationshipTypes as $key => $value) {
+            if ($value['name_b_a'] == $role['name']
+              || $value['name_a_b'] == $role['name']) {
+              $caseTypeToCaseRolesList[] = $value['id'];
+            }
           }
         }
       }


### PR DESCRIPTION
## Overview
Previously the following Apis used to return a Syntax Error
- Getdetails
- Getstats
- Gettypedetails

## Before
![2019-07-19 at 3 05 PM](https://user-images.githubusercontent.com/5058867/61525754-b13c8480-aa36-11e9-9d87-4e9857a40a36.jpg)
![2019-07-19 at 3 05 PM](https://user-images.githubusercontent.com/5058867/61525774-b994bf80-aa36-11e9-9cfe-776536c7e26d.jpg)



## After
The API return values without any error.

## Technical Details
**When this bug will occur**
If we create a `Relationship Type`, where 
`A to B`label is `CEO for` and 
`B to A`  label is `CEO`.

Then if we create a new Case Type, where we add both `CEO` and `CEO for` relationship.

Now previously `getRelationshipTypesListByCaseRole` function used to only fetch `name_b_a` for relationships, and then used to match it with the Relationship coming from Case Types.
```php
$relationshipTypes = civicrm_api3('RelationshipType', 'get', array(
  'options' => array('limit' => 0),
  'return' => array('name_b_a'),
));
```

Problem with this is, if both `A to B` and `B to A` relation is used in Case Type, then the `A to B` relation would not be found.

Hence the sql was being generated wrongly, for example
```sql
SELECT count(*) as c
FROM civicrm_case a
LEFT JOIN (SELECT * FROM civicrm_case_contact WHERE id IN (SELECT MIN(id) FROM civicrm_case_contact GROUP BY case_id)) AS ccc ON ccc.case_id = a.id
LEFT JOIN civicrm_relationship AS manager_relationship ON ccc.contact_id = manager_relationship.contact_id_a AND manager_relationship.is_active AND ((a.case_type_id = 1 AND manager_relationship.relationship_type_id = 11) OR (a.case_type_id = 2 AND manager_relationship.relationship_type_id = 13) OR (a.case_type_id = 3 AND manager_relationship.relationship_type_id = 9) OR (a.case_type_id = 4 AND manager_relationship.relationship_type_id = )) AND manager_relationship.case_id = a.id
LEFT JOIN civicrm_contact AS manager ON manager_relationship.contact_id_b = manager.id AND manager.is_deleted <> 1
INNER JOIN `civicrm_option_value` `status_id_to_civicrm_option_value` ON a.status_id = status_id_to_civicrm_option_value.value AND status_id_to_civicrm_option_value.option_group_id = (SELECT id FROM civicrm_option_group WHERE name = 'case_status')
INNER JOIN `civicrm_case_type` `case_type_id_to_civicrm_case_type` ON a.case_type_id = case_type_id_to_civicrm_case_type.id
WHERE (manager.id = "203") AND (a.id IN (SELECT case_id FROM civicrm_case_contact ccc, civicrm_contact cc WHERE ccc.contact_id = cc.id AND cc.is_deleted = 0)) AND (status_id_to_civicrm_option_value.grouping = "Opened") AND (case_type_id_to_civicrm_case_type.is_active = "1") AND (a.start_date BETWEEN "20190714000000" AND "20190720000000") AND (a.is_deleted = "0")
```

Broken  SQL - `(a.case_type_id = 4 AND manager_relationship.relationship_type_id = )`

**How is it fixed**
`getRelationshipTypesListByCaseRole` is refactored, and now both `name_b_a ` and `name_a_b` is fetched and matched with relationships from Case Types.

