### PR TITLE
CPS-6: Change "Other Case" logic in Contact Case Tab

### DIFF
--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
@@ -66,8 +66,9 @@
         name: 'related',
         title: ts('Other cases for this contact'),
         filterParams: {
-          case_manager: $scope.contactId,
           'case_type_id.case_type_category': $scope.caseTypeCategory,
+          contact_id: { '!=': $scope.contactId },
+          contact_involved: $scope.contactId,
           is_deleted: 0
         },
         showContactRole: true

--- a/ang/civicase/contact/directives/contact-icon.directive.html
+++ b/ang/civicase/contact/directives/contact-icon.directive.html
@@ -9,6 +9,7 @@
     <span ng-switch="contactIcon">
       <i class="material-icons" ng-switch-when="Individual">person</i>
       <i class="material-icons" ng-switch-when="Household">home</i>
+      <i class="material-icons" ng-switch-when="Organization">domain</i>
       <i class="material-icons" ng-switch-when="Organisation">domain</i>
     </span>
   </civicase-popover-toggle-button>

--- a/ang/civicase/contact/directives/contact-icon.directive.html
+++ b/ang/civicase/contact/directives/contact-icon.directive.html
@@ -10,7 +10,6 @@
       <i class="material-icons" ng-switch-when="Individual">person</i>
       <i class="material-icons" ng-switch-when="Household">home</i>
       <i class="material-icons" ng-switch-when="Organization">domain</i>
-      <i class="material-icons" ng-switch-when="Organisation">domain</i>
     </span>
   </civicase-popover-toggle-button>
   <civicase-popover-content>

--- a/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
+++ b/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
@@ -73,11 +73,12 @@
         ]));
       });
 
-      it('requests non deleted cases where the contact is a manager', () => {
+      it('requests non deleted cases where the contact has a role other than client', () => {
         expect(crmApi.calls.allArgs()).toContain(jasmine.arrayContaining([
           jasmine.objectContaining({
             cases: ['Case', 'getcaselist', jasmine.objectContaining({
-              case_manager: mockContactId,
+              contact_id: { '!=': $scope.contactId },
+              contact_involved: $scope.contactId,
               'case_type_id.case_type_category': 2,
               is_deleted: 0
             })]


### PR DESCRIPTION
## Overview
As part of this PR the following fixes has been made
1. Now as part of "Other Case" block in Contact Case Tab, "all Cases where the Contact has any role other than case client" would be shown.
2. Contact Icon for Organisations did not work, it is fixed now.

## Before
1
![2019-11-22 at 4 44 PM](https://user-images.githubusercontent.com/5058867/69421582-6b2a6100-0d47-11ea-9b55-7983853fa18c.jpg)

2
![2019-11-22 at 4 40 PM](https://user-images.githubusercontent.com/5058867/69421384-e2132a00-0d46-11ea-9833-85ce6697d371.jpg)

## After
1
![2019-11-22 at 4 40 PM](https://user-images.githubusercontent.com/5058867/69421346-cc9e0000-0d46-11ea-8790-996b63272522.jpg)

2
![2019-11-22 at 4 39 PM](https://user-images.githubusercontent.com/5058867/69421303-b8f29980-0d46-11ea-934a-8f98d7ab4095.jpg)

## Technical Details
1. In `contact-case-tab.directive.js ` the logic is changed.
```javascript
contact_id: { '!=': $scope.contactId },
contact_involved: $scope.contactId
```

2. The Contact Type returned by BE has changed from "Organisation" to "Organization". So changed the logic
```html
 <i class="material-icons" ng-switch-when="Organisation">domain</i>
```
