### PR TITLE
RSE-270: Only Allow Case type to be changed to another Case Type within the Same Category

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/CaseCategoryCustomFieldsProcessing.php
+++ b/CRM/Civicase/Hook/BuildForm/CaseCategoryCustomFieldsProcessing.php
@@ -41,7 +41,7 @@ class CRM_Civicase_Hook_BuildForm_CaseCategoryCustomFieldsProcessing {
    *   Case category name.
    */
   private function filterCaseTypeOptionValues(CRM_Core_Form $form, $caseCategoryName) {
-    $caseTypesInCategory = $this->getCaseTypesForCategory($caseCategoryName);
+    $caseTypesInCategory = CaseTypeCategoryHelper::getCaseTypesForCategory($caseCategoryName);
 
     if (!$caseTypesInCategory) {
       return;
@@ -76,32 +76,6 @@ class CRM_Civicase_Hook_BuildForm_CaseCategoryCustomFieldsProcessing {
     $caseTypeIdElement = &$form->getElement('case_type_id');
     $caseTypeIdElement->updateAttributes(['onchange' => "CRM.buildCustomData('{$caseCategoryName}', this.value)"]);
     $form->assign('customDataType', $caseCategoryName);
-  }
-
-  /**
-   * Returns the case type ids for a case type category.
-   *
-   * @param string $caseCategoryName
-   *   Case category name.
-   *
-   * @return array|null
-   *   The case type id's e.g [1, 2, 3]
-   */
-  private function getCaseTypesForCategory($caseCategoryName) {
-    try {
-      $result = civicrm_api3('CaseType', 'get', [
-        'return' => ['id'],
-        'case_type_category' => $caseCategoryName,
-      ]);
-
-      if ($result['count'] == 0) {
-        return NULL;
-      }
-
-      return array_column($result['values'], 'id');
-    }
-    catch (Exception $e) {
-    }
   }
 
   /**

--- a/CRM/Civicase/Hook/BuildForm/FilterByCaseCategoryOnChangeCaseType.php
+++ b/CRM/Civicase/Hook/BuildForm/FilterByCaseCategoryOnChangeCaseType.php
@@ -1,0 +1,74 @@
+<?php
+
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+
+/**
+ * FilterByCaseCategoryOnChangeCaseType class.
+ */
+class CRM_Civicase_Hook_BuildForm_FilterByCaseCategoryOnChangeCaseType {
+
+  /**
+   * Filters by case category.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   * @param string $formName
+   *   Form Name.
+   */
+  public function run(CRM_Core_Form &$form, $formName) {
+    if (!$this->shouldRun($formName, $form)) {
+      return;
+    }
+
+    $this->filterCaseTypeOptionsByCaseCategory($form);
+  }
+
+  /**
+   * Filters the options for the case type select element based on the category.
+   *
+   * @param CRM_Core_Form $form
+   *   Form class object.
+   */
+  private function filterCaseTypeOptionsByCaseCategory(CRM_Core_Form $form) {
+    $caseCategoryName = CaseCategoryHelper::getCategoryName($form->_caseId[0]);
+    $caseTypesInCategory = CaseTypeCategoryHelper::getCaseTypesForCategory($caseCategoryName);
+
+    if (!$caseTypesInCategory) {
+      return;
+    }
+
+    $caseTypeIdElement = &$form->getElement('case_type_id');
+    $options = $caseTypeIdElement->_options;
+
+    foreach ($options as $key => $option) {
+      $optionValue = $option['attr']['value'];
+      if (!in_array($optionValue, $caseTypesInCategory) && $optionValue) {
+        unset($options[$key]);
+      }
+    }
+
+    sort($options);
+    $caseTypeIdElement->_options = $options;
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * @param string $formName
+   *   Form name.
+   * @param CRM_Core_Form $form
+   *   Form class object.
+   *
+   * @return bool
+   *   returns a boolean to determine if hook will run or not.
+   */
+  private function shouldRun($formName, CRM_Core_Form $form) {
+    if ($formName != 'CRM_Case_Form_Activity') {
+      return FALSE;
+    }
+
+    return $form->_activityTypeName == 'Change Case Type';
+  }
+
+}

--- a/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
+++ b/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
@@ -29,4 +29,30 @@ class CRM_Civicase_Hook_Helper_CaseTypeCategory {
     return TRUE;
   }
 
+  /**
+   * Returns the case type ids for a case type category.
+   *
+   * @param string $caseCategoryName
+   *   Case category name.
+   *
+   * @return array|null
+   *   The case type id's e.g [1, 2, 3]
+   */
+  public static function getCaseTypesForCategory($caseCategoryName) {
+    try {
+      $result = civicrm_api3('CaseType', 'get', [
+        'return' => ['id'],
+        'case_type_category' => $caseCategoryName,
+      ]);
+
+      if ($result['count'] == 0) {
+        return NULL;
+      }
+
+      return array_column($result['values'], 'id');
+    } catch (Exception $e) {
+    }
+
+  }
+
 }

--- a/civicase.php
+++ b/civicase.php
@@ -209,6 +209,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_CaseClientPopulator(),
     new CRM_Civicase_Hook_BuildForm_CaseCategoryCustomFieldsProcessing(),
     new CRM_Civicase_Hook_BuildForm_DisableCaseCustomFieldValidations(),
+    new CRM_Civicase_Hook_BuildForm_FilterByCaseCategoryOnChangeCaseType(),
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview
When changing a case type for a case, a user is presented with all the case types in the system. This PR fixes that and only allows users to change to another case type that is in same category for that case.

## Before
User can change case type to any case type.
<img width="1277" alt="Manage Cases  case-prospect 2019-08-13 16-25-03" src="https://user-images.githubusercontent.com/6951813/62954489-69b3d900-bde7-11e9-982d-86447a2a6be8.png">


## After
User can change to only case type within the case category
<img width="1272" alt="Manage Cases  case-prospect 2019-08-13 16-24-11" src="https://user-images.githubusercontent.com/6951813/62954546-82bc8a00-bde7-11e9-9e8d-211700bfc9cd.png">


