### PR TITLE
BASW-539: Civicase Bug Fixes

### DIFF
--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
@@ -187,6 +187,7 @@
             params = {
               relationship_type_id: role.relationship_type_id,
               start_date: 'now',
+              end_date: null,
               contact_id_b: val,
               case_id: item.id,
               description: desc

--- a/civicase.php
+++ b/civicase.php
@@ -524,7 +524,7 @@ function civicase_civicrm_alterAPIPermissions($entity, $action, &$params, &$perm
     'access uploaded files',
   ];
 
-  $permissions['case']['get'] = [
+  $permissions['case']['get'] = $permissions['custom_value']['gettreevalues'] = [
     [
       'access my cases and activities',
       'access all cases and activities',


### PR DESCRIPTION
## Overview
This PR fixes two bugs in civicase.
(1) Manage Dashboard Issue with permissions assigned to CiviCase role (BASW-542)
(2) Case Manage Role Reassigning case manager role to the same user doesn't work (BASW-543)

## Before
These bugs were present.

## After
**Issue 1** happens because of a new API we introduced during the Case Category work to fetch custom fields and values for Case categories. The API inherits uses the `administer Civicrm` permissions by default but since the Civicase administrator will not have these permissions, trying to access the Manage cases page will give a blank screen for a Civicase admin. This PR sets the permission for accessing this API to be the same as that needed to access `Case.get` API.

**Issue 2** occurs because when a user already has a relationship for a Case in the database and that relationship has ended, trying to create another will result in a `Duplicate Relationship` error. To fix this, the FE now passes the end_date parameter as NULL so that the non active relationship is not taken into account but a new one created.
