### PR TITLE
RSE-336: Move New/Existing Case Types To Case Category.

### DIFF
--- a/CRM/Civicase/Hook/Post/PopulateCaseCategoryForCaseType.php
+++ b/CRM/Civicase/Hook/Post/PopulateCaseCategoryForCaseType.php
@@ -1,0 +1,60 @@
+<?php
+
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+
+/**
+ * Class CRM_Civicase_Hook_Post_PopulateCaseCategoryForCaseType.
+ */
+class CRM_Civicase_Hook_Post_PopulateCaseCategoryForCaseType {
+
+  /**
+   * Updates the Case Type category for new cases.
+   *
+   * Updates the case category for a new case to be of type "Cases".
+   *
+   * @param string $op
+   *   The operation being performed.
+   * @param string $objectName
+   *   Object name.
+   * @param mixed $objectId
+   *   Object ID.
+   * @param object $objectRef
+   *   Object reference.
+   */
+  public function run($op, $objectName, $objectId, &$objectRef) {
+    if (!$this->shouldRun($op, $objectName)) {
+      return;
+    }
+
+    $this->updateCaseTypeCategory($objectId);
+  }
+
+  /**
+   * Updates the case type category to "Cases".
+   *
+   * @param int $caseTypeId
+   *   Case Type Id.
+   */
+  private function updateCaseTypeCategory($caseTypeId) {
+    civicrm_api3('CaseType', 'create', [
+      'id' => $caseTypeId,
+      'case_type_category' => CaseCategoryHelper::CASE_TYPE_CATEGORY_NAME,
+    ]);
+  }
+
+  /**
+   * Determines if the hook should run or not.
+   *
+   * @param string $op
+   *   The operation being performed.
+   * @param string $objectName
+   *   Object name.
+   *
+   * @return bool
+   *   returns a boolean to determine if hook will run or not.
+   */
+  private function shouldRun($op, $objectName) {
+    return $op == 'create' && $objectName == 'CaseType';
+  }
+
+}

--- a/CRM/Civicase/Setup/MoveCaseTypesToCasesCategory.php
+++ b/CRM/Civicase/Setup/MoveCaseTypesToCasesCategory.php
@@ -1,0 +1,73 @@
+<?php
+
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+use CRM_Case_BAO_CaseType as CaseType;
+
+/**
+ * Class CRM_Civicase_Setup_MoveCaseTypesToCasesCategory.
+ */
+class CRM_Civicase_Setup_MoveCaseTypesToCasesCategory {
+
+  /**
+   * Moves Case Types with no category to category "Cases".
+   */
+  public function apply() {
+    $this->moveCaseTypesWithNoCategoryToCasesCategory();
+  }
+
+  /**
+   * Moves Case Types with no category to category "Cases".
+   */
+  private function moveCaseTypesWithNoCategoryToCasesCategory() {
+    $caseTypeTable = CaseType::getTableName();
+    $caseTypes = CRM_Core_DAO::executeQuery("SELECT id FROM {$caseTypeTable} WHERE case_type_category IS NULL");
+    $caseTypeIds = [];
+
+    while ($caseTypes->fetch()) {
+      $caseTypeIds[] = $caseTypes->id;
+    }
+
+    if (empty($caseTypeIds)) {
+      return;
+    }
+    $this->updateCaseTypeCategory($caseTypeIds);
+  }
+
+  /**
+   * Updates the case type category to "Cases".
+   *
+   * @param array $caseTypeId
+   *   Case Type Id.
+   */
+  private function updateCaseTypeCategory(array $caseTypeId) {
+    $caseTypeTable = CaseType::getTableName();
+    $caseCategoryOptionValue = $this->getCaseCategoryOptionValue();
+
+    CRM_Core_DAO::executeQuery(
+      "UPDATE {$caseTypeTable} SET case_type_category = %1 WHERE id IN (" . implode(',', $caseTypeId) . ")",
+      [1 => [$caseCategoryOptionValue, 'Integer']]
+    );
+  }
+
+  /**
+   * Returns the Case category option value.
+   *
+   * @return int|null
+   *   Case category value.
+   */
+  private function getCaseCategoryOptionValue() {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'option_group_id' => 'case_type_categories',
+      'name' => CaseCategoryHelper::CASE_TYPE_CATEGORY_NAME,
+      'return' => ['value'],
+    ]);
+
+    if ($result['count'] == 0) {
+      return;
+    }
+
+    return $result['values'][0]['value'];
+  }
+
+}

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -4,6 +4,7 @@ use CRM_Civicase_Setup_CaseTypeCategorySupport as CaseTypeCategorySupport;
 use CRM_Civicase_Setup_CreateCasesOptionValue as CreateCasesOptionValue;
 use CRM_Civicase_Setup_AddCaseTypesForCustomGroupExtends as AddCaseTypesForCustomGroupExtends;
 use CRM_Civicase_Setup_AddCaseCategoryWordReplacementOptionGroup as AddCaseCategoryWordReplacementOptionGroup;
