### PR TITLE
CATL-1133: Fix overview dropdown issue

### DIFF
--- a/ang/civicase/case/directives/case-overview.directive.html
+++ b/ang/civicase/case/directives/case-overview.directive.html
@@ -30,7 +30,7 @@
           <i
             class="material-icons civicase__case-overview__flow-status__icon"
             ng-click="toggleBrekdownVisibility()"
-            ng-if="caseTypesLength > 1">
+            ng-if="caseTypesLength > 0">
             {{showBreakdown ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}}
           </i>
         </div>


### PR DESCRIPTION
## Overview
This PR fixes an issue where case types would not be shown on the overview breakdown of the dashboard when only a single case type was available.

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/68804855-1137e600-0639-11ea-8d3f-03741e1f120f.gif)

## After
![pr-after](https://user-images.githubusercontent.com/1642119/68804734-d0d86800-0638-11ea-83f2-2fb7b11b3c34.gif)

## Technical Details
The issue was introduced in https://github.com/compucorp/uk.co.compucorp.civicase/pull/96 when the overview table was first introduced. It's not clear if it was made by design or if this is an actual feature, but it was requested to be removed.

The value was set to zero instead of completely removing the `if` to avoid showing the arrow when no case types are defined which would be confusing for the user.

