### PR TITLE
 RSE-336: Removed Object Type hinting

### DIFF
--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -495,6 +495,8 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
   /**
    * This is a callback for running step upgraders from the queue.
    *
+   * #ToDO Removed Object Type hinting. Not compatible with PHP < 7.2.
+   *
    * @param CRM_Queue_TaskContext $context
    *   Context.
    * @param \object $step
@@ -504,7 +506,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
    *   The queue requires that true is returned on successful upgrade, but we
    *   use exceptions to indicate an error instead.
    */
-  public static function runStepUpgrade(CRM_Queue_TaskContext $context, object $step) {
+  public static function runStepUpgrade(CRM_Queue_TaskContext $context, $step) {
     $step->apply();
     return TRUE;
   }


### PR DESCRIPTION
## Overview
Removed Object Type hinting in the `CRM_Civicase_Upgrader` upgrader class as it was preventing upgraders from running on the Civicase Dev site.

## Before
![image (4)](https://user-images.githubusercontent.com/6951813/65141840-5957d500-da09-11e9-83a2-ac03001bf1ac.png)


## After
Object Type Hinting is not available for PHP Version < [7.2](https://wiki.php.net/rfc/object-typehint). So this is removed.
The dev site will be upgraded to 7.2 ASAP after the next release is done.

