### PR TITLE
CATL-1132: Block clients from having other roles

### DIFF
--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab-placeholder.html
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab-placeholder.html
@@ -1,0 +1,51 @@
+<td class="civicase__people-tab__table-column civicase__people-tab__table-column--first">
+  <div class="civicase__loading-placeholder__oneline"
+    style="font-size: 24px;
+      margin-right: 5px;
+      width: 1em;"
+  ></div>
+  <label>
+    <div class="civicase__loading-placeholder__oneline"
+      style="margin-bottom: 5px;
+        width: 16em;"
+    ></div>
+    <div class="civicase__loading-placeholder__oneline"
+      style="margin-bottom: 5px;
+        width: 16em;"
+    ></div>
+    <div class="civicase__loading-placeholder__oneline"
+      style="margin-bottom: 5px;
+        width: 16em;"
+    ></div>
+  </label>
+</td>
+<td class="civicase__people-tab__table-column">
+  <div class="civicase__loading-placeholder__oneline"
+    style="margin-bottom: 5px;
+    width: 10em;"
+  ></div>
+</td>
+<td class="civicase__people-tab__table-column">
+  <div class="civicase__loading-placeholder__oneline"
+    style="margin-bottom: 5px;
+    width: 10em;"
+  ></div>
+</td>
+<td class="civicase__people-tab__table-column">
+  <div class="civicase__loading-placeholder__oneline"
+    style="margin-bottom: 5px;
+    width: 10em;"
+  ></div>
+</th>
+<td class="civicase__people-tab__table-column">
+  <div class="civicase__loading-placeholder__oneline"
+    style="margin-bottom: 5px;
+      width: 10em;"
+  ></div>
+</td>
+<td class="civicase__people-tab__table-column civicase__people-tab__table-column--last">
+  <div class="civicase__loading-placeholder__oneline"
+    style="font-size: 20px;
+      width: 0.5em;"
+  ></div>
+</td>

--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.html
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.html
@@ -129,59 +129,11 @@
             </div>
           </td>
         </tr>
-        <tr ng-repeat="i in [1, 2, 3]" ng-if="isRolesLoading">
-          <td class="civicase__people-tab__table-column civicase__people-tab__table-column--first">
-            <div class="civicase__loading-placeholder__oneline"
-              style="font-size: 24px;
-                margin-right: 5px;
-                width: 1em;"
-            ></div>
-            <label>
-              <div class="civicase__loading-placeholder__oneline"
-                style="margin-bottom: 5px;
-                  width: 16em;"
-              ></div>
-              <div class="civicase__loading-placeholder__oneline"
-                style="margin-bottom: 5px;
-                  width: 16em;"
-              ></div>
-              <div class="civicase__loading-placeholder__oneline"
-                style="margin-bottom: 5px;
-                  width: 16em;"
-              ></div>
-            </label>
-          </td>
-          <td class="civicase__people-tab__table-column">
-            <div class="civicase__loading-placeholder__oneline"
-              style="margin-bottom: 5px;
-              width: 10em;"
-            ></div>
-          </td>
-          <td class="civicase__people-tab__table-column">
-            <div class="civicase__loading-placeholder__oneline"
-              style="margin-bottom: 5px;
-              width: 10em;"
-            ></div>
-          </td>
-          <td class="civicase__people-tab__table-column">
-            <div class="civicase__loading-placeholder__oneline"
-              style="margin-bottom: 5px;
-              width: 10em;"
-            ></div>
-          </th>
-          <td class="civicase__people-tab__table-column">
-            <div class="civicase__loading-placeholder__oneline"
-              style="margin-bottom: 5px;
-                width: 10em;"
-            ></div>
-          </td>
-          <td class="civicase__people-tab__table-column civicase__people-tab__table-column--last">
-            <div class="civicase__loading-placeholder__oneline"
-              style="font-size: 20px;
-                width: 0.5em;"
-            ></div>
-          </td>
-        </tr>
+        <tr
+          ng-repeat="i in [1, 2, 3]"
+          ng-if="isRolesLoading"
+          ng-include="'~/civicase/case/details/people-tab/directives/case-details-people-tab-placeholder.html'"
+        ></tr>
         <tr ng-if="!roles.length && !isRolesLoading">
           <td colspan="9" class="text-center">
             <button class="btn btn-default" disabled>
