### PR TITLE
Resolve Merge Conflicts Plus Fix Issues with Add Case button

### DIFF
--- a/ang/civicase.ang.php
+++ b/ang/civicase.ang.php
@@ -401,6 +401,7 @@ function set_contact_tasks(&$options) {
 function expose_settings(&$options) {
   $options['allowMultipleCaseClients'] = (bool) Civi::settings()->get('civicaseAllowMultipleClients');
   $options['allowCaseLocks'] = (bool) Civi::settings()->get('civicaseAllowCaseLocks');
+  $options['defaultCaseCategory'] = strtolower(CRM_Civicase_Helper_CaseCategory::CASE_TYPE_CATEGORY_NAME);
 }
 
 /**

--- a/ang/civicase/dashboard/directives/dashboard.directive.html
+++ b/ang/civicase/dashboard/directives/dashboard.directive.html
@@ -27,18 +27,24 @@
             class="form-control civicase__dashboard__relation-filter"
             crm-ui-select="{allowClear: false, multiple: false, data: caseRelationshipOptions}"
             ng-model="filters.caseRelationshipType" />
-            <a ng-if="checkPerm('add cases') && !caseTypeCategoryName"
-               ng-href="{{ url('civicrm/case/add', {reset: 1, action: 'add', context: 'standalone'}) }}"
-               class="btn btn-primary crm-popup civicase__dashboard__add-case"
-               crm-popup-form-success="refresh()">
-                <i class="material-icons">add_circle</i>{{ ts('Add Case') }}
-            </a>
-            <a ng-if="checkPerm('add cases') && caseTypeCategoryName"
-               ng-href="{{ url('civicrm/case/add', {reset: 1, action: 'add', case_type_category: caseTypeCategoryName, context: 'standalone'}) }}"
-            class="btn btn-primary crm-popup civicase__dashboard__add-case"
-            crm-popup-form-success="refresh()">
+          <a ng-if="checkPerm('add cases') && caseTypeCategoryName == defaultCaseCategory && !newCaseWebformUrl"
+             ng-href="{{ url('civicrm/case/add', {reset: 1, action: 'add', context: 'standalone'}) }}"
+             class="btn btn-primary crm-popup civicase__dashboard__add-case"
+             crm-popup-form-success="refresh()">
             <i class="material-icons">add_circle</i>{{ ts('Add Case') }}
           </a>
+          <a ng-if="checkPerm('add cases') && caseTypeCategoryName != defaultCaseCategory && !newCaseWebformUrl"
+             ng-href="{{ url('civicrm/case/add', {reset: 1, action: 'add', case_type_category: caseTypeCategoryName, context: 'standalone'}) }}"
+             class="btn btn-primary crm-popup civicase__dashboard__add-case"
+             crm-popup-form-success="refresh()">
+            <i class="material-icons">add_circle</i>{{ ts('Add Case') }}
+          </a>
+          <a ng-if="checkPerm('add cases') && newCaseWebformUrl"
+             ng-href="{{ newCaseWebformUrl | civicaseCrmUrl }}"
+             class="btn btn-primary civicase__dashboard__add-case">
+            <i class="material-icons">add_circle</i>{{ ts('Add Case') }}
+          </a>
+
         </div>
       </uib-tabset>
     </div>

--- a/ang/civicase/dashboard/directives/dashboard.directive.js
+++ b/ang/civicase/dashboard/directives/dashboard.directive.js
@@ -18,12 +18,14 @@
     $scope.activityFilters = {
       case_filter: {'case_type_id.is_active': 1, contact_is_deleted: 0}
     };
+    $scope.newCaseWebformUrl = CRM.civicase.newCaseWebformUrl;
 
     (function init () {
       bindRouteParamsToScope();
       initWatchers();
       prepareCaseFilterOption();
       $scope.caseTypeCategoryName = getCaseTypeCategoryName();
+      $scope.defaultCaseCategory = CRM.civicase.defaultCaseCategory;
       $scope.ts = ts;
     }());
 

--- a/civicase.php
+++ b/civicase.php
@@ -566,9 +566,33 @@ function civicase_civicrm_navigationMenu(&$menu) {
     'civicrm/case/search?reset=1' => 'civicrm/case/a/#/case/list?sx=1',
   ];
 
-  _civicase_menu_walk($menu, function (&$item) use ($rewriteMap) {
-    if (isset($item['url']) && isset($rewriteMap[$item['url']])) {
+  /**
+   * For URLS that have hardcoded values that may change per system.
+   * or for adding dynamic menu url mappings.
+   *
+   * @var array
+   *   Array(string $oldUrl => string $newUrl).
+   */
+  $otherUrlsMap = [];
+  _civicase_addNewCaseUrlMap($otherUrlsMap);
+
+  _civicase_menu_walk($menu, function (&$item) use ($rewriteMap, $otherUrlsMap) {
+    if (!isset($item['url'])) {
+      return;
+    }
+
+    if (isset($rewriteMap[$item['url']])) {
       $item['url'] = $rewriteMap[$item['url']];
+
+      return;
+    }
+
+    foreach ($otherUrlsMap as $oldUrl => $newUrl) {
+      if (strpos($item['url'], $oldUrl) !== FALSE) {
+        $item['url'] = $newUrl;
+
+        return;
+      }
     }
   });
 
@@ -604,6 +628,22 @@ function civicase_civicrm_navigationMenu(&$menu) {
   ];
 }
 
