### PR TITLE
RSE-377: Fix Issue With Not Displayed Prospect Financial Custom Fields

### DIFF
--- a/CRM/Civicase/Helper/CaseCategory.php
+++ b/CRM/Civicase/Helper/CaseCategory.php
@@ -19,7 +19,7 @@ class CRM_Civicase_Helper_CaseCategory {
    *   The Case Category Name.
    */
   public static function getCategoryName($caseId) {
-    $caseTypeCategories = CaseType::buildOptions('case_type_category');
+    $caseTypeCategories = CaseType::buildOptions('case_type_category', 'validate');
 
     $result = civicrm_api3('Case', 'getsingle', [
       'id' => $caseId,
@@ -45,7 +45,7 @@ class CRM_Civicase_Helper_CaseCategory {
    *   Case Category Name.
    */
   public static function getCaseCategoryNameFromOptionValue($caseCategoryValue) {
-    $caseTypeCategories = CaseType::buildOptions('case_type_category');
+    $caseTypeCategories = CaseType::buildOptions('case_type_category', 'validate');
 
     return $caseTypeCategories[$caseCategoryValue];
   }


### PR DESCRIPTION
## Overview
The Prospect Case category custom financial fields were not showing up on the dev site and this is also replicated on local for a fresh prospect extension installation.

## Before
The Prospect Case category custom financial fields were not showing up on the dev site and this is also replicated on local for a fresh prospect extension installation.

## After
The `CaseCategory` helper class has  some functions that uses the `CaseType::buildOptions('case_type_category')` for fetching the case category option label and the id for some processing.  The issue with this is that the option label can be changed by the user on the UI and this is not reliable.

Also the Prospect extension adds the Prospect case type category with the name `Prospecting` and the label [`Prospects`](https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/blob/e15f4df30bd573f72c5c5b3896cbdc696cbeb7f6/CRM/Prospect/Setup/CreateProspectingOptionValue.php#L17), Because these functions were fetching the option label for the case category, matching custom fields were not found for each prospect because the custom fields extend the `Prospecting` (case category name for prospect) category.

This PR fixes the issue by ensuring that the option value name is fetched rather than the option label.

