### PR TITLE
BASWSPRT-84: Fix User cannot view contact activities without "CiviCRM: administer CiviCRM" 

### DIFF
--- a/civicase.php
+++ b/civicase.php
@@ -534,6 +534,7 @@ function civicase_civicrm_alterAPIPermissions($entity, $action, &$params, &$perm
 
   $locationTypePermissions = array_merge($permissions['default']['default'], ['access CiviCRM']);
   $permissions['location_type']['get'] = [$locationTypePermissions];
+  $permissions['relationship_type']['getcaseroles'] = $permissions['relationship_type']['get'];
 
   $permissions['case']['getcount'] = [
     [

--- a/civicase.php
+++ b/civicase.php
@@ -532,6 +532,9 @@ function civicase_civicrm_alterAPIPermissions($entity, $action, &$params, &$perm
     ],
   ];
 
+  $locationTypePermissions = array_merge($permissions['default']['default'], ['access CiviCRM']);
+  $permissions['location_type']['get'] = [$locationTypePermissions];
+
   $permissions['case']['getcount'] = [
     [
       'access my cases and activities',


### PR DESCRIPTION
## Overview
When a user with the Role Civicase user visits the Activities tab for a contact, the user is unable to view the activities. 

## Before
<img width="1280" alt="SSS SSS  CiviCase 2019-11-13 18-48-29" src="https://user-images.githubusercontent.com/6951813/68789652-28c99b80-0646-11ea-8c95-36b7c1645cd5.png">


## After

When displaying the contact card for an activity, the `LocationType.get` API is used to get the location for the contact phone number. This API uses the default permission of `administer CiviCRM`. The Civicase user does not have this permission hence the error. 
The fix is to add the `view all activities` permission in addition to the default permission required to access this API. The Civicase user has the `view all activities` permission assigned by default.

<img width="1280" alt="Monosnap 2019-11-13 18-51-39" src="https://user-images.githubusercontent.com/6951813/68789977-bdcc9480-0646-11ea-9b05-78ff6d831a2b.png">


## Comment
Also set the permission for the custom `RelationshipType.getCaseRoles` API to use same permission as RelationshipType.get which is `access CiviCRM`.