### PR TITLE
RSE-711: Fix Issue With Clicking On Save And New Button Shows Original Case Type Instead Of Case Category Form

### DIFF
--- a/CRM/Civicase/Hook/PostProcess/SetUserContextForSaveAndNewCase.php
+++ b/CRM/Civicase/Hook/PostProcess/SetUserContextForSaveAndNewCase.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Class CRM_Civicase_Hook_PostProcess_SetUserContextForSaveAndNewCase.
+ */
+class CRM_Civicase_Hook_PostProcess_SetUserContextForSaveAndNewCase {
+
+  /**
+   * Sets the User context URL when saving and adding a new case.
+   *
+   * @param string $formName
+   *   Form name.
+   * @param CRM_Core_Form $form
+   *   Form object class.
+   */
+  public function run($formName, CRM_Core_Form &$form) {
+    if (!$this->shouldRun($form, $formName)) {
+      return;
+    }
+
+    CRM_Core_Session::singleton()->replaceUserContext($form->controller->_entryURL);
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * @param CRM_Core_Form $form
+   *   Form object class.
+   * @param string $formName
+   *   Form name.
+   *
+   * @return bool
+   *   returns TRUE or FALSE.
+   */
+  private function shouldRun(CRM_Core_Form $form, $formName) {
+    $buttonName = $form->controller->getButtonName();
+    return $formName == CRM_Case_Form_Case::class && $buttonName == $form->getButtonName('upload', 'new');
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -473,6 +473,7 @@ function civicase_civicrm_postProcess($formName, &$form) {
   $hooks = [
     new CRM_Civicase_Hook_PostProcess_CaseCategoryCustomFieldsSaver(),
     new CRM_Civicase_Hook_PostProcess_ProcessCaseCategoryCustomFieldsForSave(),
+    new CRM_Civicase_Hook_PostProcess_SetUserContextForSaveAndNewCase(),
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview
When creating a new Case of a particular case type category on the Case add form and the `Save and New` button is clicked, rather than redirect to the new Case form view for the case type category, it redirects to the default Case type form. This PR fixes the issue.

## Before
Issue described in overview exists.

## After
When creating a new Case of a particular case type category on the Case add form and the `Save and New` button is clicked it opens a new for for the case type category.

## Technical Details
 The Case form to be opened is determined by the case type category parameter passed in the URL e.g for the Case creation for the Award form: `civicrm/case/add?case_type_category=prospecting&action=add`. When the `Save and New` button is clicked, rather than use the entry URL for accessing the form, Civi discards the URL parameters and sets a new URL [here:](https://github.com/civicrm/civicrm-core/blob/master/CRM/Case/Form/Activity/OpenCase.php#L332-L337) .
To fix this, we use the `civicase_civicrm_postProcess` to set the user context after the form has been submitted when the `Save and New` button is clicked.

