### PR TITLE
BASW-515: BE Solution for Activity Feed Causes Major System Slowdown

### DIFF
--- a/CRM/Civicase/APIHelpers/ActivityQueryApi.php
+++ b/CRM/Civicase/APIHelpers/ActivityQueryApi.php
@@ -1,0 +1,50 @@
+<?php
+
+use CRM_Civicase_APIHelpers_GenericApi as GenericApiHelper;
+
+/**
+ * Class CRM_Civicase_APIHelpers_ActivityQueryApi.
+ */
+class CRM_Civicase_APIHelpers_ActivityQueryApi {
+
+  /**
+   * Validates the Case Query related API parameters.
+   *
+   * @param array $params
+   *   API parameters.
+   */
+  public function validateParameters(array $params) {
+    if (!empty($params['params']) && !empty($params['id'])) {
+      throw new API_Exception("Please send either the params or Id");
+    }
+
+    if (empty($params['params']) && empty($params['id'])) {
+      throw new API_Exception("Both params and Id cannot be empty");
+    }
+  }
+
+  /**
+   * Returns the parameters for making calls to Activity.get.
+   *
+   * @param array $params
+   *   API parameters.
+   *
+   * @return array|string
+   *   The parameters for making call to Activity.get.
+   */
+  public function getActivityGetRequestApiParams(array $params) {
+    $genericApiHelper = new GenericApiHelper();
+    $apiParams = '';
+
+    if (!empty($params['id'])) {
+      $apiParams = ['id' => ['IN' => $genericApiHelper->getParameterValue($params, 'id')]];
+    }
+
+    if (!empty($params['params'])) {
+      $apiParams = $params['params'];
+    }
+
+    return $apiParams;
+  }
+
+}

--- a/CRM/Civicase/APIHelpers/EntityTagQueryApi.php
+++ b/CRM/Civicase/APIHelpers/EntityTagQueryApi.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Class CRM_Civicase_APIHelpers_EntityTagQueryApi.
+ */
+class CRM_Civicase_APIHelpers_EntityTagQueryApi {
+
+  /**
+   * Validates the Entity Tag Query related API parameters.
+   *
+   * @param array $params
+   *   API parameters.
+   */
+  public function validateParameters(array $params) {
+    if (!empty($params['params']) && !empty($params['entity_id'])) {
+      throw new API_Exception('Please send either the params or Entity ID');
+    }
+
+    if (empty($params['params']) && empty($params['entity_id'])) {
+      throw new API_Exception('Both params and Entity ID cannot be empty');
+    }
+  }
+
+  /**
+   * Returns the name of an entity given the database table name.
+   *
+   * @param string $tableName
+   *   Table name.
+   *
+   * @return null|string
+   *   Entity Name.
+   */
+  public function getEntityNameFromTable($tableName) {
+    $className = CRM_Core_DAO_AllCoreTables::getClassForTable($tableName);
+    return CRM_Core_DAO_AllCoreTables::getBriefName($className);
+  }
+
+}

--- a/CRM/Civicase/APIHelpers/GenericApi.php
+++ b/CRM/Civicase/APIHelpers/GenericApi.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Class CRM_Civicase_APIHelpers_GenericApi.
+ */
+class CRM_Civicase_APIHelpers_GenericApi {
+
+  /**
+   * Return the entity values based on the parameters passed.
+   *
+   * @param string $entityName
+   *   The entity name.
+   * @param array $params
+   *   API parameters.
+   * @param array $returnFields
+   *   The fields the API will return.
+   *
+   * @return array
+   *   Array of activities.
+   */
+  public function getEntityValues($entityName, array $params, array $returnFields = []) {
+    $entityValues = [];
+    if ($returnFields) {
+      $params['return'] = $returnFields;
+    }
+
+    $params['options'] = ['limit' => 0];
+
+    $results = civicrm_api3($entityName, 'get', $params);
+
+    if ($results['count'] > 0) {
+      $entityValues = $results['values'];
+    }
+
+    return $entityValues;
+  }
+
+  /**
+   * Gets the parameter value from $params array.
+   *
+   * This function is useful when we want the parameter to not support
+   * any SQL operator, i.e we expect a single value or an array of values to
+   * be passed in for the parameter.
+   *
+   * @param array $params
+   *   API parameters.
+   * @param string $parameterName
+   *   Parameter name.
+   *
+   * @return array
+   *   The parameter value.
+   */
+  public function getParameterValue(array $params, $parameterName) {
+    if (empty($params[$parameterName])) {
+      return [];
+    }
+
+    if (!is_array($params[$parameterName])) {
+      return [$params[$parameterName]];
+    }
+
+    $acceptedSQLOperators = CRM_Core_DAO::acceptedSQLOperators();
+    if (array_intersect($acceptedSQLOperators, array_keys($params[$parameterName]))) {
+      throw new InvalidArgumentException("No SQL operators allowed for {$parameterName}");
+    }
+
+    return $params[$parameterName];
+
+  }
+
+}

