### PR TITLE
CATL-1134: Remove Bulk Email from Filters dropdown

### DIFF
--- a/ang/civicase.ang.php
+++ b/ang/civicase.ang.php
@@ -31,6 +31,7 @@ $options = [
 ];
 
 set_option_values_to_js_vars($options);
+remove_bulk_email_activity_type($options['activityTypes']);
 set_case_types_to_js_vars($options);
 set_relationship_types_to_js_vars($options);
 set_file_categories_to_js_vars($options);
@@ -60,6 +61,21 @@ if (!function_exists('glob_recursive')) {
     return $files;
   }
 
+}
+
+/**
+ * Removes the Bulk Email Activity Type.
+ *
+ * @param array $activityTypes
+ *   Activity Types.
+ */
+function remove_bulk_email_activity_type(array &$activityTypes) {
+  foreach ($activityTypes as $index => $activityType) {
+    if ($activityType['name'] === 'Bulk Email') {
+      unset($activityTypes[$index]);
+      break;
+    }
+  }
 }
 
 /**
@@ -192,7 +208,9 @@ function set_tags_to_js_vars(&$options) {
 function set_option_values_to_js_vars(&$options) {
   foreach ($options as &$option) {
     $result = civicrm_api3('OptionValue', 'get', [
-      'return' => ['value', 'label', 'color', 'icon', 'name', 'grouping', 'weight'],
+      'return' => [
+        'value', 'label', 'color', 'icon', 'name', 'grouping', 'weight',
+      ],
       'option_group_id' => $option,
       'is_active' => 1,
       'options' => ['limit' => 0, 'sort' => 'weight'],

--- a/civicase.php
+++ b/civicase.php
@@ -30,10 +30,19 @@ function civicase_civicrm_tabset($tabsetName, &$tabs, $context) {
           ]);
         }
         if ($tab['id'] === 'activity') {
+          $activity_types = array_flip(CRM_Activity_BAO_Activity::buildOptions('activity_type_id', 'validate'));
           $useAng = TRUE;
           $tab['url'] = CRM_Utils_System::url('civicrm/case/contact-act-tab', [
             'cid' => $context['contact_id'],
           ]);
+          // Exclude bulk email activity type from the Activity count because
+          // there are issues with target contact for this activity type.
+          // To remove this code once issue is fixed from core.
+          $params = [
+            'activity_type_exclude_id' => $activity_types['Bulk Email'],
+            'contact_id' => $context['contact_id'],
+          ];
+          $tab['count'] = CRM_Activity_BAO_Activity::getActivitiesCount($params);
         }
       }
 


### PR DESCRIPTION
## Overview
As part of this PR
* Bulk Email Activity Type is removed from Activity Feed filters.

## Before
![2019-09-27 at 5 26 PM](https://user-images.githubusercontent.com/5058867/65767627-00481980-e14c-11e9-9ecd-eeecadf9a5de.jpg)

## After
![2019-09-27 at 5 26 PM](https://user-images.githubusercontent.com/5058867/65767601-f2929400-e14b-11e9-893b-d7615b45ae84.jpg)

## Technical Details
1. In `civicase.ang.php`, added a new function `remove_bulk_email_activity_type` to remove Bulk Email Activity.