### PR TITLE
RSE-644: Show review activity form

### DIFF
--- a/ang/civicase/activity/factories/view-in-popup.factory.js
+++ b/ang/civicase/activity/factories/view-in-popup.factory.js
@@ -30,6 +30,10 @@
         activityFormUrl = 'civicrm/case/activity';
       }
 
+      if (activity.type === 'Applicant Review') {
+        activityFormUrl = 'civicrm/awardreview';
+      }
+
       if (checkIfDraftEmailOrPDFActivity(activity)) {
         activityFormUrl = 'civicrm/activity/email/add';
       }

--- a/ang/civicase/activity/panel/directives/activity-panel.directive.html
+++ b/ang/civicase/activity/panel/directives/activity-panel.directive.html
@@ -1,4 +1,4 @@
-<div class="civicase__activity-panel" ng-controller="caseActivityCardController">
+<div class="civicase__activity-panel civicase__activity-panel--{{(activity.type).split(' ').join('_')}}" ng-controller="caseActivityCardController">
   <div class="panel panel-default panel-w-subheading">
     <div class="panel-heading clearfix">
       <span class="civicase__activity-panel__id">ID-{{activity.id}}</span>

--- a/ang/civicase/activity/panel/directives/activity-panel.directive.js
+++ b/ang/civicase/activity/panel/directives/activity-panel.directive.js
@@ -53,24 +53,36 @@
        * @param {object} activity activity
        */
       function loadActivityForm (event, activity) {
+        CRM.loadForm(getActivityFormURL(activity), {
+          target: $(element).find('.civicase__activity-panel__core_container')
+        });
+
+        element.find('.crm-submit-buttons a.edit').addClass('btn btn-primary');
+      }
+
+      /**
+       * Get the url for the activity form
+       *
+       * @param {object} activity activity object
+       * @returns {string} url
+       */
+      function getActivityFormURL (activity) {
         var context = activity.case_id ? 'case' : 'activity';
 
         if (activity.type === 'Applicant Review') {
-          CRM.loadForm(CRM.url('civicrm/awardreview', {
+          return CRM.url('civicrm/awardreview', {
             action: 'view',
             id: activity.id,
             reset: 1
-          }), { target: $(element).find('.civicase__activity-panel__core_container') });
+          });
         } else {
-          CRM.loadForm(CRM.url('civicrm/activity', {
+          return CRM.url('civicrm/activity', {
             action: 'view',
             id: activity.id,
             reset: 1,
             context: context
-          }), { target: $(element).find('.civicase__activity-panel__core_container') });
+          });
         }
-
-        element.find('.crm-submit-buttons a.edit').addClass('btn btn-primary');
       }
 
       /**

--- a/ang/civicase/activity/panel/directives/activity-panel.directive.js
+++ b/ang/civicase/activity/panel/directives/activity-panel.directive.js
@@ -55,12 +55,20 @@
       function loadActivityForm (event, activity) {
         var context = activity.case_id ? 'case' : 'activity';
 
-        CRM.loadForm(CRM.url('civicrm/activity', {
-          action: 'view',
-          id: activity.id,
-          reset: 1,
-          context: context
-        }), { target: $(element).find('.civicase__activity-panel__core_container') });
+        if (activity.type === 'Applicant Review') {
+          CRM.loadForm(CRM.url('civicrm/awardreview', {
+            action: 'view',
+            id: activity.id,
+            reset: 1
+          }), { target: $(element).find('.civicase__activity-panel__core_container') });
+        } else {
+          CRM.loadForm(CRM.url('civicrm/activity', {
+            action: 'view',
+            id: activity.id,
+            reset: 1,
+            context: context
+          }), { target: $(element).find('.civicase__activity-panel__core_container') });
+        }
 
         element.find('.crm-submit-buttons a.edit').addClass('btn btn-primary');
       }


### PR DESCRIPTION
## Overview
This PR displays the review custom form when viewing activities of the review type.

## Before

### Opening review activity popup
![popup-before](https://user-images.githubusercontent.com/1642119/72028502-1ee4a300-3259-11ea-81e1-e7c70cc563f7.gif)

### View Review Activity details
![activity-before](https://user-images.githubusercontent.com/1642119/72028572-6bc87980-3259-11ea-818d-00eac33b9799.gif)

## After

### Opening review activity popup
![popup-after](https://user-images.githubusercontent.com/1642119/72028300-60c11980-3258-11ea-97b8-8d9c43589c4b.gif)

### View Review Activity details
![activity-after](https://user-images.githubusercontent.com/1642119/72028354-8f3ef480-3258-11ea-933f-5c143df0c8f4.gif)

## Technical Details

* `ang/civicase/activity/factories/view-in-popup.factory.js` checks if the activity type is for a review and loads the form accordingly.
* `ang/civicase/activity/panel/directives/activity-panel.directive.html ` adds the activity type as a class for the form so it can be targeted using CSS (For an implementation please check: https://github.com/compucorp/uk.co.compucorp.civiawards/pull/43/files#diff-557ba156ae919ea30d57a9eb989fb46bR46)
* `ang/civicase/activity/panel/directives/activity-panel.directive.js` also checks for the activity type before showing the right form.
