### PR TITLE
RSE-355: Send case category from FE

### DIFF
--- a/ang/civicase/activity/directives/add-activity-menu.directive.js
+++ b/ang/civicase/activity/directives/add-activity-menu.directive.js
@@ -104,7 +104,7 @@
      * @returns {string} url
      */
     $scope.newActivityUrl = function (actType) {
-      var caseQueryParams = JSON.stringify(getCaseQueryParams($scope.case.id));
+      var caseQueryParams = JSON.stringify(getCaseQueryParams({ caseId: $scope.case.id }));
       var path = 'civicrm/case/activity';
       var args = {
         action: 'add',

--- a/ang/civicase/case/details/directives/case-details.directive.js
+++ b/ang/civicase/case/details/directives/case-details.directive.js
@@ -9,7 +9,8 @@
       scope: {
         activeTab: '=civicaseTab',
         isFocused: '=civicaseFocused',
-        item: '=civicaseCaseDetails'
+        item: '=civicaseCaseDetails',
+        caseTypeCategory: '='
       }
     };
   });
@@ -280,7 +281,7 @@
      * @returns {string} url
      */
     function caseGetParams () {
-      return getCaseQueryParams($scope.item.id, panelLimit);
+      return getCaseQueryParams($scope.item.id, panelLimit, $scope.caseTypeCategory);
     }
 
     /**

--- a/ang/civicase/case/details/directives/case-details.directive.js
+++ b/ang/civicase/case/details/directives/case-details.directive.js
@@ -281,7 +281,11 @@
      * @returns {string} url
      */
     function caseGetParams () {
-      return getCaseQueryParams($scope.item.id, panelLimit, $scope.caseTypeCategory);
+      return getCaseQueryParams({
+        caseId: $scope.item.id,
+        panelLimit: panelLimit,
+        caseTypeCategory: $scope.caseTypeCategory
+      });
     }
 
     /**

--- a/ang/civicase/case/factories/get-case-query-params.factory.js
+++ b/ang/civicase/case/factories/get-case-query-params.factory.js
@@ -2,7 +2,7 @@
   var module = angular.module('civicase');
 
   module.factory('getCaseQueryParams', function () {
-    return function getCaseQueryParams (caseId, panelLimit) {
+    return function getCaseQueryParams (caseId, panelLimit, caseTypeCategory) {
       var activityReturnParams = [
         'subject', 'details', 'activity_type_id', 'status_id', 'source_contact_name',
         'target_contact_name', 'assignee_contact_name', 'activity_date_time', 'is_star',
@@ -27,15 +27,16 @@
       return {
         id: caseId,
         return: caseReturnParams,
+        'case_type_id.case_type_category': caseTypeCategory || CRM.civicase.defaultCaseCategory,
         'api.Case.getcaselist.relatedCasesByContact': {
-          contact_id: {IN: '$value.contact_id'},
-          id: {'!=': '$value.id'},
+          contact_id: { IN: '$value.contact_id' },
+          id: { '!=': '$value.id' },
           is_deleted: 0,
           return: caseListReturnParams
         },
         // Linked cases
         'api.Case.getcaselist.linkedCases': {
-          id: {IN: '$value.related_case_ids'},
+          id: { IN: '$value.related_case_ids' },
           is_deleted: 0,
           return: caseListReturnParams
         },
@@ -45,9 +46,9 @@
           is_current_revision: 1,
           is_test: 0,
           activity_type_id: { '!=': 'Bulk Email' },
-          'activity_type_id.grouping': {LIKE: '%communication%'},
+          'activity_type_id.grouping': { LIKE: '%communication%' },
           'status_id.filter': 1,
-          options: {limit: panelLimit, sort: 'activity_date_time DESC'},
+          options: { limit: panelLimit, sort: 'activity_date_time DESC' },
           return: activityReturnParams
         },
         // For the "tasks" panel
@@ -56,17 +57,17 @@
           is_current_revision: 1,
           is_test: 0,
           activity_type_id: { '!=': 'Bulk Email' },
-          'activity_type_id.grouping': {LIKE: '%task%'},
+          'activity_type_id.grouping': { LIKE: '%task%' },
           'status_id.filter': 0,
-          options: {limit: panelLimit, sort: 'activity_date_time ASC'},
+          options: { limit: panelLimit, sort: 'activity_date_time ASC' },
           return: activityReturnParams
         },
         // For the "Next Activity" panel
         'api.Activity.get.nextActivitiesWhichIsNotMileStone': {
           case_id: caseId,
-          status_id: {'!=': 'Completed'},
+          status_id: { '!=': 'Completed' },
           activity_type_id: { '!=': 'Bulk Email' },
-          'activity_type_id.grouping': {'NOT LIKE': '%milestone%'},
+          'activity_type_id.grouping': { 'NOT LIKE': '%milestone%' },
           options: {
             limit: 1
           },
@@ -77,7 +78,7 @@
           is_current_revision: 1,
           is_deleted: 0,
           activity_type_id: { '!=': 'Bulk Email' },
-          'status_id': 'Scheduled'
+          status_id: 'Scheduled'
         },
         // For the "scheduled-overdue" count
         'api.Activity.getcount.scheduled_overdue': {

--- a/ang/civicase/case/list/directives/case-list-table.directive.html
+++ b/ang/civicase/case/list/directives/case-list-table.directive.html
@@ -113,6 +113,7 @@
     ng-class="{'civicase__case-details-panel--focused': caseIsFocused, 'civicase__case-details-panel--summary': viewingCase}"
     civicase-case-details="viewingCaseDetails"
     civicase-tab="viewingCaseTab"
-    civicase-focused="caseIsFocused">
+    civicase-focused="caseIsFocused"
+    case-type-category="filters.case_type_category">
   </div>
 </div>

--- a/ang/civicase/case/list/directives/case-list-table.directive.js
+++ b/ang/civicase/case/list/directives/case-list-table.directive.js
@@ -323,7 +323,10 @@
       if (sort.field !== 'id') {
         returnCaseParams.options.sort += ', id';
       }
-      var params = { 'case_type_id.is_active': 1 };
+      var params = {
+        'case_type_id.is_active': 1,
+        'case_type_id.case_type_category': CRM.civicase.defaultCaseCategory
+      };
       _.each(filters, function (val, filter) {
         if (val || typeof val === 'boolean') {
           if (filter === 'case_type_category') {

--- a/ang/test/civicase/case/details/directives/case-details.directive.spec.js
+++ b/ang/test/civicase/case/details/directives/case-details.directive.spec.js
@@ -262,7 +262,7 @@
     });
 
     /**
-     *
+     * Compiles the directive
      */
     function compileDirective () {
       $scope.viewingCaseDetails = formatCase(CasesData.get().values[0]);
@@ -291,7 +291,7 @@
      * Mocks a directive
      * TODO: Have a more generic usage - Maybe create a service/factory
      *
-     * @param {string} directiveName
+     * @param {string} directiveName name of the directive
      */
     function killDirective (directiveName) {
       angular.mock.module(function ($compileProvider) {

--- a/ang/test/civicase/case/details/directives/case-details.directive.spec.js
+++ b/ang/test/civicase/case/details/directives/case-details.directive.spec.js
@@ -127,6 +127,12 @@
         expect(element.isolateScope().item.category_count.incomplete.task).toBe(2);
       });
 
+      it('checks whether the user has permission to fetch case details', function () {
+        expect(crmApi).toHaveBeenCalledWith('Case', 'getdetails', jasmine.objectContaining({
+          'case_type_id.case_type_category': 'cases'
+        }));
+      });
+
       describe('Related Cases', function () {
         describe('related cases', function () {
           var relatedCasesByContact, linkedCases;
@@ -213,7 +219,7 @@
 
         controller.getPrintActivityUrl(activitiesMockData.get());
         selectedActivities = activitiesMockData.get().map(function (item) {
-          return item['id'];
+          return item.id;
         }).join(',');
       });
 
@@ -255,16 +261,20 @@
       });
     });
 
