### PR TITLE
BASW-517: FE Solution for Activity Feed Causes Major System Slowdown

### DIFF
--- a/ang/civicase/activity/actions/directives/activity-actions.directive.html
+++ b/ang/civicase/activity/actions/directives/activity-actions.directive.html
@@ -14,27 +14,27 @@
   </a>
 </li>
 <li>
-  <a href ng-click="moveCopyActivity(selectedActivities, 'move')">
+  <a href ng-click="moveCopyActivity(selectedActivities, 'move', isSelectAll, params, totalCount)">
     <i class="material-icons">next_week</i> {{ ts('Move to Case') }}
   </a>
 </li>
 <li>
-  <a href ng-click="moveCopyActivity(selectedActivities, 'copy')">
+  <a href ng-click="moveCopyActivity(selectedActivities, 'copy', isSelectAll, params, totalCount)">
     <i class="material-icons">filter_none</i> {{ ts('Copy to Case') }}
   </a>
 </li>
-<li ng-repeat="link in selectedActivities[0]['api.Activity.getactionlinks']">
+<li ng-if="mode !== 'case-activity-bulk-action'" ng-repeat="link in selectedActivities[0]['api.Activity.getactionlinks']">
   <a ng-href="{{ link.url }}" class="{{ link.class }}">
     <i class="material-icons">filter_none</i>{{ link.name }}
   </a>
 </li>
 <li ng-if="mode === 'case-activity-bulk-action'">
-  <a href ng-click="manageTags('add', selectedActivities)">
+  <a href ng-click="manageTags('add', selectedActivities, isSelectAll, params, totalCount)">
     <i class="material-icons">add_circle</i> {{ ts('Tag - add to activities') }}
   </a>
 </li>
 <li ng-if="mode === 'case-activity-bulk-action'">
-  <a href ng-click="manageTags('remove', selectedActivities)">
+  <a href ng-click="manageTags('remove', selectedActivities, isSelectAll, params, totalCount)">
     <i class="material-icons">remove_circle</i> {{ ts('Tag - remove from activities') }}
   </a>
 </li>
@@ -46,7 +46,7 @@
 </li>
 <li class="divider"></li>
 <li>
-  <a href ng-click="deleteActivity(selectedActivities)">
+  <a href ng-click="deleteActivity(selectedActivities, isSelectAll, params, totalCount)">
     <i class="material-icons">delete</i> {{ ts('Delete') }}
   </a>
 </li>

--- a/ang/civicase/activity/actions/directives/activity-actions.directive.js
+++ b/ang/civicase/activity/actions/directives/activity-actions.directive.js
@@ -5,7 +5,10 @@
     return {
       scope: {
         mode: '@',
-        selectedActivities: '='
+        selectedActivities: '=',
+        isSelectAll: '=',
+        totalCount: '=',
+        params: '='
       },
       require: '?^civicaseCaseDetails',
       controller: civicaseActivityActionsController,
@@ -33,10 +36,10 @@
 
   module.controller('civicaseActivityActionsController', civicaseActivityActionsController);
 
-  function civicaseActivityActionsController ($window, $rootScope, $scope, crmApi, getActivityFeedUrl, MoveCopyActivityAction, TagsActivityAction, ts) {
+  function civicaseActivityActionsController ($window, $rootScope, $scope, crmApi, getActivityFeedUrl, MoveCopyActivityAction, TagsActivityAction, DeleteActivityAction, ts) {
     $scope.ts = ts;
     $scope.getActivityFeedUrl = getActivityFeedUrl;
-    $scope.deleteActivity = deleteActivity;
+    $scope.deleteActivity = DeleteActivityAction.deleteActivity;
     $scope.moveCopyActivity = MoveCopyActivityAction.moveCopyActivities;
     $scope.manageTags = TagsActivityAction.manageTags;
     $scope.isActivityEditable = isActivityEditable;
@@ -66,35 +69,6 @@
       ];
 
       return !_.includes(nonEditableActivityTypes, activityType) && $scope.getEditActivityUrl;
-    }
-
-    /**
-     * Delete activities
-     *
-     * @param {Array} activities
-     * @param {jQuery} dialog - the dialog which should be closed once deletion
-     *   is over
-     */
-    function deleteActivity (activities, dialog) {
-      CRM.confirm({
-        title: ts('Delete Activity'),
-        message: ts('Permanently delete %1 activit%2?', {1: activities.length, 2: activities.length > 1 ? 'ies' : 'y'})
-      }).on('crmConfirm:yes', function () {
-        var apiCalls = [];
-
-        _.each(activities, function (activity) {
-          apiCalls.push(['Activity', 'delete', {id: activity.id}]);
-        });
-
-        crmApi(apiCalls)
-          .then(function () {
-            $rootScope.$broadcast('civicase::activity::updated');
-          });
-
-        if (dialog && $(dialog).data('uiDialog')) {
-          $(dialog).dialog('close');
-        }
-      });
     }
   }
 })(CRM.$, CRM._, angular);

