### PR TITLE
RSE-467: Use Hook to allow adding dependent modules of Civicase

### DIFF
--- a/CRM/Civicase/Hook/addDependentAngularModules.php
+++ b/CRM/Civicase/Hook/addDependentAngularModules.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Class CRM_Civicase_Hook_addDependentAngularModules
+ */
+class CRM_Civicase_Hook_addDependentAngularModules {
+
+  /**
+   * This hook allows other extensions add modules dependent on Civicase.
+   *
+   * @param array $dependentModules
+   *   Modules dependent on Civicase.
+   *
+   * @return array
+   *   Array of dependent modules.
+   */
+  public static function invoke(array $dependentModules) {
+    CRM_Utils_Hook::singleton()->invoke(['dependentModules'],
+      $dependentModules,
+      CRM_Utils_Hook::$_nullObject,
+      CRM_Utils_Hook::$_nullObject,
+      CRM_Utils_Hook::$_nullObject,
+      CRM_Utils_Hook::$_nullObject,
+      CRM_Utils_Hook::$_nullObject,
+      'addCiviCaseDependentAngularModules'
+    );
+
+    return $dependentModules;
+  }
+
+}
+

--- a/ang/civicase.ang.php
+++ b/ang/civicase.ang.php
@@ -30,6 +30,21 @@ $options = [
   'caseTypeCategories' => 'case_type_categories',
 ];
 
+$requires = [
+  'crmAttachment',
+  'crmUi',
+  'crmUtil',
+  'ngRoute',
+  'angularFileUpload',
+  'bw.paging',
+  'crmRouteBinder',
+  'crmResource',
+  'ui.bootstrap',
+  'uibTabsetClass',
+  'dialogService',
+];
+$requires = CRM_Civicase_Hook_addDependentAngularModules::invoke($requires);
+
 set_option_values_to_js_vars($options);
 set_case_types_to_js_vars($options);
 set_relationship_types_to_js_vars($options);
@@ -437,10 +452,6 @@ return [
     'ang/civicase',
   ],
   'settings' => $options,
-  'requires' => [
-    'crmAttachment', 'crmUi', 'crmUtil', 'ngRoute', 'angularFileUpload',
-    'bw.paging', 'crmRouteBinder', 'crmResource', 'ui.bootstrap',
-    'uibTabsetClass', 'dialogService',
-  ],
+  'requires' => $requires,
   'basePages' => [],
 ];


### PR DESCRIPTION
## Overview
Previously, when adding dependent modules for Civicase, we modify the Civix file manually as seen [here](https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/blob/master/prospect.civix.php#L375-L386).  This PR adds a new hook to allow an extension provide the dependent modules.

## Before
The `addCiviCaseDependentAngularModules` hook does not exist.

## After
The `addCiviCaseDependentAngularModules` hook is added.
Sample usage is seen below e.g in the Civi Awards extension

```php
function civiawards_addCiviCaseDependentAngularModules(&$dependentModules) {
  $dependentModules[] = "NewModule";
}
```