+use CRM_Civicase_Setup_MoveCaseTypesToCasesCategory as MoveCaseTypesToCasesCategory;
 
 /**
  * Collection of upgrade steps.
@@ -67,6 +68,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
       new AddCaseCategoryWordReplacementOptionGroup(),
       new CreateCasesOptionValue(),
       new AddCaseTypesForCustomGroupExtends(),
+      new MoveCaseTypesToCasesCategory(),
     ];
     foreach ($steps as $step) {
       $step->apply();

--- a/CRM/Civicase/Upgrader/Steps/Step0007.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0007.php
@@ -1,0 +1,23 @@
+<?php
+
+use CRM_Civicase_Setup_MoveCaseTypesToCasesCategory as MoveCaseTypesToCasesCategory;
+
+/**
+ * Class CRM_Civicase_Upgrader_Steps_Step0007.
+ */
+class CRM_Civicase_Upgrader_Steps_Step0007 {
+
+  /**
+   * Moves Case Types with no category to category "Cases".
+   *
+   * @return bool
+   *   Return value in boolean.
+   */
+  public function apply() {
+    $step = new MoveCaseTypesToCasesCategory();
+    $step->apply();
+
+    return TRUE;
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -445,6 +445,19 @@ function civicase_civicrm_validateForm($formName, &$fields, &$files, &$form, &$e
 }
 
 /**
+ * Implements hook_civicrm_post().
+ */
+function civicase_civicrm_post($op, $objectName, $objectId, &$objectRef) {
+  $hooks = [
+    new CRM_Civicase_Hook_Post_PopulateCaseCategoryForCaseType(),
+  ];
+
+  foreach ($hooks as $hook) {
+    $hook->run($op, $objectName, $objectId, $objectRef);
+  }
+}
+
+/**
  * Implements hook_civicrm_postProcess().
  */
 function civicase_civicrm_postProcess($formName, &$form) {
@@ -629,13 +642,16 @@ function civicase_civicrm_navigationMenu(&$menu) {
 }
 
 /**
+ * Civicase Add new case URL map.
+ *
  * Adds the add case URL mapping to the array depending on
  * the case settings config for the system. IF an alternate add Case
  * URL is set, the url mapping is added.
  *
  * @param array $urlMapArray
+ *   URL Map array.
  */
-function _civicase_addNewCaseUrlMap(&$urlMapArray) {
+function _civicase_addNewCaseUrlMap(array &$urlMapArray) {
   $allowCaseWebform = Civi::settings()->get('civicaseAllowCaseWebform');
   $newCaseWebformUrl = $allowCaseWebform ? Civi::settings()
     ->get('civicaseWebformUrl') : NULL;
@@ -644,6 +660,7 @@ function _civicase_addNewCaseUrlMap(&$urlMapArray) {
     $urlMapArray['civicrm/case/add?reset=1'] = $newCaseWebformUrl;
   }
 }
+
 /**
  * Visit every link in the navigation menu, and alter it using $callback.
  *


### PR DESCRIPTION
## Overview
After merging the work done on Case Type category to the develop branch, the develop site does not show cases when visiting the Dashboard. 
This is rightly so because the case types on the site does not have a case category assigned and we don't have a UI to do this.

This PR adds an upgrader to mark all existing case types without a case category to be of category Cases when case extension is upgraded/installed. Also when adding a new case type, the case category is set to be of Cases by default via a `civicase_civicrm_post` hook.

## Before
Existing/New Case types will not have a default Case category assigned. 

## After
The Cases category is assigned by default to existing case types without a case category or for new case types.

Installing the prospect extension comes with it's own case type Default Prospect Workflow which has the prospect category assigned by default so this change does not affect that functionality. Also when adding a new Case Type that is to be of prospect category, this will be done manually in the database for now.

## Technical Details
- In the `CRM_Civicase_Setup_MoveCaseTypesToCasesCategory` class, rather than using API's to fetch the Case Types and update the case type category column, SQL queries were used, the reason is because for new installation, the API calls were not working as the `case_type_category` fields was not part of the fields returned for the case type entity most likely because the `civicase_civicrm_entityTypes` responsible for adding this field is not yet invoked upon installation.

