### PR TITLE
CATL-1128: Fix open case details

### DIFF
--- a/ang/civicase-base/services/case-status.service.js
+++ b/ang/civicase-base/services/case-status.service.js
@@ -7,8 +7,32 @@
    * Case Status Service
    */
   function CaseStatus () {
-    this.getAll = function () {
-      return CRM['civicase-base'].caseStatuses;
-    };
+    var caseStatuses = CRM['civicase-base'].caseStatuses;
+
+    this.getAll = getAll;
+    this.getLabelsForValues = getLabelsForValues;
+
+    /**
+     * @returns {object[]} a list of all the case statuses.
+     */
+    function getAll () {
+      return caseStatuses;
+    }
+
+    /**
+     * Returns the labels for the given case status values.
+     *
+     * @param {string[]} statusValues a list of case status values.
+     * @returns {string[]} a list of case status labels.
+     */
+    function getLabelsForValues (statusValues) {
+      return _.map(statusValues, function (statusValue) {
+        var caseStatus = _.find(caseStatuses, function (caseStatus) {
+          return caseStatus.value === statusValue;
+        });
+
+        return caseStatus.label;
+      });
+    }
   }
 })(angular, CRM.$, CRM._, CRM);

--- a/ang/civicase-base/services/case-type.service.js
+++ b/ang/civicase-base/services/case-type.service.js
@@ -7,8 +7,28 @@
    * CaseType Service
    */
   function CaseType () {
-    this.getAll = function () {
-      return CRM['civicase-base'].caseTypes;
-    };
+    var caseTypes = CRM['civicase-base'].caseTypes;
+
+    this.getAll = getAll;
+    this.getTitlesForNames = getTitlesForNames;
+
+    /**
+     * @returns {object[]} a list of case types.
+     */
+    function getAll () {
+      return caseTypes;
+    }
+
+    /**
+     * Returns a list of case type titles for the given names.
+     *
+     * @param {string[]} caseTypeNames the case type names.
+     * @returns {string[]} a list of case type titles.
+     */
+    function getTitlesForNames (caseTypeNames) {
+      return _.map(caseTypeNames, function (caseTypeName) {
+        return _.findWhere(caseTypes, { name: caseTypeName }).title;
+      });
+    }
   }
 })(angular, CRM.$, CRM._, CRM);

--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
@@ -246,7 +246,7 @@
       <!-- End Last Modified -->
     </div>
     <div class="civicase__contact-cases-tab__panel-row civicase__contact-cases-tab__panel-actions">
-      <a ng-href="/civicrm/case/a/#/case/list?caseId={{item.id}}" class="btn btn-primary">
+      <a ng-href="{{getCaseDetailsUrl(item)}}" class="btn btn-primary">
         Go To Case
       </a>
     </div>

--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.js
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.js
@@ -3,6 +3,7 @@
 
   module.directive('civicaseContactCaseTabCaseDetails', function () {
     return {
+      controller: 'CivicaseContactCaseTabCaseDetailsController',
       restrict: 'EA',
       replace: true,
       templateUrl: '~/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html',
@@ -12,4 +13,26 @@
       }
     };
   });
+
+  module.controller('CivicaseContactCaseTabCaseDetailsController', CivicaseContactCaseTabCaseDetailsController);
+
+  /**
+   * @param {object} $scope the scope reference.
+   */
+  function CivicaseContactCaseTabCaseDetailsController ($scope) {
+    $scope.getCaseDetailsUrl = getCaseDetailsUrl;
+
+    /**
+     * Returns the URL needed to open the case details page for the given case.
+     * The status id parameter is appended otherwise non "Opened" cases would be hidden
+     * since the details page filters by "Opened" cases by default when no status is sent.
+     *
+     * @param {object} caseItem the case data.
+     * @returns {string} the case details page url.
+     */
+    function getCaseDetailsUrl (caseItem) {
+      return '/civicrm/case/a/#/case/list?caseId=' + caseItem.id +
+        '&cf={"status_id":[' + caseItem.status_id + ']}';
+    }
+  }
 })(angular, CRM.$, CRM._);

