### PR TITLE
CATL-1115: Fix Case Status Order In Case Dashboard Pages

### DIFF
--- a/ang/civicase.ang.php
+++ b/ang/civicase.ang.php
@@ -192,7 +192,7 @@ function set_tags_to_js_vars(&$options) {
 function set_option_values_to_js_vars(&$options) {
   foreach ($options as &$option) {
     $result = civicrm_api3('OptionValue', 'get', [
-      'return' => ['value', 'label', 'color', 'icon', 'name', 'grouping'],
+      'return' => ['value', 'label', 'color', 'icon', 'name', 'grouping', 'weight'],
       'option_group_id' => $option,
       'is_active' => 1,
       'options' => ['limit' => 0, 'sort' => 'weight'],

--- a/ang/civicase/case/details/directives/case-details-header.html
+++ b/ang/civicase/case/details/directives/case-details-header.html
@@ -64,11 +64,11 @@
         <li>
           <span class="list-group-item-info">{{ ts("Change status to:") }}</span>
         </li>
-        <li ng-repeat="(id, status) in allowedCaseStatuses" ng-if="id != item.status_id">
+        <li ng-repeat="status in allowedCaseStatuses" ng-if="status.value != item.status_id">
           <a
             crm-popup-form-success="pushCaseData($data.civicase_reload[0])"
             class="crm-popup"
-            ng-href="{{ 'civicrm/case/activity' | civicaseCrmUrl:{ action: 'add', reset: 1, cid: item.client[0].contact_id, caseid: item.id, atype: getActivityType('Change Case Status'), case_status_id: id, civicase_reload: caseGetParams() } }}">
+            ng-href="{{ 'civicrm/case/activity' | civicaseCrmUrl:{ action: 'add', reset: 1, cid: item.client[0].contact_id, caseid: item.id, atype: getActivityType('Change Case Status'), case_status_id: status.value, civicase_reload: caseGetParams() } }}">
             {{ status.label }}
           </a>
         </li>

--- a/ang/civicase/case/details/directives/case-details.directive.js
+++ b/ang/civicase/case/details/directives/case-details.directive.js
@@ -334,6 +334,10 @@
 
     function getAllowedCaseStatuses (definition) {
       var ret = _.cloneDeep(caseStatuses);
+      ret = _.chain(ret)
+        .sortBy(function (status) { return status.weight; })
+        .indexBy('weight')
+        .value();
       if (definition.statuses && definition.statuses.length) {
         _.each(_.cloneDeep(ret), function (status, id) {
           if (definition.statuses.indexOf(status.name) < 0) {

--- a/ang/civicase/case/directives/case-overview.directive.html
+++ b/ang/civicase/case/directives/case-overview.directive.html
@@ -37,7 +37,7 @@
         <div
           class="civicase__case-overview__flow-status civicase__case-overview__flow-status--hoverable"
           ng-if="!status.isHidden"
-          ng-repeat="(statusId, status) in caseStatuses"
+          ng-repeat="status in caseStatuses"
           uib-popover="{{ status.label }}"
           popover-trigger="'mouseenter'"
           popover-placement="bottom"
@@ -45,7 +45,7 @@
           popover-class="civicase__tooltip-popup-list">
           <div class="civicase__case-overview__flow-status__count">
             <a ng-href="{{ caseListLink(null, status.name) }}">
-              {{ summaryData.all[statusId] || '0' }}
+              {{ summaryData.all[status.value] || '0' }}
             </a>
           </div>
           <div class="civicase__case-overview__flow-status__description">
@@ -80,9 +80,9 @@
         <div
           class="civicase__case-overview__breakdown-field"
           ng-if="!status.isHidden"
-          ng-repeat="(statusId, status) in caseStatuses">
+          ng-repeat="status in caseStatuses">
           <a ng-href="{{ caseListLink(caseType.name, status.name) }}">
-            {{ summaryData[ctid][statusId] || '0' }}
+            {{ summaryData[ctid][status.value] || '0' }}
           </a>
         </div>
         <div class="civicase__case-overview__breakdown-field" ng-if="areAllStatusesHidden()"> - </div>

--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -47,11 +47,11 @@
     var caseTypes = CRM.civicase.caseTypes;
     var caseTypeCategories = CRM.civicase.caseTypeCategories;
 
+    $scope.summaryData = [];
     $scope.caseStatuses = _.chain(CRM.civicase.caseStatuses)
       .sortBy(function (status) { return status.weight; })
       .indexBy('weight')
       .value();
-    $scope.summaryData = [];
 
     (function init () {
       setCaseTypesBasedOnCategory();

--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -47,7 +47,10 @@
     var caseTypes = CRM.civicase.caseTypes;
     var caseTypeCategories = CRM.civicase.caseTypeCategories;
 
-    $scope.caseStatuses = CRM.civicase.caseStatuses;
+    $scope.caseStatuses = _.chain(CRM.civicase.caseStatuses)
+      .sortBy(function (status) { return status.weight; })
+      .indexBy('weight')
+      .value();
     $scope.summaryData = [];
 
     (function init () {


### PR DESCRIPTION
## Overview
In the following placed the field “civicrm_option_value.weight” is not respected in the ordering. Case status should be ordered by the weight property.

Case dashboard
Case dashboard select items
https://nimb.ws/ehKJ2i

Change case status on case itself.
https://nimb.ws/3ka1G4

## Before
The case status order was not obeying the weights.
https://nimb.ws/ehKJ2i
https://nimb.ws/3ka1G4

## After
Now case status in the above areas obey weight and are sorted based on that.
In the following 'testfirst' had the lowest weight, and 'test1' had the most weight.
![screenshot-localhost-2019 09 18-12_46_29](https://user-images.githubusercontent.com/36624620/65125317-d9cf0380-da12-11e9-91cc-1cb149d270c0.png)
![screenshot-localhost-2019 09 18-12_47_01](https://user-images.githubusercontent.com/36624620/65125320-da679a00-da12-11e9-8295-8e34ad82d56a.png)

## Technical Details
In civicase.ang.php, the 'weight' attribute was added to the options array so that for case statuses we have the weight. This was then used in case-details.directive.js and case-overview.directive.js to sort and index them by weight. case-details-header.html and case-overview.directive.html are then updated in places where the id is used and changed it to use status.value.