@@ -309,47 +261,11 @@
             </div>
           </td>
         </tr>
-        <tr ng-repeat="i in [1, 2, 3]" ng-if="isRelationshipLoading">
-          <td class="civicase__people-tab__table-column civicase__people-tab__table-column--first">
-            <div class="civicase__loading-placeholder__oneline"
-              style="font-size: 24px;
-                margin-right: 5px;
-                width: 1em;"
-              ></div>
-            <label>
-              <div class="civicase__loading-placeholder__oneline"
-                style="margin-bottom: 5px;
-                  width: 16em;"
-              ></div>
-              <div class="civicase__loading-placeholder__oneline"
-                style="margin-bottom: 5px;
-                  width: 16em;"
-              ></div>
-              <div class="civicase__loading-placeholder__oneline"
-                style="margin-bottom: 5px;
-                  width: 16em;"
-              ></div>
-            </label>
-          </td>
-          <td class="civicase__people-tab__table-column">
-            <div class="civicase__loading-placeholder__oneline"
-              style="margin-bottom: 5px;
-                width: 10em; "
-              ></div>
-          </th>
-          <td class="civicase__people-tab__table-column">
-            <div class="civicase__loading-placeholder__oneline"
-              style="margin-bottom: 5px;
-                width: 10em; "
-              ></div>
-          </td>
-          <td class="civicase__people-tab__table-column civicase__people-tab__table-column--last">
-            <div class="civicase__loading-placeholder__oneline"
-              style=" font-size: 20px;
-              width: 0.5em;"
-            ></div>
-          </td>
-        </tr>
+        <tr
+          ng-repeat="i in [1, 2, 3]"
+          ng-if="isRelationshipLoading"
+          ng-include="'~/civicase/case/details/people-tab/directives/case-details-people-tab-placeholder.html'"
+        ></tr>
         <tr ng-if="!relations.length && !isRelationshipLoading">
           <td colspan="9" class="text-center">
             <button class="btn btn-default" disabled>

--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.html
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.html
@@ -15,10 +15,10 @@
         </button>
         <ul class="dropdown-menu dropdown-menu-right">
           <li ng-if="allowMultipleCaseClients">
-            <a href ng-click="assignRole({role: ts('Client')})">{{ ts('Client') }}</a>
+            <a href ng-click="assignRoleOrClient()">{{ ts('Client') }}</a>
           </li>
           <li ng-repeat="role in allRoles">
-            <a href ng-click="assignRole(role)">{{ role.role }}</a>
+            <a href ng-click="assignRoleOrClient(role)">{{ role.role }}</a>
           </li>
         </ul>
       </div>
@@ -78,7 +78,7 @@
         </tr>
       </thead>
       <tbody class="civicase__people-tab__table-body">
-        <tr ng-repeat="role in roles track by $index" ng-if="!isRolesLoading" ng-class="{unassigned: !role.contact_id}">
+        <tr class="contact--{{role.contact_id}}" ng-repeat="role in roles track by $index" ng-if="!isRolesLoading" ng-class="{unassigned: !role.contact_id}">
           <td class="civicase__people-tab__table-column civicase__people-tab__table-column--first">
             <span ng-if="role.contact_id" class="civicase__checkbox" >
               <input id="select-role-{{ $index }}" class="civicase__people-tab__table-checkbox" type="checkbox" ng-model="role.checked" ng-click="setSelectionMode('checked', 'roles')" />
@@ -98,7 +98,10 @@
           <td class="civicase__people-tab__table-column">{{ role.phone }}</td>
           <td class="civicase__people-tab__table-column">{{ role.email }}</td>
           <td class="civicase__people-tab__table-column civicase__people-tab__table-column--last">
-            <div class="civicase__people-tab__table-assign-icon" ng-if="!role.contact_id" ng-click="assignRole(role)">
+            <div class="civicase__people-tab__table-assign-icon"
+              ng-if="!role.contact_id"
+              ng-click="assignRoleOrClient(role)"
+            >
               <i class="fa fa-user-plus"></i>
             </div>
             <div ng-if="role.contact_id" class="btn-group btn-group-sm">
@@ -107,10 +110,10 @@
               </button>
               <ul class="dropdown-menu dropdown-menu-right">
                 <li>
