### PR TITLE
CPS-29: Fix wrong client in case contact tab

### DIFF
--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
@@ -59,7 +59,7 @@
     </div>
     <div class="civicase__contact-cases-tab__panel-row civicase__contact-cases-tab__panel-row--dark  clearfix">
       <div class="pull-left">
-        <div class="civicase__contact-card--client" civicase-contact-card contacts="item.contacts"></div>
+        <div class="civicase__contact-card--client" civicase-contact-card contacts="item.client"></div>
         <div class="civicase__summary-tab__subject">
           <p
             crm-editable="item"


### PR DESCRIPTION
## Overview
In the Contacts Case tab, contacts added as non client relationships were being shown as clients, this PR fixes the same.

## Before
![2019-11-19 at 12 24 PM](https://user-images.githubusercontent.com/5058867/69123502-8be48380-0ac7-11ea-9694-a8decd8c577d.jpg)

## After
![2019-11-19 at 12 23 PM](https://user-images.githubusercontent.com/5058867/69123473-7a9b7700-0ac7-11ea-8b73-dbf853eceac6.jpg)

## Technical Details
Previously all contacts with relationship were shown, now only the client are being shown.