### PR TITLE
CATL-1134: Remove Bulk Email from FE

### DIFF
--- a/ang/civicase.ang.php
+++ b/ang/civicase.ang.php
@@ -31,7 +31,6 @@ $options = [
 ];
 
 set_option_values_to_js_vars($options);
-remove_bulk_email_activity_type($options['activityTypes']);
 set_case_types_to_js_vars($options);
 set_relationship_types_to_js_vars($options);
 set_file_categories_to_js_vars($options);
@@ -61,21 +60,6 @@ if (!function_exists('glob_recursive')) {
     return $files;
   }
 
-}
-
-/**
- * Removes the Bulk Email Activity Type.
- *
- * @param array $activityTypes
- *   Activity Types.
- */
-function remove_bulk_email_activity_type(array &$activityTypes) {
-  foreach ($activityTypes as $index => $activityType) {
-    if ($activityType['name'] === 'Bulk Email') {
-      unset($activityTypes[$index]);
-      break;
-    }
-  }
 }
 
 /**

--- a/ang/civicase/activity/filters/directives/activity-filters.directive.js
+++ b/ang/civicase/activity/filters/directives/activity-filters.directive.js
@@ -132,7 +132,12 @@
             name: 'activity_type_id',
             label: ts('Activity type'),
             html_type: 'Select',
-            options: _.map(CRM.civicase.activityTypes, mapSelectOptions)
+            options: _.chain(CRM.civicase.activityTypes)
+              .filter(function (activity) {
+                return activity.name !== 'Bulk Email';
+              })
+              .map(mapSelectOptions)
+              .value()
           },
           {
             name: 'status_id',


### PR DESCRIPTION
## Overview
This PR changes the implementation to Remove Bulk Email from filters.

## Before
![2019-09-27 at 6 44 PM](https://user-images.githubusercontent.com/5058867/65771895-ce888000-e156-11e9-84aa-48e76177077b.jpg)

## After
![2019-09-27 at 6 43 PM](https://user-images.githubusercontent.com/5058867/65771858-c2042780-e156-11e9-87e2-9988cf3e36d4.jpg)


## Technical Details
Previously the Bulk Email was removed using BE, but this way the user cant create Bulk Email. So the implementation is moved to FE.