### PR TITLE
RSE-241: Allow Editing Of Custom Fields on Manage Case Category Page

### DIFF
--- a/CRM/Civicase/Hook/PostProcess/ProcessCaseCategoryCustomFieldsForSave.php
+++ b/CRM/Civicase/Hook/PostProcess/ProcessCaseCategoryCustomFieldsForSave.php
@@ -1,0 +1,71 @@
+<?php
+
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+
+/**
+ * CRM_Civicase_Hook_PostProcess_ProcessCaseCategoryCustomFieldsForSave class.
+ */
+class CRM_Civicase_Hook_PostProcess_ProcessCaseCategoryCustomFieldsForSave {
+
+  /**
+   * Processes/Displays the case category custom fields.
+   *
+   * The case category custom fields on Manage Case category page will not work
+   * well without this, basically it allows the the custom field values for
+   * the case category to be saved/updated.
+   *
+   * @param string $formName
+   *   Form name.
+   * @param CRM_Core_Form $form
+   *   Form object class.
+   */
+  public function run($formName, CRM_Core_Form &$form) {
+    if (!$this->shouldRun($formName)) {
+      return;
+    }
+
+    $caseId = CRM_Utils_Request::retrieve('entityID', 'Positive', $form, TRUE);
+    $caseCategoryName = CaseCategoryHelper::getCategoryName($caseId);
+
+    if ($caseCategoryName == 'Cases') {
+      return;
+    }
+
+    $this->saveCaseCategoryCustomFieldValues($form, $caseCategoryName);
+  }
+
+  /**
+   * Processes the Case Category custom fields values.
+   *
+   * Allows them to be saved for case categories other than 'Case'.
+   *
+   * @param CRM_Core_Form $form
+   *   Form name.
+   * @param string $caseCategoryName
+   *   Case Category name.
+   */
+  private function saveCaseCategoryCustomFieldValues(CRM_Core_Form $form, $caseCategoryName) {
+    $params = $form->controller->exportValues();
+    $caseId = CRM_Utils_Request::retrieve('entityID', 'Positive', $form, TRUE);
+
+    CRM_Core_BAO_CustomValueTable::postProcess($params,
+      'civicrm_case',
+      $caseId,
+      $caseCategoryName
+    );
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * @param string $formName
+   *   Form name.
+   *
+   * @return bool
+   *   returns TRUE or FALSE.
+   */
+  private function shouldRun($formName) {
+    return $formName == CRM_Case_Form_CustomData::class;
+  }
+
+}

--- a/CRM/Civicase/Hook/PreProcess/ProcessCaseCategoryCustomFieldsForEdit.php
+++ b/CRM/Civicase/Hook/PreProcess/ProcessCaseCategoryCustomFieldsForEdit.php
@@ -1,0 +1,68 @@
+<?php
+
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+
+/**
+ * CRM_Civicase_Hook_PreProcess_ProcessCaseCategoryCustomFieldsForEdit class.
+ */
+class CRM_Civicase_Hook_PreProcess_ProcessCaseCategoryCustomFieldsForEdit {
+
+  /**
+   * Processes/Displays the case category custom fields.
+   *
+   * The case category custom fields on Manage Case category page will not work
+   * well without this, basically custom field for the case category and their
+   * default values are set here and their values can be edited.
+   *
+   * @param string $formName
+   *   Form name.
+   * @param CRM_Core_Form $form
+   *   Form object class.
+   */
+  public function run($formName, CRM_Core_Form &$form) {
+    if (!$this->shouldRun($formName)) {
+      return;
+    }
+
+    $caseId = CRM_Utils_Request::retrieve('entityID', 'Positive', $form, TRUE);
+    $caseCategoryName = CaseCategoryHelper::getCategoryName($caseId);
+
+    if ($caseCategoryName == 'Cases') {
+      return;
+    }
+
+    $this->processCaseCategoryCustomFieldsForEdit($form, $caseCategoryName);
+  }
+
+  /**
+   * Processes the Case Category custom fields.
+   *
+   * Allows them to be editable for case categories other than 'Case'.
+   *
+   * @param CRM_Core_Form $form
+   *   Form name.
+   * @param string $caseCategoryName
+   *   Case Category name.
+   */
+  private function processCaseCategoryCustomFieldsForEdit(CRM_Core_Form $form, $caseCategoryName) {
+    $caseTypeId = CRM_Utils_Request::retrieve('subType', 'Positive', $form, TRUE);
+    CRM_Custom_Form_CustomData::preProcess($form, NULL, $caseTypeId, 1, $caseCategoryName);
+    CRM_Custom_Form_CustomData::buildQuickForm($form);
+    CRM_Core_BAO_CustomGroup::setDefaults($form->_groupTree, $form->_defaults);
+    $form->setDefaults($form->_defaults);
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * @param string $formName
+   *   Form name.
+   *
+   * @return bool
+   *   returns TRUE or FALSE.
+   */
+  private function shouldRun($formName) {
+    return $formName == CRM_Case_Form_CustomData::class;
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -447,6 +447,7 @@ function civicase_civicrm_validateForm($formName, &$fields, &$files, &$form, &$e
 function civicase_civicrm_postProcess($formName, &$form) {
   $hooks = [
     new CRM_Civicase_Hook_PostProcess_CaseCategoryCustomFieldsSaver(),
+    new CRM_Civicase_Hook_PostProcess_ProcessCaseCategoryCustomFieldsForSave(),
   ];
 
   foreach ($hooks as $hook) {
@@ -682,6 +683,7 @@ function civicase_civicrm_permission_check($permission, &$granted) {
 function civicase_civicrm_preProcess($formName, &$form) {
   $hooks = [
     new CRM_Civicase_Hook_PreProcess_CaseCategoryCustomFieldsSetDefaultValues(),
+    new CRM_Civicase_Hook_PreProcess_ProcessCaseCategoryCustomFieldsForEdit(),
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview
Currently, When adding a new Case for a case category e.g Prospect, the custom fields saved with the case are not editable. This PR fixes the issue.

## Before
- The Custom field values on Manage Case category page is not editable.

![EditCustomFieldBefore](https://user-images.githubusercontent.com/6951813/62303926-edc7a180-b474-11e9-9298-e68c33d71d7b.gif)

## After
- The Custom field values on Manage Case category page are now editable.

![EditCustomField](https://user-images.githubusercontent.com/6951813/62303940-f7510980-b474-11e9-9b6e-50edef18e649.gif)


## Technical Details
- Hook PreProcess and Hook PostProcess was implemented to check if the case type category is not of case (Civi already takes care of this by default), then the custom fields are added for editing and saving for the relevant case category.

