### PR TITLE
CPS-27: Strip strange characters from role names

### DIFF
--- a/CRM/Civicase/Form/Report/Case/CaseWithActivityPivot.php
+++ b/CRM/Civicase/Form/Report/Case/CaseWithActivityPivot.php
@@ -168,7 +168,7 @@ class CRM_Civicase_Form_Report_Case_CaseWithActivityPivot extends CRM_Civicase_F
       $prefix .= strtolower($value)."_";
     }
 
-    return $prefix;
+    return preg_replace("/[^A-Z0-9_-]/i", '', $prefix);
   }
 
   /**


### PR DESCRIPTION
## Overview
This PR fixes the error that breaks Javascript and causes the pivot table to be shown below

## Before
![CPS-27-before](https://raw.githubusercontent.com/16kilobyte/screenshots/master/CPS-27-before.png)

## After
![CPS-27-before](https://raw.githubusercontent.com/16kilobyte/screenshots/master/CPS-27-after.png)

## Technical Details
The Case Activity Pivot Table report fetches the Contact data for the case roles involved in a Case.
This means that when the Contact data for the Case roles are fetched, we need to alias Contact table in the JOIN  for each case role contact data in order to distinguish the join to contact table for each of the case roles involved.

This is done by prefixing the Contact table for each case role contact data with the Case role/relationship name, the contact fields are also aliased with this prefix(https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/Form/Report/Case/CaseWithActivityPivot.php#L97). This is fine but when adding these fields as form elements, Extended Report uses the aliased field names to generate the form elements names and ID. https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/Form/Report/ExtendedReport.php#L6469-L6573

For Fields that require Javascript events like Date fields, these field names are used in the Jquery selectors for some other dom elements that need to be displayed. If the relationship name/case role name contains characters like ampersand, forward slash, it eventually makes it's way to these selector names and breaks the Jquery code and throws errors in  the console making the Pivot report un-usable 