### PR TITLE
CATL-1145: Activity feed Doesnot load when Payment type Activity is present.

### DIFF
--- a/ang/civicase/activity/feed/directives/activity-feed.directive.js
+++ b/ang/civicase/activity/feed/directives/activity-feed.directive.js
@@ -373,18 +373,11 @@
         ],
         options: options
       };
-      var getActionLinksParams = {
-        activity_id: '$value.id',
-        activity_type_id: '$value.activity_type_id',
-        source_record_id: '$value.source_record_id',
-        case_id: '$value.case_id'
-      };
       var params = {
         is_current_revision: 1,
         is_deleted: 0,
         is_test: 0,
         activity_type_id: { '!=': 'Bulk Email' },
-        'api.Activity.getactionlinks': getActionLinksParams,
         options: {}
       };
 
@@ -430,7 +423,7 @@
       );
 
       return crmApi({
-        acts: ['Activity', apiAction, $.extend(true, {}, returnParams, params)],
+        acts: ['Activity', apiAction, prepareActivityParams(returnParams, params)],
         all: ['Activity', apiActionAll, params]
       }).then(function (result) {
         return $q.all([
@@ -477,6 +470,26 @@
         direction: 'down',
         monthNavClicked: true
       });
+    }
+
+    /**
+     * Prepares Activity Params
+     * Adds Action Links chained Api call
+     *
+     * @param {Object} returnParams
+     * @param {Object} params
+     *
+     * @return {Array}
+     */
+    function prepareActivityParams (returnParams, params) {
+      var actionLinksParams = { 'api.Activity.getactionlinks': {
+        activity_id: '$value.id',
+        activity_type_id: '$value.activity_type_id',
+        source_record_id: '$value.source_record_id',
+        case_id: '$value.case_id'
+      }};
+
+      return $.extend(true, actionLinksParams, returnParams, params);
     }
 
     /**

--- a/api/v3/Activity/Getactionlinks.php
+++ b/api/v3/Activity/Getactionlinks.php
@@ -1,16 +1,19 @@
 <?php
 
+/**
+ * @file
+ * Activity.getactionlinks file.
+ */
+
 const ACTIONS_DEFINED_BY_CIVICASE = ['Delete', 'File on Case', 'Edit'];
 
 /**
- * Activity.getactionlinks API specification (optional)
- * This is used for documentation and validation.
+ * Activity.getactionlinks API specification (optional).
  *
- * @param array $spec description of fields supported by this API call
- * @return void
- * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
+ * @param array $spec
+ *   description of fields supported by this API call.
  */
-function _civicrm_api3_activity_getactionlinks_spec(&$spec) {
+function _civicrm_api3_activity_getactionlinks_spec(array &$spec) {
   $spec['activity_type_id']['api.required'] = 1;
   $spec['source_record_id']['api.required'] = 1;
   $spec['activity_id']['api.required'] = 1;
@@ -18,17 +21,21 @@ function _civicrm_api3_activity_getactionlinks_spec(&$spec) {
 }
 
 /**
- * Activity.getactionlinks API
+ * Activity.getactionlinks API.
+ *
  * This API returns the activity action links for an activity record.
  * Basically it adds the action links added by core plus the action links
  * added by various extensions via hooks. Action links differ per activity
- * as some logic may determine which links are available for a particular activity.
+ * as some logic may determine which links are available for a particular
+ * activity.
  *
  * @param array $params
+ *   Params.
  *
  * @return array
+ *   Links
  */
-function civicrm_api3_activity_getactionlinks($params) {
+function civicrm_api3_activity_getactionlinks(array $params) {
   return _civicrm_api3_activity_getActivityActionLinks($params);
 }
 
@@ -36,16 +43,23 @@ function civicrm_api3_activity_getactionlinks($params) {
  * Returns activity links for the activity ID in the params.
  *
  * @param array $params
+ *   Params.
  *
  * @return array
+ *   Links.
  */
-function _civicrm_api3_activity_getActivityActionLinks($params) {
-  $actionLinks = CRM_Activity_Selector_Activity::actionLinks(
-    CRM_Utils_Array::value('activity_type_id', $params),
-    CRM_Utils_Array::value('source_record_id', $params),
-    FALSE,
-    CRM_Utils_Array::value('activity_id', $params)
-  );
+function _civicrm_api3_activity_getActivityActionLinks(array $params) {
+  try {
+    $actionLinks = CRM_Activity_Selector_Activity::actionLinks(
+      CRM_Utils_Array::value('activity_type_id', $params),
+      CRM_Utils_Array::value('source_record_id', $params),
+      FALSE,
+      CRM_Utils_Array::value('activity_id', $params)
+    );
+  }
+  catch (Exception $e) {
+    return [];
+  }
 
   $actionMask = array_sum(array_keys($actionLinks));
 
@@ -62,7 +76,7 @@ function _civicrm_api3_activity_getActivityActionLinks($params) {
     'caseid' => CRM_Utils_Array::value('case_id', $params),
   ];
 
-  //Invoke hook links for activity tab rows.
+  // Invoke hook links for activity tab rows.
   CRM_Utils_Hook::links(
     'activity.tab.row',
     'Activity',
@@ -72,26 +86,27 @@ function _civicrm_api3_activity_getActivityActionLinks($params) {
     $values
   );
 
- return  _civicrm_api3_activity_GetActionLinks_processLinks($seqLinks);
+  return _civicrm_api3_activity_GetActionLinks_processLinks($seqLinks);
 }
 
 /**
- * Process activity links
+ * Process activity links.
  *
  * @param array $activityActionLinks
+ *   Activity Action Links.
  *
  * @return array
+ *   Activity Action Links.
  */
-function _civicrm_api3_activity_GetActionLinks_processLinks($activityActionLinks) {
-  foreach($activityActionLinks as $id => $link) {
-
-    //remove action links already added by civicase
-    if (in_array($link['name'], ACTIONS_DEFINED_BY_CIVICASE )) {
+function _civicrm_api3_activity_GetActionLinks_processLinks(array $activityActionLinks) {
+  foreach ($activityActionLinks as $id => $link) {
+    // Remove action links already added by civicase.
+    if (in_array($link['name'], ACTIONS_DEFINED_BY_CIVICASE)) {
       unset($activityActionLinks[$id]);
       continue;
     }
 
-    //format link URL
+    // Format link URL.
     if (isset($link['qs']) && !CRM_Utils_System::isNull($link['qs'])) {
       $urlPath = CRM_Utils_System::url(CRM_Core_Action::replace($link['url'], $values),
         CRM_Core_Action::replace($link['qs'], $values), FALSE, NULL, TRUE
@@ -103,7 +118,7 @@ function _civicrm_api3_activity_GetActionLinks_processLinks($activityActionLinks
 
     $activityActionLinks[$id]['url'] = $urlPath;
 
-    // Add link classes
+    // Add link classes.
     $classes = 'action-item';
     if (isset($link['ref'])) {
       $classes .= ' ' . strtolower($link['ref']);


### PR DESCRIPTION
## Overview
When Payment type Activity is present, the Activity Load does not load.
Also the Month Nav is visible now.

## Before
![2019-10-02 at 1 19 PM](https://user-images.githubusercontent.com/5058867/66026845-4bc94180-e517-11e9-97f4-8c051d2fd844.jpg)

## After
![2019-10-02 at 1 18 PM](https://user-images.githubusercontent.com/5058867/66026803-37854480-e517-11e9-9d84-a69ffa593e7d.jpg)

## Technical Details
1. Moved the `getactionlinks` Chained API call into a new function.
2. `getactionlinks` Chained API call is only applied to fetch the Activities, and not to other calls, which fixes the Month Nav.
3. In "api/v3/Activity/Getactionlinks.php" `_civicrm_api3_activity_getActivityActionLinks` function, the `CRM_Activity_Selector_Activity::actionLinks` call generates throws an error for Payment type Activities.
This is because `actionLinks` calls `CRM_Core_DAO::getFieldValue('CRM_Event_BAO_ParticipantPayment', $sourceRecordId, 'participant_id', 'contribution_id')`. Here `$sourceRecordId` is empty, so an error is thrown https://github.com/civicrm/civicrm-core/blob/b064b7052ff2cb2b490a05266b4e31d52848dd7e/CRM/Core/DAO.php#L1196

The same happens in Core Activity screen, the View Link does not work for Payment type activity. 
Hence a `try catch` block has been added to fix this.