-                  <a href ng-click="assignRole(role, true)">{{ ts('Reassign %1', {1: role.role}) }}</a>
+                  <a href ng-click="replaceRoleOrClient(role)">{{ ts('Reassign %1', {1: role.role}) }}</a>
                 </li>
                 <li ng-if="role.relationship_type_id || allowMultipleCaseClients">
-                  <a href ng-click="assignRole(role)">{{ ts('Add Another %1', {1: role.role}) }}</a>
+                  <a href ng-click="assignRoleOrClient(role)">{{ ts('Add Another %1', {1: role.role}) }}</a>
                 </li>
                 <li ng-if="role.relationship_type_id || item.client.length > 1">
                   <a href ng-click="unassignRole(role)">{{ ts('Remove %1', {1: role.role}) }}</a>

--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.html
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.html
@@ -128,27 +128,55 @@
         </tr>
         <tr ng-repeat="i in [1, 2, 3]" ng-if="isRolesLoading">
           <td class="civicase__people-tab__table-column civicase__people-tab__table-column--first">
-            <div class="civicase__loading-placeholder__oneline" style="width: 1em; font-size: 24px; margin-right: 5px;"></div>
+            <div class="civicase__loading-placeholder__oneline"
+              style="font-size: 24px;
+                margin-right: 5px;
+                width: 1em;"
+            ></div>
             <label>
-              <div class="civicase__loading-placeholder__oneline" style="width: 16em; margin-bottom: 5px;"></div>
-              <div class="civicase__loading-placeholder__oneline" style="width: 16em; margin-bottom: 5px;"></div>
-              <div class="civicase__loading-placeholder__oneline" style="width: 16em; margin-bottom: 5px;"></div>
+              <div class="civicase__loading-placeholder__oneline"
+                style="margin-bottom: 5px;
+                  width: 16em;"
+              ></div>
+              <div class="civicase__loading-placeholder__oneline"
+                style="margin-bottom: 5px;
+                  width: 16em;"
+              ></div>
+              <div class="civicase__loading-placeholder__oneline"
+                style="margin-bottom: 5px;
+                  width: 16em;"
+              ></div>
             </label>
           </td>
           <td class="civicase__people-tab__table-column">
-            <div class="civicase__loading-placeholder__oneline" style="width: 10em; margin-bottom: 5px;"></div>
+            <div class="civicase__loading-placeholder__oneline"
+              style="margin-bottom: 5px;
+              width: 10em;"
+            ></div>
           </td>
           <td class="civicase__people-tab__table-column">
-            <div class="civicase__loading-placeholder__oneline" style="width: 10em; margin-bottom: 5px;"></div>
+            <div class="civicase__loading-placeholder__oneline"
+              style="margin-bottom: 5px;
+              width: 10em;"
+            ></div>
           </td>
           <td class="civicase__people-tab__table-column">
-            <div class="civicase__loading-placeholder__oneline" style="width: 10em; margin-bottom: 5px;"></div>
+            <div class="civicase__loading-placeholder__oneline"
+              style="margin-bottom: 5px;
+              width: 10em;"
+            ></div>
           </th>
           <td class="civicase__people-tab__table-column">
-            <div class="civicase__loading-placeholder__oneline" style="width: 10em; margin-bottom: 5px;"></div>
+            <div class="civicase__loading-placeholder__oneline"
+              style="margin-bottom: 5px;
+                width: 10em;"
+            ></div>
           </td>
           <td class="civicase__people-tab__table-column civicase__people-tab__table-column--last">
-            <div class="civicase__loading-placeholder__oneline" style="width: 0.5em; font-size: 20px;"></div>
+            <div class="civicase__loading-placeholder__oneline"
+              style="font-size: 20px;
+                width: 0.5em;"
+            ></div>
           </td>
         </tr>
         <tr ng-if="!roles.length && !isRolesLoading">
@@ -280,21 +308,43 @@
         </tr>
         <tr ng-repeat="i in [1, 2, 3]" ng-if="isRelationshipLoading">
           <td class="civicase__people-tab__table-column civicase__people-tab__table-column--first">
-            <div class="civicase__loading-placeholder__oneline" style="width: 1em; font-size: 24px; margin-right: 5px;"></div>
+            <div class="civicase__loading-placeholder__oneline"
+              style="font-size: 24px;
+                margin-right: 5px;
+                width: 1em;"
+              ></div>
             <label>
