### PR TITLE
Fixed for console error : empty result on case dashboard

### DIFF
--- a/ang/civicase/dashboard/directives/dashboard-tab.directive.js
+++ b/ang/civicase/dashboard/directives/dashboard-tab.directive.js
@@ -292,7 +292,7 @@
     function resultsHandler (formatFn, contactsProp, results) {
       // Flattened list of all the contact ids of all the contacts of all the cases
       var contactIds = _(results).pluck(contactsProp).flatten().pluck('contact_id').uniq().value();
-      var formattedResults = results.map(formatFn);
+      var formattedResults = (results && results.length > 0 )? results.map(formatFn) : null;
       // The try/catch block is necessary because the service does not
       // return a Promise if it doesn't find any new contacts to fetch
       try {


### PR DESCRIPTION
## Overview
When there is no result for CiviCase dashboard it gives console error.

## Before
While loading Civicase dashboard and if there is no data for cases it gives console error and nothing is loaded on dashboard.

## After
While loading Civicase dashboard and if there is no data for cases we are checking if result is null and dashboard is working fine.
