### PR TITLE
RSE-298: Fix Case Creation URL

### DIFF
--- a/CRM/Civicase/Hook/PageRun/ViewCasePageRedirect.php
+++ b/CRM/Civicase/Hook/PageRun/ViewCasePageRedirect.php
@@ -37,14 +37,14 @@ class CRM_Civicase_Hook_PageRun_ViewCasePageRedirect {
       'id' => $caseId,
       'return' => [
         'case_type_id.name',
-        'status_id.name',
+        'status_id',
         'case_type_id.case_type_category',
       ],
     ]);
 
     $caseCategoryName = CaseCategoryHelper::getCaseCategoryNameFromOptionValue($case['case_type_id.case_type_category']);
     $url = CRM_Utils_System::url('civicrm/case/a/', ['case_type_category' => strtolower($caseCategoryName)], TRUE,
-      "/case/list?sf=id&sd=DESC&caseId={$caseId}&cf=%7B%22status_id%22:%5B%22{$case['status_id.name']}%22%5D,%22case_type_id%22:%5B%22{$case['case_type_id.name']}%22%5D%7D",
+      "/case/list?sf=id&sd=DESC&caseId={$caseId}&cf=%7B%22case_type_category%22:%22" . strtolower($caseCategoryName) . "%22,%22status_id%22:%5B%22{$case['status_id']}%22%5D,%22case_type_id%22:%5B%22{$case['case_type_id.name']}%22%5D%7D",
       FALSE);
 
     CRM_Utils_System::redirect($url);


### PR DESCRIPTION
## Overview
When a new case is created(any case type), the browser gets redirected to Manage Cases page. But the url should contain the 'case_type_category' value, so that cases from that category is shown. This was not happening before. This PR fixes the same.

## URL Before
`civicrm/case/a/?case_type_category=cases#/case/list?sf=id&sd=DESC&caseId=13&cf=%7B%22status_id%22:%5B%22Open%22%5D,%22case_type_id%22:%5B%22adult_day_care_referral%22%5D%7D`

## URL After
`civicrm/case/a/?case_type_category=cases#/case/list?sf=id&sd=DESC&caseId=12&cf=%7B%22case_type_category%22:%22cases%22,%22status_id%22:%5B%221%22%5D,%22case_type_id%22:%5B%22adult_day_care_referral%22%5D%7D`

## Technical Details
1. In `ViewCasePageRedirect.php`, added `case_type_category` query string which is used by angular.
2. Also, the url now sends `status_id` instead of status name. Because https://github.com/compucorp/uk.co.compucorp.civicase/blob/870cd93dd8a878b3ef2c6d4505845f79cd33f112/ang/civicase/case/search/directives/search.directive.js#L396 expects the ID.