### PR TITLE
CATL-1113: Set case clients as default recipients to send email popup

### DIFF
--- a/ang/civicase/activity/activity-forms/services/draft-email-or-pdf-activity-form.service.js
+++ b/ang/civicase/activity/activity-forms/services/draft-email-or-pdf-activity-form.service.js
@@ -6,10 +6,9 @@
   /**
    * Draft email or PDF activity form service.
    *
-   * @param {object} CasesUtils cases utility service
    * @param {Function} checkIfDraftEmailOrPDFActivity the check if draft email or pdf activity function.
    */
-  function DraftEmailOrPdfActivityForm (CasesUtils, checkIfDraftEmailOrPDFActivity) {
+  function DraftEmailOrPdfActivityForm (checkIfDraftEmailOrPDFActivity) {
     this.canHandleActivity = checkIfDraftEmailOrPDFActivity;
     this.getActivityFormUrl = getActivityFormUrl;
 
@@ -21,7 +20,7 @@
       return getCrmUrl('civicrm/activity/email/add', {
         action: 'add',
         caseId: activity.case_id,
-        cid: CasesUtils.getAllCaseClientContactIds(activity['case_id.contacts']).join(','),
+        context: 'standalone',
         draft_id: activity.id,
         reset: '1'
       });

--- a/ang/civicase/activity/activity-forms/services/draft-email-or-pdf-activity-form.service.js
+++ b/ang/civicase/activity/activity-forms/services/draft-email-or-pdf-activity-form.service.js
@@ -6,9 +6,10 @@
   /**
    * Draft email or PDF activity form service.
    *
+   * @param {Function} CasesUtils service
    * @param {Function} checkIfDraftEmailOrPDFActivity the check if draft email or pdf activity function.
    */
-  function DraftEmailOrPdfActivityForm (checkIfDraftEmailOrPDFActivity) {
+  function DraftEmailOrPdfActivityForm (CasesUtils, checkIfDraftEmailOrPDFActivity) {
     this.canHandleActivity = checkIfDraftEmailOrPDFActivity;
     this.getActivityFormUrl = getActivityFormUrl;
 
@@ -17,30 +18,13 @@
      * @returns {string} the form URL for activities that are either email drafts or PDF drafts.
      */
     function getActivityFormUrl (activity) {
-      var caseClientsIds = getCaseClientsIds(activity).join(',');
-
       return getCrmUrl('civicrm/activity/email/add', {
         action: 'add',
         caseId: activity.case_id,
-        cid: caseClientsIds,
+        cid: CasesUtils.getAllCaseClientContactIdsFromAllContacts(activity['case_id.contacts']).join(','),
         draft_id: activity.id,
         reset: '1'
       });
-    }
-
-    /**
-     * @param {object} activity an activity object.
-     * @returns {Array} of all client ids.
-     */
-    function getCaseClientsIds (activity) {
-      return _.chain(activity['case_id.contacts'])
-        .filter(function (contact) {
-          return contact.role === 'Client';
-        })
-        .map(function (client) {
-          return client.contact_id;
-        })
-        .value();
     }
   }
 })(CRM._, angular, CRM.url);

--- a/ang/civicase/activity/activity-forms/services/draft-email-or-pdf-activity-form.service.js
+++ b/ang/civicase/activity/activity-forms/services/draft-email-or-pdf-activity-form.service.js
@@ -17,13 +17,30 @@
      * @returns {string} the form URL for activities that are either email drafts or PDF drafts.
      */
     function getActivityFormUrl (activity) {
+      var caseClientsIds = getCaseClientsIds(activity).join(',');
+
       return getCrmUrl('civicrm/activity/email/add', {
         action: 'add',
         caseId: activity.case_id,
-        context: 'standalone',
+        cid: caseClientsIds,
         draft_id: activity.id,
         reset: '1'
       });
+    }
+
+    /**
+     * @param {object} activity an activity object.
+     * @returns {Array} of all client ids.
+     */
+    function getCaseClientsIds (activity) {
+      return _.chain(activity['case_id.contacts'])
+        .filter(function (contact) {
+          return contact.role === 'Client';
+        })
+        .map(function (client) {
+          return client.contact_id;
+        })
+        .value();
     }
   }
 })(CRM._, angular, CRM.url);