+    /**
+     *
+     */
     function compileDirective () {
       $scope.viewingCaseDetails = formatCase(CasesData.get().values[0]);
-      element = $compile('<div civicase-case-details="viewingCaseDetails"></div>')($scope);
+      $scope.caseTypeCategory = 'cases';
+      element = $compile('<div civicase-case-details="viewingCaseDetails" case-type-category="caseTypeCategory"></div>')($scope);
       $scope.$digest();
     }
 
     /**
      * Initializes the case details controller.
      *
-     * @param {Object} caseItem a case item to pass to the controller. Defaults to
+     * @param {object} caseItem a case item to pass to the controller. Defaults to
      * a case from the mock data.
      */
     function initController (caseItem) {
@@ -281,7 +291,7 @@
      * Mocks a directive
      * TODO: Have a more generic usage - Maybe create a service/factory
      *
-     * @param {String} directiveName
+     * @param {string} directiveName
      */
     function killDirective (directiveName) {
       angular.mock.module(function ($compileProvider) {
@@ -384,7 +394,7 @@
     /**
      * Initializes the case details controller.
      *
-     * @param {Object} caseItem a case item to pass to the controller. Defaults to
+     * @param {object} caseItem a case item to pass to the controller. Defaults to
      * a case from the mock data.
      */
     function initController (caseItem) {

--- a/ang/test/civicase/case/list/directives/case-list-table.directive.spec.js
+++ b/ang/test/civicase/case/list/directives/case-list-table.directive.spec.js
@@ -78,7 +78,7 @@
      * Initializes the civicaseActivityMonthNav directive
      */
     function initDirective () {
-      var html = `<div civicase-case-list-table></div>`;
+      var html = '<div civicase-case-list-table></div>';
 
       $compile(html)($scope);
       $scope.$digest();
@@ -130,21 +130,23 @@
       beforeEach(function () {
         expectedApiCallParams = [
           ['Case', 'getcaselist', jasmine.objectContaining({
-            'sequential': 1,
+            sequential: 1,
             return: [
               'subject', 'case_type_id', 'status_id', 'is_deleted', 'start_date',
               'modified_date', 'contacts', 'activity_summary', 'category_count',
               'tag_id.name', 'tag_id.color', 'tag_id.description'
             ],
-            'options': jasmine.any(Object),
+            options: jasmine.any(Object),
             'case_type_id.is_active': 1,
-            'id': { 'LIKE': '%' + $scope.filters.id + '%' },
-            'contact_is_deleted': 0
+            'case_type_id.case_type_category': CRM.civicase.defaultCaseCategory,
+            id: { LIKE: '%' + $scope.filters.id + '%' },
+            contact_is_deleted: 0
           })],
           ['Case', 'getdetailscount', jasmine.objectContaining({
             'case_type_id.is_active': 1,
-            'id': { 'LIKE': '%' + $scope.filters.id + '%' },
-            'contact_is_deleted': 0
+            id: { LIKE: '%' + $scope.filters.id + '%' },
+            'case_type_id.case_type_category': CRM.civicase.defaultCaseCategory,
+            contact_is_deleted: 0
           })],
           ['Case', 'getcaselistheaders']
         ];

--- a/ang/test/global.js
+++ b/ang/test/global.js
@@ -3,6 +3,7 @@
 (function (CRM) {
   CRM['civicase-base'] = {};
   CRM.civicase = {};
+  CRM.civicase.defaultCaseCategory = 'cases';
   CRM.angular = { requires: {} };
   /**
    * Dependency Injection for civicase module, defined in ang/civicase.ang.php


### PR DESCRIPTION
## Overview
As part of this PR, the case type category is being sent to backend for the Manage Case screens. This is used to validate whether the logged in user has permission to view case of a particular case type category.

## Technical Details
1. In `case-list-table.directive.js`, setting the default Case Type category. So that incase even if browser URL does not have the case type category mentioned, still the case type category will be sent to backend.

2. In `case-list-table.directive.html`, the case type category is sent to the `civicase-case-details` directive. Which send the same to the `getCaseQueryParams` factory. Inside `getCaseQueryParams`, the Case Type Category is sent to BE via API call.
