### PR TITLE
CATL-1176: Remove Cases from disabled Case Types

### DIFF
--- a/ang/civicase/activity/feed/directives/activity-feed.directive.js
+++ b/ang/civicase/activity/feed/directives/activity-feed.directive.js
@@ -401,7 +401,6 @@
         is_deleted: 0,
         is_test: 0,
         activity_type_id: { '!=': 'Bulk Email' },
-        case_filter: { 'case_type_id.is_active': 1 },
         options: {}
       };
 
@@ -410,6 +409,7 @@
       } else if (!$scope.displayOptions.include_case) {
         params.case_id = { 'IS NULL': 1 };
       } else {
+        params.case_filter = { 'case_type_id.is_active': 1 };
         returnParams.return = returnParams.return.concat(['case_id.case_type_id', 'case_id.status_id', 'case_id.contacts']);
       }
 

--- a/ang/civicase/activity/feed/directives/activity-feed.directive.js
+++ b/ang/civicase/activity/feed/directives/activity-feed.directive.js
@@ -401,6 +401,7 @@
         is_deleted: 0,
         is_test: 0,
         activity_type_id: { '!=': 'Bulk Email' },
+        case_filter: { 'case_type_id.is_active': 1 },
         options: {}
       };
 

--- a/ang/civicase/case/factories/get-case-query-params.factory.js
+++ b/ang/civicase/case/factories/get-case-query-params.factory.js
@@ -28,15 +28,17 @@
         id: caseId,
         return: caseReturnParams,
         'api.Case.getcaselist.relatedCasesByContact': {
-          contact_id: {IN: '$value.contact_id'},
-          id: {'!=': '$value.id'},
+          contact_id: { IN: '$value.contact_id' },
+          id: { '!=': '$value.id' },
           is_deleted: 0,
+          'case_type_id.is_active': 1,
           return: caseListReturnParams
         },
         // Linked cases
         'api.Case.getcaselist.linkedCases': {
-          id: {IN: '$value.related_case_ids'},
+          id: { IN: '$value.related_case_ids' },
           is_deleted: 0,
+          'case_type_id.is_active': 1,
           return: caseListReturnParams
         },
         // For the "recent communication" panel
@@ -45,9 +47,9 @@
           is_current_revision: 1,
           is_test: 0,
           activity_type_id: { '!=': 'Bulk Email' },
-          'activity_type_id.grouping': {LIKE: '%communication%'},
+          'activity_type_id.grouping': { LIKE: '%communication%' },
           'status_id.filter': 1,
-          options: {limit: panelLimit, sort: 'activity_date_time DESC'},
+          options: { limit: panelLimit, sort: 'activity_date_time DESC' },
           return: activityReturnParams
         },
         // For the "tasks" panel
@@ -56,17 +58,17 @@
           is_current_revision: 1,
           is_test: 0,
           activity_type_id: { '!=': 'Bulk Email' },
-          'activity_type_id.grouping': {LIKE: '%task%'},
+          'activity_type_id.grouping': { LIKE: '%task%' },
           'status_id.filter': 0,