--- a/ang/civicase/activity/activity-forms/services/draft-email-or-pdf-activity-form.service.js
+++ b/ang/civicase/activity/activity-forms/services/draft-email-or-pdf-activity-form.service.js
@@ -6,7 +6,7 @@
   /**
    * Draft email or PDF activity form service.
    *
-   * @param {Function} CasesUtils service
+   * @param {object} CasesUtils cases utility service
    * @param {Function} checkIfDraftEmailOrPDFActivity the check if draft email or pdf activity function.
    */
   function DraftEmailOrPdfActivityForm (CasesUtils, checkIfDraftEmailOrPDFActivity) {
@@ -21,7 +21,7 @@
       return getCrmUrl('civicrm/activity/email/add', {
         action: 'add',
         caseId: activity.case_id,
-        cid: CasesUtils.getAllCaseClientContactIdsFromAllContacts(activity['case_id.contacts']).join(','),
+        cid: CasesUtils.getAllCaseClientContactIds(activity['case_id.contacts']).join(','),
         draft_id: activity.id,
         reset: '1'
       });

--- a/ang/civicase/activity/feed/directives/activity-feed.directive.js
+++ b/ang/civicase/activity/feed/directives/activity-feed.directive.js
@@ -397,7 +397,7 @@
           'subject', 'details', 'activity_type_id', 'status_id',
           'source_contact_name', 'target_contact_name', 'assignee_contact_name',
           'activity_date_time', 'is_star', 'original_id', 'tag_id.name', 'tag_id.description',
-          'tag_id.color', 'file_id', 'is_overdue', 'case_id', 'priority_id'
+          'tag_id.color', 'file_id', 'is_overdue', 'case_id', 'priority_id', 'case_id.contacts'
         ],
         options: options
       };
