### PR TITLE
CATL-1134: Dont show Bulk Email

### DIFF
--- a/CRM/Civicase/Activity/ContactActivitiesSelector.php
+++ b/CRM/Civicase/Activity/ContactActivitiesSelector.php
@@ -1,18 +1,27 @@
 <?php
 
+/**
+ * Class CRM_Civicase_Activity_ContactActivitiesSelector.
+ */
 class CRM_Civicase_Activity_ContactActivitiesSelector {
 
   const API_DEFAULT_LIMIT = 25;
 
   /**
-   * Returns all the activities for a given contact. The contact must be either the creator,
-   * the client, or be one of the assignees for the activity. Also, the activity should
-   * not be assigned to someone else unless the contact is also an assignee.
+   * Get Acitivities for a Contact.
+   *
+   * Returns all the activities for a given contact. The contact must be
+   * either the creator, the client, or be one of the assignees for the
+   * activity. Also, the activity should not be assigned to someone else
+   * unless the contact is also an assignee.
    *
    * @param array $params
+   *   Parameters.
+   *
    * @return array
+   *   Activities.
    */
-  public function getAllActivitiesForContact($params) {
+  public function getAllActivitiesForContact(array $params) {
     $newParams = $this->getParamsWithoutOffsetsAndLimits($params);
 
     $this->addAssigneeContactIdToReturnParams($newParams);
@@ -25,13 +34,17 @@ class CRM_Civicase_Activity_ContactActivitiesSelector {
   }
 
   /**
-   * Returns paginated activities for the given contact using the limit and offset
-   * options.
+   * Returns paginated activities for the given contact.
+   *
+   * Uses the limit and offset options.
    *
    * @param array $params
+   *   Parameters.
+   *
    * @return array
+   *   Activities.
    */
-  public function getPaginatedActivitiesForContact($params) {
+  public function getPaginatedActivitiesForContact(array $params) {
     $activities = $this->getAllActivitiesForContact($params);
 
     $this->paginateActivityRecords($activities, $params);
@@ -43,9 +56,12 @@ class CRM_Civicase_Activity_ContactActivitiesSelector {
    * Returns the number of activities for the given contact.
    *
    * @param array $params
+   *   Parameters.
+   *
    * @return int
+   *   Count.
    */
-  public function getActivitiesForContactCount($params) {
+  public function getActivitiesForContactCount(array $params) {
     $activities = $this->getAllActivitiesForContact($params);
 
     return $activities['count'];
@@ -55,9 +71,12 @@ class CRM_Civicase_Activity_ContactActivitiesSelector {
    * Returns the original parameters, but without any offsets or limits.
    *
    * @param array $params
+   *   Parameters.
+   *
    * @return array
+   *   Paramaters.
    */
-  private function getParamsWithoutOffsetsAndLimits($params) {
+  private function getParamsWithoutOffsetsAndLimits(array $params) {
     $options = CRM_Utils_Array::value('options', $params, []);
     $options['limit'] = 0;
     $options['offset'] = 0;
@@ -67,13 +86,15 @@ class CRM_Civicase_Activity_ContactActivitiesSelector {
   }
 
   /**
-   * Adds the `assignee_contact_id` field to the return parameter. This field
-   * is necesary in order to properly filter the activities for the contact and
-   * remove activities that have been delegated to someone else.
+   * Adds the `assignee_contact_id` field to the return parameter.
+   *
+   * This field is necesary in order to properly filter the activities for the
+   * contact and remove activities that have been delegated to someone else.
    *
    * @param array $params
+   *   Parameters.
    */
-  private function addAssigneeContactIdToReturnParams(&$params) {
+  private function addAssigneeContactIdToReturnParams(array &$params) {
     $return = (array) CRM_Utils_Array::value('return', $params, []);
     $return[] = 'assignee_contact_id';
     $return = array_unique($return);
@@ -82,15 +103,21 @@ class CRM_Civicase_Activity_ContactActivitiesSelector {
   }
 
   /**
-   * Removes any activities that have been assigned to another contact other than
-   * the requested one. It also updates the activities count in order to reflect the
-   * new value.
+   * Removes activities assigned to other contacts.
+   *
+   * Removes any activities that have been assigned to another contact other
+   * than the requested one. It also updates the activities count in order to
+   * reflect the new value.
    *
    * @param array $activities
+   *   Activities.
    * @param array $params
+   *   Parameters.
+   *
    * @return array
+   *   Activities.
    */
-  private function filterOutActivitiesNotBelongingToContact(&$activities, $params) {
+  private function filterOutActivitiesNotBelongingToContact(array &$activities, array $params) {
     $activities['values'] = array_filter($activities['values'], function ($activity) use ($params) {
       $hasNoAssignee = empty($activity['assignee_contact_id']);
       $isContactAssignedToActivity = in_array($params['contact_id'], $activity['assignee_contact_id']);
@@ -105,9 +132,11 @@ class CRM_Civicase_Activity_ContactActivitiesSelector {
    * Paginates the activity records according to the limit and offset params.
    *
    * @param array $activities
+   *   Activities.
    * @param array $params
+   *   Paramaters.
    */
-  private function paginateActivityRecords(&$activities, $params) {
+  private function paginateActivityRecords(array &$activities, array $params) {
     $options = CRM_Utils_Array::value('options', $params, []);
     $limit = CRM_Utils_Array::value('limit', $options, self::API_DEFAULT_LIMIT);
     $offset = CRM_Utils_Array::value('offset', $options, 0);

--- a/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
+++ b/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
@@ -427,13 +427,14 @@
       }
 
       return crmApi('Activity', 'get', _.assign(params, {
-        'return': [
+        return: [
           'subject', 'details', 'activity_type_id', 'status_id',
           'source_contact_name', 'target_contact_name', 'assignee_contact_name',
           'activity_date_time', 'is_star', 'original_id', 'tag_id.name', 'tag_id.description',
           'tag_id.color', 'file_id', 'is_overdue', 'case_id', 'priority_id',
           'case_id.case_type_id', 'case_id.status_id', 'case_id.contacts'
         ],
+        activity_type_id: { '!=': 'Bulk Email' },
         sequential: 1,
         options: {
           // We try to get one activity more than the display limit, so we can
@@ -504,6 +505,7 @@
       var params = {};
       var dateMoment = moment(date);
 
+      params.activity_type_id = { '!=': 'Bulk Email' };
       params.status_id = status;
       params.activity_date_time = {
         BETWEEN: [

--- a/ang/civicase/activity/feed/directives/activity-feed.directive.js
+++ b/ang/civicase/activity/feed/directives/activity-feed.directive.js
@@ -383,6 +383,7 @@
         is_current_revision: 1,
         is_deleted: 0,
         is_test: 0,
+        activity_type_id: { '!=': 'Bulk Email' },
         'api.Activity.getactionlinks': getActionLinksParams,
         options: {}
       };

--- a/ang/civicase/case/factories/get-case-query-params.factory.js
+++ b/ang/civicase/case/factories/get-case-query-params.factory.js
@@ -44,6 +44,7 @@
           case_id: caseId,
           is_current_revision: 1,
           is_test: 0,
+          activity_type_id: { '!=': 'Bulk Email' },
           'activity_type_id.grouping': {LIKE: '%communication%'},
           'status_id.filter': 1,
           options: {limit: panelLimit, sort: 'activity_date_time DESC'},
@@ -54,6 +55,7 @@
           case_id: caseId,
           is_current_revision: 1,
           is_test: 0,
+          activity_type_id: { '!=': 'Bulk Email' },
           'activity_type_id.grouping': {LIKE: '%task%'},
           'status_id.filter': 0,
           options: {limit: panelLimit, sort: 'activity_date_time ASC'},
@@ -63,6 +65,7 @@
         'api.Activity.get.nextActivitiesWhichIsNotMileStone': {
           case_id: caseId,
           status_id: {'!=': 'Completed'},
+          activity_type_id: { '!=': 'Bulk Email' },
           'activity_type_id.grouping': {'NOT LIKE': '%milestone%'},
           options: {
             limit: 1
@@ -73,6 +76,7 @@
           case_id: caseId,
           is_current_revision: 1,
           is_deleted: 0,
+          activity_type_id: { '!=': 'Bulk Email' },
           'status_id': 'Scheduled'
         },
         // For the "scheduled-overdue" count
@@ -81,6 +85,7 @@
           is_current_revision: 1,
           is_deleted: 0,
           is_overdue: 1,
+          activity_type_id: { '!=': 'Bulk Email' },
           status_id: 'Scheduled'
         },
         // Custom data

--- a/ang/civicase/dashboard/directives/dashboard-tab.directive.js
+++ b/ang/civicase/dashboard/directives/dashboard-tab.directive.js
@@ -19,6 +19,7 @@
       'is_deleted': 0,
       'is_test': 0,
       'activity_type_id.grouping': { 'NOT LIKE': '%milestone%' },
+      'activity_type_id': { '!=': 'Bulk Email' },
       'status_id': { 'IN': CRM.civicase.activityStatusTypes.incomplete },
       'options': { 'sort': 'is_overdue DESC, activity_date_time ASC' },
       'return': [

--- a/api/v3/Activity/Getdayswithactivities.php
+++ b/api/v3/Activity/Getdayswithactivities.php
@@ -1,15 +1,19 @@
 <?php
 
 /**
- * Activity.getdayswithactivities API specification
- *
- * @param array $spec description of fields supported by this API call
- *
- * @return void
+ * @file
+ * Activity.getdayswithactivities file.
  */
-function _civicrm_api3_activity_getdayswithactivities_spec(&$spec) {
+
+/**
+ * Activity.getdayswithactivities API specification.
+ *
+ * @param array $spec
+ *   Description of fields supported by this API call.
+ */
+function _civicrm_api3_activity_getdayswithactivities_spec(array &$spec) {
   $allowed = ['activity_date_time', 'activity_status_id', 'case_id'];
-  $all = civicrm_api3('Activity', 'getfields', array('api_action' => 'get'))['values'];
+  $all = civicrm_api3('Activity', 'getfields', ['api_action' => 'get'])['values'];
 
   $spec = array_filter($all, function ($name) use ($allowed) {
     return in_array($name, $allowed);
@@ -17,14 +21,15 @@ function _civicrm_api3_activity_getdayswithactivities_spec(&$spec) {
 }
 
 /**
- * Returns list of unique YYYY-MM-DD dates with at least an activity
+ * Returns list of unique YYYY-MM-DD dates with at least an activity.
  *
- * @param array $params parameters to be passed to API call to obtain activities list
+ * @param array $params
+ *   Parameters to be passed to API call to obtain activities list.
  *
  * @return array
  *   API result with the list of days
  */
-function civicrm_api3_activity_getdayswithactivities($params) {
+function civicrm_api3_activity_getdayswithactivities(array $params) {
   $query = CRM_Utils_SQL_Select::from('civicrm_activity a');
   $query->select(['a.activity_date_time']);
 
@@ -53,16 +58,18 @@ function civicrm_api3_activity_getdayswithactivities($params) {
   return civicrm_api3_create_success($uniqueDates, $params, 'Activity', 'getdayswithactivities');
 }
 
-
 /**
- * Creates a WHERE clause with the given API parameter and column name
+ * Creates a WHERE clause with the given API parameter and column name.
  *
  * @param array $param
- * @param string $param
- * @param CRM_Utils_SQL_Select $param
+ *   Parameters.
+ * @param string $column
+ *   Column.
+ * @param CRM_Utils_SQL_Select $query
+ *   Query.
  */
-function _civicrm_api3_activity_getdayswithactivities_handle_id_param($param, $column, $query) {
-  $param = is_array($param) ? $param : array('=' => $param);
+function _civicrm_api3_activity_getdayswithactivities_handle_id_param(array $param, $column, CRM_Utils_SQL_Select $query) {
+  $param = is_array($param) ? $param : ['=' => $param];
 
   $query->where(CRM_Core_DAO::createSQLFilter($column, $param));
 }

--- a/api/v3/Activity/Getdayswithactivities.php
+++ b/api/v3/Activity/Getdayswithactivities.php
@@ -12,7 +12,9 @@
  *   Description of fields supported by this API call.
  */
 function _civicrm_api3_activity_getdayswithactivities_spec(array &$spec) {
-  $allowed = ['activity_date_time', 'activity_status_id', 'case_id'];
+  $allowed = [
+    'activity_date_time', 'activity_status_id', 'case_id', 'activity_type_id',
+  ];
   $all = civicrm_api3('Activity', 'getfields', ['api_action' => 'get'])['values'];
 
   $spec = array_filter($all, function ($name) use ($allowed) {
@@ -32,6 +34,10 @@ function _civicrm_api3_activity_getdayswithactivities_spec(array &$spec) {
 function civicrm_api3_activity_getdayswithactivities(array $params) {
   $query = CRM_Utils_SQL_Select::from('civicrm_activity a');
   $query->select(['a.activity_date_time']);
+
+  if (!empty($params['activity_type_id'])) {
+    _civicrm_api3_activity_getdayswithactivities_handle_id_param($params['activity_type_id'], 'a.activity_type_id', $query);
+  }
 
   if (!empty($params['activity_date_time'])) {
     _civicrm_api3_activity_getdayswithactivities_handle_id_param($params['activity_date_time'], 'a.activity_date_time', $query);

--- a/api/v3/Activity/Getdayswithactivities.php
+++ b/api/v3/Activity/Getdayswithactivities.php
@@ -67,14 +67,12 @@ function civicrm_api3_activity_getdayswithactivities(array $params) {
 /**
  * Creates a WHERE clause with the given API parameter and column name.
  *
- * @param array $param
- *   Parameters.
  * @param string $column
  *   Column.
  * @param CRM_Utils_SQL_Select $query
  *   Query.
  */
-function _civicrm_api3_activity_getdayswithactivities_handle_id_param(array $param, $column, CRM_Utils_SQL_Select $query) {
+function _civicrm_api3_activity_getdayswithactivities_handle_id_param($param, $column, CRM_Utils_SQL_Select $query) {
   $param = is_array($param) ? $param : ['=' => $param];
 
   $query->where(CRM_Core_DAO::createSQLFilter($column, $param));

--- a/api/v3/Case/Getdetails.php
+++ b/api/v3/Case/Getdetails.php
@@ -154,6 +154,7 @@ function civicrm_api3_case_getdetails(array $params) {
         'case_id' => ['IN' => $ids],
         'is_current_revision' => 1,
         'is_test' => 0,
+        'activity_type_id' => ['!=' => "Bulk Email"],
         'status_id.filter' => CRM_Activity_BAO_Activity::INCOMPLETE,
         'options' => [
           'limit' => 0,

--- a/api/v3/Case/Getdetails.php
+++ b/api/v3/Case/Getdetails.php
@@ -154,7 +154,7 @@ function civicrm_api3_case_getdetails(array $params) {
         'case_id' => ['IN' => $ids],
         'is_current_revision' => 1,
         'is_test' => 0,
-        'activity_type_id' => ['!=' => "Bulk Email"],
+        'activity_type_id' => ['!=' => 'Bulk Email'],
         'status_id.filter' => CRM_Activity_BAO_Activity::INCOMPLETE,
         'options' => [
           'limit' => 0,

--- a/api/v3/Case/Getdetails.php
+++ b/api/v3/Case/Getdetails.php
@@ -1,27 +1,34 @@
 <?php
-require_once 'api/v3/Case.php';
 
 /**
- * Case.getdetails API specification
- *
- * @param array $spec description of fields supported by this API call
- * @return void
+ * @file
+ * Activity.getDetails file.
  */
-function _civicrm_api3_case_getdetails_spec(&$spec) {
-  $result = civicrm_api3('Case', 'getfields', array('api_action' => 'get'));
+
+require_once 'api/v3/Case.php';
+use Civi\CCase\Utils as CiviCaseUtils;
+
+/**
+ * Case.getdetails API specification.
+ *
+ * @param array $spec
+ *   description of fields supported by this API call.
+ */
+function _civicrm_api3_case_getdetails_spec(array &$spec) {
+  $result = civicrm_api3('Case', 'getfields', ['api_action' => 'get']);
   $spec = $result['values'];
 
-  $spec['case_manager'] = array(
+  $spec['case_manager'] = [
     'title' => 'Case Manager',
     'description' => 'Contact id of the case manager',
     'type' => CRM_Utils_Type::T_INT,
-  );
+  ];
 
-  $spec['contact_involved'] = array(
+  $spec['contact_involved'] = [
     'title' => 'Contact Involved',
     'description' => 'Id of the contact involved as case roles',
     'type' => CRM_Utils_Type::T_INT,
-  );
+  ];
 
   $spec['has_role'] = [
     'title' => 'Case has role',
@@ -29,36 +36,45 @@ function _civicrm_api3_case_getdetails_spec(&$spec) {
     'type' => CRM_Utils_Type::T_STRING,
   ];
 
-  $spec['contact_is_deleted'] = array(
+  $spec['contact_is_deleted'] = [
     'title' => 'Contact Is Deleted',
     'description' => 'Set FALSE to filter out cases for deleted contacts, TRUE to return only cases of deleted contacts',
     'type' => CRM_Utils_Type::T_BOOLEAN,
-  );
+  ];
 }
 
 /**
- * Case.getdetails API
- * This is provided by the CiviCase extension. It gives more robust output than the regular get action.
+ * Case.getdetails API.
+ *
+ * Provided by the CiviCase extension.
+ * It gives more robust output than the regular get action.
  *
  * @param array $params
- * @return array API result
+ *   Parameters.
+ *
+ * @return array
+ *   API result.
+ *
  * @throws API_Exception
  */
-function civicrm_api3_case_getdetails($params) {
-  $resultMetadata = array();
-  $params += array('return' => array());
+function civicrm_api3_case_getdetails(array $params) {
+  $resultMetadata = [];
+  $params += ['return' => []];
   if (is_string($params['return'])) {
     $params['return'] = explode(',', str_replace(' ', '', $params['return']));
   }
   $toReturn = $params['return'];
-  $params['options'] = CRM_Utils_Array::value('options', $params, array());
-  $extraReturnProperties = array('activity_summary', 'last_update', 'activity_count', 'category_count', 'unread_email_count', 'related_case_ids');
+  $params['options'] = CRM_Utils_Array::value('options', $params, []);
+  $extraReturnProperties = [
+    'activity_summary', 'last_update', 'activity_count', 'category_count',
+    'unread_email_count', 'related_case_ids',
+  ];
   $params['return'] = array_diff($params['return'], $extraReturnProperties);
 
-  // Support additional sort params
+  // Support additional sort params.
   $sql = _civicrm_api3_case_getdetails_extrasort($params);
 
-  // Add clause to search by manager
+  // Add clause to search by manager.
   if (!empty($params['case_manager'])) {
     CRM_Civicase_APIHelpers_CasesByManager::filter($sql, $params['case_manager']);
   }
@@ -67,23 +83,23 @@ function civicrm_api3_case_getdetails($params) {
     _civicrm_api3_case_getdetails_handle_role_filters($sql, $params);
   }
 
-  // Add clause to search by non manager role and non client
+  // Add clause to search by non manager role and non client.
   if (!empty($params['contact_involved'])) {
     CRM_Civicase_APIHelpers_CasesByContactInvolved::filter($sql, $params['contact_involved']);
   }
 
-  // Filter deleted contacts from results
+  // Filter deleted contacts from results.
   if (isset($params['contact_is_deleted'])) {
     $isDeleted = (int) $params['contact_is_deleted'];
     $sql->where("a.id IN (SELECT case_id FROM civicrm_case_contact ccc, civicrm_contact cc WHERE ccc.contact_id = cc.id AND cc.is_deleted = $isDeleted)");
   }
 
-  // Set page number dynamically based on selected record
+  // Set page number dynamically based on selected record.
   if (!empty($params['options']['page_of_record'])) {
-    $prParams = array('sequential' => 1) + $params;
-    $prParams['return'] = array('id');
+    $prParams = ['sequential' => 1] + $params;
+    $prParams['return'] = ['id'];
     $prParams['options']['limit'] = $prParams['options']['offset'] = 0;
-    foreach (CRM_Utils_Array::value('values', civicrm_api3_case_get($prParams), array()) as $num => $case) {
+    foreach (CRM_Utils_Array::value('values', civicrm_api3_case_get($prParams), []) as $num => $case) {
       if ($case['id'] == $params['options']['page_of_record']) {
         $resultMetadata['page'] = floor($num / $params['options']['limit']) + 1;
         $params['options']['offset'] = $params['options']['limit'] * ($resultMetadata['page'] - 1);
@@ -92,53 +108,58 @@ function civicrm_api3_case_getdetails($params) {
     }
   }
 
-  // Call the case api
-  $result = civicrm_api3_case_get(array('sequential' => 0) + $params, $sql);
+  // Call the case api.
+  $result = civicrm_api3_case_get(['sequential' => 0] + $params, $sql);
   if (!empty($result['values'])) {
     $ids = array_keys($result['values']);
 
-    // Remove legacy cruft
+    // Remove legacy cruft.
     foreach ($result['values'] as &$case) {
       unset($case['client_id']);
     }
 
-    $activityCategories = civicrm_api3('OptionValue', 'get', array(
-      'return' => array('name'),
+    $activityCategories = civicrm_api3('OptionValue', 'get', [
+      'return' => ['name'],
       'option_group_id' => "activity_category",
-    ));
+    ]);
     $activityCategories = CRM_Utils_Array::collect('name', $activityCategories['values']);
 
-    // Get activity summary
+    // Get activity summary.
     if (in_array('activity_summary', $toReturn)) {
       $catetoryLimits = CRM_Utils_Array::value('categories', $params['options'], array_fill_keys($activityCategories, 1));
-      $categories = array_fill_keys(array_keys($catetoryLimits), array());
+      $categories = array_fill_keys(array_keys($catetoryLimits), []);
       foreach ($result['values'] as &$case) {
         $case['activity_summary'] = $categories;
       }
-      $allTypes = array();
+      $allTypes = [];
       foreach (array_keys($categories) as $grouping) {
-        $option = civicrm_api3('OptionValue', 'get', array(
-          'return' => array('value'),
+        $option = civicrm_api3('OptionValue', 'get', [
+          'return' => ['value'],
           'option_group_id' => 'activity_type',
-          'grouping' => array('LIKE' => "%{$grouping}%"),
-          'options' => array('limit' => 0),
-        ));
+          'grouping' => ['LIKE' => "%{$grouping}%"],
+          'options' => ['limit' => 0],
+        ]);
         foreach ($option['values'] as $val) {
           $categories[$grouping][] = $allTypes[] = $val['value'];
         }
       }
-      $activities = civicrm_api3('Activity', 'get', array(
-        'return' => array('activity_type_id', 'subject', 'activity_date_time', 'status_id', 'case_id', 'target_contact_name', 'assignee_contact_name', 'is_overdue', 'is_star', 'file_id', 'tag_id.name', 'tag_id.description', 'tag_id.color'),
+      $activities = civicrm_api3('Activity', 'get', [
+        'return' => [
+          'activity_type_id', 'subject', 'activity_date_time', 'status_id',
+          'case_id', 'target_contact_name', 'assignee_contact_name',
+          'is_overdue', 'is_star', 'file_id', 'tag_id.name',
+          'tag_id.description', 'tag_id.color',
+        ],
         'check_permissions' => !empty($params['check_permissions']),
-        'case_id' => array('IN' => $ids),
+        'case_id' => ['IN' => $ids],
         'is_current_revision' => 1,
         'is_test' => 0,
         'status_id.filter' => CRM_Activity_BAO_Activity::INCOMPLETE,
-        'options' => array(
+        'options' => [
           'limit' => 0,
           'sort' => 'activity_date_time',
-        ),
-      ));
+        ],
+      ]);
       foreach ($activities['values'] as $act) {
         foreach ((array) $act['case_id'] as $actCaseId) {
           if (isset($result['values'][$actCaseId])) {
@@ -155,7 +176,7 @@ function civicrm_api3_case_getdetails($params) {
         }
       }
     }
-    // Get activity count
+    // Get activity count.
     if (in_array('activity_count', $toReturn)) {
       foreach ($result['values'] as $id => &$case) {
         $query = "SELECT COUNT(a.id) as count, a.activity_type_id
@@ -169,36 +190,36 @@ function civicrm_api3_case_getdetails($params) {
         }
       }
     }
-    // Get count of activities by category
+    // Get count of activities by category.
     if (in_array('category_count', $toReturn)) {
-      $statusTypes = array(
+      $statusTypes = [
         'incomplete' => implode(',', array_keys(\CRM_Activity_BAO_Activity::getStatusesByType(\CRM_Activity_BAO_Activity::INCOMPLETE))),
         'completed' => implode(',', array_keys(\CRM_Activity_BAO_Activity::getStatusesByType(\CRM_Activity_BAO_Activity::COMPLETED))),
-      );
-      // Creates category_count object with empty values
+      ];
+      // Creates category_count object with empty values.
       foreach ($result['values'] as &$case) {
-        $case['category_count'] = array_fill_keys(array_values($activityCategories), array());
+        $case['category_count'] = array_fill_keys(array_values($activityCategories), []);
       }
 
-      // fills each category with respective counts
+      // Fills each category with respective counts.
       foreach ($activityCategories as $category) {
-        // calculates complete and incomplete activities
+        // Calculates complete and incomplete activities.
         foreach ($statusTypes as $statusType => $statusTypeIds) {
           calculate_activities_for_category($category, $ids, $statusTypeIds, $statusType, FALSE, $result);
         }
-        // calculates overdue activities
+        // Calculates overdue activities.
         calculate_activities_for_category($category, $ids, $statusTypes['incomplete'], $statusType, TRUE, $result);
       }
 
-      // calculates activities which does not have any activity category
+      // Calculates activities which does not have any activity category.
       foreach ($statusTypes as $statusType => $statusTypeIds) {
         calculate_activities_for_category(NULL, $ids, $statusTypeIds, $statusType, FALSE, $result);
       }
 
-      // calculates overdue activities which does not have any activity category
+      // Calculates overdue activities not having any activity category.
       calculate_activities_for_category(NULL, $ids, $statusTypes['incomplete'], $statusType, TRUE, $result);
     }
-    // Unread email activity count
+    // Unread email activity count.
     if (in_array('unread_email_count', $toReturn)) {
       $query = "SELECT COUNT(a.id) as count, ca.case_id
         FROM civicrm_activity a, civicrm_case_activity ca
@@ -211,15 +232,15 @@ function civicrm_api3_case_getdetails($params) {
         $result['values'][$dao->case_id]['unread_email_count'] = (int) $dao->count;
       }
     }
-    // Get related_case_ids
+    // Get related_case_ids.
     if (in_array('related_case_ids', $toReturn)) {
       foreach ($result['values'] as &$case) {
         $case['related_case_ids'] = CRM_Case_BAO_Case::getRelatedCaseIds($case['id']);
       }
     }
-    // Get last update
+    // Get last update.
     if (in_array('last_update', $toReturn)) {
-      // todo
+      // todo.
     }
     if (!empty($params['sequential'])) {
       $result['values'] = array_values($result['values']);
@@ -229,16 +250,22 @@ function civicrm_api3_case_getdetails($params) {
 }
 
 /**
- * Calculates the number of activities for the given category
+ * Calculates the number of activities for the given category.
  *
- * @param {String} $category
- * @param {Array} $ids
- * @param {String} $statusTypeIds
- * @param {String} $statusType
- * @param {Boolean} $isOverdue
- * @param {Array} $result
+ * @param string $category
+ *   Category.
+ * @param array $ids
+ *   IDs.
+ * @param string $statusTypeIds
+ *   Status Type IDs.
+ * @param string $statusType
+ *   Status Type.
+ * @param bool $isOverdue
+ *   Is Overdue.
+ * @param array $result
+ *   Result.
  */
-function calculate_activities_for_category($category, $ids, $statusTypeIds, $statusType, $isOverdue, &$result) {
+function calculate_activities_for_category($category, array $ids, $statusTypeIds, $statusType, $isOverdue, array &$result) {
   $isOverdueCondition = $isOverdue ? "AND a.activity_date_time < NOW()" : "";
   $categoryCondition = empty($category) ? "IS NULL" : "LIKE '%$category%'";
 
@@ -246,8 +273,8 @@ function calculate_activities_for_category($category, $ids, $statusTypeIds, $sta
   FROM civicrm_activity a, civicrm_case_activity ca
   WHERE ca.activity_id = a.id AND a.is_current_revision = 1 AND a.is_test = 0 AND ca.case_id IN (" . implode(',', $ids) . ")
   AND a.activity_type_id IN (SELECT value FROM civicrm_option_value WHERE grouping "
-  . $categoryCondition ." AND option_group_id = (SELECT id FROM civicrm_option_group WHERE name = 'activity_type'))
-  ". $isOverdueCondition ."
+  . $categoryCondition . " AND option_group_id = (SELECT id FROM civicrm_option_group WHERE name = 'activity_type'))
+  " . $isOverdueCondition . "
   AND is_current_revision = 1
   AND is_deleted = 0
   AND a.status_id IN ($statusTypeIds)
@@ -261,39 +288,45 @@ function calculate_activities_for_category($category, $ids, $statusTypeIds, $sta
     $result['values'][$dao->case_id]['category_count'][$categoryName][$statusTypeName] = (int) $dao->count;
   }
 }
+
 /**
  * Support extra sorting in case.getdetails.
  *
- * @param $params
+ * @param array $params
+ *   Parameters.
+ *
  * @return \CRM_Utils_SQL_Select
+ *   Sql Select query.
+ *
  * @throws \API_Exception
  */
-function _civicrm_api3_case_getdetails_extrasort(&$params) {
+function _civicrm_api3_case_getdetails_extrasort(array &$params) {
   $sql = CRM_Utils_SQL_Select::fragment();
   $options = _civicrm_api3_get_options_from_params($params);
 
   if (!empty($options['sort'])) {
     $sort = explode(', ', $options['sort']);
 
-    // For each one of our special fields we swap it for the placeholder (1) so it will be ignored by the case api.
+    // For each one of our special fields we swap it for the placeholder (1)
+    // so it will be ignored by the case api.
     foreach ($sort as $index => &$sortString) {
-      // Get sort field and direction
+      // Get sort field and direction.
       list($sortField, $dir) = array_pad(explode(' ', $sortString), 2, 'ASC');
       list($sortJoin, $sortField) = array_pad(explode('.', $sortField), 2, 'id');
-      // Sort by case manager
+      // Sort by case manager.
       if ($sortJoin == 'case_manager') {
-        // Validate inputs
+        // Validate inputs.
         if (!array_key_exists($sortField, CRM_Contact_DAO_Contact::fieldKeys()) || ($dir != 'ASC' && $dir != 'DESC')) {
           throw new API_Exception("Unknown field specified for sort. Cannot order by '$sortString'");
         }
-        \Civi\CCase\Utils::joinOnRelationship($sql, 'manager');
+        CiviCaseUtils::joinOnRelationship($sql, 'manager');
         $sql->orderBy("manager.$sortField $dir", NULL, $index);
         $sortString = '(1)';
       }
-      // Sort by my role
+      // Sort by my role.
       elseif ($sortJoin == 'my_role') {
         $me = CRM_Core_Session::getLoggedInContactID();
-        // Validate inputs
+        // Validate inputs.
         if (!array_key_exists($sortField, CRM_Contact_DAO_RelationshipType::fieldKeys()) || ($dir != 'ASC' && $dir != 'DESC')) {
           throw new API_Exception("Unknown field specified for sort. Cannot order by '$sortString'");
         }
@@ -303,19 +336,19 @@ function _civicrm_api3_case_getdetails_extrasort(&$params) {
         $sql->orderBy("my_relationship_type.$sortField $dir", NULL, $index);
         $sortString = '(1)';
       }
-      // Sort by upcoming activities
+      // Sort by upcoming activities.
       elseif (strpos($sortString, 'next_activity') === 0) {
         $sortString = '(1)';
         $category = str_replace('next_activity_category_', '', $sortJoin);
         $actClause = '';
-        // If we're limiting to a particiular category
+        // If we're limiting to a particiular category.
         if ($category != 'next_activity') {
-          $actTypes = civicrm_api3('OptionValue', 'get', array(
+          $actTypes = civicrm_api3('OptionValue', 'get', [
             'sequential' => 1,
             'option_group_id' => "activity_type",
-            'options' => array('limit' => 0),
-            'grouping' => array('LIKE' => "%$category%"),
-          ));
+            'options' => ['limit' => 0],
+            'grouping' => ['LIKE' => "%$category%"],
+          ]);
           $actTypes = implode(',', CRM_Utils_Array::collect('value', $actTypes['values']));
           if (!$actTypes) {
             continue;
@@ -332,7 +365,7 @@ function _civicrm_api3_case_getdetails_extrasort(&$params) {
         $sql->orderBy("$sortJoin.activity_date_time $dir", NULL, $index);
       }
     }
-    // Remove our extra sort params so the basic_get function doesn't see them
+    // Remove our extra sort params so the basic_get function doesn't see them.
     $params['options']['sort'] = implode(', ', $sort);
     unset($params['option_sort'], $params['option.sort'], $params['sort']);
   }
@@ -343,10 +376,12 @@ function _civicrm_api3_case_getdetails_extrasort(&$params) {
 /**
  * Filters cases by contacts related to the case and their relationship types.
  *
- * @param CRM_Utils_SQL_Select $sql a reference to the SQL object.
- * @param array $params as provided by the original api action.
+ * @param CRM_Utils_SQL_Select $sql
+ *   a reference to the SQL object.
+ * @param array $params
+ *   As provided by the original api action.
  */
-function _civicrm_api3_case_getdetails_handle_role_filters ($sql, $params) {
+function _civicrm_api3_case_getdetails_handle_role_filters(CRM_Utils_SQL_Select $sql, array $params) {
   $hasRole = $params['has_role'];
   $canBeAClient = !isset($hasRole['can_be_client']) || $hasRole['can_be_client'];
   $hasOtherRolesThanClient = isset($hasRole['role_type']);
@@ -366,10 +401,12 @@ function _civicrm_api3_case_getdetails_handle_role_filters ($sql, $params) {
 
       $roleSubQuery->where('case_relationship.case_id IS NOT NULL
       OR case_client.case_id IS NOT NULL');
-    } else {
+    }
+    else {
       $roleSubQuery->where('case_client.case_id IS NOT NULL');
     }
-  } else {
+  }
+  else {
     _civicrm_api3_case_getdetails_join_relationships($roleSubQuery, $hasRole, [
       'joinType' => 'JOIN',
     ]);
@@ -386,10 +423,12 @@ function _civicrm_api3_case_getdetails_handle_role_filters ($sql, $params) {
 /**
  * Joins the given SQL object with the case clients table.
  *
- * @param CRM_Utils_SQL_Select $sql the SQL object reference
- * @param array $params list of filters to pass to the client join.
+ * @param CRM_Utils_SQL_Select $sql
+ *   the SQL object reference.
+ * @param array $params
+ *   List of filters to pass to the client join.
  */
-function _civicrm_api3_case_getdetails_join_client ($sql, $params) {
+function _civicrm_api3_case_getdetails_join_client(CRM_Utils_SQL_Select $sql, array $params) {
   _civicase_prepare_param_for_filtering($params, 'contact');
 
   $contactFilter = CRM_Core_DAO::createSQLFilter('case_client.contact_id', $params['contact']);
@@ -404,10 +443,12 @@ function _civicrm_api3_case_getdetails_join_client ($sql, $params) {
 /**
  * Joins the given SQL object with the relationships table.
  *
- * @param CRM_Utils_SQL_Select $sql the SQL object reference
- * @param array $params list of filters to pass to the relationship join.
+ * @param CRM_Utils_SQL_Select $sql
+ *   the SQL object reference.
+ * @param array $params
+ *   List of filters to pass to the relationship join.
  */
-function _civicrm_api3_case_getdetails_join_relationships ($sql, $params, $options = []) {
+function _civicrm_api3_case_getdetails_join_relationships(CRM_Utils_SQL_Select $sql, array $params, $options = []) {
   _civicase_prepare_param_for_filtering($params, 'contact');
 
   $contactFilter = CRM_Core_DAO::createSQLFilter('case_relationship.contact_id_b', $params['contact']);
@@ -418,7 +459,7 @@ function _civicrm_api3_case_getdetails_join_relationships ($sql, $params, $optio
     AND $contactFilter
   ";
 
-  if(!empty($params['role_type'])) {
+  if (!empty($params['role_type'])) {
     _civicase_prepare_param_for_filtering($params, 'role_type');
 
     $roleTypeFilter = CRM_Core_DAO::createSQLFilter('case_relationship.relationship_type_id', $params['role_type']);
@@ -430,17 +471,20 @@ function _civicrm_api3_case_getdetails_join_relationships ($sql, $params, $optio
 
 /**
  * Corrects the param structure if not organized using the array notation.
- *   From ['paramName' => 'value']
- *   To ['paramName' => ['=' => 'value']]
+ *
+ * From ['paramName' => 'value']
+ * To ['paramName' => ['=' => 'value']]
  * The later is the expected format when using `CRM_Core_DAO::createSQLFilter`.
  *
- * @param array $params the list of params as provided by the action.
- * @param string $paramName the name of the specific parameter to fix.
+ * @param array $params
+ *   The list of params as provided by the action.
+ * @param string $paramName
+ *   The name of the specific parameter to fix.
  */
-function _civicase_prepare_param_for_filtering (&$params, $paramName) {
+function _civicase_prepare_param_for_filtering(array &$params, $paramName) {
   if (!is_array($params[$paramName])) {
     $params[$paramName] = [
-      '=' => $params[$paramName]
+      '=' => $params[$paramName],
     ];
   }
 }


### PR DESCRIPTION
## Overview
As part of this PR the Bulk Emails have been hidden from the Civicase.

## Before
![2019-09-27 at 3 02 PM](https://user-images.githubusercontent.com/5058867/65759082-cbca6280-e137-11e9-91d7-c7745501f5db.jpg)

## After
![2019-09-27 at 3 02 PM](https://user-images.githubusercontent.com/5058867/65759111-dbe24200-e137-11e9-8f1d-c021911e5ea0.jpg)

## Technical Details
From the following files/components, the Bulk Email activities are filtered
1. `activities-calendar.directive.js`
2. `activity-feed.directive.js `
3. `get-case-query-params.factory.js`
4. `dashboard-tab.directive.js`
5. `Getdayswithactivities.php`
6. `Getdetails.php`

