### PR TITLE
Release v1.0.0-alpha11

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">http://FIXME</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2019-10-02</releaseDate>
-  <version>1.0.0-alpha10</version>
+  <releaseDate>2019-10-18</releaseDate>
+  <version>1.0.0-alpha11</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>


### PR DESCRIPTION
### **Release Update - 18th Oct, 2019**


**Fixes:**
- Fixed Civicase unit tests and added JsDoc.
- Fixed permission issues that does not allow a user without administer Civicrm permission to view Manage Cases page.
- Fixed issue with Reassigning case manager role to the same user.
- Member modal pop-up on CiviCase now matches that of contact record data.
- Fixed Filtering by activity type not working on manage case activities tab.