@@ -414,7 +414,7 @@
       } else if (!$scope.displayOptions.include_case) {
         params.case_id = { 'IS NULL': 1 };
       } else {
-        returnParams.return = returnParams.return.concat(['case_id.case_type_id', 'case_id.status_id', 'case_id.contacts']);
+        returnParams.return = returnParams.return.concat(['case_id.case_type_id', 'case_id.status_id']);
       }
 
       _.each($scope.filters, function (val, key) {

--- a/ang/civicase/case/actions/services/email-managers-case-action.service.js
+++ b/ang/civicase/case/actions/services/email-managers-case-action.service.js
@@ -8,8 +8,9 @@
    */
   function EmailManagersCaseAction () {
     /**
-     * Click event handler for the Action.
-     * Spits error if no case manager, opens popup otherwise
+     * Returns the configuration options to open up a mail popup to
+     * communicate with the case managers. Displays an error message
+     * when no case managers have been assigned to the case.
      *
      * @param {Array} cases
      * @param {object} action
@@ -24,7 +25,6 @@
         }
       });
 
-      // Spit error if no case manager is present
       if (managers.length === 0) {
         CRM.alert('Please add a contact as a case manager', 'No case managers available', 'error');
 

--- a/ang/civicase/case/actions/services/email-managers-case-action.service.js
+++ b/ang/civicase/case/actions/services/email-managers-case-action.service.js
@@ -12,8 +12,8 @@
      * communicate with the case managers. Displays an error message
      * when no case managers have been assigned to the case.
      *
-     * @param {Array} cases object
-     * @param {object} action to be performed
+     * @param {Array} cases list of cases
+     * @param {object} action action to be performed
      * @param {Function} callbackFn the callback function
      *
      * @returns {string} path for the popup

--- a/ang/civicase/case/actions/services/email-managers-case-action.service.js
+++ b/ang/civicase/case/actions/services/email-managers-case-action.service.js
@@ -4,7 +4,7 @@
   module.service('EmailManagersCaseAction', EmailManagersCaseAction);
 
   /**
-   *
+   * EmailManagersCaseAction service callback function.
    */
   function EmailManagersCaseAction () {
     /**

--- a/ang/civicase/case/actions/services/email-managers-case-action.service.js
+++ b/ang/civicase/case/actions/services/email-managers-case-action.service.js
@@ -3,12 +3,15 @@
 
   module.service('EmailManagersCaseAction', EmailManagersCaseAction);
 
+  /**
+   *
+   */
   function EmailManagersCaseAction () {
     /**
      * Click event handler for the Action
      *
      * @param {Array} cases
-     * @param {Object} action
+     * @param {object} action
      * @param {Function} callbackFn
      */
     this.doAction = function (cases, action, callbackFn) {
@@ -20,20 +23,24 @@
         }
       });
 
-      var popupPath = {
-        path: 'civicrm/activity/email/add',
-        query: {
-          action: 'add',
-          reset: 1,
-          cid: _.uniq(managers).join(',')
+      if (managers.length > 0) {
+        var popupPath = {
+          path: 'civicrm/activity/email/add',
+          query: {
+            action: 'add',
+            reset: 1,
+            cid: _.uniq(managers).join(',')
+          }
+        };
+
+        if (cases.length === 1) {
+          popupPath.query.caseid = cases[0].id;
         }
-      };
 
-      if (cases.length === 1) {
-        popupPath.query.caseid = cases[0].id;
+        return popupPath;
+      } else {
+        CRM.alert('Please add a contact as a case manager', 'No case managers available', 'error');
       }
-
-      return popupPath;
     };
   }
 })(angular, CRM.$, CRM._);

--- a/ang/civicase/case/actions/services/email-managers-case-action.service.js
+++ b/ang/civicase/case/actions/services/email-managers-case-action.service.js
@@ -8,7 +8,8 @@
    */
   function EmailManagersCaseAction () {
     /**
-     * Click event handler for the Action
+     * Click event handler for the Action.
+     * Spits error if no case manager, opens popup otherwise
      *
      * @param {Array} cases
      * @param {object} action
@@ -23,24 +24,27 @@
         }
       });
 
-      if (managers.length > 0) {
-        var popupPath = {
-          path: 'civicrm/activity/email/add',
-          query: {
-            action: 'add',
-            reset: 1,
-            cid: _.uniq(managers).join(',')
-          }
-        };
-
-        if (cases.length === 1) {
-          popupPath.query.caseid = cases[0].id;
-        }
-
-        return popupPath;
-      } else {
+      // Spit error if no case manager is present
+      if (managers.length === 0) {
         CRM.alert('Please add a contact as a case manager', 'No case managers available', 'error');
+
+        return;
       }
+
+      var popupPath = {
+        path: 'civicrm/activity/email/add',
+        query: {
+          action: 'add',
+          reset: 1,
+          cid: _.uniq(managers).join(',')
+        }
+      };
+
+      if (cases.length === 1) {
+        popupPath.query.caseid = cases[0].id;
+      }
+
+      return popupPath;
     };
   }
 })(angular, CRM.$, CRM._);

--- a/ang/civicase/case/actions/services/email-managers-case-action.service.js
+++ b/ang/civicase/case/actions/services/email-managers-case-action.service.js
@@ -12,9 +12,11 @@
      * communicate with the case managers. Displays an error message
      * when no case managers have been assigned to the case.
      *
-     * @param {Array} cases
-     * @param {object} action
-     * @param {Function} callbackFn
+     * @param {Array} cases object
+     * @param {object} action to be performed
+     * @param {Function} callbackFn the callback function
+     *
+     * @returns {string} path for the popup
      */
     this.doAction = function (cases, action, callbackFn) {
       var managers = [];
@@ -26,7 +28,7 @@
       });
 
       if (managers.length === 0) {
-        CRM.alert('Please add a contact as a case manager', 'No case managers available', 'error');
+        CRM.alert('Please add a contact as a case manager.', 'No case managers available', 'error');
 
         return;
       }

--- a/ang/civicase/case/details/directives/case-details.directive.js
+++ b/ang/civicase/case/details/directives/case-details.directive.js
@@ -82,18 +82,12 @@
      * Opens the popup for Creating Email
      */
     $scope.createEmail = function () {
-      var caseClients = _.filter($scope.item.contacts, function (contact) {
-        return contact.role === 'Client';
-      });
-
-      var caseClientsIds = _.map(caseClients, function (client) { return client.contact_id; });
-
       var createEmailURLParams = {
         action: 'add',
         caseid: $scope.item.id,
         atype: '3',
         reset: 1,
-        cid: caseClientsIds.join(',')
+        cid: CasesUtils.getAllCaseClientContactIdsFromAllContacts($scope.item.contacts).join(',')
       };
 
       CRM

--- a/ang/civicase/case/details/directives/case-details.directive.js
+++ b/ang/civicase/case/details/directives/case-details.directive.js
@@ -82,16 +82,18 @@
      * Opens the popup for Creating Email
      */
     $scope.createEmail = function () {
-      var caseClients = [];
-      angular.forEach($scope.item.contacts, function (contact, key) {
-        caseClients.push(contact.contact_id);
+      var caseClients = _.filter($scope.item.contacts, function (contact) {
+        return contact.role === 'Client';
       });
+
+      var caseClientsIds = _.map(caseClients, function (client) { return client.contact_id; });
+
       var createEmailURLParams = {
         action: 'add',
         caseid: $scope.item.id,
         atype: '3',
         reset: 1,
-        cid: caseClients.join(',')
+        cid: caseClientsIds.join(',')
       };
 
       CRM

--- a/ang/civicase/case/details/directives/case-details.directive.js
+++ b/ang/civicase/case/details/directives/case-details.directive.js
@@ -87,7 +87,7 @@
         caseid: $scope.item.id,
         atype: '3',
         reset: 1,
-        cid: CasesUtils.getAllCaseClientContactIdsFromAllContacts($scope.item.contacts).join(',')
+        cid: CasesUtils.getAllCaseClientContactIds($scope.item.contacts).join(',')
       };
 
       CRM

--- a/ang/civicase/case/details/directives/case-details.directive.js
+++ b/ang/civicase/case/details/directives/case-details.directive.js
@@ -82,12 +82,16 @@
      * Opens the popup for Creating Email
      */
     $scope.createEmail = function () {
+      var caseClients = [];
+      angular.forEach($scope.item.contacts, function (contact, key) {
+        caseClients.push(contact.contact_id);
+      });
       var createEmailURLParams = {
         action: 'add',
         caseid: $scope.item.id,
         atype: '3',
         reset: 1,
-        context: 'standalone'
+        cid: caseClients.join(',')
       };
 
       CRM

--- a/ang/civicase/case/services/cases-utils.service.js
+++ b/ang/civicase/case/services/cases-utils.service.js
@@ -5,7 +5,7 @@
     /**
      * Fetch additional information about the contacts
      *
-     * @param {array} cases
+     * @param {Array} cases array to be fetched from
      */
     this.fetchMoreContactsInformation = function (cases) {
       var contacts = [];
@@ -18,10 +18,28 @@
     };
 
     /**
+     * Process all case clients contacts ids.
+     *
+     * @param {Array} contacts of a case.
+     * @returns {Array} of all client ids.
+     */
+    this.getAllCaseClientContactIdsFromAllContacts = function (contacts) {
+      return _.chain(contacts)
+        .filter(function (contact) {
+          return contact.role === 'Client';
+        })
+        .map(function (client) {
+          return client.contact_id;
+        })
+        .value();
+    };
+
+    /**
      * Get all the contacts of the given case
      *
-     * @param {object} caseObj
-     * @return {array}
+     * @param {object} caseObj - case object to be processed
+     *
+     * @returns {Array} of all contact ids
      */
     function getAllContactIdsForCase (caseObj) {
       var contacts = [];

--- a/ang/civicase/case/services/cases-utils.service.js
+++ b/ang/civicase/case/services/cases-utils.service.js
@@ -5,7 +5,7 @@
     /**
      * Fetch additional information about the contacts
      *
-     * @param {Array} cases array to be fetched from
+     * @param {Array} cases list of cases
      */
     this.fetchMoreContactsInformation = function (cases) {
       var contacts = [];
@@ -18,12 +18,13 @@
     };
 
     /**
-     * Process all case clients contacts ids.
+     * Get all case clients ids for a case contacts list
      *
-     * @param {Array} contacts of a case.
-     * @returns {Array} of all client ids.
+     * @param {Array} contacts contacts of a case
+     *
+     * @returns {Array} contact contacts of all client ids
      */
-    this.getAllCaseClientContactIdsFromAllContacts = function (contacts) {
+    this.getAllCaseClientContactIds = function (contacts) {
       return _.chain(contacts)
         .filter(function (contact) {
           return contact.role === 'Client';

--- a/ang/test/civicase/activity/activity-forms/services/draft-email-or-pdf-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/draft-email-or-pdf-activity-form.service.spec.js
@@ -2,15 +2,14 @@
 ((_, getCrmUrl) => {
   describe('DraftEmailOrPdfActivityForm', () => {
     let activity, activityFormUrl, checkIfDraftEmailOrPDFActivity,
-      DraftEmailOrPdfActivityForm, CasesUtils, expectedActivityFormUrl;
+      DraftEmailOrPdfActivityForm, expectedActivityFormUrl;
 
     beforeEach(module('civicase', 'civicase-base', 'civicase.data'));
 
     beforeEach(inject((_activitiesMockData_, _checkIfDraftEmailOrPDFActivity_,
-      _DraftEmailOrPdfActivityForm_, _CasesUtils_) => {
+      _DraftEmailOrPdfActivityForm_) => {
       checkIfDraftEmailOrPDFActivity = _checkIfDraftEmailOrPDFActivity_;
       DraftEmailOrPdfActivityForm = _DraftEmailOrPdfActivityForm_;
-      CasesUtils = _CasesUtils_;
       activity = _.chain(_activitiesMockData_.get())
         .first()
         .cloneDeep()
@@ -29,8 +28,7 @@
         activityFormUrl = DraftEmailOrPdfActivityForm.getActivityFormUrl(activity);
         expectedActivityFormUrl = getCrmUrl('civicrm/activity/email/add', {
           action: 'add',
-          caseId: activity.case_id,
-          cid: CasesUtils.getAllCaseClientContactIds(activity['case_id.contacts']).join(','),
+          context: 'standalone',
           draft_id: activity.id,
           reset: '1'
         });

--- a/ang/test/civicase/activity/activity-forms/services/draft-email-or-pdf-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/draft-email-or-pdf-activity-form.service.spec.js
@@ -2,14 +2,15 @@
 ((_, getCrmUrl) => {
   describe('DraftEmailOrPdfActivityForm', () => {
     let activity, activityFormUrl, checkIfDraftEmailOrPDFActivity,
-      DraftEmailOrPdfActivityForm, expectedActivityFormUrl;
+      DraftEmailOrPdfActivityForm, CasesUtils, expectedActivityFormUrl;
 
     beforeEach(module('civicase', 'civicase-base', 'civicase.data'));
 
     beforeEach(inject((_activitiesMockData_, _checkIfDraftEmailOrPDFActivity_,
-      _DraftEmailOrPdfActivityForm_) => {
+      _DraftEmailOrPdfActivityForm_, _CasesUtils_) => {
       checkIfDraftEmailOrPDFActivity = _checkIfDraftEmailOrPDFActivity_;
       DraftEmailOrPdfActivityForm = _DraftEmailOrPdfActivityForm_;
+      CasesUtils = _CasesUtils_;
       activity = _.chain(_activitiesMockData_.get())
         .first()
         .cloneDeep()
@@ -29,7 +30,7 @@
         expectedActivityFormUrl = getCrmUrl('civicrm/activity/email/add', {
           action: 'add',
           caseId: activity.case_id,
-          context: 'standalone',
+          cid: CasesUtils.getAllCaseClientContactIdsFromAllContacts(activity['case_id.contacts']).join(','),
           draft_id: activity.id,
           reset: '1'
         });

--- a/ang/test/civicase/activity/activity-forms/services/draft-email-or-pdf-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/draft-email-or-pdf-activity-form.service.spec.js
@@ -30,7 +30,7 @@
         expectedActivityFormUrl = getCrmUrl('civicrm/activity/email/add', {
           action: 'add',
           caseId: activity.case_id,
-          cid: CasesUtils.getAllCaseClientContactIdsFromAllContacts(activity['case_id.contacts']).join(','),
+          cid: CasesUtils.getAllCaseClientContactIds(activity['case_id.contacts']).join(','),
           draft_id: activity.id,
           reset: '1'
         });

--- a/ang/test/civicase/case/actions/services/email-managers-case-action.service.spec.js
+++ b/ang/test/civicase/case/actions/services/email-managers-case-action.service.spec.js
@@ -1,0 +1,38 @@
+/* eslint-env jasmine */
+
+(function (_, $) {
+  describe('EmailManagersCaseAction', function () {
+    var EmailManagersCaseAction, CasesMockData, caseObj, actualCRMAlert;
+
+    beforeEach(module('civicase', 'civicase.data'));
+
+    beforeEach(inject(function (_EmailManagersCaseAction_, _CasesData_) {
+      EmailManagersCaseAction = _EmailManagersCaseAction_;
+      CasesMockData = _CasesData_;
+    }));
+
+    beforeEach(function () {
+      caseObj = CasesMockData.get().values[0];
+      actualCRMAlert = CRM.alert;
+      CRM.alert = jasmine.createSpy('CRMAlert');
+    });
+
+    afterEach(function () {
+      CRM.alert = actualCRMAlert;
+    });
+
+    describe('doAction()', function () {
+      describe('when no case manager assigned', function () {
+        beforeEach(function () {
+          delete caseObj.manager;
+
+          EmailManagersCaseAction.doAction(caseObj, 'email', jasmine.any(Function));
+        });
+
+        it('calls CRM.alert and return', function () {
+          expect(CRM.alert).toHaveBeenCalledWith('Please add a contact as a case manager.', 'No case managers available', 'error');
+        });
+      });
+    });
+  });
+})(CRM._, CRM.$);

--- a/ang/test/civicase/case/actions/services/email-managers-case-action.service.spec.js
+++ b/ang/test/civicase/case/actions/services/email-managers-case-action.service.spec.js
@@ -29,7 +29,7 @@
           EmailManagersCaseAction.doAction(caseObj, 'email', jasmine.any(Function));
         });
 
-        it('calls CRM.alert and return', function () {
+        it('shows an error messages', function () {
           expect(CRM.alert).toHaveBeenCalledWith('Please add a contact as a case manager.', 'No case managers available', 'error');
         });
       });

--- a/ang/test/civicase/case/details/directives/case-details.directive.spec.js
+++ b/ang/test/civicase/case/details/directives/case-details.directive.spec.js
@@ -323,21 +323,23 @@
   });
 
   describe('civicaseCaseDetailsController', function () {
-    var $controller, $provide, $rootScope, $route, $scope, CasesData, crmApiMock;
+    var $controller, $provide, $rootScope, $route, $scope, CasesData, CasesUtils, crmApiMock, loadFormBefore;
 
     beforeEach(module('civicase', 'civicase.data', function (_$provide_) {
       $provide = _$provide_;
+      crmApiMock = jasmine.createSpy('crmApi');
+
+      $provide.value('crmApi', crmApiMock);
     }));
 
-    beforeEach(inject(function (_$controller_, $q, _$rootScope_, _$route_, _CasesData_) {
+    beforeEach(inject(function (_$controller_, $q, _$rootScope_, _$route_, _CasesData_, _CasesUtils_) {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       $route = _$route_;
       CasesData = _CasesData_;
-      crmApiMock = jasmine.createSpy('crmApi').and
-        .returnValue($q.defer().promise);
-
-      $provide.value('crmApi', crmApiMock);
+      CasesUtils = _CasesUtils_;
+      crmApiMock.and
+        .returnValue($q.resolve({ values: CasesData.get() }));
     }));
 
     describe('viewing the case', function () {
@@ -370,14 +372,9 @@
 
     describe('when creating an email', function () {
       var loadFormArguments;
-      var caseClients, caseClientsIds;
 
       beforeEach(function () {
         initController();
-        caseClients = _.filter($scope.item.contacts, function (contact) {
-          return contact.role === 'Client';
-        });
-        caseClientsIds = _.map(caseClients, function (client) { return client.contact_id; });
         spyOn($rootScope, '$broadcast');
         loadFormBefore = CRM.loadForm;
         CRM.loadForm = jasmine.createSpy();
@@ -400,7 +397,7 @@
           caseid: $scope.item.id,
           atype: '3',
           reset: 1,
-          cid: caseClientsIds.join(',')
+          cid: CasesUtils.getAllCaseClientContactIdsFromAllContacts($scope.item.contacts).join(',')
         });
       });
 

--- a/ang/test/civicase/case/details/directives/case-details.directive.spec.js
+++ b/ang/test/civicase/case/details/directives/case-details.directive.spec.js
@@ -397,7 +397,7 @@
           caseid: $scope.item.id,
           atype: '3',
           reset: 1,
-          cid: CasesUtils.getAllCaseClientContactIdsFromAllContacts($scope.item.contacts).join(',')
+          cid: CasesUtils.getAllCaseClientContactIds($scope.item.contacts).join(',')
         });
       });
 

--- a/ang/test/civicase/case/details/directives/case-details.directive.spec.js
+++ b/ang/test/civicase/case/details/directives/case-details.directive.spec.js
@@ -279,7 +279,7 @@
     });
 
     /**
-     * Compiles the directive.
+     * Compiles the civicase-case-details directive.
      */
     function compileDirective () {
       $scope.viewingCaseDetails = formatCase(CasesData.get().values[0]);

--- a/ang/test/civicase/case/details/directives/case-details.directive.spec.js
+++ b/ang/test/civicase/case/details/directives/case-details.directive.spec.js
@@ -369,10 +369,15 @@
     });
 
     describe('when creating an email', function () {
-      var loadFormArguments, loadFormBefore;
+      var loadFormArguments;
+      var caseClients, caseClientsIds;
 
       beforeEach(function () {
         initController();
+        caseClients = _.filter($scope.item.contacts, function (contact) {
+          return contact.role === 'Client';
+        });
+        caseClientsIds = _.map(caseClients, function (client) { return client.contact_id; });
         spyOn($rootScope, '$broadcast');
         loadFormBefore = CRM.loadForm;
         CRM.loadForm = jasmine.createSpy();
@@ -395,7 +400,7 @@
           caseid: $scope.item.id,
           atype: '3',
           reset: 1,
-          context: 'standalone'
+          cid: caseClientsIds.join(',')
         });
       });
 

--- a/ang/test/civicase/case/services/cases-utils.service.spec.js
+++ b/ang/test/civicase/case/services/cases-utils.service.spec.js
@@ -30,5 +30,17 @@
         expect(ContactsCache.add).toHaveBeenCalledWith([1, 2, 3, 4]);
       });
     });
+
+    describe('getAllCaseClientContactIdsFromAllContacts()', function () {
+      var cases;
+
+      beforeEach(function () {
+        cases = CasesData.get().values[0];
+      });
+
+      it('fetches all contacts of the case', function () {
+        expect(CasesUtils.getAllCaseClientContactIdsFromAllContacts(cases.contacts)).toEqual(['170']);
+      });
+    });
   });
 })(CRM._);

--- a/ang/test/civicase/case/services/cases-utils.service.spec.js
+++ b/ang/test/civicase/case/services/cases-utils.service.spec.js
@@ -31,15 +31,15 @@
       });
     });
 
-    describe('getAllCaseClientContactIdsFromAllContacts()', function () {
+    describe('getAllCaseClientContactIds()', function () {
       var cases;
 
       beforeEach(function () {
         cases = CasesData.get().values[0];
       });
 
-      it('fetches all contacts of the case', function () {
-        expect(CasesUtils.getAllCaseClientContactIdsFromAllContacts(cases.contacts)).toEqual(['170']);
+      it('fetches all client contact ids of the case', function () {
+        expect(CasesUtils.getAllCaseClientContactIds(cases.contacts)).toEqual(['170']);
       });
     });
   });


### PR DESCRIPTION
## Overview
This PR adds case clients as default recipients to send email popup on civicase detail pane. And add a proper error validation message for email case manager popup when no case manager are selected.

## Before

<img width="720" alt="Screenshot 2020-01-02 at 8 57 52 PM" src="https://user-images.githubusercontent.com/3340537/71674932-a25a4c00-2da2-11ea-8c02-8296d2d091de.png">
<img width="365" alt="Screenshot 2020-01-02 at 8 32 36 PM" src="https://user-images.githubusercontent.com/3340537/71674940-a9815a00-2da2-11ea-8135-fd74f6430e9d.png">

## After

<img width="479" alt="Screenshot 2020-01-02 at 8 29 43 PM" src="https://user-images.githubusercontent.com/3340537/71674951-b1d99500-2da2-11ea-99ac-a7be55021f02.png">
<img width="365" alt="Screenshot 2020-01-02 at 8 32 36 PM" src="https://user-images.githubusercontent.com/3340537/71674952-b1d99500-2da2-11ea-960e-25ec82ca1b05.png">

## Technical Details
* In `email-managers-case-action.service.js` if no case managers are available then there are no error validation messages for this use case. So we have added a proper error validation message
 * In `case-details.directive.js` set `cid` to contacts id which are the case clients for the particular case. 

## Update
This PR also adds the same solution to the activity pdf letter draft activity popup on the activity panel.
#### Before
<img width="955" alt="Screenshot 2020-01-14 at 12 25 21 PM" src="https://user-images.githubusercontent.com/3340537/72323070-d81a0180-36cd-11ea-92f3-90d002da3876.png">

#### After
<img width="955" alt="Screenshot 2020-01-14 at 12 24 23 PM" src="https://user-images.githubusercontent.com/3340537/72323087-e10ad300-36cd-11ea-956c-648763ce8494.png">

#### Technical Details
While fetching all the activities we now need the related case clients array too. So, the same is added in return params in `loadactivities` function in `activity-feed` directive.
Since this is added in default return param. The same key is removed from the `else` condition attached.
 Now, as we have the case clients object we process them to get the `,` separated list case clients ids to be passed to the activity popup in `view-in-popup` factory inside `getFormParams` function and changed `standalone` context to required value.
Also, when I put `context: standalone` the `To` textbox doesn’t fill up with case clients email addresses. I believe that `cid` doesn’t work with `context` param and hence we have remove `context: standalone` param wherever we have used `cid` param to the popup.