-              <div class="civicase__loading-placeholder__oneline" style="width: 16em; margin-bottom: 5px;"></div>
-              <div class="civicase__loading-placeholder__oneline" style="width: 16em; margin-bottom: 5px;"></div>
-              <div class="civicase__loading-placeholder__oneline" style="width: 16em; margin-bottom: 5px;"></div>
+              <div class="civicase__loading-placeholder__oneline"
+                style="margin-bottom: 5px;
+                  width: 16em;"
+              ></div>
+              <div class="civicase__loading-placeholder__oneline"
+                style="margin-bottom: 5px;
+                  width: 16em;"
+              ></div>
+              <div class="civicase__loading-placeholder__oneline"
+                style="margin-bottom: 5px;
+                  width: 16em;"
+              ></div>
             </label>
           </td>
           <td class="civicase__people-tab__table-column">
-            <div class="civicase__loading-placeholder__oneline" style="width: 10em; margin-bottom: 5px;"></div>
+            <div class="civicase__loading-placeholder__oneline"
+              style="margin-bottom: 5px;
+                width: 10em; "
+              ></div>
           </th>
           <td class="civicase__people-tab__table-column">
-            <div class="civicase__loading-placeholder__oneline" style="width: 10em; margin-bottom: 5px;"></div>
+            <div class="civicase__loading-placeholder__oneline"
+              style="margin-bottom: 5px;
+                width: 10em; "
+              ></div>
           </td>
           <td class="civicase__people-tab__table-column civicase__people-tab__table-column--last">
-            <div class="civicase__loading-placeholder__oneline" style="width: 0.5em; font-size: 20px;"></div>
+            <div class="civicase__loading-placeholder__oneline"
+              style=" font-size: 20px;
+              width: 0.5em;"
+            ></div>
           </td>
         </tr>
         <tr ng-if="!relations.length && !isRelationshipLoading">

--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
@@ -516,17 +516,18 @@ included in the confirmation dialog.
        */
       function showContactSelectionError (message) {
         var contactSelector = $('[name=caseRoleSelector]', dialogElement).select2('container');
-        var hasError = contactSelector.find('.contact-selection-error').length > 0;
+        var hasError = dialogElement.find('.contact-selection-error').length > 0;
 
         if (hasError) {
           return;
         }
 
         contactSelector.addClass('crm-error');
-        $('<p class="contact-selection-error"></p>')
+        $('<div class="contact-selection-error crm-error crm-error-label"></div>')
           .text(message)
           .prepend('<i class="fa fa-times"></i>')
-          .appendTo(contactSelector);
+          .css('max-width', contactSelector.width())
+          .insertAfter(contactSelector);
       }
     }
 