--- a/ang/civicase/activity/actions/services/delete-activity-action.service.js
+++ b/ang/civicase/activity/actions/services/delete-activity-action.service.js
@@ -1,0 +1,57 @@
+(function (angular, $, _) {
+  var module = angular.module('civicase');
+
+  module.service('DeleteActivityAction', DeleteActivityAction);
+
+  function DeleteActivityAction ($rootScope, crmApi, dialogService) {
+    var ts = CRM.ts('civicase');
+
+    /**
+     * Delete Activities
+     *
+     * @param {Array} activities
+     * @param {Boolean} isSelectAll
+     * @param {Object} params
+     * @param {int} totalCount
+     */
+    this.deleteActivity = function (activities, isSelectAll, params, totalCount) {
+      var activityLength = isSelectAll ? totalCount : activities.length;
+
+      CRM.confirm({
+        title: ts('Delete Activity'),
+        message: ts('Permanently delete %1 activit%2?', {1: activityLength, 2: activityLength > 1 ? 'ies' : 'y'})
+      }).on('crmConfirm:yes', function () {
+        var apiCalls = prepareApiCalls(activities, isSelectAll, params);
+
+        crmApi(apiCalls)
+          .then(function () {
+            $rootScope.$broadcast('civicase::activity::updated');
+          });
+      });
+    };
+
+    /**
+     * Prepare the API calls for the delete operation
+     *
+     * @param {Array} activities
+     * @param {Boolean} isSelectAll
+     * @param {Object} params
+     * @return {Array}
+     */
+    function prepareApiCalls (activities, isSelectAll, params) {
+      var apiCalls = [];
+
+      if (isSelectAll) {
+        apiCalls = ['Activity', 'deletebyquery', params];
+      } else {
+        apiCalls = ['Activity', 'deletebyquery', {
+          id: activities.map(function (activity) {
+            return activity.id;
+          })
+        }];
+      }
+
+      return apiCalls;
+    }
+  }
+})(angular, CRM.$, CRM._);

