### PR TITLE
CATL-1129: Fix pending upgrader issues after Civicase install.

### DIFF
--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -509,7 +509,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     if (empty($currentRevisionNum)) {
       return TRUE;
     }
-    return ($currentRevisionNum < max(array_keys($revisions)));
+    return ($currentRevisionNum < max($revisions));
   }
 
   /**
@@ -519,7 +519,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
    */
   public function enqueuePendingRevisions(CRM_Queue_Queue $queue) {
     $currentRevisionNum = (int) $this->getCurrentRevision();
-    foreach ($this->getRevisions() as $revisionNum => $revisionClass) {
+    foreach ($this->getRevisions() as $revisionClass => $revisionNum) {
       if ($revisionNum <= $currentRevisionNum) {
         continue;
       }
@@ -563,7 +563,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
    * Get a list of revisions.
    *
    * @return array
-   *   An array of revision classes sorted numerically by their key
+   *   An array of revisions sorted by the upgrader class as keys
    */
   public function getRevisions() {
     $extensionRoot = __DIR__;
@@ -574,9 +574,10 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
       $numberPrefix = 'Steps_Step';
       $startPos = strpos($class, $numberPrefix) + strlen($numberPrefix);
       $revisionNum = (int) substr($class, $startPos);
-      $sortedKeyedClasses[$revisionNum] = $class;
+      $sortedKeyedClasses[$class] = $revisionNum;
     }
-    ksort($sortedKeyedClasses, SORT_NUMERIC);
+    asort($sortedKeyedClasses, SORT_NUMERIC);
+
     return $sortedKeyedClasses;
   }
 


### PR DESCRIPTION
## Overview
The When installing the civicase extension for a site, after installation, there is a notice that extension updates are available. This should not happen as a fresh install of the extension should set the schema version to the version of the latest upgrader.

## Before
The scenario described above is observed.
After installing the civicase extension the schema version column for the extension record in the database has the Upgrader class name rather than the latest version number. i.e `CRM_Civicase_Upgrader_Steps_Step0007`

## After
After installing the civicase extension the schema version column for the extension record now has the latest version number and there is no notice that extension updates are available.

## Technical Details
The Civicase extension follows the new way of adding upgraders described [here](https://compucorp.atlassian.net/wiki/spaces/TD/pages/835092529/Adding+a+CiviCRM+Upgrader). This is why this issue is only observed for extensions that use this new process. The process involves overriding some functions present in the `CRM_Civicase_Upgrader_Base` class.

However the function [here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/Upgrader/Base.php#L315) expects the `getRevisions` function to return an array with the revision numbers as the values in order to set the schema version after an extension install. The custom overridden function here returns the upgrader class names as the array rather than the revision numbers.

This PR fixes the issue by flipping the array and having the upgrader classes as the key instead. 
Also other places where this function is used is modified to reflect this change

## Comments
After this PR is approved, the Upgrade documentation will be updated and this fix will be applied for the prospect and Award extension that use the same way of adding upgraders.