### PR TITLE
CATL-1141: Fix Custom Group Page inaccessible when Civicase extension is disabled

### DIFF
--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -5,6 +5,7 @@ use CRM_Civicase_Setup_CreateCasesOptionValue as CreateCasesOptionValue;
 use CRM_Civicase_Setup_AddCaseTypesForCustomGroupExtends as AddCaseTypesForCustomGroupExtends;
 use CRM_Civicase_Setup_AddCaseCategoryWordReplacementOptionGroup as AddCaseCategoryWordReplacementOptionGroup;
 use CRM_Civicase_Setup_MoveCaseTypesToCasesCategory as MoveCaseTypesToCasesCategory;
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 
 /**
  * Collection of upgrade steps.
@@ -221,6 +222,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     }
 
     $this->removeNav('Manage Cases');
+    $this->restoreCaseCustomGroupExtendClassToDefault();
   }
 
   /**
@@ -361,6 +363,50 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
   }
 
   /**
+   * Restores the Case Custom Group Extend Class To Default.
+   *
+   * When the civicase extension is installed, it modifies the class
+   * that returns the case types for cases to one that returns only the
+   * one in cases category. This function restores that original value.
+   */
+  private function restoreCaseCustomGroupExtendClassToDefault() {
+    $this->setCaseCustomGroupExtendClass('CRM_Case_PseudoConstant::caseType;');
+  }
+
+  /**
+   * Sets the Case Custom Group Extend Class For Case Type Category.
+   *
+   * Setting this class allows the case types when adding custom group
+   * that extend a case to return case types belonging only to the case
+   * category.
+   */
+  private function setCaseCustomGroupExtendClassForCaseTypeCategory() {
+    $this->setCaseCustomGroupExtendClass('CRM_Civicase_Helper_CaseCategory::getCaseTypesForCase;');
+  }
+
+  /**
+   * Sets the Case Custom Group Extend Class.
+   *
+   * @param string $caseTypeClass
+   *   Case Type class for retrieving case types.
+   */
+  private function setCaseCustomGroupExtendClass($caseTypeClass) {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'cg_extend_objects',
+      'label' => CaseCategoryHelper::CASE_TYPE_CATEGORY_NAME,
+    ]);
+
+    if (empty($result['id'])) {
+      return;
+    }
+
+    civicrm_api3('OptionValue', 'create', [
+      'id' => $result['id'],
+      'description' => $caseTypeClass,
+    ]);
+  }
+
+  /**
    * Remove nav.
    *
    * @param string $name
@@ -379,6 +425,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     $this->swapCaseMenuItems();
 
     $this->toggleNav('Manage Cases', TRUE);
+    $this->setCaseCustomGroupExtendClassForCaseTypeCategory();
   }
 
   /**
@@ -388,6 +435,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     $this->swapCaseMenuItems();
 
     $this->toggleNav('Manage Cases', FALSE);
+    $this->restoreCaseCustomGroupExtendClassToDefault();
   }
 
   /**


### PR DESCRIPTION
## Overview
The Custom group/fields page `civicrm/admin/custom/group` becomes inaccessible when the civicase extension is disabled shows an error.

## Before
An error `Warning: require_once(CRM/Civicase/Helper/CaseCategory.php): failed to open stream: No such file or directory in require_once() (line 2099 of /var/www/site/profiles/compuclient/modules/contrib/civicrm/CRM/Core/BAO/CustomGroup.php).`

## After
Custom group page is accessible when civicase extension is disabled.

## Technical Details
A class was added [here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/Setup/AddCaseTypesForCustomGroupExtends.php#L14) as part of the parameters for the option group value for the `cg_extend_objects` that allows the Case Types returned on the Custom Group page when adding a custom field set to a Case to only be those case types belonging to Cases category. When the civicase extension is disabled, this class becomes unavailable. 

The solution was to revert back to the default class used by Civi to fetch the case types when the civicase exension is disabled and the replace this with the class for fetching only case type categories when the civicase extension is enabled back again

## Comments
This same issue will be observed for the prospect and Awards extension, i.e when these extensions are disabled, the custom field page becomes inaccessible. The fix here however will be a bit different since these extensions create new option group values for the `cg_extend_objects` option group rather than modifying an existing one.

To fix this, in the enable/disable extension hook, we would toggle the visibility o these option values. This will not however work for now as Civi fetches all the option values whether active or inactive, [See](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/BAO/CustomGroup.php#L2083). 
I have created a Core PR to fix this here: https://github.com/civicrm/civicrm-core/pull/15759 and will implement the solution for prospect and awards when PR is merged.