--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
@@ -199,11 +199,9 @@
     $scope.assignRoleOrClient = function (role) {
       var isAssigningRole = role && !!role.relationship_type_id;
 
-      if (isAssigningRole) {
-        assignRole(role);
-      } else {
-        assignClient();
-      }
+      isAssigningRole
+        ? assignRole(role)
+        : assignClient();
     };
 
     /**

--- a/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
@@ -2,7 +2,7 @@
 
 describe('Case Details People Tab', () => {
   let $controller, $rootScope, $scope, CasesData, caseRoleSelectorContact,
-    ContactsData, crmConfirmDialog, originalCrmConfirm, originalDialog,
+    ContactsData, crmConfirmDialog, crmConfirmYesEvent, originalCrmConfirm,
     originalSelect2;
   const CONTACT_CANT_HAVE_ROLE_MESSAGE = 'Case clients cannot be selected for a case role. Please select another contact.';
 
@@ -19,16 +19,16 @@ describe('Case Details People Tab', () => {
     $scope.refresh = jasmine.createSpy('refresh');
 
     originalCrmConfirm = CRM.confirm;
-    originalDialog = CRM.$.fn.dialog;
     originalSelect2 = CRM.$.fn.select2;
     crmConfirmDialog = CRM.$('<div class="mock-crm-confirm-dialog"></div>');
+    crmConfirmYesEvent = CRM.$.Event('crmConfirm:yes');
+    crmConfirmYesEvent.preventDefault = jasmine.createSpy('preventDefault');
     CRM.confirm = function (options) {
       crmConfirmDialog.append(options.message);
       options.open();
 
       return crmConfirmDialog;
     };
-    CRM.$.fn.dialog = jasmine.createSpy('dialog').and.returnValue(crmConfirmDialog);
     CRM.$.fn.select2 = jasmine.createSpy('select2').and.callFake(function (option) {
       if (option === 'data') {
         return caseRoleSelectorContact;
@@ -40,7 +40,6 @@ describe('Case Details People Tab', () => {
 
   afterEach(() => {
     CRM.confirm = originalCrmConfirm;
-    CRM.$.fn.dialog = originalDialog;
     CRM.$.fn.select2 = originalSelect2;
 
     crmConfirmDialog.remove();
@@ -72,7 +71,7 @@ describe('Case Details People Tab', () => {
         });
         setRoleContact(contact);
         setRoleDescription(roleDescription);
-        crmConfirmDialog.trigger('crmConfirm:yes');
+        crmConfirmDialog.trigger(crmConfirmYesEvent);
         $rootScope.$digest();
       });
 
@@ -103,7 +102,7 @@ describe('Case Details People Tab', () => {
       });
 
       it('closes the contact selection dialog', () => {
-        expect(CRM.$.fn.dialog).toHaveBeenCalledWith('close');
+        expect(crmConfirmYesEvent.preventDefault).not.toHaveBeenCalled();
       });
     });
 
@@ -119,7 +118,7 @@ describe('Case Details People Tab', () => {
         });
         setRoleContact(contact);
         setRoleDescription(roleDescription);
-        crmConfirmDialog.trigger('crmConfirm:yes');
+        crmConfirmDialog.trigger(crmConfirmYesEvent);
         $rootScope.$digest();
       });
 
@@ -167,7 +166,7 @@ describe('Case Details People Tab', () => {
       });
 
       it('closes the contact selection dialog', () => {
-        expect(CRM.$.fn.dialog).toHaveBeenCalledWith('close');
+        expect(crmConfirmYesEvent.preventDefault).not.toHaveBeenCalled();
       });
     });
 
@@ -182,7 +181,7 @@ describe('Case Details People Tab', () => {
           id: client.contact_id
         }));
         setRoleDescription(roleDescription);
-        crmConfirmDialog.trigger('crmConfirm:yes');
+        crmConfirmDialog.trigger(crmConfirmYesEvent);
         $rootScope.$digest();
       });
 
@@ -195,7 +194,7 @@ describe('Case Details People Tab', () => {
       });
 
       it('does not close the contact selection dialog', () => {
-        expect(CRM.$.fn.dialog).not.toHaveBeenCalledWith('close');
+        expect(crmConfirmYesEvent.preventDefault).toHaveBeenCalled();
       });
     });
 
@@ -210,7 +209,7 @@ describe('Case Details People Tab', () => {
           id: client.contact_id
         }));
         setRoleDescription(roleDescription);
-        crmConfirmDialog.trigger('crmConfirm:yes');
+        crmConfirmDialog.trigger(crmConfirmYesEvent);
         $rootScope.$digest();
       });
 
@@ -223,7 +222,7 @@ describe('Case Details People Tab', () => {
       });
 
       it('does not close the contact selection dialog', () => {
-        expect(CRM.$.fn.dialog).not.toHaveBeenCalledWith('close');
+        expect(crmConfirmYesEvent.preventDefault).toHaveBeenCalled();
       });
     });
 
@@ -233,7 +232,7 @@ describe('Case Details People Tab', () => {
           role: 'Client'
         });
         setRoleContact(contact);
-        crmConfirmDialog.trigger('crmConfirm:yes');
+        crmConfirmDialog.trigger(crmConfirmYesEvent);
         $rootScope.$digest();
       });
 
@@ -259,7 +258,7 @@ describe('Case Details People Tab', () => {
       });
 
       it('closes the contact selection dialog', () => {
-        expect(CRM.$.fn.dialog).toHaveBeenCalledWith('close');
+        expect(crmConfirmYesEvent.preventDefault).not.toHaveBeenCalled();
       });
     });
 
@@ -273,7 +272,7 @@ describe('Case Details People Tab', () => {
           role: 'Client'
         }, true);
         setRoleContact(contact);
-        crmConfirmDialog.trigger('crmConfirm:yes');
+        crmConfirmDialog.trigger(crmConfirmYesEvent);
         $rootScope.$digest();
       });
 
@@ -312,7 +311,7 @@ describe('Case Details People Tab', () => {
       });
 
       it('closes the contact selection dialog', () => {
-        expect(CRM.$.fn.dialog).toHaveBeenCalledWith('close');
+        expect(crmConfirmYesEvent.preventDefault).not.toHaveBeenCalled();
       });
     });
   });

--- a/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
@@ -1,0 +1,263 @@
+/* eslint-env jasmine */
+
+describe('Case Details People Tab', () => {
+  let $controller, $rootScope, $scope, CasesData, ContactsData, crmConfirmDialog, originalCrmConfirm, originalSelect2;
+
+  beforeEach(module('civicase', 'civicase.data'));
+
+  beforeEach(inject(function (_$controller_, _$rootScope_, _CasesData_, _ContactsData_) {
+    $controller = _$controller_;
+    $rootScope = _$rootScope_;
+    CasesData = _CasesData_;
+    ContactsData = _ContactsData_;
+
+    $scope = $rootScope.$new();
+    $scope.$bindToRoute = jasmine.createSpy('$bindToRoute');
+    $scope.refresh = jasmine.createSpy('refresh');
+
+    originalCrmConfirm = CRM.confirm;
+    originalSelect2 = CRM.$.fn.select2;
+    CRM.$.fn.select2 = jasmine.createSpy('select2');
+    crmConfirmDialog = CRM.$('<div class="mock-crm-confirm-dialog"></div>');
+    CRM.confirm = function (options) {
+      crmConfirmDialog.append(options.message);
+      options.open();
+
+      return crmConfirmDialog;
+    };
+  }));
+
+  afterEach(() => {
+    CRM.confirm = originalCrmConfirm;
+    CRM.$.fn.select2 = originalSelect2;
+
+    crmConfirmDialog.remove();
+  });
+
+  beforeEach(() => {
+    $scope.item = CasesData.get().values[0];
+
+    initController({
+      $scope: $scope
+    });
+  });
+
+  describe('assigning roles', () => {
+    const roleName = 'Service Provider';
+    const roleDescription = 'Service Provider Role Description';
+    let contact, previousContact, relationshipTypeId;
+
+    beforeEach(() => {
+      contact = CRM._.sample(ContactsData.values);
+      relationshipTypeId = CRM._.uniq();
+    });
+
+    describe('when assigning a new role', () => {
+      beforeEach(() => {
+        $scope.assignRole({
+          relationship_type_id: relationshipTypeId,
+          role: roleName
+        });
+        setRoleContact(contact);
+        setRoleDescription(roleDescription);
+        crmConfirmDialog.trigger('crmConfirm:yes');
+      });
+
+      it('creates a new relationship between the case client and the selected contact using the given role', () => {
+        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
+          ['Relationship', 'create', {
+            relationship_type_id: relationshipTypeId,
+            start_date: 'now',
+            end_date: null,
+            contact_id_b: contact.contact_id,
+            case_id: $scope.item.id,
+            description: roleDescription,
+            contact_id_a: $scope.item.client[0].contact_id
+          }]
+        ]));
+      });
+
+      it('creates a new completed activity to record the contact being assigned a role to the case', () => {
+        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
+          ['Activity', 'create', {
+            case_id: $scope.item.id,
+            target_contact_id: contact.contact_id,
+            status_id: 'Completed',
+            activity_type_id: 'Assign Case Role',
+            subject: `${contact.display_name} added as ${roleName}`
+          }]
+        ]));
+      });
+    });
+
+    describe('when replacing a role', () => {
+      beforeEach(() => {
+        previousContact = CRM._.sample(ContactsData.values);
+
+        $scope.assignRole({
+          contact_id: previousContact.contact_id,
+          display_name: previousContact.display_name,
+          relationship_type_id: relationshipTypeId,
+          role: roleName
+        }, true);
+        setRoleContact(contact);
+        setRoleDescription(roleDescription);
+        crmConfirmDialog.trigger('crmConfirm:yes');
+      });
+
+      it('marks the current role relationship as finished', () => {
+        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
+          ['Relationship', 'get', {
+            relationship_type_id: relationshipTypeId,
+            contact_id_b: previousContact.contact_id,
+            case_id: $scope.item.id,
+            is_active: 1,
+            'api.Relationship.create': {
+              is_active: 0, end_date: 'now'
+            }
+          }]
+        ]));
+      });
+
+      it('creates a new relationship between the case client and the selected contact using the given role', () => {
+        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
+          ['Relationship', 'create', {
+            relationship_type_id: relationshipTypeId,
+            start_date: 'now',
+            end_date: null,
+            contact_id_b: contact.contact_id,
+            case_id: $scope.item.id,
+            description: roleDescription,
+            contact_id_a: $scope.item.client[0].contact_id
+          }]
+        ]));
+      });
+
+      it('creates a new completed activity to record the case role has been reassigned', () => {
+        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
+          ['Activity', 'create', {
+            case_id: $scope.item.id,
+            target_contact_id: jasmine.arrayContaining([
+              previousContact.contact_id,
+              contact.contact_id
+            ]),
+            status_id: 'Completed',
+            activity_type_id: 'Assign Case Role',
+            subject: `${contact.display_name} replaced ${previousContact.display_name} as ${roleName}`
+          }]
+        ]));
+      });
+    });
+
+    describe('when adding a new case client', () => {
+      beforeEach(() => {
+        $scope.assignRole({
+          role: 'Client'
+        });
+        setRoleContact(contact);
+        crmConfirmDialog.trigger('crmConfirm:yes');
+      });
+
+      it('creates a new client using the selected contact', () => {
+        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
+          ['CaseContact', 'create', {
+            case_id: $scope.item.id,
+            contact_id: contact.contact_id
+          }]
+        ]));
+      });
+
+      it('creates a new completed activity to record the contact being assigned as a client to the case', () => {
+        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
+          ['Activity', 'create', {
+            case_id: $scope.item.id,
+            target_contact_id: contact.contact_id,
+            status_id: 'Completed',
+            activity_type_id: 'Add Client To Case',
+            subject: `${contact.display_name} added as Client`
+          }]
+        ]));
+      });
+    });
+
+    describe('when replacing the case client', () => {
+      beforeEach(() => {
+        previousContact = CRM._.sample(ContactsData.values);
+
+        $scope.assignRole({
+          contact_id: previousContact.contact_id,
+          display_name: previousContact.display_name,
+          role: 'Client'
+        }, true);
+        setRoleContact(contact);
+        crmConfirmDialog.trigger('crmConfirm:yes');
+      });
+
+      it('removes the existing client from the case', () => {
+        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
+          ['CaseContact', 'get', {
+            case_id: $scope.item.id,
+            contact_id: previousContact.contact_id,
+            'api.CaseContact.delete': {}
+          }]
+        ]));
+      });
+
+      it('creates a new client using the selected contact', () => {
+        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
+          ['CaseContact', 'create', {
+            case_id: $scope.item.id,
+            contact_id: contact.contact_id
+          }]
+        ]));
+      });
+
+      it('creates a new completed activity to record the case being reassigned to another client', () => {
+        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
+          ['Activity', 'create', {
+            case_id: $scope.item.id,
+            target_contact_id: jasmine.arrayContaining([
+              previousContact.contact_id,
+              contact.contact_id
+            ]),
+            status_id: 'Completed',
+            activity_type_id: 'Reassigned Case',
+            subject: `${contact.display_name} replaced ${previousContact.display_name} as Client`
+          }]
+        ]));
+      });
+    });
+  });
+
+  /**
+   * Initializes the controller.
+   *
+   * @param {object} dependencies the list of dependencies to pass to the controller.
+   */
+  function initController (dependencies) {
+    $controller('civicaseViewPeopleController', dependencies);
+  }
+
+  /**
+   * Sets the given contact as the selected value of the case role selector dropdown.
+   *
+   * @param {object} contact a contact.
+   */
+  function setRoleContact (contact) {
+    CRM.$('[name=caseRoleSelector]', crmConfirmDialog).val(contact.id);
+    CRM.$.fn.select2.and.returnValue({
+      id: contact.id,
+      text: contact.display_name,
+      extra: contact
+    });
+  }
+
+  /**
+   * Sets the description for the role being created using the confirm dialog.
+   *
+   * @param {string} description a drescription for the role.
+   */
+  function setRoleDescription (description) {
+    CRM.$('[name=description]', crmConfirmDialog).val(description);
+  }
+});

