### PR TITLE
CATL-1147: Fix activity filters

### DIFF
--- a/ang/civicase/activity/filters/directives/activity-filters.directive.js
+++ b/ang/civicase/activity/filters/directives/activity-filters.directive.js
@@ -219,12 +219,11 @@
        * Maps Options to be used in the dropdown
        *
        * @param {Object} option
-       * @param {int/string} id
        * @return {Object}
        */
-      function mapSelectOptions (option, id) {
+      function mapSelectOptions (option) {
         return {
-          id: id,
+          id: option.value,
           text: option.label,
           color: option.color,
           icon: option.icon


### PR DESCRIPTION
## Overview
This PR fixes an issue with the Case Activities' filters where filtering by activity type was not working.

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/66087225-bba1f100-e544-11e9-9a9a-bdd6ccc8ad4d.gif)

## After
![pr-after](https://user-images.githubusercontent.com/1642119/66087124-62d25880-e544-11e9-938c-c2605b5c3768.gif)

## Technical Details
The issue happens because on https://github.com/compucorp/uk.co.compucorp.civicase/pull/267 we started filtering the option values. The problem is that when you use lodash's `filter` method, the index values are not preserved.

As an example on this screenshot you can see that "Secure temporary housing" now has the index value for "Medical Evaluation":
![Screen Shot 2019-10-03 at 6 41 47 PM](https://user-images.githubusercontent.com/1642119/66169925-0b99ba00-e610-11e9-81c5-b5bb0186d409.png)

To fix this we use the option's value property instead of the index:

```js
      function mapSelectOptions (option) {
        return {
          id: option.value,
          text: option.label,
          color: option.color,
          icon: option.icon
        };
      }
```

Both `CRM.civicase.activityStatuses` and `CRM.civicase.activityTypes` (the objects mapped using `mapSelectOptions`) have a `value` property for each option so this is the right approach.

## Comments
* Was not able to configure tests on my local dev env, so was not able to add or make sure tests are not broken.