### PR TITLE
CATL-1143: Fix custom field edit form datepickers

### DIFF
--- a/ang/civicase/shared/directives/edit-custom-data.directive.js
+++ b/ang/civicase/shared/directives/edit-custom-data.directive.js
@@ -1,97 +1,140 @@
 (function (angular, $, _, CRM) {
   var module = angular.module('civicase');
 
-  module.directive('civicaseEditCustomData', function () {
+  module.directive('civicaseEditCustomData', function ($timeout) {
     return {
       restrict: 'A',
       link: civicaseEditCustomDataLinkFunction
     };
-  });
-
-  /**
-   * Editable custom data blocks
-   *
-   * @param {object} scope the timeout wrapper
-   * @param {document#element} elem the DOM element reference
-   * @param {object} attrs the element attributes
-   */
-  function civicaseEditCustomDataLinkFunction (scope, elem, attrs) {
-    var form;
-
-    (function init () {
-      elem
-        .addClass('crm-editable-enabled')
-        .on('click', loadCustomFieldEditForm);
-    })();
 
     /**
-     * Cancels the editing of the custom fields by removing the form and showing the
-     * the original element.
-     */
-    function close () {
-      form.remove();
-      elem.show();
-      form = null;
-    }
-
-    /**
-     * Returns the URL needed to load the custom fields edit form.
+     * Editable custom data blocks
      *
-     * @returns {string} the form url
+     * @param {object} scope the timeout wrapper
+     * @param {document#element} elem the DOM element reference
+     * @param {object} attrs the element attributes
      */
-    function getCustomFieldsEditFormUrl () {
-      return CRM.url('civicrm/case/cd/edit', {
-        cgcount: 1,
-        action: 'update',
-        reset: 1,
-        type: 'Case',
-        entityID: scope.item.id,
-        groupID: scope.customGroup.id,
-        cid: scope.item.client[0].contact_id,
-        subType: scope.item.case_type_id,
-        civicase_reload: scope.caseGetParams()
-      });
-    }
+    function civicaseEditCustomDataLinkFunction (scope, elem, attrs) {
+      var form;
+      var jQueryFocusMethod = $.fn.focus;
+      var noopFocusMethod = function () { return this; };
 
-    /**
-     * Workaround bug where href="#" changes the angular route
-     */
-    function handleFormLoaded () {
-      $('a.crm-clear-link', form).removeAttr('href');
-    }
+      (function init () {
+        elem
+          .addClass('crm-editable-enabled')
+          .on('click', loadCustomFieldEditForm);
+      })();
 
-    /**
-     * Updates the parent scope by providing the updated custom field values.
-     *
-     * @param {document#event} event DOM event triggered by the form submission
-     * @param {object} data the form submitted data.
-     */
-    function handleFormSubmit (event, data) {
-      scope.$apply(function () {
-        scope.pushCaseData(data.civicase_reload[0]);
-        close();
-      });
-    }
-
-    /**
-     * Loads the custom field edit form onto the element associated to the directive.
-     */
-    function loadCustomFieldEditForm () {
-      var isFormLoading = !!form;
-
-      if (isFormLoading) {
-        return;
+      /**
+       * Blocks jQuery's focus method by providing a noop function. This is done in order
+       * to avoid core's loadForm method from focusing on calendar inputs.
+       */
+      function blockFocusMethod () {
+        $.fn.focus = noopFocusMethod;
       }
 
-      var url = getCustomFieldsEditFormUrl();
-      form = $('<div></div>').html(elem.hide().html());
+      /**
+       * Cancels the editing of the custom fields by removing the form and showing the
+       * the original element.
+       */
+      function close () {
+        form.remove();
+        elem.show();
+        form = null;
+      }
 
-      form.insertAfter(elem)
-        .on('click', '.cancel', close)
-        .on('crmLoad', handleFormLoaded)
-        .on('crmFormSuccess', handleFormSubmit);
+      /**
+       * Workaround bug where href="#" changes the angular route
+       */
+      function removeFormClearLinksHref () {
+        $('a.crm-clear-link', form).removeAttr('href');
+      }
 
-      CRM.loadForm(url, { target: form });
+      /**
+       * Focuses on the first visible input element. It disables datepicker's from
+       * popping up when their inputs have been triggered. It restores the normal behaviour
+       * after the focus have been applied.
+       */
+      function focusOnFirstInputWithoutTriggeringCalendars () {
+        form.find('input:visible:first')
+          .datepicker('option', 'showOn', 'button')
+          .focus()
+          .datepicker('option', 'showOn', 'focus');
+      }
+
+      /**
+       * Returns the URL needed to load the custom fields edit form.
+       *
+       * @returns {string} the form url
+       */
+      function getCustomFieldsEditFormUrl () {
+        return CRM.url('civicrm/case/cd/edit', {
+          cgcount: 1,
+          action: 'update',
+          reset: 1,
+          type: 'Case',
+          entityID: scope.item.id,
+          groupID: scope.customGroup.id,
+          cid: scope.item.client[0].contact_id,
+          subType: scope.item.case_type_id,
+          civicase_reload: scope.caseGetParams()
+        });
+      }
+
+      /**
+       * Triggered when the edit form loads. Fixes an issue with a's href attributes,
+       * Restores the original jQuery's method, and focuses on the first input element.
+       */
+      function handleFormLoaded () {
+        removeFormClearLinksHref();
+
+        $timeout(function () {
+          restoreFocusMethod();
+          focusOnFirstInputWithoutTriggeringCalendars();
+        });
+      }
+
+      /**
+       * Updates the parent scope by providing the updated custom field values.
+       *
+       * @param {document#event} event DOM event triggered by the form submission
+       * @param {object} data the form submitted data.
+       */
+      function handleFormSubmit (event, data) {
+        scope.$apply(function () {
+          scope.pushCaseData(data.civicase_reload[0]);
+          close();
+        });
+      }
+
+      /**
+       * Loads the custom field edit form onto the element associated to the directive.
+       */
+      function loadCustomFieldEditForm () {
+        var isFormLoading = !!form;
+
+        if (isFormLoading) {
+          return;
+        }
+
+        var url = getCustomFieldsEditFormUrl();
+        form = $('<div></div>').html(elem.hide().html());
+
+        form.insertAfter(elem)
+          .on('click', '.cancel', close)
+          .on('crmLoad', handleFormLoaded)
+          .on('crmFormSuccess', handleFormSubmit);
+
+        blockFocusMethod();
+        CRM.loadForm(url, { target: form });
+      }
+
+      /**
+       * Restores the original function used by jQuery's focus method.
+       */
+      function restoreFocusMethod () {
+        $.fn.focus = jQueryFocusMethod;
+      }
     }
-  }
+  });
 })(angular, CRM.$, CRM._, CRM);

--- a/ang/civicase/shared/directives/edit-custom-data.directive.js
+++ b/ang/civicase/shared/directives/edit-custom-data.directive.js
@@ -1,51 +1,63 @@
 (function (angular, $, _, CRM) {
   var module = angular.module('civicase');
 
-  // Editable custom data blocks
-  module.directive('civicaseEditCustomData', function ($timeout) {
+  module.directive('civicaseEditCustomData', function () {
     return {
       restrict: 'A',
-      link: function (scope, elem, attrs) {
-        var form;
-
-        function close () {
-          form.remove();
-          elem.show();
-          form = null;
-        }
-
-        elem
-          .addClass('crm-editable-enabled')
-          .on('click', function (e) {
-            if (!form) {
-              var url = CRM.url('civicrm/case/cd/edit', {
-                cgcount: 1,
-                action: 'update',
-                reset: 1,
-                type: 'Case',
-                entityID: scope.item.id,
-                groupID: scope.customGroup.id,
-                cid: scope.item.client[0].contact_id,
-                subType: scope.item.case_type_id,
-                civicase_reload: scope.caseGetParams()
-              });
-              form = $('<div></div>').html(elem.hide().html());
-              form.insertAfter(elem)
-                .on('click', '.cancel', close)
-                .on('crmLoad', function () {
-                  // Workaround bug where href="#" changes the angular route
-                  $('a.crm-clear-link', form).removeAttr('href');
-                })
-                .on('crmFormSuccess', function (e, data) {
-                  scope.$apply(function () {
-                    scope.pushCaseData(data.civicase_reload[0]);
-                    close();
-                  });
-                });
-              CRM.loadForm(url, {target: form});
-            }
-          });
-      }
+      link: civicaseEditCustomDataLinkFunction
     };
   });
+
+  /**
+   * Editable custom data blocks
+   *
+   * @param {object} scope the timeout wrapper
+   * @param {document#element} elem the DOM element reference
+   * @param {object} attrs the element attributes
+   */
+  function civicaseEditCustomDataLinkFunction (scope, elem, attrs) {
+    var form;
+
+    elem
+      .addClass('crm-editable-enabled')
+      .on('click', function (e) {
+        if (!form) {
+          var url = CRM.url('civicrm/case/cd/edit', {
+            cgcount: 1,
+            action: 'update',
+            reset: 1,
+            type: 'Case',
+            entityID: scope.item.id,
+            groupID: scope.customGroup.id,
+            cid: scope.item.client[0].contact_id,
+            subType: scope.item.case_type_id,
+            civicase_reload: scope.caseGetParams()
+          });
+          form = $('<div></div>').html(elem.hide().html());
+          form.insertAfter(elem)
+            .on('click', '.cancel', close)
+            .on('crmLoad', function () {
+              // Workaround bug where href="#" changes the angular route
+              $('a.crm-clear-link', form).removeAttr('href');
+            })
+            .on('crmFormSuccess', function (e, data) {
+              scope.$apply(function () {
+                scope.pushCaseData(data.civicase_reload[0]);
+                close();
+              });
+            });
+          CRM.loadForm(url, { target: form });
+        }
+      });
+
+    /**
+     * Cancels the editing of the custom fields by removing the form and showing the
+     * the original element.
+     */
+    function close () {
+      form.remove();
+      elem.show();
+      form = null;
+    }
+  }
 })(angular, CRM.$, CRM._, CRM);

--- a/ang/civicase/shared/directives/edit-custom-data.directive.js
+++ b/ang/civicase/shared/directives/edit-custom-data.directive.js
@@ -18,37 +18,11 @@
   function civicaseEditCustomDataLinkFunction (scope, elem, attrs) {
     var form;
 
-    elem
-      .addClass('crm-editable-enabled')
-      .on('click', function (e) {
-        if (!form) {
-          var url = CRM.url('civicrm/case/cd/edit', {
-            cgcount: 1,
-            action: 'update',
-            reset: 1,
-            type: 'Case',
-            entityID: scope.item.id,
-            groupID: scope.customGroup.id,
-            cid: scope.item.client[0].contact_id,
-            subType: scope.item.case_type_id,
-            civicase_reload: scope.caseGetParams()
-          });
-          form = $('<div></div>').html(elem.hide().html());
-          form.insertAfter(elem)
-            .on('click', '.cancel', close)
-            .on('crmLoad', function () {
-              // Workaround bug where href="#" changes the angular route
-              $('a.crm-clear-link', form).removeAttr('href');
-            })
-            .on('crmFormSuccess', function (e, data) {
-              scope.$apply(function () {
-                scope.pushCaseData(data.civicase_reload[0]);
-                close();
-              });
-            });
-          CRM.loadForm(url, { target: form });
-        }
-      });
+    (function init () {
+      elem
+        .addClass('crm-editable-enabled')
+        .on('click', loadCustomFieldEditForm);
+    })();
 
     /**
      * Cancels the editing of the custom fields by removing the form and showing the
@@ -58,6 +32,66 @@
       form.remove();
       elem.show();
       form = null;
+    }
+
+    /**
+     * Returns the URL needed to load the custom fields edit form.
+     *
+     * @returns {string} the form url
+     */
+    function getCustomFieldsEditFormUrl () {
+      return CRM.url('civicrm/case/cd/edit', {
+        cgcount: 1,
+        action: 'update',
+        reset: 1,
+        type: 'Case',
+        entityID: scope.item.id,
+        groupID: scope.customGroup.id,
+        cid: scope.item.client[0].contact_id,
+        subType: scope.item.case_type_id,
+        civicase_reload: scope.caseGetParams()
+      });
+    }
+
+    /**
+     * Workaround bug where href="#" changes the angular route
+     */
+    function handleFormLoaded () {
+      $('a.crm-clear-link', form).removeAttr('href');
+    }
+
+    /**
+     * Updates the parent scope by providing the updated custom field values.
+     *
+     * @param {document#event} event DOM event triggered by the form submission
+     * @param {object} data the form submitted data.
+     */
+    function handleFormSubmit (event, data) {
+      scope.$apply(function () {
+        scope.pushCaseData(data.civicase_reload[0]);
+        close();
+      });
+    }
+
+    /**
+     * Loads the custom field edit form onto the element associated to the directive.
+     */
+    function loadCustomFieldEditForm () {
+      var isFormLoading = !!form;
+
+      if (isFormLoading) {
+        return;
+      }
+
+      var url = getCustomFieldsEditFormUrl();
+      form = $('<div></div>').html(elem.hide().html());
+
+      form.insertAfter(elem)
+        .on('click', '.cancel', close)
+        .on('crmLoad', handleFormLoaded)
+        .on('crmFormSuccess', handleFormSubmit);
+
+      CRM.loadForm(url, { target: form });
     }
   }
 })(angular, CRM.$, CRM._, CRM);


### PR DESCRIPTION
## Overview
This PR fixes an issue that happens when opening the custom field edit form where datepickers would automatically show their calendar popup.

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/68797742-83a1c980-062b-11ea-895b-5e04958cab91.gif)

## After
![pr-after](https://user-images.githubusercontent.com/1642119/68797531-286fd700-062b-11ea-9284-571a9e8f4201.gif)

## Technical Details

The issue happens because core focuses on the first visible input method after loading the form:
https://github.com/civicrm/civicrm-core/blob/master/js/crm.ajax.js#L528

There's no way to stop core from doing this so our solution patches the jQuery focus method momentarily with a no operation function, and then restores it after the form loads:
```js
// not the actual code:
var jQueryFocusMethod = $.fn.focus;
var noopFocusMethod = function () { return this; };

form.insertAfter(elem)
  // ...
  .on('crmLoad', function () {
    // ...
    $timeout(function () {
      // restore original focus method:
      $.fn.focus = jQueryFocusMethod;
      // focus on first input without triggering the calendar:
      form.find('input:visible:first')
        .datepicker('option', 'showOn', 'button')
        .focus()
        .datepicker('option', 'showOn', 'focus');
    });
  });

// replaces the focus method with a mock one:
$.fn.focus = noopFocusMethod;
CRM.loadForm(url, { target: form });
```

Note: the `$timeout` function is needed to ensure that we restore things after core tries to focus on the input element. This is because core does the `focus` after triggering the `crmLoad` event.

As a final note, the `edit-custom-data.directive.js` directive file was refactored so it's easier to understand and also so it follows a common structure similar to what we have in other directives. Some 1 line statements were added into wrapper functions because it allows us to add comments explaining the reason for the line.