--- a/ang/civicase/activity/actions/services/move-copy-activity-action.service.js
+++ b/ang/civicase/activity/actions/services/move-copy-activity-action.service.js
@@ -5,32 +5,27 @@
 
   function MoveCopyActivityAction ($rootScope, crmApi, dialogService) {
     var ts = CRM.ts('civicase');
-    var MOVE_COPY_ACTIVITY_LIMIT = 200;
 
     /**
      * Move/Copy activities
      *
      * @param {Array} activities
      * @param {String} operation
+     * @param {Boolean} isSelectAll
+     * @param {Object} params
+     * @param {int} totalCount
      */
-    this.moveCopyActivities = function (activities, operation) {
-      var isActivityLimitReached = activities.length > MOVE_COPY_ACTIVITY_LIMIT;
-
-      if (isActivityLimitReached) {
-        displayActivityLimitWarning(activities);
-        return;
-      }
-
+    this.moveCopyActivities = function (activities, operation, isSelectAll, params, totalCount) {
       var activitiesCopy = _.cloneDeep(activities);
       var title = operation[0].toUpperCase() + operation.slice(1) +
         ((activities.length === 1)
           ? ts(' %1Activity', {1: activities[0].type ? activities[0].type + ' ' : ''})
-          : ts(' %1 Activities', {1: activities.length}));
+          : ts(' %1 Activities', {1: isSelectAll ? totalCount : activities.length}));
       var model = {
         ts: ts,
-        case_id: activities.length > 1 ? '' : activitiesCopy[0].case_id,
+        case_id: (activities.length > 1 || isSelectAll) ? '' : activitiesCopy[0].case_id,
         isSubjectVisible: activities.length === 1,
-        subject: activities.length > 1 ? '' : activitiesCopy[0].subject
+        subject: (activities.length > 1 || isSelectAll) ? '' : activitiesCopy[0].subject
       };
 
       dialogService.open('MoveCopyActCard', '~/civicase/activity/actions/services/move-copy-activity-action.html', model, {
@@ -42,7 +37,11 @@
           text: ts('Save'),
           icons: {primary: 'fa-check'},
           click: function () {
-            moveCopyConfirmationHandler.call(this, operation, activities, model);
+            moveCopyConfirmationHandler.call(this, operation, model, {
+              selectedActivities: activities,
+              isSelectAll: isSelectAll,
+              searchParams: params
+            });
           }
         }]
       });
@@ -52,21 +51,18 @@
      * Handles the click event when the move/copy operation is confirmed
      *
      * @param {String} operation
-     * @param {Array} activities
      * @param {Object} model
+     * @param {Object} activitiesObject
      */