--- a/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
@@ -5,7 +5,7 @@ describe('Case Details People Tab', () => {
 
   beforeEach(module('civicase', 'civicase.data'));
 
-  beforeEach(inject(function (_$controller_, _$rootScope_, _CasesData_, _ContactsData_) {
+  beforeEach(inject(function (_$controller_, _$q_, _$rootScope_, _CasesData_, _ContactsData_) {
     $controller = _$controller_;
     $rootScope = _$rootScope_;
     CasesData = _CasesData_;
@@ -49,18 +49,19 @@ describe('Case Details People Tab', () => {
 
     beforeEach(() => {
       contact = CRM._.sample(ContactsData.values);
-      relationshipTypeId = CRM._.uniq();
+      relationshipTypeId = CRM._.uniqueId();
     });
 
     describe('when assigning a new role', () => {
       beforeEach(() => {
-        $scope.assignRole({
+        $scope.assignRoleOrClient({
           relationship_type_id: relationshipTypeId,
           role: roleName
         });
         setRoleContact(contact);
         setRoleDescription(roleDescription);
         crmConfirmDialog.trigger('crmConfirm:yes');
+        $rootScope.$digest();
       });
 
       it('creates a new relationship between the case client and the selected contact using the given role', () => {
@@ -94,15 +95,16 @@ describe('Case Details People Tab', () => {
       beforeEach(() => {
         previousContact = CRM._.sample(ContactsData.values);
 
-        $scope.assignRole({
+        $scope.replaceRoleOrClient({
           contact_id: previousContact.contact_id,
           display_name: previousContact.display_name,
           relationship_type_id: relationshipTypeId,
           role: roleName
-        }, true);
+        });
         setRoleContact(contact);
         setRoleDescription(roleDescription);
         crmConfirmDialog.trigger('crmConfirm:yes');
+        $rootScope.$digest();
       });
 
       it('marks the current role relationship as finished', () => {
@@ -151,11 +153,12 @@ describe('Case Details People Tab', () => {
 
     describe('when adding a new case client', () => {
       beforeEach(() => {
-        $scope.assignRole({
+        $scope.assignRoleOrClient({
           role: 'Client'
         });
         setRoleContact(contact);
         crmConfirmDialog.trigger('crmConfirm:yes');
+        $rootScope.$digest();
       });
 
       it('creates a new client using the selected contact', () => {
@@ -184,13 +187,14 @@ describe('Case Details People Tab', () => {
       beforeEach(() => {
         previousContact = CRM._.sample(ContactsData.values);
 
-        $scope.assignRole({
+        $scope.replaceRoleOrClient({
           contact_id: previousContact.contact_id,
           display_name: previousContact.display_name,
           role: 'Client'
         }, true);
         setRoleContact(contact);
         crmConfirmDialog.trigger('crmConfirm:yes');
+        $rootScope.$digest();
       });
 
       it('removes the existing client from the case', () => {

--- a/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
@@ -342,7 +342,7 @@ describe('Case Details People Tab', () => {
   /**
    * Sets the description for the role being created using the confirm dialog.
    *
-   * @param {string} description a drescription for the role.
+   * @param {string} description a description for the role.
    */
   function setRoleDescription (description) {
     CRM.$('[name=description]', crmConfirmDialog).val(description);


### PR DESCRIPTION
## Overview
This PR displays an error message when adding a client as another role type for the case. Previously this would fail silently.

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/69998205-2adb9780-152c-11ea-9fbe-94a750db9b69.gif)
The request fails and this is not shown to the user.

## After
![pr-after](https://user-images.githubusercontent.com/1642119/70577913-994ed400-1b82-11ea-9730-652f3778e67a.gif)

## Technical Details

### Refactoring

The `assignRole` function was refactored and splitted into 3 different functions. The reason for this is that the same function was used to do at least 4 different things:

* Assign a case clients
* Assign a case role
* Replace a case client
* Replace a case role

This lead to a lot of conditions inside of the `assignRole` function which made it difficult to follow.

The new functions are `assignClient`, `assignRole`, `replaceRoleOrClient`. The code for displaying the contact selection dialog was moved to `promptForContact` and is used by all of these functions.

### Client can't be role error message

To display the error message and blocking the selection dialog we use `event.preventDefault()`. The message itself is appended using jQuery.

