### PR TITLE
CATL-1120: Add Case Webforms Notification And Fix Theme Based On Shoreditch

### DIFF
--- a/CRM/Civicase/Form/CaseWebforms.php
+++ b/CRM/Civicase/Form/CaseWebforms.php
@@ -81,6 +81,7 @@ class CRM_Civicase_Form_CaseWebforms extends CRM_Admin_Form {
       }
     }
     Civi::settings()->set('civi_drupal_webforms', $items);
+    CRM_Core_Session::setStatus(ts('Your changes have been saved successfully.'), 'Case Webforms', 'success');
   }
 
 }

--- a/templates/CRM/Civicase/Form/CaseWebforms.tpl
+++ b/templates/CRM/Civicase/Form/CaseWebforms.tpl
@@ -1,20 +1,22 @@
-{if $errorMsg}
-    <div class="messages warning no-popup">{$errorMsg}</div>
-{else}
-    <p>Select Drupal Webforms which should be linked from case view page.</p>
-    <table style="width: 100%">
-        {assign var="x" value=0}
-        {foreach from=$nids item=row}
-            {if $x mod 2 eq 1}
-                <tr style="background-color: #E6E6DC;">
-                    {else}
-                <tr style="background-color: #FFFFFF;">
-            {/if}
-            <td>{$form.$row.label}</td>
-            <td>{$form.$row.html}</td>
-            </tr>
-            {assign var="x" value=$x+1}
-        {/foreach}
-    </table>
-    <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
-{/if}
+<div class="crm-block crm-form-block">
+    {if $errorMsg}
+        <div class="messages warning no-popup">{$errorMsg}</div>
+    {else}
+        <div class="help">Select Drupal Webforms which should be linked from case view page.</div>
+        <table style="width: 100%" class="selector">
+            {assign var="x" value=0}
+            {foreach from=$nids item=row}
+                {if $x mod 2 eq 1}
+                    <tr style="background-color: #E6E6DC;">
+                        {else}
+                    <tr style="background-color: #FFFFFF;">
+                {/if}
+                <td>{$form.$row.label}</td>
+                <td>{$form.$row.html}</td>
+                </tr>
+                {assign var="x" value=$x+1}
+            {/foreach}
+        </table>
+        <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+    {/if}
+</div>


### PR DESCRIPTION
## Overview
1. On case webforms page (civicrm/case/webforms), add saved notification on save. Stay on same page after save.
https://nimb.ws/jteH1F

2. Update to use correct markup to have shoreditch looking table if possible.

## Before
The above 2 issues were not addressed.

## After
Both the above issues are handled.
![screenshot-localhost-2019 09 18-12_05_25](https://user-images.githubusercontent.com/36624620/65121974-b190d600-da0d-11e9-9018-4180be1a6c68.png)

## Technical Details
The save notification was added to CaseWebforms class using CRM_Core_Session::setStatus.
The markup of the case webforms page was modified to support UI based on Shoreditch theme.