### PR TITLE
Contact summary Go to Case button issue

### DIFF
--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
@@ -246,7 +246,7 @@
       <!-- End Last Modified -->
     </div>
     <div class="civicase__contact-cases-tab__panel-row civicase__contact-cases-tab__panel-actions">
-      <a ng-href="/civicrm/case/a/#/case/list?caseId={{item.id}}" class="btn btn-primary">
+      <a ng-href='/civicrm/case/a/#/case/list?caseId={{item.id}}&cf={ "status_id":["{{ item.name }}"] }' class="btn btn-primary">
         Go To Case
       </a>
     </div>

--- a/ang/civicase/case/factories/format-case.factory.js
+++ b/ang/civicase/case/factories/format-case.factory.js
@@ -10,6 +10,7 @@
       item.client = [];
       item.subject = (typeof item.subject === 'undefined') ? '' : item.subject;
       item.status = caseStatuses[item.status_id].label;
+      item.name = caseStatuses[item.status_id].name;
       item.color = caseStatuses[item.status_id].color;
       item.case_type = caseTypes[item.case_type_id].title;
       item.selected = false;


### PR DESCRIPTION
## Overview
From Contact summary pages if we go to Case tab and click on 'Go to Case' it will work only for cases having status open. As by default in list ew are showing all open cases. We need to update this link with case status also.

## Before
On contact summary page under case tab if we go on close (resolved ) case and click on 'Go to Case'  nothing shows.
It will show something like 
![before-patch](https://user-images.githubusercontent.com/445545/65046361-1997db80-d97e-11e9-82f8-9095abf9cb49.png)

## After
On contact summary page under case tab if we go on close (resolved ) case and click on 'Go to Case'  it will show the result.
It will show something like 
![after](https://user-images.githubusercontent.com/445545/65046723-c2463b00-d97e-11e9-95fa-b2022ef22048.png)

Updated the "go to case" button url with status name so it will work for all case status.

