### PR TITLE
RSE-175: Add refresh logic

### DIFF
--- a/ang/civicase/case/actions/directives/case-actions.directive.js
+++ b/ang/civicase/case/actions/directives/case-actions.directive.js
@@ -1,7 +1,7 @@
 (function (angular, $, _) {
   var module = angular.module('civicase');
 
-  module.directive('civicaseCaseActions', function ($window, $injector, dialogService, PrintMergeCaseAction) {
+  module.directive('civicaseCaseActions', function ($window, $rootScope, $injector, dialogService, PrintMergeCaseAction) {
     return {
       restrict: 'A',
       templateUrl: '~/civicase/case/actions/directives/case-actions.directive.html',
@@ -77,6 +77,7 @@
             // Listen for success events and buffer them so we only trigger once
             .on('crmFormSuccess crmPopupFormSuccess', function (e, data) {
               formData = data;
+              $rootScope.$broadcast('updateCaseData');
               refreshDataForActions();
             })
             .on('dialogclose.crmPopup', function (e, data) {

--- a/ang/civicase/case/details/directives/case-details.directive.js
+++ b/ang/civicase/case/details/directives/case-details.directive.js
@@ -164,7 +164,7 @@
 
     $scope.pushCaseData = function (data) {
       // If the user has already clicked through to another case by the time we get this data back, stop.
-      if ($scope.item && data.id === $scope.item.id) {
+      if ($scope.item && data && data.id === $scope.item.id) {
         // Maintain the reference to the variable in the parent scope.
         delete ($scope.item.tag_id);
         _.assign($scope.item, formatCaseDetails(data));


### PR DESCRIPTION
## Overview
Previously, when Pledge/Contribution was edited, the Custom field values did not get updated. This PR fixes that.

## Before
![before](https://user-images.githubusercontent.com/5058867/62755497-d8b0cb00-ba91-11e9-84e8-eed9e6a15c58.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/62755435-a737ff80-ba91-11e9-872d-d2b43e10da41.gif)

## Technical Details
1. In `case-actions.directive.js`, `$rootScope.$broadcast('updateCaseData');` is fired to fetch the latest data.
2. In `case-details.directive.js`, added a check to eliminate console errors
```js
 if ($scope.item && data && data.id === $scope.item.id) {
```