--- a/ang/civicase/case/search/directives/search.directive.html
+++ b/ang/civicase/case/search/directives/search.directive.html
@@ -1,7 +1,9 @@
 <div class="panel panel-default civicase__case-filter-panel clearfix" ng-class="{'case-is-focused': $parent.caseIsFocused}">
   <div crm-ui-debug="filters"></div>
   <div class="panel-header">
-    <h3 class="civicase__case-filter-panel__title"> {{ pageTitle }} </h3>
+    <h3 class="civicase__case-filter-panel__title" title="{{ pageTitle }}">
+      {{ pageTitle }}
+    </h3>
     <form class="form-inline civicase__case-filters-container">
       <input class="form-control civicase__case-filter__input" ng-list crm-ui-select="{allowClear: true, multiple: true, placeholder: ts('Case Type: Any'), data: caseTypeOptions}" ng-model="filters.case_type_id" />
       <input class="form-control civicase__case-filter__input" ng-list crm-ui-select="{allowClear: true, multiple: true, placeholder: ts('Status: All open cases'), data: caseStatusOptions}" ng-model="filters.status_id" />

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -380,7 +380,7 @@
     function setPageTitle (event, displayNameOfSelectedItem, totalCount) {
       var filters = $scope.filters;
       var hasCaseTypeFilters = filters.case_type_id && filters.case_type_id.length;
-      var hasFiltersNotUsedForTitle = _.size(_.omit(filters, ['status_id', 'case_type_id']));
+      var hasFiltersNotUsedForTitle = _.size(_.omit(filters, ['status_id', 'case_type_category', 'case_type_id']));
       var hasStatusFilters = filters.status_id && filters.status_id.length;
       var hasTotalCount = typeof totalCount === 'number';
 

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -379,36 +379,30 @@
      */
     function setPageTitle (event, displayNameOfSelectedItem, totalCount) {
       var filters = $scope.filters;
+      var hasCaseTypeFilters = filters.case_type_id && filters.case_type_id.length;
+      var hasFiltersNotUsedForTitle = _.size(_.omit(filters, ['status_id', 'case_type_id']));
+      var hasStatusFilters = filters.status_id && filters.status_id.length;
+      var hasTotalCount = typeof totalCount === 'number';
 
       if (displayNameOfSelectedItem) {
         $scope.pageTitle = displayNameOfSelectedItem;
         return;
       }
 
-      if (_.size(_.omit(filters, ['status_id', 'case_type_id']))) {
+      if (hasFiltersNotUsedForTitle) {
         $scope.pageTitle = ts('Case Search Results');
       } else {
-        var status = [];
-        if (filters.status_id && filters.status_id.length) {
-          _.each(filters.status_id, function (statusNameOrId) {
-            var caseStatus = _.findWhere(caseStatuses, function (caseStatus) {
-              return caseStatus.name === statusNameOrId || caseStatus.id === statusNameOrId;
-            });
+        var status = hasStatusFilters
+          ? CaseStatus.getLabelsForValues(filters.status_id)
+          : [ts('All Open')];
+        var types = hasCaseTypeFilters
+          ? CaseType.getTitlesForNames(filters.case_type_id)
+          : [];
 
-            status.push(caseStatus.label);
-          });
-        } else {
-          status = [ts('All Open')];
-        }
-        var type = [];
-        if (filters.case_type_id && filters.case_type_id.length) {
-          _.each(filters.case_type_id, function (t) {
-            type.push(_.findWhere(caseTypes, { name: t }).title);
-          });
-        }
-        $scope.pageTitle = status.join(' & ') + ' ' + type.join(' & ') + ' ' + ts('Cases');
+        $scope.pageTitle = status.join(' & ') + ' ' + types.join(' & ') + ' ' + ts('Cases');
       }
-      if (typeof totalCount === 'number') {
+
+      if (hasTotalCount) {
         $scope.pageTitle += ' (' + totalCount + ')';
       }
     }

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -390,8 +390,12 @@
       } else {
         var status = [];
         if (filters.status_id && filters.status_id.length) {
-          _.each(filters.status_id, function (s) {
-            status.push(_.findWhere(caseStatuses, { name: s }).label);
+          _.each(filters.status_id, function (statusNameOrId) {
+            var caseStatus = _.findWhere(caseStatuses, function (caseStatus) {
+              return caseStatus.name === statusNameOrId || caseStatus.id === statusNameOrId;
+            });
+
+            status.push(caseStatus.label);
           });
         } else {
           status = [ts('All Open')];

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
@@ -12,14 +12,21 @@
 
   module.controller('CivicaseContactCaseTabController', CivicaseContactCaseTabController);
 
+  /**
+   * @param $scope
+   * @param crmApi
+   * @param formatCase
+   * @param Contact
+   * @param ContactsCache
+   */
   function CivicaseContactCaseTabController ($scope, crmApi, formatCase, Contact, ContactsCache) {
     var commonConfigs = {
-      'isLoaded': false,
-      'showSpinner': false,
-      'isLoadMoreAvailable': false,
-      'page': {
-        'size': 3,
-        'num': 1
+      isLoaded: false,
+      showSpinner: false,
+      isLoadMoreAvailable: false,
+      page: {
+        size: 3,
+        num: 1
       }
     };
 
@@ -29,28 +36,28 @@
     $scope.newCaseWebformClient = CRM.civicase.newCaseWebformClient;
     $scope.casesListConfig = [
       {
-        'name': 'opened',
-        'title': 'Open Cases',
-        'filterParams': {
+        name: 'opened',
+        title: 'Open Cases',
+        filterParams: {
           'status_id.grouping': 'Opened',
-          'contact_id': $scope.contactId
+          contact_id: $scope.contactId
         },
-        'showContactRole': false
+        showContactRole: false
       }, {
-        'name': 'closed',
-        'title': 'Resolved cases',
-        'filterParams': {
+        name: 'closed',
+        title: 'Resolved cases',
+        filterParams: {
           'status_id.grouping': 'Closed',
-          'contact_id': $scope.contactId
+          contact_id: $scope.contactId
         },
-        'showContactRole': false
+        showContactRole: false
       }, {
-        'name': 'related',
-        'title': 'Other cases for this contact',
-        'filterParams': {
-          'case_manager': $scope.contactId
+        name: 'related',
+        title: 'Other cases for this contact',
+        filterParams: {
+          case_manager: $scope.contactId
         },
-        'showContactRole': true
+        showContactRole: true
       }
     ];
 
@@ -74,8 +81,8 @@
     /**
      * Watcher for civicase::contact-record-list::loadmore event
      *
-     * @param {Object} event
-     * @param {String} name of the list
+     * @param {object} event
+     * @param {string} name of the list
      */
     function contactRecordListLoadmoreWatcher (event, name) {
       var caseListIndex = _.findIndex($scope.casesListConfig, function (caseObj) {
@@ -93,6 +100,10 @@
      * @params {Object} event
      * @params {Object} caseObj case object of the list
      */
+    /**
+     * @param event
+     * @param caseObj
+     */
     function contactRecordListViewCaseWatcher (event, caseObj) {
       setCaseAsSelected(caseObj);
     }
@@ -101,7 +112,7 @@
      * Fetch additional information about the contacts
      *
      * @param {object} event
-     * @param {array} cases
+     * @param {Array} cases
      */
     function fetchContactsData (cases) {
       var contacts = [];
@@ -117,7 +128,7 @@
      * Get all the contacts of the given case
      *
      * @param {object} caseObj
-     * @return {array}
+     * @returns {Array}
      */
     function getAllContactIdsForCase (caseObj) {
       var contacts = [];
@@ -155,9 +166,10 @@
      * Get parameters to load cases
      *
      * @param {object} filters
+     * @param filter
      * @param {object} sort
      * @param {object} page
-     * @return {array}
+     * @returns {Array}
      */
     function getCaseApiParams (filter, page) {
       var caseReturnParams = [
@@ -175,7 +187,7 @@
           offset: page.size * (page.num - 1)
         }
       };
-      var params = {'case_type_id.is_active': 1};
+      var params = { 'case_type_id.is_active': 1 };
 
       return {
         cases: ['Case', 'getcaselist', $.extend(true, returnCaseParams, filter, params)],
@@ -186,8 +198,8 @@
     /**
      * Returns contact role for the currently viewing contact
      *
-     * @param {Object} caseObj
-     * @return {String} role
+     * @param {object} caseObj
+     * @returns {string} role
      */
     function getContactRole (caseObj) {
       var contact = _.find(caseObj.contacts, {
@@ -254,6 +266,7 @@
      * Sets passed case object as selected case
      *
      * @params {Object} caseObj
+     * @param caseObj
      */
     function setCaseAsSelected (caseObj) {
       $scope.selectedCase = caseObj;
@@ -271,7 +284,7 @@
     /**
      * Updates the list with new entries
      *
-     * @param {String} caseListIndex
+     * @param {string} caseListIndex
      * @param {Array} params
      */
     function updateCase (caseListIndex, params) {

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
@@ -40,7 +40,8 @@
         title: 'Open Cases',
         filterParams: {
           'status_id.grouping': 'Opened',
-          contact_id: $scope.contactId
+          contact_id: $scope.contactId,
+          is_deleted: 0
         },
         showContactRole: false
       }, {
@@ -48,14 +49,16 @@
         title: 'Resolved cases',
         filterParams: {
           'status_id.grouping': 'Closed',
-          contact_id: $scope.contactId
+          contact_id: $scope.contactId,
+          is_deleted: 0
         },
         showContactRole: false
       }, {
         name: 'related',
         title: 'Other cases for this contact',
         filterParams: {
-          case_manager: $scope.contactId
+          case_manager: $scope.contactId,
+          is_deleted: 0
         },
         showContactRole: true
       }

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
@@ -13,11 +13,11 @@
   module.controller('CivicaseContactCaseTabController', CivicaseContactCaseTabController);
 
   /**
-   * @param $scope
-   * @param crmApi
-   * @param formatCase
-   * @param Contact
-   * @param ContactsCache
+   * @param {object} $scope the controller scope
+   * @param {Function} crmApi the crm api service
+   * @param {Function} formatCase the format case service
+   * @param {object} Contact the contact service
+   * @param {object} ContactsCache the contacts cache service
    */
   function CivicaseContactCaseTabController ($scope, crmApi, formatCase, Contact, ContactsCache) {
     var commonConfigs = {
@@ -81,7 +81,7 @@
     /**
      * Watcher for civicase::contact-record-list::loadmore event
      *
-     * @param {object} event
+     * @param {object} event scope watch event reference
      * @param {string} name of the list
      */
     function contactRecordListLoadmoreWatcher (event, name) {
@@ -94,15 +94,11 @@
       updateCase(caseListIndex, params);
     }
 
-    /*
+    /**
      * Watcher for civicase::contact-record-list::view-case event
      *
-     * @params {Object} event
-     * @params {Object} caseObj case object of the list
-     */
-    /**
-     * @param event
-     * @param caseObj
+     * @param {object} event scope watch event reference
+     * @param {object} caseObj the data belonging to a case
      */
     function contactRecordListViewCaseWatcher (event, caseObj) {
       setCaseAsSelected(caseObj);
@@ -111,8 +107,7 @@
     /**
      * Fetch additional information about the contacts
      *
-     * @param {object} event
-     * @param {Array} cases
+     * @param {object[]} cases a list of cases
      */
     function fetchContactsData (cases) {
       var contacts = [];
@@ -125,10 +120,10 @@
     }
 
     /**
-     * Get all the contacts of the given case
+     * Returns all the contact ids for the given case
      *
-     * @param {object} caseObj
-     * @returns {Array}
+     * @param {object} caseObj the data belonging to a case
+     * @returns {number[]} a list of contact ids
      */
     function getAllContactIdsForCase (caseObj) {
       var contacts = [];
@@ -165,11 +160,9 @@
     /**
      * Get parameters to load cases
      *
-     * @param {object} filters
-     * @param filter
-     * @param {object} sort
-     * @param {object} page
-     * @returns {Array}
+     * @param {object} filter the filters to use when loading the cases
+     * @param {object} page the current page and the page size
+     * @returns {object} the parameters needed to load cases
      */
     function getCaseApiParams (filter, page) {
       var caseReturnParams = [
@@ -198,7 +191,7 @@
     /**
      * Returns contact role for the currently viewing contact
      *
-     * @param {object} caseObj
+     * @param {object} caseObj the data belonging to a case
      * @returns {string} role
      */
     function getContactRole (caseObj) {
@@ -212,7 +205,7 @@
     /**
      * Fetches count of all the cases a contact have
      *
-     * @param {Array} apiCall
+     * @param {Array|object} apiCall the api call parameters to use for counting cases
      */
     function getTotalCasesCount (apiCall) {
       var count = 0;
@@ -265,8 +258,7 @@
     /**
      * Sets passed case object as selected case
      *
-     * @params {Object} caseObj
-     * @param caseObj
+     * @param {object} caseObj the data belonging to a case
      */
     function setCaseAsSelected (caseObj) {
       $scope.selectedCase = caseObj;
@@ -274,6 +266,8 @@
 
     /**
      * Watcher function for cases collections
+     *
+     * @returns {boolean} true when all cases list have been loaded
      */
     function isAllCasesLoaded () {
       return _.reduce($scope.casesListConfig, function (memoriser, data) {
@@ -284,8 +278,8 @@
     /**
      * Updates the list with new entries
      *
-     * @param {string} caseListIndex
-     * @param {Array} params
+     * @param {string} caseListIndex the case list config index to update
+     * @param {Array} params the parameters to use when updating the case list
      */
     function updateCase (caseListIndex, params) {
       crmApi(params).then(function (response) {

--- a/ang/test/civicase-base/services/case-status.service.spec.js
+++ b/ang/test/civicase-base/services/case-status.service.spec.js
@@ -1,0 +1,38 @@
+/* eslint-env jasmine */
+
+(() => {
+  describe('Case Status', () => {
+    let CaseStatus, CaseStatusData;
+
+    beforeEach(module('civicase', 'civicase.data'));
+
+    beforeEach(inject((_CaseStatus_, _CaseStatuses_) => {
+      CaseStatus = _CaseStatus_;
+      CaseStatusData = _CaseStatuses_.values;
+    }));
+
+    describe('when getting all case statuses', () => {
+      let returnedCaseStatuses;
+
+      beforeEach(() => {
+        returnedCaseStatuses = CaseStatus.getAll();
+      });
+
+      it('returns all the case statuses', () => {
+        expect(returnedCaseStatuses).toEqual(CaseStatusData);
+      });
+    });
+
+    describe('when getting the labels for case statuses using status values', () => {
+      let returnedLabels;
+
+      beforeEach(() => {
+        returnedLabels = CaseStatus.getLabelsForValues(['2', '3']);
+      });
+
+      it('returns the labels for the given status values', () => {
+        expect(returnedLabels).toEqual(['Resolved', 'Urgent']);
+      });
+    });
+  });
+})();

--- a/ang/test/civicase-base/services/case-type.service.spec.js
+++ b/ang/test/civicase-base/services/case-type.service.spec.js
@@ -1,0 +1,44 @@
+/* eslint-env jasmine */
+
+(() => {
+  describe('Case Type', () => {
+    let CaseType, CaseTypesData;
+
+    beforeEach(module('civicase', 'civicase.data'));
+
+    beforeEach(inject((_CaseType_, _CaseTypes_) => {
+      CaseType = _CaseType_;
+      CaseTypesData = _CaseTypes_.get();
+    }));
+
+    describe('when getting all case types', () => {
+      let returnedCaseTypes;
+
+      beforeEach(() => {
+        returnedCaseTypes = CaseType.getAll();
+      });
+
+      it('returns all the case types', () => {
+        expect(returnedCaseTypes).toEqual(CaseTypesData);
+      });
+    });
+
+    describe('when getting the titles for case types using their name', () => {
+      let returnedTitles;
+
+      beforeEach(() => {
+        returnedTitles = CaseType.getTitlesForNames([
+          'housing_support',
+          'adult_day_care_referral'
+        ]);
+      });
+
+      it('returns the title for the given case types', () => {
+        expect(returnedTitles).toEqual([
+          'Housing Support',
+          'Adult Day Care Referral'
+        ]);
+      });
+    });
+  });
+})();

--- a/ang/test/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.spec.js
+++ b/ang/test/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.spec.js
@@ -1,1 +1,40 @@
-// Todo write unit tests for ContactCaseTabCaseDetails.js
+/* eslint-env jasmine */
+
+(() => {
+  describe('Contact Case Tab Case Details', () => {
+    let $controller, $rootScope, $scope, mockCase;
+
+    beforeEach(module('civicase', 'civicase.data'));
+
+    beforeEach(inject((_$controller_, _$rootScope_, _CasesData_, _crmApi_) => {
+      $controller = _$controller_;
+      $rootScope = _$rootScope_;
+      mockCase = _CasesData_.get().values[0];
+
+      initController();
+    }));
+
+    describe('when requesting the case details page URL', () => {
+      let expectedUrl, returnedUrl;
+
+      beforeEach(() => {
+        expectedUrl = '/civicrm/case/a/#/case/list' +
+          `?caseId=${mockCase.id}&cf={"status_id":[${mockCase.status_id}]}`;
+        returnedUrl = $scope.getCaseDetailsUrl(mockCase);
+      });
+
+      it('returns the case details page url for the given case', () => {
+        expect(returnedUrl).toEqual(expectedUrl);
+      });
+    });
+
+    /**
+     * Initializes the contact case tab case details controller.
+     */
+    function initController () {
+      $scope = $rootScope.$new();
+
+      $controller('CivicaseContactCaseTabCaseDetailsController', { $scope: $scope });
+    }
+  });
+})();

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -247,6 +247,20 @@
           });
         });
 
+        describe('when cases are filtered by case type category', () => {
+          beforeEach(() => {
+            $scope.filters = {
+              case_type_category: '1'
+            };
+
+            $scope.$emit(updateTitleEventName);
+          });
+
+          it('displays an "all open cases" title', () => {
+            expect($scope.pageTitle).toEqual('All Open  Cases');
+          });
+        });
+
         describe('when there are filters not used for describing the title', () => {
           beforeEach(() => {
             $scope.filters = [{ case_manager: [1] }];

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -1,5 +1,5 @@
 /* eslint-env jasmine */
-(function ($) {
+(function ($, _) {
   describe('civicaseSearch', function () {
     var $controller, $rootScope, $scope, CaseFilters, CaseStatuses, CaseTypes, crmApi, affixOriginalFunction,
       offsetOriginalFunction, originalDoSearch, orginalParentScope, affixReturnValue,
@@ -335,6 +335,18 @@
             });
           });
         });
+
+        describe('when a case count is provided', () => {
+          const randomCount = _.random(0, 1000);
+
+          beforeEach(() => {
+            $scope.$emit(updateTitleEventName, null, randomCount);
+          });
+
+          it('adds the count at the end of the title', () => {
+            expect($scope.pageTitle).toEqual(`All Open  Cases (${randomCount})`);
+          });
+        });
       });
     });
 
@@ -350,4 +362,4 @@
       });
     }
   });
-}(CRM.$));
+}(CRM.$, CRM._));

--- a/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
+++ b/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
@@ -2,7 +2,7 @@
 
 ((_) => {
   describe('Contact Case Tab', () => {
-    var $controller, $rootScope, $scope, mockContactId, mockContactService;
+    var $controller, $rootScope, $scope, crmApi, mockContactId, mockContactService;
 
     beforeEach(module('civicase', ($provide) => {
       mockContactService = jasmine.createSpyObj('Contact', ['getContactIDFromUrl']);
@@ -10,9 +10,10 @@
       $provide.value('Contact', mockContactService);
     }));
 
-    beforeEach(inject((_$controller_, _$rootScope_) => {
+    beforeEach(inject((_$controller_, _$rootScope_, _crmApi_) => {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
+      crmApi = _crmApi_;
     }));
 
     beforeEach(() => {
@@ -25,6 +26,43 @@
     describe('on init', () => {
       it('stores the contact id extracted from the URL', () => {
         expect($scope.contactId).toBe(mockContactId);
+      });
+    });
+
+    describe('when loading cases', () => {
+      it('requests non deleted opened cases for the given contact', () => {
+        expect(crmApi.calls.allArgs()).toContain(jasmine.arrayContaining([
+          jasmine.objectContaining({
+            cases: ['Case', 'getcaselist', jasmine.objectContaining({
+              'status_id.grouping': 'Opened',
+              contact_id: mockContactId,
+              is_deleted: 0
+            })]
+          })
+        ]));
+      });
+
+      it('requests non deleted closed cases for the given contact', () => {
+        expect(crmApi.calls.allArgs()).toContain(jasmine.arrayContaining([
+          jasmine.objectContaining({
+            cases: ['Case', 'getcaselist', jasmine.objectContaining({
+              'status_id.grouping': 'Closed',
+              contact_id: mockContactId,
+              is_deleted: 0
+            })]
+          })
+        ]));
+      });
+
+      it('requests non deleted cases where the contact is a manager', () => {
+        expect(crmApi.calls.allArgs()).toContain(jasmine.arrayContaining([
+          jasmine.objectContaining({
+            cases: ['Case', 'getcaselist', jasmine.objectContaining({
+              case_manager: mockContactId,
+              is_deleted: 0
+            })]
+          })
+        ]));
       });
     });
 

--- a/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
+++ b/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
@@ -1,29 +1,29 @@
 /* eslint-env jasmine */
 
-(function (_) {
-  describe('Contact Case Tab', function () {
+((_) => {
+  describe('Contact Case Tab', () => {
     var $controller, $rootScope, $scope, mockContactId, mockContactService;
 
-    beforeEach(module('civicase', function ($provide) {
+    beforeEach(module('civicase', ($provide) => {
       mockContactService = jasmine.createSpyObj('Contact', ['getContactIDFromUrl']);
 
       $provide.value('Contact', mockContactService);
     }));
 
-    beforeEach(inject(function (_$controller_, _$rootScope_) {
+    beforeEach(inject((_$controller_, _$rootScope_) => {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
     }));
 
-    beforeEach(function () {
+    beforeEach(() => {
       mockContactId = _.uniqueId();
 
       mockContactService.getContactIDFromUrl.and.returnValue(mockContactId);
       initController();
     });
 
-    describe('on init', function () {
-      it('stores the contact id extracted from the URL', function () {
+    describe('on init', () => {
+      it('stores the contact id extracted from the URL', () => {
         expect($scope.contactId).toBe(mockContactId);
       });
     });

--- a/ang/test/karma.conf.js
+++ b/ang/test/karma.conf.js
@@ -43,7 +43,8 @@ module.exports = function (config) {
       // Spec files
       { pattern: extPath + '/ang/test/mocks/modules.mock.js' },
       { pattern: extPath + '/ang/test/mocks/**/*.js' },
-      { pattern: extPath + '/ang/test/civicase/**/*.js' }
+      { pattern: extPath + '/ang/test/civicase/**/*.js' },
+      { pattern: extPath + '/ang/test/civicase-base/**/*.js' }
     ],
     exclude: [
     ],


### PR DESCRIPTION
## Overview
This PR fixes an issue that happens when trying to open the case details page for a case that has any status other than "Opened".

This PR closes #251 for *Before* and *After* screens of the issue please find them in the previous PR.

It also fixes a regression issue related to the case search title.

## Opening the case details

The issue happens because the case manager filters by "Opened" cases by default. Since the selected case has a different status they are completely and the details can't be shown.

To fix this we pass the status id through the URL which in turn is read by the manager and the case can be properly fetched. 

## Search title

### Before
![pr-before](https://user-images.githubusercontent.com/1642119/68551385-e5232780-03e2-11ea-93fa-94f03e705969.gif)

### After
![pr-after](https://user-images.githubusercontent.com/1642119/68551396-113ea880-03e3-11ea-8561-6433f5accce7.gif)

### Technical details

The regression was introduced after we started filtering cases by category on the dashboard. The issue happens because the title can only be built for case type or case status filters. If any other filter is shown it will fall back to a generic "Case Search Results" title. To fix this we added the `case_type_category` filter to the list of allowed filters for the title.

Some refactoring was done to the code and added missing tests to avoid breaking this feature.

#### Status and case types services

Some new methods were added to the status and case type services and the structure was changed.

This is the proposed structure:

```js
function ServiceName () {
  var privateVar = '...';

  this.method1 = method1;
  this.method2 = method2;

  function method1 () {
    // ...
  }

  function method2 () {
    // ...
  }
}
```

The advantage of this structure is that it makes the service look similar to the structure followed by controllers. It's also easier to create docs for this structure since it's not missed by JSDocs and our linter.

The `getTitlesForNames` and `getLabelsForValues` methods were added to these services to reduce the amount of code in the search directive, and not necessarily for their reusability. 

Coming back to the search directive refactoring, the condition operations were moved to variables to explain better their purpose. It's easier to read `if (hasFiltersNotUsedForTitle) {` than to read `if (_.size(_.omit(filters, ['status_id', 'case_type_category', 'case_type_id']))) {`