### PR TITLE
RSE-298: Fix Permission Errors

### DIFF
--- a/CRM/Civicase/Hook/alterAPIPermissions/Case.php
+++ b/CRM/Civicase/Hook/alterAPIPermissions/Case.php
@@ -72,6 +72,7 @@ class CRM_Civicase_Hook_alterAPIPermissions_Case {
     $permissions['relationship_type']['getcaseroles'] = $permissions['relationship_type']['get'];
     $permissions['case']['getcount'] = [$basicCasePermissions];
     $permissions['case_type']['get'] = [$basicCasePermissions];
+    $permissions['case_type']['create'] = [$caseCategoryPermissions['ADMINISTER_CASE_CATEGORY']['name']];
     $permissions['casetype']['getcount'] = [$basicCasePermissions];
     $permissions['custom_value']['gettreevalues'] = [$basicCasePermissions];
 
@@ -239,4 +240,5 @@ class CRM_Civicase_Hook_alterAPIPermissions_Case {
 
     return CaseCategoryHelper::getCaseCategoryNameFromOptionValue($caseTypeCategory);
   }
+
 }

--- a/CRM/Civicase/Hook/alterAPIPermissions/Case.php
+++ b/CRM/Civicase/Hook/alterAPIPermissions/Case.php
@@ -72,7 +72,7 @@ class CRM_Civicase_Hook_alterAPIPermissions_Case {
     $permissions['relationship_type']['getcaseroles'] = $permissions['relationship_type']['get'];
     $permissions['case']['getcount'] = [$basicCasePermissions];
     $permissions['case_type']['get'] = [$basicCasePermissions];
-    $permissions['case_type']['create'] = [$caseCategoryPermissions['ADMINISTER_CASE_CATEGORY']['name']];
+    $permissions['case_type']['create'] = $permissions['case_type']['update'] = [$caseCategoryPermissions['ADMINISTER_CASE_CATEGORY']['name']];
     $permissions['casetype']['getcount'] = [$basicCasePermissions];
     $permissions['custom_value']['gettreevalues'] = [$basicCasePermissions];
 


### PR DESCRIPTION
## Overview
Each case category like Awards, Prospects now have their own respective permissions defined and the permission is needed to access the respective pages for each of the categories.
When testing this functionality, an errors came up for the Award manager when trying to create an Award : `API Permission check failed for CaseType/create call: insufficient permission: require Administer Civicase`

## Before
Error when Award manager is trying to create an Award.

## After
The CaseType.create API requires the `Administer Civicase`. The PR fixes the issue by using the equivalent `Administer Civiawards` permission when the case type category is awards. The award manager already has the `Administer Civiawards` permission and hence is able to create the Award.