### PR TITLE
BASW-566: Fix Activities are not displayed on print case action

### DIFF
--- a/ang/civicase/case/actions/services/print-case-action.service.js
+++ b/ang/civicase/case/actions/services/print-case-action.service.js
@@ -17,7 +17,6 @@
         all: 1,
         redact: 0,
         cid: selectedCase.client[0].contact_id,
-        asn: 'standard_timeline',
         caseID: selectedCase.id
       });
       var win = window.open(url, '_blank');


### PR DESCRIPTION
## Overview
When clicking the Print case action on the actions menu for a case, the case activities are not displayed in the report.

## Before
Case activities are not displayed in the print case report:

<img width="1282" alt="Standard Timeline 2019-11-29 11-44-14" src="https://user-images.githubusercontent.com/6951813/69863699-bb507880-129d-11ea-85e7-19869493cda1.png">




## After
Case activities are now displayed in the print case report:

<img width="1274" alt="case-site localcivicrmcasereportprintall1redact0cid3caseID1 2019-11-29 11-50-45" src="https://user-images.githubusercontent.com/6951813/69864076-87298780-129e-11ea-8088-beb48cca5479.png">


## Technical Details
Part of the parameters passed to the report URL is the timeline parameter and it is hardcoded to `standard_timeline` , the implication of this is that the report will only generate activities report for activity types added to the standard timeline, if the standard timeline has no activity types added, the activities section on the report will be empty, See [here](https://monosnap.com/file/OY376OmhcAAP8KOqnHxM76ROeqha9k) 
This fix of removing this parameter ensures that reports will always be generated for all activities on the case.

