### PR TITLE
BASW-544: Show all phone numbers

### DIFF
--- a/ang/civicase/contact/directives/contact-popover-content.directive.html
+++ b/ang/civicase/contact/directives/contact-popover-content.directive.html
@@ -4,13 +4,9 @@
     <hr />
   </div>
   <div class="civicase__contact-popover__column">
-    <div class="civicase__contact-popover__detail-group">
-      <div class="civicase__contact-popover__detail-header"><strong>Home Phone</strong></div>
-      <div class="civicase__contact-popover__detail-value">{{contact.phone.phone}}</div>
-    </div>
-    <div class="civicase__contact-popover__detail-group">
-      <div class="civicase__contact-popover__detail-header"><strong>Home Mobile</strong></div>
-      <div class="civicase__contact-popover__detail-value">{{contact.mobile.phone}}</div>
+    <div class="civicase__contact-popover__detail-group" ng-repeat="phoneNumber in contact.phoneNumbers">
+      <div class="civicase__contact-popover__detail-header"><strong>{{phoneNumber.type}}</strong></div>
+      <div class="civicase__contact-popover__detail-value">{{phoneNumber.number}}</div>
     </div>
     <div class="civicase__contact-popover__detail-group">
       <div class="civicase__contact-popover__detail-header"><strong>Primary Address</strong></div>

--- a/ang/civicase/contact/services/contacts-cache.service.js
+++ b/ang/civicase/contact/services/contacts-cache.service.js
@@ -80,7 +80,7 @@
         return null;
       }
 
-      prepareContactPhoneNumbers(contact);
+      formatContactPhoneNumbers(contact);
 
       contact.groups = _.map(contact['api.GroupContact.get'].values, 'title').join(', ');
       contact.tags = (contact.tags + '').split(',').join(', '); // Adds spacing to the tags
@@ -116,7 +116,7 @@
      *
      * @param {Object} contact
      */
-    function prepareContactPhoneNumbers (contact) {
+    function formatContactPhoneNumbers (contact) {
       var phoneNumbers = [];
 
       _.each(contact['api.Phone.get'].values, function (numberObject) {

--- a/ang/civicase/contact/services/contacts-cache.service.js
+++ b/ang/civicase/contact/services/contacts-cache.service.js
@@ -48,7 +48,8 @@
         'api.Phone.get': {
           'contact_id': '$value.id',
           'phone_type_id.name': { 'IN': [ 'Mobile', 'Phone' ] },
-          'return': [ 'phone', 'phone_type_id.name' ]
+          'return': ['phone', 'phone_type_id.name', 'location_type_id'],
+          'api.LocationType.get': { 'id': '$value.location_type_id' }
         },
         'api.GroupContact.get': {
           'contact_id': '$value.id',
@@ -73,16 +74,14 @@
      * @return {Object} contact object of the passed contact ID.
      */
     this.getCachedContact = function (contactID) {
-      var phones;
       var contact = _.clone(savedContactDetails[contactID]);
 
       if (!contact) {
         return null;
       }
 
-      phones = _.indexBy(contact['api.Phone.get'].values, 'phone_type_id.name');
-      contact.mobile = phones['Mobile'];
-      contact.phone = phones['Phone'];
+      prepareContactPhoneNumbers(contact);
+
       contact.groups = _.map(contact['api.GroupContact.get'].values, 'title').join(', ');
       contact.tags = (contact.tags + '').split(',').join(', '); // Adds spacing to the tags
 
@@ -111,5 +110,23 @@
     this.getContactIconOf = function (contactID) {
       return savedContactDetails[contactID] ? savedContactDetails[contactID].contact_type : '';
     };
+
+    /**
+     * Formats the phone numbers in an array which can be used in the html
+     *
+     * @param {Object} contact
+     */
+    function prepareContactPhoneNumbers (contact) {
+      var phoneNumbers = [];
+
+      _.each(contact['api.Phone.get'].values, function (numberObject) {
+        phoneNumbers.push({
+          type: numberObject['api.LocationType.get'].values[0].display_name + ' ' + numberObject['phone_type_id.name'],
+          number: numberObject.phone || numberObject.mobile
+        });
+      });
+
+      contact.phoneNumbers = phoneNumbers;
+    }
   }
 })(angular, CRM.$, CRM._);


### PR DESCRIPTION
## Overview
Previously Contact phone numbers were not mapped correctly, this PR fixes that.

Correct Phone Numbers in Contact Record Page
![2019-10-16 at 12 29 PM](https://user-images.githubusercontent.com/5058867/66895515-a206ac00-f010-11e9-98ca-52a16730cee2.jpg)

## Before
![2019-10-16 at 12 29 PM](https://user-images.githubusercontent.com/5058867/66895500-974c1700-f010-11e9-9cb0-e24957924b80.jpg)

## After
![2019-10-16 at 12 28 PM](https://user-images.githubusercontent.com/5058867/66895479-8a2f2800-f010-11e9-9ffc-c08501df56ce.jpg)

## Technical Details
1. In `contacts-cache.service.js`, the api call has been changed, and now the Location Type ID is also fetched.
```javascript
'return': ['phone', 'phone_type_id.name', 'location_type_id'],
'api.LocationType.get': { 'id': '$value.location_type_id' }
```

2. A new function `prepareContactPhoneNumbers` has been created, which Adds the Location type with the Phone number to get a correct mapping of phone numbers.

3. `contact-popover-content.directive.html` is edited, here  a loop is created for `contact.phoneNumbers`.

## Notes
Unit tests are not working inside vagrant, I will create a ticket to fix this.