### PR TITLE
BASW-514: Disable Select All Bulk Action

### DIFF
--- a/ang/civicase/activity/feed/directives/activity-feed.directive.js
+++ b/ang/civicase/activity/feed/directives/activity-feed.directive.js
@@ -58,7 +58,6 @@
     var activityStartingOffset = 0;
     var caseId = $scope.params ? $scope.params.case_id : null;
     var pageNum = { down: 0, up: 0 };
-    var allActivities = [];
 
     $scope.isMonthNavVisible = true;
     $scope.isLoading = true;
@@ -117,7 +116,7 @@
      */
     $scope.toggleSelected = function (activity) {
       if (!$scope.findActivityById($scope.selectedActivities, activity.id)) {
-        $scope.selectedActivities.push($scope.findActivityById(allActivities, activity.id));
+        $scope.selectedActivities.push($scope.findActivityById($scope.activities, activity.id));
       } else {
         _.remove($scope.selectedActivities, { id: activity.id });
       }
@@ -198,8 +197,6 @@
         deselectAllActivities();
       } else if (condition === 'visible') {
         selectDisplayedActivities();
-      } else if (condition === 'all') {
-        selectEveryActivity();
       }
     }
 
@@ -229,15 +226,6 @@
     }
 
     /**
-     * Select all Activity
-     */
-    function selectEveryActivity () {
-      $scope.selectedActivities = [];
-      $scope.selectedActivities = _.cloneDeep(allActivities);
-      selectDisplayedActivities(); // Update the UI model with displayed cases selected;
-    }
-
-    /**
      * Select All visible data.
      */
     function selectDisplayedActivities () {
@@ -247,7 +235,7 @@
         isCurrentActivityInSelectedCases = $scope.findActivityById($scope.selectedActivities, activity.id);
 
         if (!isCurrentActivityInSelectedCases) {
-          $scope.selectedActivities.push($scope.findActivityById(allActivities, activity.id));
+          $scope.selectedActivities.push($scope.findActivityById($scope.activities, activity.id));
         }
       });
     }
@@ -328,12 +316,11 @@
         return loadActivities(mode);
       }).then(function (result) {
         var newActivities = _.each(result[0].acts.values, formatActivity);
-        allActivities = result[0].all.values;
 
         buildActivitiesArray(mode, newActivities);
 
         $scope.activityGroups = groupActivities($scope.activities);
-        $scope.totalCount = allActivities.length;
+        $scope.totalCount = result[0].all;
         // reset viewingActivity to get latest data
         $scope.viewingActivity = {};
         $scope.viewActivity($scope.aid);
@@ -358,6 +345,7 @@
       var options = setActivityAPIOptions(mode);
       var isMyActivitiesFilter = $scope.filters['@involvingContact'] === 'myActivities';
       var apiAction = isMyActivitiesFilter ? 'getcontactactivities' : 'get';
+      var apiActionAll = isMyActivitiesFilter ? 'getcontactactivitiescount' : 'getcount';
       var returnParams = {
         sequential: 1,
         return: [
@@ -369,16 +357,16 @@
         options: options
       };
       var getActionLinksParams = {
-        activity_id :'$value.id',
-        activity_type_id :'$value.activity_type_id',
+        activity_id: '$value.id',
+        activity_type_id: '$value.activity_type_id',
         source_record_id: '$value.source_record_id',
-        case_id :'$value.case_id'
+        case_id: '$value.case_id'
       };
       var params = {
         is_current_revision: 1,
         is_deleted: 0,
         is_test: 0,
-        'api.Activity.getactionlinks' : getActionLinksParams,
+        'api.Activity.getactionlinks': getActionLinksParams,
         options: {}
       };
 
@@ -425,10 +413,7 @@
 
       return crmApi({
         acts: ['Activity', apiAction, $.extend(true, {}, returnParams, params)],
-        all: ['Activity', apiAction, $.extend(true, {
-          sequential: 1,
-          return: ['id'],
-          options: { limit: 0 }}, params)] // all activities, also used to get count
+        all: ['Activity', apiActionAll, params]
       }).then(function (result) {
         return $q.all([
           result,

--- a/ang/civicase/bulk-action/directives/bulk-actions-checkboxes.directive.html
+++ b/ang/civicase/bulk-action/directives/bulk-actions-checkboxes.directive.html
@@ -17,16 +17,6 @@
     <li>
       <a
         href=""
-        ng-disabled="!isSelectAllAvailable"
-        ng-class="{'civicase__link-disabled disabled': !isSelectAllAvailable}"
-        ng-click="select('all')"
-        ng-attr-title="{{isSelectAllAvailable ? 'Select everything that matches search.' : 'Loading, Please wait! ...'}}">
-        Everything ({{everythingCount}})
-      </a>
-    </li>
-    <li>
-      <a
-        href=""
         ng-click="select('visible')"
         title="Select all displayed items">
         Displayed ({{displayedCount}})


### PR DESCRIPTION
## Overview
As part of this PR, the Select All Bulk Action has been disabled. 
The "Select All" needed all Activity IDs to be fetched via API, but this making the API call really slow and making the site unusable. So this feature is disabled temporarily, until a better solution is found.

## Before
![2019-09-16 at 7 32 PM](https://user-images.githubusercontent.com/5058867/64964448-b55f1400-d8b8-11e9-98ea-c7fde9a679ef.jpg)


## After
![2019-09-16 at 7 07 PM](https://user-images.githubusercontent.com/5058867/64962560-47fdb400-d8b5-11e9-9970-5569261ce34f.jpg)

## Technical Details
Select All HTML markup and related code has been removed.
