### PR TITLE
RSE-187: Case Category filter support for  "Case.getstats"

### DIFF
--- a/api/v3/Case/Getstats.php
+++ b/api/v3/Case/Getstats.php
@@ -137,7 +137,7 @@ function _civicrm_api3_case_add_case_category_query_filter($query, array $caseTy
  * @param array $params
  *   The $params array passed to the API.
  *
- * @return array
+ * @return array|string
  *   Return Value.
  */
 function _civicrm_api3_case_get_case_category_from_params(array $params) {


### PR DESCRIPTION
## Overview
Currently the `Case.getstats` API does not support filtering by case type categories. This is really needed as we need to be able to return results based on the category filter.

## Before
- The `Case.getstats` API does not support filtering by case type categories

## After
- The `Case.getstats` API now supports filtering by case type categories
The API can now be called as follows: 
```php
civicrm_api3('Case', 'getstats', [
  'case_type_id.case_type_category' => ['IN' => ["Prospecting", "Cases"]],
]);

civicrm_api3('Case', 'getstats', [
  'case_type_id.case_type_category' => "prospecting",
]);
```