### PR TITLE
RSE-643: Dashboard Case Type Buttons custom templates

### DIFF
--- a/ang/civicase-base/providers/case-type.provider.js
+++ b/ang/civicase-base/providers/case-type.provider.js
@@ -17,25 +17,25 @@
     /**
      * Returns an instance of the case type service.
      *
-     * @param {object} DashboardCaseTypeButtons the dashboard case type buttons.
+     * @param {object} DashboardCaseTypeItems the dashboard case type items.
      * @returns {object} the case type service.
      */
-    function $get (DashboardCaseTypeButtons) {
+    function $get (DashboardCaseTypeItems) {
       return {
         getAll: getAll,
-        getButtonsForCaseType: getButtonsForCaseType,
         getByCategory: getByCategory,
+        getItemsForCaseType: getItemsForCaseType,
         getTitlesForNames: getTitlesForNames
       };
 
       /**
-       * Returns the Dashboard buttons for the given case type.
+       * Returns the Dashboard items for the given case type.
        *
        * @param {string} caseTypeName the name of the case type to get the buttons for.
        * @returns {object[]} a list of buttons.
        */
-      function getButtonsForCaseType (caseTypeName) {
-        return DashboardCaseTypeButtons[caseTypeName] || [];
+      function getItemsForCaseType (caseTypeName) {
+        return DashboardCaseTypeItems[caseTypeName] || [];
       }
     }
 

--- a/ang/civicase-base/providers/dashboard-case-type-items.provider.js
+++ b/ang/civicase-base/providers/dashboard-case-type-items.provider.js
@@ -1,11 +1,11 @@
 (function (angular, $, _) {
   var module = angular.module('civicase-base');
 
-  module.provider('DashboardCaseTypeButtons', function () {
-    var dashboardCaseTypeButtons = {};
+  module.provider('DashboardCaseTypeItems', function () {
+    var dashboardCaseTypeItems = {};
 
     this.$get = $get;
-    this.addButtons = addButtons;
+    this.addItems = addItems;
 
     /**
      * Provides the case type buttons.
@@ -14,7 +14,7 @@
      *   to them.
      */
     function $get () {
-      return dashboardCaseTypeButtons;
+      return dashboardCaseTypeItems;
     }
 
     /**
@@ -28,14 +28,14 @@
      * @param {string} caseTypeName the name for the case type the buttons belong to.
      * @param {ButtonConfig[]} buttonsConfig a list of case type buttons configurations.
      */
-    function addButtons (caseTypeName, buttonsConfig) {
-      var areButtonsDefined = !!dashboardCaseTypeButtons[caseTypeName];
+    function addItems (caseTypeName, buttonsConfig) {
+      var areButtonsDefined = !!dashboardCaseTypeItems[caseTypeName];
 
       if (!areButtonsDefined) {
-        dashboardCaseTypeButtons[caseTypeName] = [];
+        dashboardCaseTypeItems[caseTypeName] = [];
       }
 
-      dashboardCaseTypeButtons[caseTypeName] = dashboardCaseTypeButtons[caseTypeName]
+      dashboardCaseTypeItems[caseTypeName] = dashboardCaseTypeItems[caseTypeName]
         .concat(buttonsConfig);
     }
   });

--- a/ang/civicase/case/directives/case-overview.directive.html
+++ b/ang/civicase/case/directives/case-overview.directive.html
@@ -76,11 +76,9 @@
           <a ng-href="{{ caseListLink(caseType.name) }}">
             {{ caseType.title }}
           </a>
-          <a class="btn btn-link"
-            ng-href="{{button.url}}"
-            ng-repeat="button in getButtonsForCaseType(caseType.name)">
-            <i class="{{button.icon}}"></i>
-          </a>
+          <span
+            ng-repeat="caseTypeItem in getItemsForCaseType(caseType.name)"
+            ng-include="caseTypeItem.templateUrl"></span>
         </div>
         <div
           class="civicase__case-overview__breakdown-field"

--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -162,7 +162,8 @@
       var params = {
         sequential: 1,
         case_type_category: $scope.caseFilter['case_type_id.case_type_category'],
-        id: $scope.caseFilter.case_type_id
+        id: $scope.caseFilter.case_type_id,
+        is_active: 1
       };
 
       return crmApi('CaseType', 'get', params)

--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -48,7 +48,7 @@
   function civicaseCaseOverviewController ($scope, crmApi, BrowserCache, CaseStatus, CaseType) {
     var BROWSER_CACHE_IDENTIFIER = 'civicase.CaseOverview.hiddenCaseStatuses';
 
-    $scope.getButtonsForCaseType = CaseType.getButtonsForCaseType;
+    $scope.getItemsForCaseType = CaseType.getItemsForCaseType;
     $scope.summaryData = [];
     $scope.caseStatuses = _.chain(CaseStatus.getAll())
       .sortBy(function (status) { return status.weight; })

--- a/ang/civicase/dashboard/directives/dashboard-tab.directive.js
+++ b/ang/civicase/dashboard/directives/dashboard-tab.directive.js
@@ -323,7 +323,7 @@
     function resultsHandler (formatFn, contactsProp, results) {
       // Flattened list of all the contact ids of all the contacts of all the cases
       var contactIds = _(results).pluck(contactsProp).flatten().pluck('contact_id').uniq().value();
-      var formattedResults = results.map(formatFn);
+      var formattedResults = _.map(results, formatFn);
       // The try/catch block is necessary because the service does not
       // return a Promise if it doesn't find any new contacts to fetch
       try {

--- a/ang/test/civicase-base/providers/dashboard-case-type-items.provider.spec.js
+++ b/ang/test/civicase-base/providers/dashboard-case-type-items.provider.spec.js
@@ -1,47 +1,43 @@
 /* eslint-env jasmine */
 
 (function (_, angular) {
-  describe('DashboardCaseTypeButtons', () => {
-    let DashboardCaseTypeButtons, DashboardCaseTypeButtonsProvider;
+  describe('DashboardCaseTypeItems', () => {
+    let DashboardCaseTypeItems, DashboardCaseTypeItemsProvider;
 
     beforeEach(() => {
       initSpyModule('civicase.spy', ['civicase']);
       module('civicase', 'civicase.data', 'civicase.spy');
     });
 
-    beforeEach(inject((_DashboardCaseTypeButtons_) => {
-      DashboardCaseTypeButtons = _DashboardCaseTypeButtons_;
+    beforeEach(inject((_DashboardCaseTypeItems_) => {
+      DashboardCaseTypeItems = _DashboardCaseTypeItems_;
     }));
 
     describe('when no buttons have been defined', () => {
       it('returns an empty object', () => {
-        expect(DashboardCaseTypeButtons).toEqual({});
+        expect(DashboardCaseTypeItems).toEqual({});
       });
     });
 
     describe('when adding buttons to case types', () => {
       beforeEach(() => {
-        DashboardCaseTypeButtonsProvider.addButtons('housing_support', [{
-          icon: 'fa fa-cog',
-          url: 'http://housing_support.co.uk/'
+        DashboardCaseTypeItemsProvider.addItems('housing_support', [{
+          templateUrl: '~/civicase/mock-button-template.html'
         }]);
-        DashboardCaseTypeButtonsProvider.addButtons('adult_day_care_referral', [{
-          icon: 'fa fa-cog',
-          url: 'http://adult_day_care_referral.co.uk/'
+        DashboardCaseTypeItemsProvider.addItems('adult_day_care_referral', [{
+          templateUrl: '~/civicase/mock-button-template.html'
         }]);
       });
 
       it('adds the corresponding button to housing support', () => {
-        expect(DashboardCaseTypeButtons.housing_support).toEqual([{
-          icon: 'fa fa-cog',
-          url: 'http://housing_support.co.uk/'
+        expect(DashboardCaseTypeItems.housing_support).toEqual([{
+          templateUrl: '~/civicase/mock-button-template.html'
         }]);
       });
 
       it('adds the corresponding button to adult day care referral', () => {
-        expect(DashboardCaseTypeButtons.adult_day_care_referral).toEqual([{
-          icon: 'fa fa-cog',
-          url: 'http://adult_day_care_referral.co.uk/'
+        expect(DashboardCaseTypeItems.adult_day_care_referral).toEqual([{
+          templateUrl: '~/civicase/mock-button-template.html'
         }]);
       });
     });
@@ -54,8 +50,8 @@
      */
     function initSpyModule (spyModuleName, spyModuleRequirements) {
       angular.module(spyModuleName, spyModuleRequirements)
-        .config((_DashboardCaseTypeButtonsProvider_) => {
-          DashboardCaseTypeButtonsProvider = _DashboardCaseTypeButtonsProvider_;
+        .config((_DashboardCaseTypeItemsProvider_) => {
+          DashboardCaseTypeItemsProvider = _DashboardCaseTypeItemsProvider_;
         });
     }
   });

--- a/ang/test/civicase/case/directives/case-overview.directive.spec.js
+++ b/ang/test/civicase/case/directives/case-overview.directive.spec.js
@@ -52,11 +52,12 @@
         compileDirective({ caseTypeCategory: 'cases', caseTypeID: [1, 2] });
       });
 
-      it('fetches the case types', function () {
+      it('fetches the active case types', function () {
         expect(crmApi).toHaveBeenCalledWith('CaseType', 'get', {
           sequential: 1,
           case_type_category: 'cases',
-          id: [1, 2]
+          id: [1, 2],
+          is_active: 1
         });
       });
     });


### PR DESCRIPTION
## Overview
This PR changes how the case type buttons are configured to allow custom templates to be used instead of defining buttons through configuration objects.

**Important:** This PR is related to https://github.com/compucorp/uk.co.compucorp.civiawards/pull/48. Please refer to this one for Before and After pictures.

## Technical Details

* the `DashboardCaseTypeButtons` was renamed to `DashboardCaseTypeItems` and it now accepts a `templateUrl` parameter. This is used to include the template next to the corresponding dashboard case type.
* There was an issue introduced by https://github.com/compucorp/uk.co.compucorp.civicase/pull/318 when loading case types. It would load all case types, even those that were not active. This was fixed.
