### PR TITLE
BASW-514: Fix case action error

### DIFF
--- a/ang/civicase/case/actions/directives/case-actions.directive.js
+++ b/ang/civicase/case/actions/directives/case-actions.directive.js
@@ -38,7 +38,7 @@
         var isCaseLockAllowed = CRM.civicase.allowCaseLocks;
         var caseActionService = getCaseActionService(action.action);
 
-        if (caseActionService.isActionAllowed) {
+        if (caseActionService && caseActionService.isActionAllowed) {
           isActionAllowed = caseActionService.isActionAllowed(action, $scope.cases);
         }
 
@@ -114,7 +114,11 @@
        * @return {Object}
        */
       function getCaseActionService (action) {
-        return $injector.get(action + 'CaseAction');
+        try {
+          return $injector.get(action + 'CaseAction');
+        } catch (e) {
+          return null;
+        }
       }
 
       /**
@@ -127,7 +131,7 @@
         _.each($scope.caseActions, function (action) {
           var caseActionService = getCaseActionService(action.action);
 
-          if (caseActionService.refreshData) {
+          if (caseActionService && caseActionService.refreshData) {
             caseActionService.refreshData($scope.cases);
           }
         });


### PR DESCRIPTION
## Overview
This PR fixes console errors related to Manage Case Page.

## Before
![2019-09-20 at 3 46 PM](https://user-images.githubusercontent.com/5058867/65319708-e0e64500-dbbd-11e9-92c6-fb72cbeacbe0.jpg)

## After
No console errors.

## Technical Details
In case the `caseActionService` is not found, angular was throwing Injector Not Found error. So the code is placed inside a `try/catch` block.