+/**
+ * Adds the add case URL mapping to the array depending on
+ * the case settings config for the system. IF an alternate add Case
+ * URL is set, the url mapping is added.
+ *
+ * @param array $urlMapArray
+ */
+function _civicase_addNewCaseUrlMap(&$urlMapArray) {
+  $allowCaseWebform = Civi::settings()->get('civicaseAllowCaseWebform');
+  $newCaseWebformUrl = $allowCaseWebform ? Civi::settings()
+    ->get('civicaseWebformUrl') : NULL;
+
+  if ($newCaseWebformUrl) {
+    $urlMapArray['civicrm/case/add?reset=1'] = $newCaseWebformUrl;
+  }
+}
 /**
  * Visit every link in the navigation menu, and alter it using $callback.
  *


### PR DESCRIPTION
## Overview
This PR fixes some issues that came up when creating a PR #244 to merge `prospect-develop` into `develop.`
This PR #203 brings about some changes that needs to be factored in when determining the URL for the Add Case button on the Manage Case page.

The fix was to add a new variable `defaultCaseCategory` that allows us determine the correct URL for the Add Case button taking the `newCaseWebformUrl` into consideration.

```php
     <a ng-if="checkPerm('add cases') && caseTypeCategoryName == defaultCaseCategory && !newCaseWebformUrl"
             ng-href="{{ url('civicrm/case/add', {reset: 1, action: 'add', context: 'standalone'}) }}"
             class="btn btn-primary crm-popup civicase__dashboard__add-case"
             crm-popup-form-success="refresh()">
            <i class="material-icons">add_circle</i>{{ ts('Add Case') }}
          </a>
          <a ng-if="checkPerm('add cases') && caseTypeCategoryName != defaultCaseCategory && !newCaseWebformUrl"
             ng-href="{{ url('civicrm/case/add', {reset: 1, action: 'add', case_type_category: caseTypeCategoryName, context: 'standalone'}) }}"
             class="btn btn-primary crm-popup civicase__dashboard__add-case"
             crm-popup-form-success="refresh()">
            <i class="material-icons">add_circle</i>{{ ts('Add Case') }}
          </a>
          <a ng-if="checkPerm('add cases') && newCaseWebformUrl"
             ng-href="{{ newCaseWebformUrl | civicaseCrmUrl }}"
             class="btn btn-primary civicase__dashboard__add-case">
            <i class="material-icons">add_circle</i>{{ ts('Add Case') }}
          </a>
```