-          options: {limit: panelLimit, sort: 'activity_date_time ASC'},
+          options: { limit: panelLimit, sort: 'activity_date_time ASC' },
           return: activityReturnParams
         },
         // For the "Next Activity" panel
         'api.Activity.get.nextActivitiesWhichIsNotMileStone': {
           case_id: caseId,
-          status_id: {'!=': 'Completed'},
+          status_id: { '!=': 'Completed' },
           activity_type_id: { '!=': 'Bulk Email' },
-          'activity_type_id.grouping': {'NOT LIKE': '%milestone%'},
+          'activity_type_id.grouping': { 'NOT LIKE': '%milestone%' },
           options: {
             limit: 1
           },
@@ -77,7 +79,7 @@
           is_current_revision: 1,
           is_deleted: 0,
           activity_type_id: { '!=': 'Bulk Email' },
-          'status_id': 'Scheduled'
+          status_id: 'Scheduled'
         },
         // For the "scheduled-overdue" count
         'api.Activity.getcount.scheduled_overdue': {

--- a/api/v3/Case/Getstats.php
+++ b/api/v3/Case/Getstats.php
@@ -59,7 +59,8 @@ function civicrm_api3_case_getstats(array $params) {
   $query->select(['a.case_type_id as case_type_id, a.status_id as status_id, COUNT(a.id) as count']);
   $caseTypesParams = [
     'options' => ['limit' => 0],
-    'return' => 'id, is_active',
+    'is_active' => 1,
+    'return' => 'id',
   ];
 
   $caseTypes = [];
@@ -103,9 +104,7 @@ function civicrm_api3_case_getstats(array $params) {
   foreach ($result as $row) {
     $tabulated[$row['case_type_id']][$row['status_id']] = $row['count'];
     $tabulated['all'] += [$row['status_id'] => 0];
-    if($caseTypes['values'][$row['case_type_id']]['is_active']) {
-      $tabulated['all'][$row['status_id']] += (int) $row['count'];
-    }
+    $tabulated['all'][$row['status_id']] += (int) $row['count'];
   }
 
   return civicrm_api3_create_success($tabulated, $params, 'Case', 'getstats');

--- a/api/v3/Case/Getstats.php
+++ b/api/v3/Case/Getstats.php
@@ -59,7 +59,7 @@ function civicrm_api3_case_getstats(array $params) {
   $query->select(['a.case_type_id as case_type_id, a.status_id as status_id, COUNT(a.id) as count']);
   $caseTypesParams = [
     'options' => ['limit' => 0],
-    'return' => 'id',
+    'return' => 'id, is_active',
   ];
 
   $caseTypes = [];
@@ -97,12 +97,15 @@ function civicrm_api3_case_getstats(array $params) {
   if (empty($caseTypes)) {
     $caseTypes = civicrm_api3('CaseType', 'get', $caseTypesParams);
   }
+
   $tabulated = array_fill_keys(array_keys($caseTypes['values']), []);
   $tabulated['all'] = [];
   foreach ($result as $row) {
     $tabulated[$row['case_type_id']][$row['status_id']] = $row['count'];
     $tabulated['all'] += [$row['status_id'] => 0];
-    $tabulated['all'][$row['status_id']] += (int) $row['count'];
+    if($caseTypes['values'][$row['case_type_id']]['is_active']) {
+      $tabulated['all'][$row['status_id']] += (int) $row['count'];
+    }
   }
 
   return civicrm_api3_create_success($tabulated, $params, 'Case', 'getstats');

--- a/civicase.php
+++ b/civicase.php
@@ -28,6 +28,8 @@ function civicase_civicrm_tabset($tabsetName, &$tabs, $context) {
           $tab['url'] = CRM_Utils_System::url('civicrm/case/contact-case-tab', [
             'cid' => $context['contact_id'],
           ]);
+
+          $tab['count'] = get_case_count();
         }
         if ($tab['id'] === 'activity') {
           $activity_types = array_flip(CRM_Activity_BAO_Activity::buildOptions('activity_type_id', 'validate'));
@@ -55,7 +57,7 @@ function civicase_civicrm_tabset($tabsetName, &$tabs, $context) {
           ]),
           'title' => ts('Cases'),
           'weight' => 20,
-          'count' => CRM_Contact_BAO_Contact::getCountComponent('case', $context['contact_id']),
+          'count' => get_case_count(),
           'class' => 'livePage',
         ];
       }
@@ -70,6 +72,19 @@ function civicase_civicrm_tabset($tabsetName, &$tabs, $context) {
     $loader->setModules(['civicase']);
     $loader->load();
   }
+}
+
+/**
+ * Count the number of Cases for current user.
+ */
+function get_case_count() {
+  $params = [
+    'contact_id' => $context['contact_id'],
+    'case_type_id.is_active' => TRUE,
+    'options' => ['is_count' => TRUE],
+  ];
+
+  return civicrm_api3_case_get($params)['values'];
 }
 
 /**

--- a/civicase.php
+++ b/civicase.php
@@ -78,13 +78,13 @@ function civicase_civicrm_tabset($tabsetName, &$tabs, $context) {
  * Count the number of Cases for current user.
  */
 function get_case_count() {
-  $params = [
+  $noOfCases = civicrm_api3('Case', 'getcount', [
     'contact_id' => $context['contact_id'],
     'case_type_id.is_active' => TRUE,
-    'options' => ['is_count' => TRUE],
-  ];
+    'is_deleted' => FALSE,
+  ]);
 
-  return civicrm_api3_case_get($params)['values'];
+  return $noOfCases;
 }
 
 /**


### PR DESCRIPTION
## Overview
Throughout the Civicase, cases from disabled Case Types were shown. This PR fixes that.

## Before
![2019-11-27 at 11 55 AM](https://user-images.githubusercontent.com/5058867/69699005-dfc91b00-110c-11ea-821f-cbccd9afe5cf.jpg)

![2019-11-27 at 4 28 PM](https://user-images.githubusercontent.com/5058867/69717888-f84c2c00-1132-11ea-9d54-1c79843ebde4.jpg)

![2019-11-27 at 4 28 PM](https://user-images.githubusercontent.com/5058867/69717918-069a4800-1133-11ea-802d-85d30ef79489.jpg)


## After
![2019-11-27 at 11 55 AM](https://user-images.githubusercontent.com/5058867/69698988-d344c280-110c-11ea-935b-8ee6343e1edd.jpg)

![2019-11-27 at 4 21 PM](https://user-images.githubusercontent.com/5058867/69717429-106f7b80-1132-11ea-8d8e-44cfc98860a0.jpg)


## Technical Details
In `Getstats.php`, only the active case types are considered towards the total count.
```php
if($caseTypes['values'][$row['case_type_id']]['is_active']) {
  $tabulated['all'][$row['status_id']] += (int) $row['count'];
}
```

In `activity-feed.directive.js`, the Cases from disabled case types are filtered.

In `civicase.php`, new function `get_case_count` is created to count the cases which from enabled case types only.