### PR TITLE
RSE-168: Change Case Menu URLS

### DIFF
--- a/CRM/Civicase/Setup/UpdateMenuLinks.php
+++ b/CRM/Civicase/Setup/UpdateMenuLinks.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Updates the Manage Cases Menu URLs.
+ */
+class CRM_Civicase_Setup_UpdateMenuLinks {
+
+  /**
+   * Updates the Manage Cases Menu URLs.
+   */
+  public function apply() {
+    $this->updateManageCasesMenuLink();
+
+    return TRUE;
+  }
+
+  /**
+   * Updates the Manage Cases Menu URL.
+   *
+   * To filter with `cases` case type category.
+   */
+  private function updateManageCasesMenuLink() {
+    $casesParentMenu = civicrm_api3('Navigation', 'getsingle', [
+      'name' => "cases",
+    ]);
+
+    if ($casesParentMenu['id']) {
+      $manageCasesMenuItem = civicrm_api3('Navigation', 'getsingle', [
+        'name' => "Manage Cases",
+        'parent_id' => $casesParentMenu['id'],
+      ]);
+    }
+
+    if ($manageCasesMenuItem['id']) {
+      civicrm_api3('Navigation', 'create', [
+        'id' => $manageCasesMenuItem['id'],
+        'url' => 'civicrm/case/a/#/case/list?cf=%7B"case_type_category":"cases"%7D',
+      ]);
+    }
+
+  }
+
+}

--- a/CRM/Civicase/Setup/UpdateMenuLinks.php
+++ b/CRM/Civicase/Setup/UpdateMenuLinks.php
@@ -10,8 +10,6 @@ class CRM_Civicase_Setup_UpdateMenuLinks {
    */
   public function apply() {
     $this->updateManageCasesMenuLink();
-
-    return TRUE;
   }
 
   /**
@@ -21,12 +19,12 @@ class CRM_Civicase_Setup_UpdateMenuLinks {
    */
   private function updateManageCasesMenuLink() {
     $casesParentMenu = civicrm_api3('Navigation', 'getsingle', [
-      'name' => "cases",
+      'name' => 'cases',
     ]);
 
     if ($casesParentMenu['id']) {
       $manageCasesMenuItem = civicrm_api3('Navigation', 'getsingle', [
-        'name' => "Manage Cases",
+        'name' => 'Manage Cases',
         'parent_id' => $casesParentMenu['id'],
       ]);
     }

--- a/CRM/Civicase/Upgrader/Steps/Step0005.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0005.php
@@ -1,0 +1,20 @@
+<?php
+
+use CRM_Civicase_Setup_UpdateMenuLinks as UpdateMenuLinks;
+
+/**
+ * Updates the Manage Cases Menu URLs.
+ */
+class CRM_Civicase_Upgrader_Steps_Step0005 {
+
+  /**
+   * Updates the Manage Cases Menu URLs.
+   */
+  public function apply() {
+    $step = new UpdateMenuLinks();
+    $step->apply();
+
+    return TRUE;
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -577,7 +577,7 @@ function civicase_civicrm_navigationMenu(&$menu) {
    *   Array(string $oldUrl => string $newUrl).
    */
   $rewriteMap = [
-    'civicrm/case?reset=1' => 'civicrm/case/a/#/case',
+    'civicrm/case?reset=1' => 'civicrm/case/a/#/case?case_type_category=cases',
     'civicrm/case/search?reset=1' => 'civicrm/case/a/#/case/list?sx=1',
   ];
 


### PR DESCRIPTION
## Overview
As part of this PR, the Dashboard and Manage Cases menu item for Cases has been changed so that it filters Cases with `cases` case type category only.

## Technical Details
New Class `UpdateMenuLinks` and `Step0005` has been created to change Manage Cases menu.
In `civicase.php` the Dashboard menu item link is changed.