--- a/api/v3/Activity/Copybyquery.php
+++ b/api/v3/Activity/Copybyquery.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @file
+ * Activity.CopyByQuery file.
+ */
+
+/**
+ * Activity.CopyByQuery API specification.
+ *
+ * @param array $spec
+ *   Description of fields supported by this API call.
+ */
+function _civicrm_api3_activity_copybyquery_spec(array &$spec) {
+  $spec['case_id'] = [
+    'title' => 'Case ID',
+    'api.required' => 1,
+    'description' => 'Activity ID',
+    'type' => CRM_Utils_Type::T_INT,
+  ];
+  $spec['id'] = [
+    'title' => 'Activity ID',
+    'description' => 'Activity ID',
+  ];
+  $spec['params'] = [
+    'title' => 'Params for Activity Get',
+    'description' => 'Array of parameters for Activity.Get API',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+}
+
+/**
+ * Activity.Copybyquery API.
+ *
+ * This API uses copies activities and creates new activities
+ * with the case ID sent. The activity ID's to be copied can be sent in the id
+ * parameter or they can be fetched with a call to Activity.get using
+ * the parameters sent in params to query Activity.get API.
+ *
+ * @param array $params
+ *   API parameters.
+ *
+ * @return array
+ *   API result descriptor
+ */
+function civicrm_api3_activity_copybyquery(array $params) {
+  $activityQueryApiHelper = new CRM_Civicase_APIHelpers_ActivityQueryApi();
+  $activityQueryApiHelper->validateParameters($params);
+  $activityApiParams = $activityQueryApiHelper->getActivityGetRequestApiParams($params);
+  $genericApiHelper = new CRM_Civicase_APIHelpers_GenericApi();
+  $activities = $genericApiHelper->getEntityValues('Activity', $activityApiParams);
+
+  $activityIds = [];
+  foreach ($activities as $activity) {
+    $activityIds[] = $activity['id'];
+    unset($activity['id']);
+    $activity['case_id'] = $params['case_id'];
+    civicrm_api3('Activity', 'create', $activity);
+  }
+
+  return civicrm_api3_create_success($activityIds, $params, 'Activity', 'copybyquery');
+}

--- a/api/v3/Activity/Copybyquery.php
+++ b/api/v3/Activity/Copybyquery.php
@@ -52,10 +52,10 @@ function civicrm_api3_activity_copybyquery(array $params) {
 
   $activityIds = [];
   foreach ($activities as $activity) {
-    $activityIds[] = $activity['id'];
     unset($activity['id']);
     $activity['case_id'] = $params['case_id'];
-    civicrm_api3('Activity', 'create', $activity);
+    $result = civicrm_api3('Activity', 'create', $activity);
+    $activityIds[] = $result['id'];
   }
 
   return civicrm_api3_create_success($activityIds, $params, 'Activity', 'copybyquery');

--- a/api/v3/Activity/Deletebyquery.php
+++ b/api/v3/Activity/Deletebyquery.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @file
+ * Activity.DeleteByQuery file.
+ */
+
+/**
+ * Activity.DeleteByQuery API specification.
+ *
+ * @param array $spec
+ *   Description of fields supported by this API call.
+ */
+function _civicrm_api3_activity_deletebyquery_spec(array &$spec) {
+  $spec['id'] = [
+    'title' => 'Activity ID',
+    'description' => 'Activity ID',
+  ];
+  $spec['params'] = [
+    'title' => 'Params for Activity Get',
+    'description' => 'Array of parameters for Activity.Get API',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+}
+
+/**
+ * Activity.DeletByQuery API.
+ *
+ * This API uses deletes activities using the Activity.Delete API
+ * The activity ID's can be sent in the id parameter or they can be
+ * fetched with a call to Activity.get using the parameters sent in params
+ * to query Activity.get API and then delete the fetched ID's.
+ *
+ * @param array $params
+ *   API parameters.
+ *
+ * @return array
+ *   API result descriptor
+ */
+function civicrm_api3_activity_deletebyquery(array $params) {
+  $activityQueryApiHelper = new CRM_Civicase_APIHelpers_ActivityQueryApi();
+  $activityQueryApiHelper->validateParameters($params);
+  $genericApiHelper = new CRM_Civicase_APIHelpers_GenericApi();
+
+  if (!empty($params['id'])) {
+    $activities = $genericApiHelper->getParameterValue($params, 'id');
+  }
+  else {
+    $activityApiParams = $activityQueryApiHelper->getActivityGetRequestApiParams($params);
+    $activities = array_column($genericApiHelper->getEntityValues('Activity', $activityApiParams, ['id']), 'id');
+  }
+
+  $activityIds = [];
+  foreach ($activities as $activityId) {
+    try {
+      civicrm_api3('Activity', 'delete', [
+        'id' => $activityId,
+      ]);
+      $activityIds[] = $activityId;
+    } catch (Exception $e) {
+    }
+
+  }
+
+  return civicrm_api3_create_success($activityIds, $params, 'Activity', 'copybyquery');
+}

--- a/api/v3/Activity/Movebyquery.php
+++ b/api/v3/Activity/Movebyquery.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * @file
+ * Activity.MoveByQuery file.
+ */
+
+/**
+ * Activity.MoveByQuery API specification.
+ *
+ * @param array $spec
+ *   Description of fields supported by this API call.
+ */
+function _civicrm_api3_activity_Movebyquery_spec(array &$spec) {
+  $spec['case_id'] = [
+    'title' => 'Case ID',
+    'api.required' => 1,
+    'description' => 'Activity ID',
+    'type' => CRM_Utils_Type::T_INT,
+  ];
+  $spec['id'] = [
+    'title' => 'Activity ID',
+    'description' => 'Activity ID',
+  ];
+  $spec['params'] = [
+    'title' => 'Params for Activity Get',
+    'description' => 'Array of parameters for Activity.Get API',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+}
+
+/**
+ * Activity.Movebyquery API.
+ *
+ * This API uses moves activities to a new case type using the sent case_id.
+ * The activity ID's to be moved can be sent in the id parameter or they can
+ * be fetched with a call to Activity.get using the parameters sent in params
+ * to query Activity.get API to fetch Activity id's to be moved.
+ *
+ * @param array $params
+ *   API parameters.
+ *
+ * @return array
+ *   API result descriptor.
+ */
+function civicrm_api3_activity_movebyquery(array $params) {
+  $activityQueryApiHelper = new CRM_Civicase_APIHelpers_ActivityQueryApi();
+  $activityQueryApiHelper->validateParameters($params);
+  $genericApiHelper = new CRM_Civicase_APIHelpers_GenericApi();
+
+  if (!empty($params['id'])) {
+    $activities = $genericApiHelper->getParameterValue($params, 'id');
+  }
+  else {
+    $activityApiParams = $activityQueryApiHelper->getActivityGetRequestApiParams($params);
+    $activities = array_column($genericApiHelper->getEntityValues('Activity', $activityApiParams, ['id']), 'id');
+  }
+
+  $activityIds = [];
+  foreach ($activities as $activityId) {
+    $activityIds[] = $activityId;
+    civicrm_api3('Activity', 'create', [
+      'id' => $activityId,
+      'case_id' => $params['case_id'],
+    ]);
+  }
+
+  return civicrm_api3_create_success($activityIds, $params, 'Activity', 'copybyquery');
+}

--- a/api/v3/EntityTag/Createbyquery.php
+++ b/api/v3/EntityTag/Createbyquery.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * @file
+ * EntityTag.CreateByQuery file.
+ */
+
+/**
+ * EntityTag.Createbyquery API specification.
+ *
+ * @param array $spec
+ *   Description of fields supported by this API call.
+ */
+function _civicrm_api3_entity_tag_createbyquery_spec(array &$spec) {
+  $spec['entity_table'] = [
+    'title' => 'Entity Table',
+    'description' => 'Physical tablename for entity being joined to file, e.g. civicrm_contact',
+    'api.required' => 1,
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+  $spec['tag_id'] = [
+    'title' => 'Tag Id',
+    'description' => 'A single tag Id or array of Tag Ids',
+    'api.required' => 1,
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+  $spec['params'] = [
+    'title' => 'Params for API Get',
+    'description' => 'Array of parameters for Activity.Get API',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+  $spec['entity_id'] = [
+    'title' => 'Entity ID',
+    'type' => CRM_Utils_Type::T_INT,
+  ];
+}
+
+/**
+ * EntityTag.Createbyquery API.
+ *
+ * The API allows to create entity tags based on the parameters sent.
+ * When the params parameter is present, the API gets the entity name from
+ * the entity table and uses that to query the Entity get API with the params
+ * sent in order to get the entity ids that needs tags to be created for.
+ * When Id's are present, these id's are used directly for the
+ * entity tag creation.
+ *
+ * @param array $params
+ *   API parameters.
+ *
+ * @return array
+ *   API result descriptor
+ */
+function civicrm_api3_entity_tag_createbyquery(array $params) {
+  $entityTagQueryApiHelper = new CRM_Civicase_APIHelpers_EntityTagQueryApi();
+  $entityTagQueryApiHelper->validateParameters($params);
+  $genericApiHelper = new CRM_Civicase_APIHelpers_GenericApi();
+
+  if (!empty($params['entity_id'])) {
+    $entityValues = $genericApiHelper->getParameterValue($params, 'entity_id');
+  }
+  else {
+    $entityName = $entityTagQueryApiHelper->getEntityNameFromTable($params['entity_table']);
+    $entityValues = array_column($genericApiHelper->getEntityValues($entityName, $params['params'], ['id']), 'id');
+  }
+
+  $entityIds = [];
+  foreach ($entityValues as $entityValue) {
+    try {
+      civicrm_api3('EntityTag', 'create', [
+        'entity_table' => $params['entity_table'],
+        'tag_id' => $params['tag_id'],
+        'entity_id' => $entityValue,
+      ]);
+      $entityIds[] = $entityValue;
+    } catch (Exception $e) {
+    }
+
+  }
+
+  return civicrm_api3_create_success($entityIds, $params, 'EntityTag', 'createbyquery');
+}

--- a/api/v3/EntityTag/Deletebyquery.php
+++ b/api/v3/EntityTag/Deletebyquery.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * @file
+ * EntityTag.DeleteByQuery file.
+ */
+
+/**
+ * EntityTag.Deletebyquery API specification.
+ *
+ * @param array $spec
+ *   Description of fields supported by this API call.
+ */
+function _civicrm_api3_entity_tag_deletebyquery_spec(array &$spec) {
+  $spec['entity_table'] = [
+    'title' => 'Entity Table',
+    'description' => 'Physical tablename for entity being joined to file, e.g. civicrm_contact',
+    'api.required' => 1,
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+  $spec['tag_id'] = [
+    'title' => 'Tag Id',
+    'description' => 'A single tag Id or array of Tag Ids',
+    'api.required' => 1,
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+  $spec['params'] = [
+    'title' => 'Params for API Get',
+    'description' => 'Array of parameters for Activity.Get API',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+  $spec['entity_id'] = [
+    'title' => 'Entity ID',
+    'type' => CRM_Utils_Type::T_INT,
+  ];
+}
+
+/**
+ * EntityTag.Deletebyquery API.
+ *
+ * The API allows to delete entity tags based on the parameters sent.
+ * When the params parameter is present, the API gets the entity name from
+ * the entity table and uses that to query the Entity get API with the params
+ * sent in order to get the entity ids that needs tags to be deleted for.
+ * When Id's are present, these id's are used directly for the entity
+ * tag deletion.
+ *
+ * @param array $params
+ *   API parameters.
+ *
+ * @return array
+ *   API result descriptor
+ */
+function civicrm_api3_entity_tag_deletebyquery(array $params) {
+  $entityTagQueryApiHelper = new CRM_Civicase_APIHelpers_EntityTagQueryApi();
+  $entityTagQueryApiHelper->validateParameters($params);
+  $genericApiHelper = new CRM_Civicase_APIHelpers_GenericApi();
+
+  if (!empty($params['entity_id'])) {
+    $entityValues = $genericApiHelper->getParameterValue($params, 'entity_id');
+  }
+  else {
+    $entityName = $entityTagQueryApiHelper->getEntityNameFromTable($params['entity_table']);
+    $entityValues = array_column($genericApiHelper->getEntityValues($entityName, $params['params'], ['id']), 'id');
+  }
+
+  $entityIds = [];
+  foreach ($entityValues as $entityValue) {
+    try {
+      civicrm_api3('EntityTag', 'delete', [
+        'entity_table' => $params['entity_table'],
+        'tag_id' => $params['tag_id'],
+        'entity_id' => $entityValue,
+      ]);
+      $entityIds[] = $entityValue;
+    } catch (Exception $e) {
+    }
+
+  }
+
+  return civicrm_api3_create_success($entityIds, $params, 'EntityTag', 'deletebyquery');
+
+}


### PR DESCRIPTION
## Overview
When accessing activities for a contact on the Activities tab on the contact summary page for a contact that has a lot of activities (say ~10k), the page becomes un-responsive.

After investigation, the reason for the slowness was because the FE has to fetch all the activity ID's so that they can be used for performing bulk actions like `Delete All`, Move to Case` e.t.c. 

This PR fixes that issue by moving the bulk action operations to the Back End such that the Front end does not need to fetch all the activity Id's, all the FE needs to send to the newly created API;s is the API parameters needed to fetch the activities from the database or a list of Activity Id's , the BE will then fetch these Id's and perform the bulk operations.

## Before
When accessing activities for a contact on the Activities tab on the contact summary page for a contact that has a lot of activities (say ~10k), the page becomes un-responsive.

## After
When accessing activities for a contact on the Activities tab on the contact summary page for a contact that has a lot of activities (say ~10k), the page is now responsive.

## Technical Details
A couple of new API's were created to handle the bulk action operations:
**Activity.deleteByQuery**: Delete Activities in bulk using a criteria or a list of activity id's.
```php
civicrm_api3('Activity', 'deleteByQuery', [
  'id' => <it can be an array or a single value of activity ids>,
  'params' => {} //parameters needed to make an Activity.get API call
])
```

**Activity.copyByQuery**: Copy activities to a new case in bulk using a criteria or a list of activity id's.
```php
civicrm_api3('Activity', 'copyByQuery', [
  'case_id' => Case ID,
  'id' => <it can be an array or a single value of activity ids>,
  'params' => {} //parameters needed to make an Activity.get API call
])
```

**Activity.moveByQuery**: Move activities to a new case in bulk using a criteria or a list of activity id's.
```php
civicrm_api3('Activity', 'moveByQuery', [
 'case_id' => Case ID,
  'id' => <it can be an array or a single value of activity ids>,
  'params' => {} //parameters needed to make an Activity.get API call
])
```

**EntityTag.createByQuery**: Create tags in bulk for an entity using a criteria or a list of entity id's
```php
civicrm_api3('Activity', 'createByQuery', [
  'entity_table' => E.g civicrm_activity,
  'tag_id' => List of Tags,
  'entity_id' => <it can be an array or a single value of entity ids>,
  'params' => {} //parameters needed to make an Entity get API call for the entity
])
```

**EntityTag.deleteByQuery**:  Delete tags in bulk for an entity using a criteria or a list of entity id's
```php
civicrm_api3('Activity', 'deleteByQuery', [
  'entity_table' => E.g civicrm_activity,
  'tag_id' => List of Tags,
  'entity_id' => <it can be an array or a single value of entity ids>,
  'params' => {} //parameters needed to make an Entity get API call for the entity
])
```