-    function moveCopyConfirmationHandler (operation, activities, model) {
-      var isCaseIdNew = !_.find(activities, function (activity) {
+    function moveCopyConfirmationHandler (operation, model, activitiesObject) {
+      var isCaseIdNew = !_.find(activitiesObject.selectedActivities, function (activity) {
         return activity.case_id === model.case_id;
       });
 
       if (model.case_id && isCaseIdNew) {
-        fetchActivitiesInfo(activities)
-          .then(function (activitiesData) {
-            var apiCalls = prepareApiCalls(activitiesData, operation, model);
+        var apiCalls = prepareApiCalls(activitiesObject, operation, model);
 
-            return crmApi(apiCalls);
-          })
+        crmApi(apiCalls)
           .then(function () {
             $rootScope.$broadcast('civicase::activity::updated');
           });
@@ -78,66 +74,31 @@
     /**
      * Prepare the API calls for the move/copy operation
      *
-     * @param {Array} activitiesData
+     * @param {Object} activitiesObject
      * @param {String} operation
      * @param {Object} model
-     * @return {Array} apiCalls
+     * @return {Array}
      */
-    function prepareApiCalls (activitiesData, operation, model) {
+    function prepareApiCalls (activitiesObject, operation, model) {
       var apiCalls = [];
+      var action = operation === 'copy' ? 'copybyquery' : 'movebyquery';
 
-      _.each(activitiesData, function (activity) {
-        if (operation === 'copy') {
-          delete activity.id;
-        }
-        if (activitiesData.length === 1) {
-          activity.subject = model.subject;
-        }
-        activity.case_id = model.case_id;
-        apiCalls.push(['Activity', 'create', activity]);
-      });
+      if (activitiesObject.isSelectAll) {
+        apiCalls = ['Activity', action, {
+          params: activitiesObject.searchParams,
+          caseid: model.case_id
+        }];
+      } else {
+        apiCalls = ['Activity', action, {
+          caseid: model.case_id,
+          id: activitiesObject.selectedActivities.map(function (activity) {
+            return activity.id;
+          }),
+          subject: model.subject
+        }];
+      }
 
       return apiCalls;
-    }
-
-    /**
-     * Displays a warning message about activity limit reached
-     *
-     * @param {Array} activities
-     */
-    function displayActivityLimitWarning (activities) {
-      var errorMsg = ts('The maximum number of Activities you can select to move/copy is %1. ' +
-        'You have selected %2.' +
-        ' Please select fewer Activities from your search results and try again.',
-      { 1: MOVE_COPY_ACTIVITY_LIMIT, 2: activities.length });
-
-      CRM.alert(errorMsg, 'Maximum Exceeded', 'error');
-    }
-
-    /**
-     * Fetch more information about activities
-     *
-     * @param {Array} activities
-     * @return {Promise}
-     */
-    function fetchActivitiesInfo (activities) {
-      var activityIds = activities.map(function (activity) {
-        return activity.id;
-      });
-
-      return crmApi([['Activity', 'get', {
-        sequential: 1,
-        options: {limit: 0},
-        return: [
-          'subject', 'details', 'activity_type_id', 'status_id',
-          'source_contact_name', 'target_contact_name', 'assignee_contact_name',
-          'activity_date_time', 'is_star', 'original_id', 'tag_id.name', 'tag_id.description',
-          'tag_id.color', 'file_id', 'is_overdue', 'case_id', 'priority_id'
-        ],
-        id: { 'IN': activityIds }
-      }]]).then(function (activitiesResponse) {
-        return activitiesResponse[0].values;
-      });
     }
   }
 })(angular, CRM.$, CRM._);

--- a/ang/civicase/activity/actions/services/move-copy-activity-action.service.js
+++ b/ang/civicase/activity/actions/services/move-copy-activity-action.service.js
@@ -80,7 +80,46 @@
      * @return {Array}
      */
     function prepareApiCalls (activitiesObject, operation, model) {
+      if (activitiesObject.selectedActivities.length === 1) {
+        return prepareAPICallsForSingleActivity(activitiesObject, operation, model);
+      } else {
+        return prepareAPICallsForMultipleActivities(activitiesObject, operation, model);
+      }
+    }
+
+    /**
+     * Prepare the API calls for the move/copy operation
+     *
+     * @param {Object} activitiesObject
+     * @param {String} operation
+     * @param {Object} model
+     * @return {Array}
+     */
+    function prepareAPICallsForSingleActivity (activitiesObject, operation, model) {
+      var activity = activitiesObject.selectedActivities[0];
       var apiCalls = [];
+
+      if (operation === 'copy') {
+        delete activity.id;
+      }
+
+      activity.subject = model.subject;
+      activity.case_id = model.case_id;
+      apiCalls = ['Activity', 'create', activity];
+
+      return apiCalls;
+    }
+
+    /**
+     * Prepare the API calls for the move/copy operation
+     *
+     * @param {Object} activitiesObject
+     * @param {String} operation
+     * @param {Object} model
+     * @return {Array}
+     */
+    function prepareAPICallsForMultipleActivities (activitiesObject, operation, model) {
+      var apiCalls;
       var action = operation === 'copy' ? 'copybyquery' : 'movebyquery';
 
       if (activitiesObject.isSelectAll) {

--- a/ang/civicase/activity/actions/services/tags-activity-action.service.js
+++ b/ang/civicase/activity/actions/services/tags-activity-action.service.js
@@ -9,8 +9,11 @@
      *
      * @param {String} operation
      * @param {Array} activities
+     * @param {Boolean} isSelectAll
+     * @param {Object} params
+     * @param {int} totalCount
      */
-    this.manageTags = function (operation, activities) {
+    this.manageTags = function (operation, activities, isSelectAll, params, totalCount) {
       var title, saveButtonLabel;
       title = saveButtonLabel = 'Tag Activities';
 
@@ -21,9 +24,13 @@
 
       getTags()
         .then(function (tags) {
-          var model = setModelObjectForModal(tags, activities);
+          var model = setModelObjectForModal(tags, activities.length || totalCount);
 
-          openTagsModal(model, title, saveButtonLabel, operation, activities);
+          openTagsModal(model, title, saveButtonLabel, operation, {
+            selectedActivities: activities,
+            isSelectAll: isSelectAll,
+            searchParams: params
+          });
         });
     };
 
@@ -31,13 +38,13 @@
      * Set the model object to be used in the modal
      *
      * @param {Array} tags
-     * @param {Array} activities
+     * @param {int} numberOfActivities
      * @return {Object}
      */
-    function setModelObjectForModal (tags, activities) {
+    function setModelObjectForModal (tags, numberOfActivities) {
       var model = {};
 
-      model.selectedActivitiesLength = activities.length;
+      model.selectedActivitiesLength = numberOfActivities;
       model.genericTags = prepareGenericTags(tags);
       model.tagSets = prepareTagSetsTree(tags);
 
@@ -70,9 +77,9 @@
      * @param {String} title
      * @param {String} saveButtonLabel
      * @param {String} operation
-     * @param {Array} activities
+     * @param {Object} activitiesObject
      */
-    function openTagsModal (model, title, saveButtonLabel, operation, activities) {
+    function openTagsModal (model, title, saveButtonLabel, operation, activitiesObject) {
       dialogService.open('TagsActivityAction', '~/civicase/activity/actions/services/tags-activity-action.html', model, {
         autoOpen: false,
         height: 'auto',
@@ -82,7 +89,7 @@
           text: saveButtonLabel,
           icons: operation === 'add' ? {primary: 'fa-check'} : false,
           click: function () {
-            addRemoveTagsConfirmationHandler.call(this, operation, activities, model);
+            addRemoveTagsConfirmationHandler.call(this, operation, activitiesObject, model);
           }
         }]
       });
@@ -92,11 +99,11 @@
      * Add/Remove tags confirmation handler
      *
      * @param {String} operation
-     * @param {Array} activities
+     * @param {Object} activitiesObject
      * @param {Object} model
      * @return {Promise}
      */
-    function addRemoveTagsConfirmationHandler (operation, activities, model) {
+    function addRemoveTagsConfirmationHandler (operation, activitiesObject, model) {
       var tagIds = model.selectedGenericTags;
 
       _.each(model.tagSets, function (tag) {
@@ -105,7 +112,7 @@
         }
       });
 
-      var apiCalls = prepareApiCalls(operation, activities, tagIds);
+      var apiCalls = prepareApiCalls(operation, activitiesObject, tagIds);
 
       crmApi(apiCalls)
         .then(function () {
@@ -119,24 +126,33 @@
      * Prepare the API calls for the Add/Remove operation
      *
      * @param {String} operation
-     * @param {Array} activities
+     * @param {Object} activitiesObject
      * @param {Array} tagIds
      * @return {Array}
      */
-    function prepareApiCalls (operation, activities, tagIds) {
+    function prepareApiCalls (operation, activitiesObject, tagIds) {
       var apiCalls = [];
-      var action = operation === 'add' ? 'create' : 'delete';
+      var action = operation === 'add' ? 'createByQuery' : 'deleteByQuery';
 
-      _.each(activities, function (activity) {
-        apiCalls.push(['EntityTag', action, {
+      if (activitiesObject.isSelectAll) {
+        apiCalls = ['EntityTag', action, {
           entity_table: 'civicrm_activity',
-          entity_id: activity.id,
-          tag_id: tagIds
-        }]);
-      });
+          tag_id: tagIds,
+          params: activitiesObject.searchParams
+        }];
+      } else {
+        apiCalls = ['EntityTag', action, {
+          entity_table: 'civicrm_activity',
+          tag_id: tagIds,
+          entity_id: activitiesObject.selectedActivities.map(function (activity) {
+            return activity.id;
+          })
+        }];
+      }
 
       return apiCalls;
     }
+
     /**
      * Get the tags for Activities from API end point
      *

--- a/ang/civicase/activity/feed/directives/activity-feed.directive.html
+++ b/ang/civicase/activity/feed/directives/activity-feed.directive.html
@@ -3,12 +3,13 @@
     civicase-activity-filters="filters" case-timelines="caseTimelines"
     display-options="displayOptions" show-checkboxes="showCheckboxes" feed-params="params"
     displayed-count="activities.length" total-count="totalCount" bulk-allowed="bulkAllowed"
-    selected-activities="selectedActivities">
+    selected-activities="selectedActivities" is-select-all="isSelectAll">
   </div>
 
   <civicase-bulk-actions-message
     selected-items="selectedActivities.length" total-count="totalCount"
-    is-select-all-available="true" show-checkboxes="showCheckboxes">
+    is-select-all-available="true" show-checkboxes="showCheckboxes"
+    is-select-all="isSelectAll">
   </civicase-bulk-actions-message>
 
   <div class="panel-body clearfix">

--- a/ang/civicase/activity/feed/directives/activity-feed.directive.js
+++ b/ang/civicase/activity/feed/directives/activity-feed.directive.js
@@ -61,6 +61,7 @@
 
     $scope.isMonthNavVisible = true;
     $scope.isLoading = true;
+    $scope.isSelectAll = false;
     $scope.activityTypes = CRM.civicase.activityTypes;
     $scope.activityStatuses = CRM.civicase.activityStatuses;
     $scope.activities = {};
@@ -115,6 +116,10 @@
      * Toggle Bulk Actions checkbox of the given activity
      */
     $scope.toggleSelected = function (activity) {
+      if ($scope.isSelectAll) {
+        deselectAllActivities();
+      }
+
       if (!$scope.findActivityById($scope.selectedActivities, activity.id)) {
         $scope.selectedActivities.push($scope.findActivityById($scope.activities, activity.id));
       } else {
@@ -224,6 +229,7 @@
      * Deselection of all activities
      */
     function deselectAllActivities () {
+      $scope.isSelectAll = false;
       $scope.selectedActivities = [];
     }
 
@@ -231,15 +237,15 @@
      * Select all Activity
      */
     function selectEveryActivity () {
-      // $scope.selectedActivities = [];
-      // $scope.selectedActivities = _.cloneDeep();
-      // selectDisplayedActivities(); // Update the UI model with displayed cases selected;
+      deselectAllActivities();
+      $scope.isSelectAll = true;
     }
 
     /**
      * Select All visible data.
      */
     function selectDisplayedActivities () {
+      $scope.isSelectAll = false;
       var isCurrentActivityInSelectedCases;
 
       _.each($scope.activities, function (activity) {

--- a/ang/civicase/activity/filters/directives/activity-filters.directive.html
+++ b/ang/civicase/activity/filters/directives/activity-filters.directive.html
@@ -31,17 +31,21 @@
       <div class="btn-group">
         <button
           type="button" class="btn btn-default"
-          ng-class="{disabled: !selectedActivities.length || !showCheckboxes}"
+          ng-class="{disabled: (!selectedActivities.length || !showCheckboxes) && !isSelectAll}"
           data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           {{ ts('Actions') }}
         </button>
         <button
           type="button" class="btn btn-default dropdown-toggle"
-          ng-class="{disabled: !selectedActivities.length || !showCheckboxes}"
+          ng-class="{disabled: (!selectedActivities.length || !showCheckboxes) && !isSelectAll}"
           data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           <span class="caret"></span>
         </button>
-        <ul class="dropdown-menu" refresh-callback="refresh" civicase-activity-actions mode="case-activity-bulk-action" selected-activities="selectedActivities">
+        <ul
+          class="dropdown-menu" refresh-callback="refresh"
+          civicase-activity-actions mode="case-activity-bulk-action"
+          selected-activities="selectedActivities" is-select-all="isSelectAll"
+          total-count="totalCount" params="combinedFilterParams">
         </ul>
       </div>
     </span>

--- a/ang/civicase/activity/filters/directives/activity-filters.directive.js
+++ b/ang/civicase/activity/filters/directives/activity-filters.directive.js
@@ -13,7 +13,8 @@
         totalCount: '=',
         filters: '=civicaseActivityFilters',
         displayOptions: '=displayOptions',
-        selectedActivities: '='
+        selectedActivities: '=',
+        isSelectAll: '='
       },
       replace: true,
       templateUrl: '~/civicase/activity/filters/directives/activity-filters.directive.html',
@@ -30,6 +31,7 @@
     function activityFiltersLink ($scope, element) {
       var ts = $scope.ts = CRM.ts('civicase');
 
+      $scope.combinedFilterParams = {};
       $scope.activityCategories = prepareActivityCategories();
       $scope.availableFilters = prepareAvailableFilters();
       // Default exposed filters
@@ -42,6 +44,7 @@
       };
 
       (function init () {
+        $scope.$on('civicaseActivityFeed.query', feedQueryListener);
         // Ensure set filters are also exposed
         _.each($scope.filters, function (filter, key) {
           $scope.exposedFilters[key] = true;
@@ -106,6 +109,17 @@
 
         $rootScope.$broadcast('civicase::activity-filters::more-filters-toggled');
       };
+
+      /**
+       * Subscribe listener for civicaseActivityFeed.query
+       *
+       * @param {Object} event
+       * @param {Object} feedQueryParams
+       */
+      function feedQueryListener (event, feedQueryParams) {
+        $scope.combinedFilterParams = angular.extend({}, feedQueryParams.apiParams, feedQueryParams.filters);
+        delete $scope.combinedFilterParams['api.Activity.getactionlinks'];
+      }
 
       /**
        * Prepare Activity Filters

--- a/ang/civicase/bulk-action/directives/bulk-actions-message.directive.html
+++ b/ang/civicase/bulk-action/directives/bulk-actions-message.directive.html
@@ -1,19 +1,19 @@
-<div class="civicase__bulkactions-message" ng-show="selectedItems > 0 && showCheckboxes">
+<div class="civicase__bulkactions-message" ng-show="(selectedItems > 0 || isSelectAll) && showCheckboxes">
   <div class="alert">
-    You have selected <strong>{{selectedItems}}</strong>
+    You have selected <strong>{{isSelectAll ? totalCount : selectedItems}}</strong>
     <ng-pluralize
       count="selectedItems"
       when="{'one': 'item', 'other': 'items'}">
     </ng-pluralize>.
     <a
-      ng-show="totalCount !== selectedItems"
+      ng-show="totalCount !== selectedItems && isSelectAll === false"
       href=""
       ng-class="{'civicase__link-disabled': !isSelectAllAvailable}"
       ng-click="select('all')">
       Select all {{totalCount}} that match the search
     </a>
     <a
-      ng-show="totalCount === selectedItems"
+      ng-show="totalCount === selectedItems || isSelectAll"
       href=""
       ng-class="{'civicase__link-disabled': !isSelectAllAvailable}"
       ng-click="select('none')">

--- a/ang/civicase/bulk-action/directives/bulk-actions-message.directive.js
+++ b/ang/civicase/bulk-action/directives/bulk-actions-message.directive.js
@@ -8,6 +8,7 @@
       templateUrl: '~/civicase/bulk-action/directives/bulk-actions-message.directive.html',
       scope: {
         selectedItems: '=',
+        isSelectAll: '=',
         isSelectAllAvailable: '=',
         totalCount: '=',
         showCheckboxes: '='


### PR DESCRIPTION
## Overview
When accessing activities for a contact on the Activities tab on the contact summary page for a contact that has a lot of activities (say ~10k), the page becomes un-responsive.

After investigation, the reason for the slowness was because the FE has to fetch all the activity ID's so that they can be used for performing bulk actions like Delete All, Move to Case` e.t.c.

https://github.com/compucorp/uk.co.compucorp.civicase/pull/259 fixes that issue by moving the bulk action operations to the Back End such that the Front end does not need to fetch all the activity Id's. In this PR, the FE uses the newly created API's.

## Technical Details
**In `delete-activity-action.service.js`**
New service  is created, where deletion action code is moved.

**In `activity-feed.directive.js `**
1. Logic for Select All has changed. Now we just set a variable `isSelectAll` to true, when All are selected, but we dont store all IDs as we did previously.
2. Now we use `getcount` api to fetch the total count.

**In `activity-actions.directive.js `**
3 new parameters are introduced, `isSelectAll`, `totalCount` and `params`.

**In `activity-actions.directive.html `**
`isSelectAll, params, totalCount` parameters are passed to the Tags/MoveCopy and Delete Bulk Actions.

**In `move-copy-activity-action.service.js ` and `tags-activity-action.service.js `**
Newly defined API endpoints are defined here.


## Comments
Unit tests are not updated because this needs to go to testing today. It will be updated later.
