### PR TITLE
RSE-377: Fix Financial Information Custom Fields not visible on Prospects Summary Page

### DIFF
--- a/CRM/Civicase/Hook/Post/PopulateCaseCategoryForCaseType.php
+++ b/CRM/Civicase/Hook/Post/PopulateCaseCategoryForCaseType.php
@@ -36,6 +36,15 @@ class CRM_Civicase_Hook_Post_PopulateCaseCategoryForCaseType {
    *   Case Type Id.
    */
   private function updateCaseTypeCategory($caseTypeId) {
+    $result = civicrm_api3('CaseType', 'getsingle', [
+      'return' => ['case_type_category'],
+      'id' => $caseTypeId,
+    ]);
+
+    if (!empty($result['case_type_category'])) {
+      return;
+    }
+
     civicrm_api3('CaseType', 'create', [
       'id' => $caseTypeId,
       'case_type_category' => CaseCategoryHelper::CASE_TYPE_CATEGORY_NAME,


### PR DESCRIPTION
## Overview
On a new site installation that contains CiviCase and Prospect extensions, when adding a new prospect, the custom fields does not show up. Also all the case types in the database are assigned the Cases category.

## Before
- The issue described in overview exists.

## After
- All the Case types in the database were set to Cases category because there is a Post hook added to set created case types to be of Case category, however, this should only be applied to Case types that does not have a Case category set yet. This fix was made in the PR and the appropriate Case Category assigned to the Default Prospect Case type on prospect installation. This also fixed the issue of custom fields not showing up as the fields as the Default Prospect Case Type was assigned to the wrong category.

