### PR TITLE
RSE-439: Merge to Develop

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">http://FIXME</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2019-09-27</releaseDate>
-  <version>1.0.0-alpha9</version>
+  <releaseDate>2019-10-02</releaseDate>
+  <version>1.0.0-alpha10</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>


### PR DESCRIPTION
## Overview
As we are moving to a new workflow, where the `develop` branch wont exist anymore. So merging from `develop` to `master`, before getting rid of `develop` branch.