### PR TITLE
CATL-1142: Hide deleted cases from contact's case tab

### DIFF
--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
@@ -12,14 +12,21 @@
 
   module.controller('CivicaseContactCaseTabController', CivicaseContactCaseTabController);
 
+  /**
+   * @param $scope
+   * @param crmApi
+   * @param formatCase
+   * @param Contact
+   * @param ContactsCache
+   */
   function CivicaseContactCaseTabController ($scope, crmApi, formatCase, Contact, ContactsCache) {
     var commonConfigs = {
-      'isLoaded': false,
-      'showSpinner': false,
-      'isLoadMoreAvailable': false,
-      'page': {
-        'size': 3,
-        'num': 1
+      isLoaded: false,
+      showSpinner: false,
+      isLoadMoreAvailable: false,
+      page: {
+        size: 3,
+        num: 1
       }
     };
 
@@ -29,28 +36,28 @@
     $scope.newCaseWebformClient = CRM.civicase.newCaseWebformClient;
     $scope.casesListConfig = [
       {
-        'name': 'opened',
-        'title': 'Open Cases',
-        'filterParams': {
+        name: 'opened',
+        title: 'Open Cases',
+        filterParams: {
           'status_id.grouping': 'Opened',
-          'contact_id': $scope.contactId
+          contact_id: $scope.contactId
         },
-        'showContactRole': false
+        showContactRole: false
       }, {
-        'name': 'closed',
-        'title': 'Resolved cases',
-        'filterParams': {
+        name: 'closed',
+        title: 'Resolved cases',
+        filterParams: {
           'status_id.grouping': 'Closed',
-          'contact_id': $scope.contactId
+          contact_id: $scope.contactId
         },
-        'showContactRole': false
+        showContactRole: false
       }, {
-        'name': 'related',
-        'title': 'Other cases for this contact',
-        'filterParams': {
-          'case_manager': $scope.contactId
+        name: 'related',
+        title: 'Other cases for this contact',
+        filterParams: {
+          case_manager: $scope.contactId
         },
-        'showContactRole': true
+        showContactRole: true
       }
     ];
 
@@ -74,8 +81,8 @@
     /**
      * Watcher for civicase::contact-record-list::loadmore event
      *
-     * @param {Object} event
-     * @param {String} name of the list
+     * @param {object} event
+     * @param {string} name of the list
      */
     function contactRecordListLoadmoreWatcher (event, name) {
       var caseListIndex = _.findIndex($scope.casesListConfig, function (caseObj) {
@@ -93,6 +100,10 @@
      * @params {Object} event
      * @params {Object} caseObj case object of the list
      */
+    /**
+     * @param event
+     * @param caseObj
+     */
     function contactRecordListViewCaseWatcher (event, caseObj) {
       setCaseAsSelected(caseObj);
     }
@@ -101,7 +112,7 @@
      * Fetch additional information about the contacts
      *
      * @param {object} event
-     * @param {array} cases
+     * @param {Array} cases
      */
     function fetchContactsData (cases) {
       var contacts = [];
@@ -117,7 +128,7 @@
      * Get all the contacts of the given case
      *
      * @param {object} caseObj
-     * @return {array}
+     * @returns {Array}
      */
     function getAllContactIdsForCase (caseObj) {
       var contacts = [];
@@ -155,9 +166,10 @@
      * Get parameters to load cases
      *
      * @param {object} filters
+     * @param filter
      * @param {object} sort
      * @param {object} page
-     * @return {array}
+     * @returns {Array}
      */
     function getCaseApiParams (filter, page) {
       var caseReturnParams = [
@@ -175,7 +187,7 @@
           offset: page.size * (page.num - 1)
         }
       };
-      var params = {'case_type_id.is_active': 1};
+      var params = { 'case_type_id.is_active': 1 };
 
       return {
         cases: ['Case', 'getcaselist', $.extend(true, returnCaseParams, filter, params)],
@@ -186,8 +198,8 @@
     /**
      * Returns contact role for the currently viewing contact
      *
-     * @param {Object} caseObj
-     * @return {String} role
+     * @param {object} caseObj
+     * @returns {string} role
      */
     function getContactRole (caseObj) {
       var contact = _.find(caseObj.contacts, {
@@ -254,6 +266,7 @@
      * Sets passed case object as selected case
      *
      * @params {Object} caseObj
+     * @param caseObj
      */
     function setCaseAsSelected (caseObj) {
       $scope.selectedCase = caseObj;
@@ -271,7 +284,7 @@
     /**
      * Updates the list with new entries
      *
-     * @param {String} caseListIndex
+     * @param {string} caseListIndex
      * @param {Array} params
      */
     function updateCase (caseListIndex, params) {

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
@@ -40,7 +40,8 @@
         title: 'Open Cases',
         filterParams: {
           'status_id.grouping': 'Opened',
-          contact_id: $scope.contactId
+          contact_id: $scope.contactId,
+          is_deleted: 0
         },
         showContactRole: false
       }, {
@@ -48,14 +49,16 @@
         title: 'Resolved cases',
         filterParams: {
           'status_id.grouping': 'Closed',
-          contact_id: $scope.contactId
+          contact_id: $scope.contactId,
+          is_deleted: 0
         },
         showContactRole: false
       }, {
         name: 'related',
         title: 'Other cases for this contact',
         filterParams: {
-          case_manager: $scope.contactId
+          case_manager: $scope.contactId,
+          is_deleted: 0
         },
         showContactRole: true
       }

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
@@ -13,11 +13,11 @@
   module.controller('CivicaseContactCaseTabController', CivicaseContactCaseTabController);
 
   /**
-   * @param $scope
-   * @param crmApi
-   * @param formatCase
-   * @param Contact
-   * @param ContactsCache
+   * @param {object} $scope the controller scope
+   * @param {Function} crmApi the crm api service
+   * @param {Function} formatCase the format case service
+   * @param {object} Contact the contact service
+   * @param {object} ContactsCache the contacts cache service
    */
   function CivicaseContactCaseTabController ($scope, crmApi, formatCase, Contact, ContactsCache) {
     var commonConfigs = {
@@ -81,7 +81,7 @@
     /**
      * Watcher for civicase::contact-record-list::loadmore event
      *
-     * @param {object} event
+     * @param {object} event scope watch event reference
      * @param {string} name of the list
      */
     function contactRecordListLoadmoreWatcher (event, name) {
@@ -94,15 +94,11 @@
       updateCase(caseListIndex, params);
     }
 
-    /*
+    /**
      * Watcher for civicase::contact-record-list::view-case event
      *
-     * @params {Object} event
-     * @params {Object} caseObj case object of the list
-     */
-    /**
-     * @param event
-     * @param caseObj
+     * @param {object} event scope watch event reference
+     * @param {object} caseObj the data belonging to a case
      */
     function contactRecordListViewCaseWatcher (event, caseObj) {
       setCaseAsSelected(caseObj);
@@ -111,8 +107,7 @@
     /**
      * Fetch additional information about the contacts
      *
-     * @param {object} event
-     * @param {Array} cases
+     * @param {object[]} cases a list of cases
      */
     function fetchContactsData (cases) {
       var contacts = [];
@@ -125,10 +120,10 @@
     }
 
     /**
-     * Get all the contacts of the given case
+     * Returns all the contact ids for the given case
      *
-     * @param {object} caseObj
-     * @returns {Array}
+     * @param {object} caseObj the data belonging to a case
+     * @returns {number[]} a list of contact ids
      */
     function getAllContactIdsForCase (caseObj) {
       var contacts = [];
@@ -165,11 +160,9 @@
     /**
      * Get parameters to load cases
      *
-     * @param {object} filters
-     * @param filter
-     * @param {object} sort
-     * @param {object} page
-     * @returns {Array}
+     * @param {object} filter the filters to use when loading the cases
+     * @param {object} page the current page and the page size
+     * @returns {object} the parameters needed to load cases
      */
     function getCaseApiParams (filter, page) {
       var caseReturnParams = [
@@ -198,7 +191,7 @@
     /**
      * Returns contact role for the currently viewing contact
      *
-     * @param {object} caseObj
+     * @param {object} caseObj the data belonging to a case
      * @returns {string} role
      */
     function getContactRole (caseObj) {
@@ -212,7 +205,7 @@
     /**
      * Fetches count of all the cases a contact have
      *
-     * @param {Array} apiCall
+     * @param {Array|object} apiCall the api call parameters to use for counting cases
      */
     function getTotalCasesCount (apiCall) {
       var count = 0;
@@ -265,8 +258,7 @@
     /**
      * Sets passed case object as selected case
      *
-     * @params {Object} caseObj
-     * @param caseObj
+     * @param {object} caseObj the data belonging to a case
      */
     function setCaseAsSelected (caseObj) {
       $scope.selectedCase = caseObj;
@@ -274,6 +266,8 @@
 
     /**
      * Watcher function for cases collections
+     *
+     * @returns {boolean} true when all cases list have been loaded
      */
     function isAllCasesLoaded () {
       return _.reduce($scope.casesListConfig, function (memoriser, data) {
@@ -284,8 +278,8 @@
     /**
      * Updates the list with new entries
      *
-     * @param {string} caseListIndex
-     * @param {Array} params
+     * @param {string} caseListIndex the case list config index to update
+     * @param {Array} params the parameters to use when updating the case list
      */
     function updateCase (caseListIndex, params) {
       crmApi(params).then(function (response) {

--- a/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
+++ b/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
@@ -2,7 +2,7 @@
 
 ((_) => {
   describe('Contact Case Tab', () => {
-    var $controller, $rootScope, $scope, mockContactId, mockContactService;
+    var $controller, $rootScope, $scope, crmApi, mockContactId, mockContactService;
 
     beforeEach(module('civicase', ($provide) => {
       mockContactService = jasmine.createSpyObj('Contact', ['getContactIDFromUrl']);
@@ -10,9 +10,10 @@
       $provide.value('Contact', mockContactService);
     }));
 
-    beforeEach(inject((_$controller_, _$rootScope_) => {
+    beforeEach(inject((_$controller_, _$rootScope_, _crmApi_) => {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
+      crmApi = _crmApi_;
     }));
 
     beforeEach(() => {
@@ -25,6 +26,43 @@
     describe('on init', () => {
       it('stores the contact id extracted from the URL', () => {
         expect($scope.contactId).toBe(mockContactId);
+      });
+    });
+
+    describe('when loading cases', () => {
+      it('requests non deleted opened cases for the given contact', () => {
+        expect(crmApi.calls.allArgs()).toContain(jasmine.arrayContaining([
+          jasmine.objectContaining({
+            cases: ['Case', 'getcaselist', jasmine.objectContaining({
+              'status_id.grouping': 'Opened',
+              contact_id: mockContactId,
+              is_deleted: 0
+            })]
+          })
+        ]));
+      });
+
+      it('requests non deleted closed cases for the given contact', () => {
+        expect(crmApi.calls.allArgs()).toContain(jasmine.arrayContaining([
+          jasmine.objectContaining({
+            cases: ['Case', 'getcaselist', jasmine.objectContaining({
+              'status_id.grouping': 'Closed',
+              contact_id: mockContactId,
+              is_deleted: 0
+            })]
+          })
+        ]));
+      });
+
+      it('requests non deleted cases where the contact is a manager', () => {
+        expect(crmApi.calls.allArgs()).toContain(jasmine.arrayContaining([
+          jasmine.objectContaining({
+            cases: ['Case', 'getcaselist', jasmine.objectContaining({
+              case_manager: mockContactId,
+              is_deleted: 0
+            })]
+          })
+        ]));
       });
     });
 

--- a/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
+++ b/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
@@ -1,29 +1,29 @@
 /* eslint-env jasmine */
 
-(function (_) {
-  describe('Contact Case Tab', function () {
+((_) => {
+  describe('Contact Case Tab', () => {
     var $controller, $rootScope, $scope, mockContactId, mockContactService;
 
-    beforeEach(module('civicase', function ($provide) {
+    beforeEach(module('civicase', ($provide) => {
       mockContactService = jasmine.createSpyObj('Contact', ['getContactIDFromUrl']);
 
       $provide.value('Contact', mockContactService);
     }));
 
-    beforeEach(inject(function (_$controller_, _$rootScope_) {
+    beforeEach(inject((_$controller_, _$rootScope_) => {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
     }));
 
-    beforeEach(function () {
+    beforeEach(() => {
       mockContactId = _.uniqueId();
 
       mockContactService.getContactIDFromUrl.and.returnValue(mockContactId);
       initController();
     });
 
-    describe('on init', function () {
-      it('stores the contact id extracted from the URL', function () {
+    describe('on init', () => {
+      it('stores the contact id extracted from the URL', () => {
         expect($scope.contactId).toBe(mockContactId);
       });
     });


### PR DESCRIPTION
## Overview
This PR hides deleted cases from the contact's cases tab

## Before
![Screen Shot 2019-11-05 at 4 04 13 PM](https://user-images.githubusercontent.com/1642119/68241946-fd133980-ffe5-11e9-9cfa-26eee32e38e5.png)
Case #1 had been deleted but is still shown

## After
![Screen Shot 2019-11-05 at 3 57 26 PM](https://user-images.githubusercontent.com/1642119/68241405-fc2dd800-ffe4-11e9-9445-5b7eeb491382.png)

## Technical Details

We added `is_deleted: 0` to the params passed to the API when requests the contact's cases.

