### PR TITLE
RSE-216: Case Custom Fields UI Solution For Cases Category

### DIFF
--- a/CRM/Civicase/Helper/CaseCategory.php
+++ b/CRM/Civicase/Helper/CaseCategory.php
@@ -7,6 +7,8 @@ use CRM_Case_BAO_CaseType as CaseType;
  */
 class CRM_Civicase_Helper_CaseCategory {
 
+  const CASE_TYPE_CATEGORY_NAME = 'Cases';
+
   /**
    * Returns the case category name for the case Id.
    *
@@ -35,6 +37,22 @@ class CRM_Civicase_Helper_CaseCategory {
     }
 
     return NULL;
+  }
+
+  /**
+   * Returns the case types for the cases category.
+   *
+   * @return array
+   *   Array of Case Types indexed by Id.
+   */
+  public static function getCaseTypesForCase() {
+    $result = civicrm_api3('CaseType', 'get', [
+      'sequential' => 1,
+      'return' => ['title', 'id'],
+      'case_type_category' => self::CASE_TYPE_CATEGORY_NAME,
+    ]);
+
+    return array_column($result['values'], 'title', 'id');
   }
 
 }

--- a/CRM/Civicase/Setup/AddCaseTypesForCustomGroupExtends.php
+++ b/CRM/Civicase/Setup/AddCaseTypesForCustomGroupExtends.php
@@ -1,0 +1,31 @@
+<?php
+
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+
+/**
+ * CRM_Civicase_Setup_CaseTypesForCustomGroupExtends class.
+ */
+class CRM_Civicase_Setup_AddCaseTypesForCustomGroupExtends {
+
+  /**
+   * Add the class and function for fetching case types for case category.
+   */
+  public function apply() {
+    $description = 'CRM_Civicase_Helper_CaseCategory::getCaseTypesForCase;';
+
+    $result = civicrm_api3('OptionValue', 'getsingle', [
+      'option_group_id' => 'cg_extend_objects',
+      'label' => CaseCategoryHelper::CASE_TYPE_CATEGORY_NAME,
+    ]);
+
+    if (empty($result['id']) || $result['description'] == $description) {
+      return;
+    }
+
+    civicrm_api3('OptionValue', 'create', [
+      'id' => $result['id'],
+      'description' => $description,
+    ]);
+  }
+
+}

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -2,6 +2,7 @@
 
 use CRM_Civicase_Setup_CaseTypeCategorySupport as CaseTypeCategorySupport;
 use CRM_Civicase_Setup_CreateCasesOptionValue as CreateCasesOptionValue;
+use CRM_Civicase_Setup_AddCaseTypesForCustomGroupExtends as AddCaseTypesForCustomGroupExtends;
 
 /**
  * Collection of upgrade steps.
@@ -63,6 +64,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     $steps = [
       new CaseTypeCategorySupport(),
       new CreateCasesOptionValue(),
+      new AddCaseTypesForCustomGroupExtends(),
     ];
     foreach ($steps as $step) {
       $step->apply();

--- a/CRM/Civicase/Upgrader/Steps/Step004.php
+++ b/CRM/Civicase/Upgrader/Steps/Step004.php
@@ -1,0 +1,23 @@
+<?php
+
+use CRM_Civicase_Setup_AddCaseTypesForCustomGroupExtends as AddCaseTypesForCustomGroupExtends;
+
+/**
+ * CRM_Civicase_Upgrader_Steps_Step004 class.
+ */
+class CRM_Civicase_Upgrader_Steps_Step004 {
+
+  /**
+   * Add the functionality for fetching case types for case category..
+   *
+   * @return bool
+   *   Return value in boolean.
+   */
+  public function apply() {
+    $step = new AddCaseTypesForCustomGroupExtends();
+    $step->apply();
+
+    return TRUE;
+  }
+
+}


### PR DESCRIPTION
## Overview
We can already add Custom Groups to extend cases but the issue is that in the field for selecting case types, all case types are shown. We only need case types belonging to the Case category. This PR fixes that issue.

## Before
- The UI shows that Custom Groups can extend Cases for all case types.

## After
- Custom Groups can extend Cases for all case types in the case category. The UI is changed to reflect this.
Civicrm uses the description field for the option value to determine which function to use to fetch the object subtypes. See [Here.](https://github.com/civicrm/civicrm-core/blob/b2ccd9fe6cb84d96d35c85582418311509f9af9b/CRM/Core/BAO/CustomGroup.php#L2084-L2101).
This PR adds a new function to only fetch case types for the cases category. The description field for the Cases option value is updated to use this new function.

<img width="1254" alt="New Custom Field Set  case-prospect 2019-08-14 16-26-46" src="https://user-images.githubusercontent.com/6951813/63033932-5c165600-beb0-11e9-8567-719f17881e41.png">
