### PR TITLE
RSE-298: Remove the Administer Case Category Permission.

### DIFF
--- a/CRM/Civicase/Hook/alterAPIPermissions/Case.php
+++ b/CRM/Civicase/Hook/alterAPIPermissions/Case.php
@@ -72,7 +72,6 @@ class CRM_Civicase_Hook_alterAPIPermissions_Case {
     $permissions['relationship_type']['getcaseroles'] = $permissions['relationship_type']['get'];
     $permissions['case']['getcount'] = [$basicCasePermissions];
     $permissions['case_type']['get'] = [$basicCasePermissions];
-    $permissions['case_type']['create'] = $permissions['case_type']['update'] = [$caseCategoryPermissions['ADMINISTER_CASE_CATEGORY']['name']];
     $permissions['casetype']['getcount'] = [$basicCasePermissions];
     $permissions['custom_value']['gettreevalues'] = [$basicCasePermissions];
 

--- a/CRM/Civicase/Service/CaseCategoryPermission.php
+++ b/CRM/Civicase/Service/CaseCategoryPermission.php
@@ -35,11 +35,6 @@ class CRM_Civicase_Service_CaseCategoryPermission {
         'label' => $this->replaceWords('CiviCase: add cases', $caseCategoryName),
         'description' => $this->replaceWords('Open a new case', $caseCategoryName),
       ],
-      'ADMINISTER_CASE_CATEGORY' => [
-        'name' => $this->replaceWords('administer CiviCase', $caseCategoryName),
-        'label' => $this->replaceWords('CiviCase: administer CiviCase', $caseCategoryName),
-        'description' => $this->replaceWords('Define case types, access deleted cases', $caseCategoryName),
-      ],
       'ACCESS_CASE_CATEGORY_AND_ACTIVITIES' => [
         'name' => $this->replaceWords('access all cases and activities', $caseCategoryName),
         'label' => $this->replaceWords('CiviCase: access all cases and activities', $caseCategoryName),

--- a/ang/civicase.ang.php
+++ b/ang/civicase.ang.php
@@ -160,7 +160,7 @@ function set_case_actions(&$options, $caseCategoryPermissions) {
       'icon' => 'fa-link',
     ],
   ];
-  if (CRM_Core_Permission::check($caseCategoryPermissions['ADMINISTER_CASE_CATEGORY']['name'])) {
+  if (CRM_Core_Permission::check('administer CiviCase')) {
     $options['caseActions'][] = [
       'title' => ts('Merge 2 Cases'),
       'number' => 2,


### PR DESCRIPTION
## Overview
When a new case type category is added, some dynamic permissions are generated for the case type category derived from the original Civicase permissions. One of such permission is the `administer CiviCase` permission. The awards category variant will be `administer CiviAwards`. This PR removes the process of generating category permission variant for this particular permission. We only want `administer CiviCase` and no other case type variant.

## Before
- Case type category variants for the `administer CiviCase` permission e.g `administer CiviAwards` exists

## After
- Case type category variants for the `administer CiviCase` permission e.g `administer CiviAwards` no longer exists

The permission `ADMINISTER_CASE_CATEGORY` key in the `get` function of the CaseCategoryPermission service was removed. Other places where this key is used is replaced with the original permission i.e `administer CiviCase`

