### PR TITLE
RSE-271: Case Category Word Replacement Changes

### DIFF
--- a/ang/civicase/activity/card/directives/activity-card-big.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-big.directive.html
@@ -62,14 +62,14 @@
             <span
               class="civicase__tooltip__ellipsis civicase__activity-type"
               ng-class="{'civicase__activity-type--completed': (activity.category.indexOf('task') > -1 && activity.is_completed)}">
-              {{ ts(activity.type) }}
+              {{ activity.type }}
             </span>
           </civicase-tooltip>
         </div>
         <!-- End - top section -->
         <span class="civicase__activity-date" ng-class="{'civicase__overdue-activity-icon': activity.is_overdue}"><i class="material-icons">event</i>{{formatDate(activity.activity_date_time, 'DD MMM YYYY') }}</span>
         <!-- Subject -->
-        <div class="civicase__activity-subject">{{ ts(activity.subject) }}</div>
+          <div class="civicase__activity-subject">{{ activity.subject }}</div>
         <!-- End - Subject -->
         <!-- Tags -->
         <civicase-tags-container

--- a/ang/civicase/activity/card/directives/activity-card-long.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-long.directive.html
@@ -23,17 +23,17 @@
         <!-- End - Task - Checkbox -->
         <!-- Title - Type/Subject -->
         <civicase-tooltip
-                tooltip-text="activity.type !== 'File Upload' ? ts(activity.type) : (ts(activity.subject) || ts(activity.type) )">
+                tooltip-text="activity.type !== 'File Upload' ? activity.type : (activity.subject || activity.type)">
           <span
             ng-if="activity.type !== 'File Upload'"
             class="civicase__tooltip__ellipsis civicase__activity-type"
             ng-class="{'civicase__activity-type--completed': (activity.category.indexOf('task') > -1 && activity.is_completed)}">
-            {{ ts(activity.type) }}
+            {{ activity.type }}
           </span>
           <span
             class="civicase__tooltip__ellipsis civicase__activity-subject"
             ng-if="activity.type === 'File Upload'">
-            {{ ts(activity.subject) || ts(activity.type) }}
+            {{ activity.subject || activity.type }}
           </span>
         </civicase-tooltip>
         </span>
@@ -103,7 +103,7 @@
       </div>
       <div class="civicase__activity-card-row">
         <!-- Subject -->
-        <div ng-if="activity.type !== 'File Upload'" class="civicase__activity-subject">{{ ts(activity.subject) }}</div>
+        <div ng-if="activity.type !== 'File Upload'" class="civicase__activity-subject">{{ activity.subject }}</div>
         <!-- End - Subject -->
       </div>
       <div class="civicase__activity-card-row civicase__activity-card-row--communication" ng-if="activity.category.indexOf('communication') > -1">

--- a/ang/civicase/activity/card/directives/activity-card-short.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-short.directive.html
@@ -80,7 +80,7 @@
           <span
             class="civicase__tooltip__ellipsis civicase__activity-type"
             ng-class="{'civicase__activity-type--completed': (activity.category.indexOf('task') > -1 && activity.is_completed)}">
-            {{ ts(activity.type) }}
+            {{ activity.type }}
           </span>
         </civicase-tooltip>
         <!-- End - Type -->

--- a/ang/civicase/activity/panel/directives/activity-panel.directive.html
+++ b/ang/civicase/activity/panel/directives/activity-panel.directive.html
@@ -57,7 +57,7 @@
       <h3 class="panel-subtitle clearfix">
         <civicase-tooltip
           tooltip-text="activity.type">
-          <span class="civicase__tooltip__ellipsis">{{ ts(activity.type) }}</span>
+            <span class="civicase__tooltip__ellipsis">{{activity.type}}</span>
         </civicase-tooltip>
         <div class="civicase__activity__right-container">
           <!-- Tags -->


### PR DESCRIPTION
## Overview
This PR reverts some changes made in last PR. Some api fields were wrapped in civi's translation function. However when some of these fields are `NULL`, it gives un-desirable results as the screen displays the variable name. To avoid this as described in the translation [best practices](https://docs.civicrm.org/dev/en/latest/translation/#best-practices), it is good to include word in strings in addition to the variables. However since the translation for API fields are not working as it should, for now, I have removed the `ts` function.

