### PR TITLE
RSE-271: Case Type Category Word Replacements

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/CaseCategoryFormLabelTranslationForChangeCase.php
+++ b/CRM/Civicase/Hook/BuildForm/CaseCategoryFormLabelTranslationForChangeCase.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Class CaseCategoryFormLabelTranslationForChangeCase.
+ */
+class CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslationForChangeCase {
+
+  /**
+   * Translate some case form labels that Civi did not run translation for.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   * @param string $formName
+   *   Form Name.
+   */
+  public function run(CRM_Core_Form &$form, $formName) {
+    if (!$this->shouldRun($formName, $form)) {
+      return;
+    }
+
+    $this->translateFormLabels($form);
+  }
+
+  /**
+   * Translate some case form labels that Civi did not run translation for.
+   *
+   * Some Form labels are not ran through Civ's Ts function. We need to
+   * do this, so this function does that.
+   *
+   * @param CRM_Core_Form $form
+   *   Page class.
+   */
+  private function translateFormLabels(CRM_Core_Form $form) {
+    $caseTypeIdElement = &$form->getElement('case_type_id');
+    $this->translateLabel([$caseTypeIdElement]);
+  }
+
+  /**
+   * Translate the form labels for an array of form elements.
+   *
+   * @param array $elements
+   *   For Elements array.
+   */
+  private function translateLabel(array $elements) {
+    foreach ($elements as $element) {
+      $label = ts($element->getLabel());
+      $element->setLabel($label);
+    }
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * @param string $formName
+   *   Form name.
+   * @param CRM_Core_Form $form
+   *   Form class object.
+   *
+   * @return bool
+   *   returns a boolean to determine if hook will run or not.
+   */
+  private function shouldRun($formName, CRM_Core_Form $form) {
+    if ($formName != 'CRM_Case_Form_Activity') {
+      return FALSE;
+    }
+
+    return $form->_activityTypeName == 'Change Case Type';
+  }
+
+}

--- a/CRM/Civicase/Hook/BuildForm/CaseCategoryFormLabelTranslationForNewCase.php
+++ b/CRM/Civicase/Hook/BuildForm/CaseCategoryFormLabelTranslationForNewCase.php
@@ -5,7 +5,7 @@ use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
 /**
  * Class CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslation.
  */
-class CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslation {
+class CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslationForNewCase {
 
   /**
    * Translate some case form labels that Civi did not run translation for.

--- a/CRM/Civicase/Hook/PreProcess/CaseCategoryWordReplacementsForChangeCase.php
+++ b/CRM/Civicase/Hook/PreProcess/CaseCategoryWordReplacementsForChangeCase.php
@@ -1,0 +1,63 @@
+<?php
+
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+
+/**
+ * Class CaseCategoryWordReplacementsForChangeCase.
+ */
+class CRM_Civicase_Hook_PreProcess_CaseCategoryWordReplacementsForChangeCase {
+
+  /**
+   * Adds the word replacements array to Civi's translation locale.
+   *
+   * @param string $formName
+   *   Form Name.
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   */
+  public function run($formName, CRM_Core_Form &$form) {
+    if (!$this->shouldRun($formName, $form)) {
+      return;
+    }
+
+    $this->addWordReplacements($form);
+  }
+
+  /**
+   * Adds the word replacements array to Civi's translation locale.
+   *
+   * This will make Civi automatically translate form labels that are
+   * displayed using the ts function.
+   *
+   * @param CRM_Core_Form $form
+   *   Page class.
+   */
+  private function addWordReplacements(CRM_Core_Form $form) {
+    $caseCategoryName = CaseCategoryHelper::getCategoryName($form->_caseId[0]);
+    CRM_Civicase_Hook_Helper_CaseTypeCategory::addWordReplacements($caseCategoryName);
+    // We need to translate this manually as Civi does not the page title
+    // through the ts function.
+    $pageTitle = $form->get_template_vars('activityTypeName');
+    CRM_Utils_System::setTitle(ts($pageTitle));
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * @param string $formName
+   *   Form name.
+   * @param CRM_Core_Form $form
+   *   Form class object.
+   *
+   * @return bool
+   *   returns a boolean to determine if hook will run or not.
+   */
+  private function shouldRun($formName, CRM_Core_Form $form) {
+    if ($formName != 'CRM_Case_Form_Activity') {
+      return FALSE;
+    }
+
+    return $form->_activityTypeName == 'Change Case Type';
+  }
+
+}

--- a/CRM/Civicase/Hook/PreProcess/CaseCategoryWordReplacementsForNewCase.php
+++ b/CRM/Civicase/Hook/PreProcess/CaseCategoryWordReplacementsForNewCase.php
@@ -5,7 +5,7 @@ use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
 /**
  * Class CRM_Civicase_Hook_PreProcess_CaseCategoryWordReplacements.
  */
-class CRM_Civicase_Hook_PreProcess_CaseCategoryWordReplacements {
+class CRM_Civicase_Hook_PreProcess_CaseCategoryWordReplacementsForNewCase {
 
   /**
    * Adds the word replacements array to Civi's translation locale.

--- a/ang/civicase/activity/actions/directives/activity-actions.directive.js
+++ b/ang/civicase/activity/actions/directives/activity-actions.directive.js
@@ -33,8 +33,8 @@
 
   module.controller('civicaseActivityActionsController', civicaseActivityActionsController);
 
-  function civicaseActivityActionsController ($window, $rootScope, $scope, crmApi, getActivityFeedUrl, MoveCopyActivityAction, TagsActivityAction) {
-    var ts = $scope.ts = CRM.ts('civicase');
+  function civicaseActivityActionsController ($window, $rootScope, $scope, crmApi, getActivityFeedUrl, MoveCopyActivityAction, TagsActivityAction, ts) {
+    $scope.ts = ts;
     $scope.getActivityFeedUrl = getActivityFeedUrl;
     $scope.deleteActivity = deleteActivity;
     $scope.moveCopyActivity = MoveCopyActivityAction.moveCopyActivities;
@@ -72,7 +72,8 @@
      * Delete activities
      *
      * @param {Array} activities
-     * @param {jQuery} dialog - the dialog which should be closed once deletion is over
+     * @param {jQuery} dialog - the dialog which should be closed once deletion
+     *   is over
      */
     function deleteActivity (activities, dialog) {
       CRM.confirm({

--- a/ang/civicase/activity/card/directives/activity-card-big.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-big.directive.html
@@ -62,14 +62,14 @@
             <span
               class="civicase__tooltip__ellipsis civicase__activity-type"
               ng-class="{'civicase__activity-type--completed': (activity.category.indexOf('task') > -1 && activity.is_completed)}">
-              {{ activity.type }}
+              {{ ts(activity.type) }}
             </span>
           </civicase-tooltip>
         </div>
         <!-- End - top section -->
         <span class="civicase__activity-date" ng-class="{'civicase__overdue-activity-icon': activity.is_overdue}"><i class="material-icons">event</i>{{formatDate(activity.activity_date_time, 'DD MMM YYYY') }}</span>
         <!-- Subject -->
-        <div class="civicase__activity-subject">{{ activity.subject }}</div>
+        <div class="civicase__activity-subject">{{ ts(activity.subject) }}</div>
         <!-- End - Subject -->
         <!-- Tags -->
         <civicase-tags-container

--- a/ang/civicase/activity/card/directives/activity-card-long.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-long.directive.html
@@ -23,17 +23,17 @@
         <!-- End - Task - Checkbox -->
         <!-- Title - Type/Subject -->
         <civicase-tooltip
-          tooltip-text="activity.type !== 'File Upload' ? activity.type : (activity.subject || activity.type)">
+                tooltip-text="activity.type !== 'File Upload' ? ts(activity.type) : (ts(activity.subject) || ts(activity.type) )">
           <span
             ng-if="activity.type !== 'File Upload'"
             class="civicase__tooltip__ellipsis civicase__activity-type"
             ng-class="{'civicase__activity-type--completed': (activity.category.indexOf('task') > -1 && activity.is_completed)}">
-            {{ activity.type }}
+            {{ ts(activity.type) }} {{activity.type}}
           </span>
           <span
             class="civicase__tooltip__ellipsis civicase__activity-subject"
             ng-if="activity.type === 'File Upload'">
-            {{ activity.subject || activity.type }}
+            {{ ts(activity.subject) || ts(activity.type) }}
           </span>
         </civicase-tooltip>
         </span>
@@ -103,7 +103,7 @@
       </div>
       <div class="civicase__activity-card-row">
         <!-- Subject -->
-        <div ng-if="activity.type !== 'File Upload'" class="civicase__activity-subject">{{ activity.subject }}</div>
+        <div ng-if="activity.type !== 'File Upload'" class="civicase__activity-subject">{{ ts(activity.subject) }}</div>
         <!-- End - Subject -->
       </div>
       <div class="civicase__activity-card-row civicase__activity-card-row--communication" ng-if="activity.category.indexOf('communication') > -1">

--- a/ang/civicase/activity/card/directives/activity-card-long.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-long.directive.html
@@ -28,7 +28,7 @@
             ng-if="activity.type !== 'File Upload'"
             class="civicase__tooltip__ellipsis civicase__activity-type"
             ng-class="{'civicase__activity-type--completed': (activity.category.indexOf('task') > -1 && activity.is_completed)}">
-            {{ ts(activity.type) }} {{activity.type}}
+            {{ ts(activity.type) }}
           </span>
           <span
             class="civicase__tooltip__ellipsis civicase__activity-subject"

--- a/ang/civicase/activity/card/directives/activity-card-short.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-short.directive.html
@@ -80,7 +80,7 @@
           <span
             class="civicase__tooltip__ellipsis civicase__activity-type"
             ng-class="{'civicase__activity-type--completed': (activity.category.indexOf('task') > -1 && activity.is_completed)}">
-            {{ activity.type }}
+            {{ ts(activity.type) }}
           </span>
         </civicase-tooltip>
         <!-- End - Type -->
@@ -97,7 +97,7 @@
       <a ng-href="{{ 'civicrm/case/a/#/case/list' | civicaseCrmUrl:{ caseId: activity.case_id } }}">
         <div class="civicase__activity-card-row civicase__activity-card-row--case-info" >
           <span>
-            <span class="civicase__activity-card__case-id__label">Case ID:</span>
+            <span class="civicase__activity-card__case-id__label">{{ ts("Case ID:") }}</span>
             <span class="civicase__activity-card__case-id__value">{{activity.case_id}}</span>
           </span>
           <span class="civicase__pipe"> | </span>

--- a/ang/civicase/activity/panel/directives/activity-panel.directive.html
+++ b/ang/civicase/activity/panel/directives/activity-panel.directive.html
@@ -57,7 +57,7 @@
       <h3 class="panel-subtitle clearfix">
         <civicase-tooltip
           tooltip-text="activity.type">
-          <span class="civicase__tooltip__ellipsis">{{activity.type}}</span>
+          <span class="civicase__tooltip__ellipsis">{{ ts(activity.type) }}</span>
         </civicase-tooltip>
         <div class="civicase__activity__right-container">
           <!-- Tags -->

--- a/ang/civicase/activity/panel/directives/activity-panel.directive.js
+++ b/ang/civicase/activity/panel/directives/activity-panel.directive.js
@@ -20,9 +20,7 @@
      * @param {Object} $scope
      * @param {Object} element
      */
-    function civicaseActivityPanelLink (scope, element, attrs) {
-      var ts = CRM.ts('civicase');
-
+    function civicaseActivityPanelLink (scope, element, attrs, ts) {
       (function init () {
         $timeout(setPanelHeight);
         scope.$on('civicase::activity-feed::show-activity-panel', loadActivityForm);

--- a/civicase.php
+++ b/civicase.php
@@ -210,7 +210,8 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_CaseCategoryCustomFieldsProcessing(),
     new CRM_Civicase_Hook_BuildForm_DisableCaseCustomFieldValidations(),
     new CRM_Civicase_Hook_BuildForm_FilterByCaseCategoryOnChangeCaseType(),
-    new CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslation(),
+    new CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslationForNewCase(),
+    new CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslationForChangeCase(),
   ];
 
   foreach ($hooks as $hook) {
@@ -669,7 +670,8 @@ function civicase_civicrm_preProcess($formName, &$form) {
   $hooks = [
     new CRM_Civicase_Hook_PreProcess_CaseCategoryCustomFieldsSetDefaultValues(),
     new CRM_Civicase_Hook_PreProcess_ProcessCaseCategoryCustomFieldsForEdit(),
-    new CRM_Civicase_Hook_PreProcess_CaseCategoryWordReplacements(),
+    new CRM_Civicase_Hook_PreProcess_CaseCategoryWordReplacementsForNewCase(),
+    new CRM_Civicase_Hook_PreProcess_CaseCategoryWordReplacementsForChangeCase(),
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview
This PR makes a couple of changes:

- Word replacement changes for Change Case Type Form
- Word replacements for activities bulk actions
- Word replacements for Calendar on Manage Case category dashboard.


## Before
<img width="1273" alt="CiviProspect Dashboard - All Prospects  case-prospect 2019-09-03 17-07-56" src="https://user-images.githubusercontent.com/6951813/64190079-7c14b600-ce6d-11e9-9109-1e8983c351f2.png">
<img width="1050" alt="Manage Cases  case-prospect 2019-09-03 17-07-21" src="https://user-images.githubusercontent.com/6951813/64190081-7cad4c80-ce6d-11e9-80f0-ee24b2055447.png">
<img width="1280" alt="Manage Cases  case-prospect 2019-09-03 17-06-48" src="https://user-images.githubusercontent.com/6951813/64190082-7d45e300-ce6d-11e9-9412-0e5f17db6242.png">


## After
<img width="1278" alt="CiviProspect Dashboard - All Prospects  case-prospect 2019-09-03 16-53-17" src="https://user-images.githubusercontent.com/6951813/64189052-7cac4d00-ce6b-11e9-97b8-4b74987234df.png">

<img width="1280" alt="Manage Cases  case-prospect 2019-09-03 16-54-46" src="https://user-images.githubusercontent.com/6951813/64189188-ad8c8200-ce6b-11e9-8f87-85d181de7042.png">
<img width="1263" alt="Manage Cases  case-prospect 2019-09-03 16-56-08" src="https://user-images.githubusercontent.com/6951813/64189317-e4629800-ce6b-11e9-815f-1d7fba768afe.png">


## Technical Details
- Word replacements for the Change Case Type form was done by adding thw word replacements for the relevant case category into civi's translation locale via the PreProcess hook. All form labels that are displayed using the `ts` function will automatically be translated to the right word out of the box, however Civi did not run some form labels through the `ts` function e.g the `Case Type` label and this had to be done manually in the buildForm hook.

- The FE screens fix was simply to import the `ts` service and use in the relevant screens in order to effect the word replacements.