### PR TITLE
RSE-644: Show reviews form

### DIFF
--- a/ang/civicase-base/providers/activity-forms.provider.js
+++ b/ang/civicase-base/providers/activity-forms.provider.js
@@ -14,7 +14,7 @@
 
     /**
      * Returns a `getActivityFormService` function that can be used to find
-     * right right form service for the given activity.
+     * the right form service for the given activity.
      *
      * @param {object} $injector the angular injector service.
      * @returns {object} The Activity Forms service.
@@ -27,7 +27,7 @@
         .value();
 
       return {
-        getActivityFormService
+        getActivityFormService: getActivityFormService
       };
 
       /**

--- a/ang/civicase-base/providers/activity-forms.provider.js
+++ b/ang/civicase-base/providers/activity-forms.provider.js
@@ -1,0 +1,74 @@
+(function (_, angular) {
+  var module = angular.module('civicase-base');
+
+  module.provider('ActivityForms', ActivityFormsProvider);
+
+  /**
+   * Activity Forms Provider.
+   */
+  function ActivityFormsProvider () {
+    var activityForms = [];
+
+    this.$get = $get;
+    this.addActivityForms = addActivityForms;
+
+    /**
+     * Returns a `getActivityFormService` function that can be used to find
+     * right right form service for the given activity.
+     *
+     * @param {object} $injector the angular injector service.
+     * @returns {object} The Activity Forms service.
+     */
+    function $get ($injector) {
+      var activityFormServices = _.chain(activityForms)
+        .sortBy('weight')
+        .map('name')
+        .map(injectActivityFormService)
+        .value();
+
+      return {
+        getActivityFormService
+      };
+
+      /**
+       * @param {object} activity an activity object.
+       * @param {object} [options={}] configuration options for the form.
+       * @returns {object|undefined} the first activity form service that can handle
+       *   the given activity.
+       */
+      function getActivityFormService (activity, options) {
+        return _.find(activityFormServices, function (activityFormService) {
+          return activityFormService && activityFormService
+            .canHandleActivity(activity, options || {});
+        });
+      }
+
+      /**
+       * @param {string} activityFormServiceName the name of the activity form service.
+       * @returns {object|null} the activity form service corresponding to the given name.
+       */
+      function injectActivityFormService (activityFormServiceName) {
+        try {
+          return $injector.get(activityFormServiceName);
+        } catch (error) {
+          return null;
+        }
+      }
+    }
+
+    /**
+     * Adds the given activity form configurations to the provider.
+     *
+     * @param {activityFormConfig[]} activityFormConfigs a list of activity form names and weights.
+     */
+    function addActivityForms (activityFormConfigs) {
+      activityForms = activityForms.concat(activityFormConfigs);
+    }
+  }
+
+  /**
+   * @typedef {object} activityFormConfig
+   * @property {string} name the activity form service name.
+   * @property {number} weight the priority value compared to other services.
+   */
+})(CRM._, angular);

--- a/ang/civicase/activity/activity-forms/activity-forms.config.js
+++ b/ang/civicase/activity/activity-forms/activity-forms.config.js
@@ -12,11 +12,11 @@
   function activityFormsConfiguration (ActivityFormsProvider) {
     var addActivityFormConfigs = [
       {
-        name: 'ActivityPopupForm',
+        name: 'DraftEmailOrPdfActivityForm',
         weight: 0
       },
       {
-        name: 'DraftEmailOrPdfActivityForm',
+        name: 'ActivityPopupForm',
         weight: 1
       },
       {

--- a/ang/civicase/activity/activity-forms/activity-forms.config.js
+++ b/ang/civicase/activity/activity-forms/activity-forms.config.js
@@ -1,0 +1,30 @@
+(function (angular) {
+  var module = angular.module('civicase');
+
+  module.config(activityFormsConfiguration);
+
+  /**
+   * Configures the list of activity forms services that will be available
+   * when displaying a form for a particular activity.
+   *
+   * @param {object} ActivityFormsProvider the activity forms provider.
+   */
+  function activityFormsConfiguration (ActivityFormsProvider) {
+    var addActivityFormConfigs = [
+      {
+        name: 'ActivityPopupForm',
+        weight: 0
+      },
+      {
+        name: 'DraftEmailOrPdfActivityForm',
+        weight: 1
+      },
+      {
+        name: 'ViewActivityForm',
+        weight: 2
+      }
+    ];
+
+    ActivityFormsProvider.addActivityForms(addActivityFormConfigs);
+  }
+})(angular);

--- a/ang/civicase/activity/activity-forms/services/activity-popup-form.service.js
+++ b/ang/civicase/activity/activity-forms/services/activity-popup-form.service.js
@@ -1,0 +1,45 @@
+(function (angular, getCrmUrl) {
+  var module = angular.module('civicase');
+
+  module.service('ActivityPopupForm', ActivityPopupForm);
+
+  /**
+   * Activity Popup Form service.
+   */
+  function ActivityPopupForm () {
+    this.canHandleActivity = canHandleActivity;
+    this.getActivityFormUrl = getActivityFormUrl;
+
+    /**
+     * Only handles activity forms that will be displayed in a popup.
+     * It supports both stand-alone activities and case activities.
+     *
+     * @param {object} activity an activity object.
+     * @param {object} [options] form options.
+     * @returns {boolean} true when it can handle the activity and form options.
+     */
+    function canHandleActivity (activity, options) {
+      return (options && options.formType === 'popup') || false;
+    }
+
+    /**
+     * @param {object} activity an activity object.
+     * @returns {string} the URL for the activity form that will be displayed in a popup.
+     */
+    function getActivityFormUrl (activity) {
+      var urlPath = 'civicrm/activity';
+      var urlParams = {
+        action: 'update',
+        id: activity.id,
+        reset: 1
+      };
+
+      if (activity.case_id) {
+        urlPath = 'civicrm/case/activity';
+        urlParams.caseid = activity.case_id;
+      }
+
+      return getCrmUrl(urlPath, urlParams);
+    }
+  }
+})(angular, CRM.url);

--- a/ang/civicase/activity/activity-forms/services/draft-email-or-pdf-activity-form.service.js
+++ b/ang/civicase/activity/activity-forms/services/draft-email-or-pdf-activity-form.service.js
@@ -1,0 +1,29 @@
+(function (_, angular, getCrmUrl) {
+  var module = angular.module('civicase');
+
+  module.service('DraftEmailOrPdfActivityForm', DraftEmailOrPdfActivityForm);
+
+  /**
+   * Draft email or PDF activity form service.
+   *
+   * @param {Function} checkIfDraftEmailOrPDFActivity the check if draft email or pdf activity function.
+   */
+  function DraftEmailOrPdfActivityForm (checkIfDraftEmailOrPDFActivity) {
+    this.canHandleActivity = checkIfDraftEmailOrPDFActivity;
+    this.getActivityFormUrl = getActivityFormUrl;
+
+    /**
+     * @param {object} activity an activity object.
+     * @returns {string} the form URL for activities that are either email drafts or PDF drafts.
+     */
+    function getActivityFormUrl (activity) {
+      return getCrmUrl('civicrm/activity/email/add', {
+        action: 'add',
+        caseId: activity.case_id,
+        context: 'standalone',
+        draft_id: activity.id,
+        reset: '1'
+      });
+    }
+  }
+})(CRM._, angular, CRM.url);

--- a/ang/civicase/activity/activity-forms/services/view-activity-form.service.js
+++ b/ang/civicase/activity/activity-forms/services/view-activity-form.service.js
@@ -1,0 +1,38 @@
+(function (angular, getCrmUrl) {
+  var module = angular.module('civicase');
+
+  module.service('ViewActivityForm', ViewActivityForm);
+
+  /**
+   * View Activity Form service.
+   */
+  function ViewActivityForm () {
+    this.canHandleActivity = canHandleActivity;
+    this.getActivityFormUrl = getActivityFormUrl;
+
+    /**
+     * The service can handle any activity that has already been saved.
+     *
+     * @param {object} activity an activity object.
+     * @returns {boolean} true when the service can handle the given activity.
+     */
+    function canHandleActivity (activity) {
+      return !!activity.id;
+    }
+
+    /**
+     * @param {object} activity an activity object.
+     * @returns {string} the URL for the form to view the given activity.
+     */
+    function getActivityFormUrl (activity) {
+      var context = activity.case_id ? 'case' : 'activity';
+
+      return getCrmUrl('civicrm/activity', {
+        action: 'view',
+        id: activity.id,
+        reset: 1,
+        context: context
+      });
+    }
+  }
+})(angular, CRM.url);

--- a/ang/civicase/activity/factories/check-if-draft-email-or-pdf.factory.js
+++ b/ang/civicase/activity/factories/check-if-draft-email-or-pdf.factory.js
@@ -1,0 +1,29 @@
+(function (_, angular) {
+  var module = angular.module('civicase');
+
+  module.factory('checkIfDraftEmailOrPDFActivity', checkIfDraftEmailOrPDFActivityFactory);
+
+  /**
+   * Check if draft email or PDF activity service.
+   *
+   * @param {object} ActivityType the activity type service.
+   * @returns {Function} the service function.
+   */
+  function checkIfDraftEmailOrPDFActivityFactory (ActivityType) {
+    var emailOrPdfActivityNames = ['Email', 'Print PDF Letter'];
+
+    return checkIfDraftEmailOrPDFActivity;
+
+    /**
+     * @param {object} activity an activity object.
+     * @returns {boolean} true if the activity is either an email draft or a PDF draft.
+     */
+    function checkIfDraftEmailOrPDFActivity (activity) {
+      var activityType = ActivityType.findById(activity.activity_type_id);
+      var isEmailOrPdf = _.includes(emailOrPdfActivityNames, activityType.name);
+      var isDraft = activity.status_name === 'Draft';
+
+      return isEmailOrPdf && isDraft;
+    }
+  }
+})(CRM._, angular);

--- a/ang/civicase/activity/factories/view-in-popup.factory.js
+++ b/ang/civicase/activity/factories/view-in-popup.factory.js
@@ -11,7 +11,7 @@
      */
     function viewInPopup ($event, activity) {
       var isClickingAButton = $event && $($event.target).is('a, a *, input, button, button *');
-      var activityForm = ActivityForms.getFormService(activity, {
+      var activityForm = ActivityForms.getActivityFormService(activity, {
         formType: 'popup'
       });
 
@@ -19,7 +19,7 @@
         return;
       }
 
-      return CRM.loadForm(activityForm.getUrl(activity));
+      return CRM.loadForm(activityForm.getActivityFormUrl(activity));
     }
 
     return viewInPopup;

--- a/ang/civicase/activity/factories/view-in-popup.factory.js
+++ b/ang/civicase/activity/factories/view-in-popup.factory.js
@@ -1,7 +1,7 @@
 (function (angular, $, _, CRM) {
   var module = angular.module('civicase');
 
-  module.factory('viewInPopup', function (ActivityType) {
+  module.factory('viewInPopup', function (ActivityForms, ActivityType) {
     /**
      * View given activity in a popup
      *
@@ -10,77 +10,16 @@
      * @returns {object} jQuery object
      */
     function viewInPopup ($event, activity) {
-      if ($event && $($event.target).is('a, a *, input, button, button *')) {
+      var isClickingAButton = $event && $($event.target).is('a, a *, input, button, button *');
+      var activityForm = ActivityForms.getFormService(activity, {
+        formType: 'popup'
+      });
+
+      if (!activityForm || isClickingAButton) {
         return;
       }
 
-      return CRM.loadForm(CRM.url(getFormUrl(activity), getFormParams(activity)));
-    }
-
-    /**
-     * Get Form url for the given activity
-     *
-     * @param {object} activity activity for which url needs to be generated
-     * @returns {string} form url
-     */
-    function getFormUrl (activity) {
-      var activityFormUrl = 'civicrm/activity';
-
-      if (activity.case_id) {
-        activityFormUrl = 'civicrm/case/activity';
-      }
-
-      if (checkIfDraftEmailOrPDFActivity(activity)) {
-        activityFormUrl = 'civicrm/activity/email/add';
-      }
-
-      return activityFormUrl;
-    }
-
-    /**
-     * Get Form parameters for the given activity
-     *
-     * @param {object} activity activity for which parameters needs to be generated
-     * @returns {object} form parameters
-     */
-    function getFormParams (activity) {
-      var activityFormParams = {
-        action: 'update',
-        id: activity.id,
-        reset: 1
-      };
-
-      if (activity.case_id) {
-        activityFormParams.caseid = activity.case_id;
-      }
-
-      if (checkIfDraftEmailOrPDFActivity(activity)) {
-        activityFormParams = {
-          action: 'add',
-          reset: '1',
-          caseId: activity.case_id,
-          context: 'standalone',
-          draft_id: activity.id
-        };
-      }
-
-      return activityFormParams;
-    }
-
-    /**
-     * Checks if the given activity is in draft state and is of email of pdf type
-     *
-     * @param {object} activity activty object
-     * @returns {boolean} if email or pdf type and if in draft state
-     */
-    function checkIfDraftEmailOrPDFActivity (activity) {
-      var activityTypeName = ActivityType.findById(activity.activity_type_id).name;
-
-      var isDraftEmailOrPdfTypeActivity =
-        (activityTypeName === 'Email' || activityTypeName === 'Print PDF Letter') &&
-        activity.status_name === 'Draft';
-
-      return isDraftEmailOrPdfTypeActivity;
+      return CRM.loadForm(activityForm.getUrl(activity));
     }
 
     return viewInPopup;

--- a/ang/civicase/activity/panel/directives/activity-panel.directive.html
+++ b/ang/civicase/activity/panel/directives/activity-panel.directive.html
@@ -1,4 +1,7 @@
-<div class="civicase__activity-panel" ng-controller="caseActivityCardController">
+<div
+  class="civicase__activity-panel civicase__activity-panel--{{(activity.type).split(' ').join('_')}}"
+  ng-controller="caseActivityCardController"
+>
   <div class="panel panel-default panel-w-subheading">
     <div class="panel-heading clearfix">
       <span class="civicase__activity-panel__id">ID-{{activity.id}}</span>

--- a/ang/test/civicase-base/providers/activity-forms.provider.spec.js
+++ b/ang/test/civicase-base/providers/activity-forms.provider.spec.js
@@ -1,0 +1,102 @@
+/* eslint-env jasmine */
+((_, angular) => {
+  describe('ActivityForms', () => {
+    let activity, activityForm, ActivityForms, CatchAllActivityFormSpy, SpyActivityForm2;
+
+    beforeEach(initSpyModule);
+
+    beforeEach(module('civicase-base', 'civicase.spy'));
+
+    beforeEach(inject((_ActivityForms_, _CatchAllActivityFormSpy_, _SpyActivityForm2_) => {
+      ActivityForms = _ActivityForms_;
+      CatchAllActivityFormSpy = _CatchAllActivityFormSpy_;
+      SpyActivityForm2 = _SpyActivityForm2_;
+    }));
+
+    describe('when requesting the form service for the activity spy 2', () => {
+      beforeEach(() => {
+        activity = { type: 'spy2' };
+        activityForm = ActivityForms.getActivityFormService(activity);
+      });
+
+      it('returns the spy 2 activity form service', () => {
+        expect(activityForm).toBe(SpyActivityForm2);
+      });
+    });
+
+    describe('when requesting the form service for any activity', () => {
+      beforeEach(() => {
+        activity = { type: 'spy99' };
+        activityForm = ActivityForms.getActivityFormService(activity);
+      });
+
+      it('returns the catch all activity form service', () => {
+        expect(activityForm).toBe(CatchAllActivityFormSpy);
+      });
+    });
+
+    /**
+     * Initializes the spy module that adds spy activity forms and a catch all activity
+     * form.
+     */
+    function initSpyModule () {
+      const module = angular.module('civicase.spy', ['civicase-base']);
+
+      (() => {
+        defineSpyActivityForms();
+        defineCatchAllActivityForm();
+        configureActivityForms();
+      })();
+
+      /**
+       * Configures all the spy activity forms.
+       */
+      function configureActivityForms () {
+        module
+          .config((ActivityFormsProvider) => {
+            ActivityFormsProvider.addActivityForms([
+              {
+                name: 'SpyActivityForm2',
+                weight: 2
+              },
+              {
+                name: 'SpyActivityForm3',
+                weight: 3
+              },
+              {
+                name: 'SpyActivityForm1',
+                weight: 1
+              },
+              {
+                name: 'CatchAllActivityFormSpy',
+                weight: 4
+              }
+            ]);
+          });
+      }
+
+      /**
+       * Defines a catch all spy form.
+       */
+      function defineCatchAllActivityForm () {
+        module.service('CatchAllActivityFormSpy', function () {
+          this.canHandleActivity = () => true;
+          this.getActivityFormUrl = _.noop;
+        });
+      }
+
+      /**
+       * Defines several spy forms.
+       */
+      function defineSpyActivityForms () {
+        _.range(1, 3)
+          .forEach((spyNumber) => {
+            module.service(`SpyActivityForm${spyNumber}`, function SpyActivityForm () {
+              this.canHandleActivity = (activity) => activity.type === `spy${spyNumber}`;
+              this.getActivityFormUrl = _.noop;
+            });
+          });
+      }
+    }
+  });
+})(CRM._, angular);

--- a/ang/test/civicase/activity/activity-forms/activity-forms.config.spec.js
+++ b/ang/test/civicase/activity/activity-forms/activity-forms.config.spec.js
@@ -14,18 +14,18 @@
     beforeEach(inject);
 
     describe('when the civicase module is configured', () => {
-      it('adds the activity popup form service', () => {
-        expect(ActivityFormsProvider.addActivityForms)
-          .toHaveBeenCalledWith(jasmine.arrayContaining([{
-            name: 'ActivityPopupForm',
-            weight: 0
-          }]));
-      });
-
       it('adds the draft email or pdf activity form service', () => {
         expect(ActivityFormsProvider.addActivityForms)
           .toHaveBeenCalledWith(jasmine.arrayContaining([{
             name: 'DraftEmailOrPdfActivityForm',
+            weight: 0
+          }]));
+      });
+
+      it('adds the activity popup form service', () => {
+        expect(ActivityFormsProvider.addActivityForms)
+          .toHaveBeenCalledWith(jasmine.arrayContaining([{
+            name: 'ActivityPopupForm',
             weight: 1
           }]));
       });

--- a/ang/test/civicase/activity/activity-forms/activity-forms.config.spec.js
+++ b/ang/test/civicase/activity/activity-forms/activity-forms.config.spec.js
@@ -1,0 +1,42 @@
+/* eslint-env jasmine */
+(() => {
+  describe('Activity forms configuration', () => {
+    let ActivityFormsProvider;
+
+    beforeEach(module('civicase-base', (_ActivityFormsProvider_) => {
+      ActivityFormsProvider = _ActivityFormsProvider_;
+
+      spyOn(ActivityFormsProvider, 'addActivityForms');
+    }));
+
+    beforeEach(module('civicase'));
+
+    beforeEach(inject);
+
+    describe('when the civicase module is configured', () => {
+      it('adds the activity popup form service', () => {
+        expect(ActivityFormsProvider.addActivityForms)
+          .toHaveBeenCalledWith(jasmine.arrayContaining([{
+            name: 'ActivityPopupForm',
+            weight: 0
+          }]));
+      });
+
+      it('adds the draft email or pdf activity form service', () => {
+        expect(ActivityFormsProvider.addActivityForms)
+          .toHaveBeenCalledWith(jasmine.arrayContaining([{
+            name: 'DraftEmailOrPdfActivityForm',
+            weight: 1
+          }]));
+      });
+
+      it('adds the view activity form service', () => {
+        expect(ActivityFormsProvider.addActivityForms)
+          .toHaveBeenCalledWith(jasmine.arrayContaining([{
+            name: 'ViewActivityForm',
+            weight: 2
+          }]));
+      });
+    });
+  });
+})();

--- a/ang/test/civicase/activity/activity-forms/services/activity-popup-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/activity-popup-form.service.spec.js
@@ -1,0 +1,76 @@
+/* eslint-env jasmine */
+((_, getCrmUrl) => {
+  describe('ActivityPopupForm', () => {
+    let activity, activityFormUrl, ActivityPopupForm, expectedActivityFormUrl, canHandle;
+
+    beforeEach(module('civicase', 'civicase-base', 'civicase.data'));
+
+    beforeEach(inject((_activitiesMockData_, _ActivityPopupForm_) => {
+      ActivityPopupForm = _ActivityPopupForm_;
+      activity = _.chain(_activitiesMockData_.get())
+        .first()
+        .cloneDeep()
+        .value();
+    }));
+
+    describe('handling activity forms', () => {
+      describe('when handling a popup form', () => {
+        beforeEach(() => {
+          canHandle = ActivityPopupForm.canHandleActivity(activity, {
+            formType: 'popup'
+          });
+        });
+
+        it('can handle the popup form', () => {
+          expect(canHandle).toBe(true);
+        });
+      });
+
+      describe('when handling any other form type', () => {
+        beforeEach(() => {
+          canHandle = ActivityPopupForm.canHandleActivity(activity);
+        });
+
+        it('cannot handle the form', () => {
+          expect(canHandle).toBe(false);
+        });
+      });
+    });
+
+    describe('getting the activity form url', () => {
+      describe('when getting the form url for a stand alone activity', () => {
+        beforeEach(() => {
+          delete activity.case_id;
+
+          activityFormUrl = ActivityPopupForm.getActivityFormUrl(activity);
+          expectedActivityFormUrl = getCrmUrl('civicrm/activity', {
+            action: 'update',
+            id: activity.id,
+            reset: 1
+          });
+        });
+
+        it('returns the popup form url for the stand alone activity', () => {
+          expect(activityFormUrl).toEqual(expectedActivityFormUrl);
+        });
+      });
+
+      describe('when getting the form url for a case activity', () => {
+        beforeEach(() => {
+          activity.case_id = _.uniqueId();
+          activityFormUrl = ActivityPopupForm.getActivityFormUrl(activity);
+          expectedActivityFormUrl = getCrmUrl('civicrm/case/activity', {
+            action: 'update',
+            id: activity.id,
+            reset: 1,
+            caseid: activity.case_id
+          });
+        });
+
+        it('returns the popup form url for the case activity', () => {
+          expect(activityFormUrl).toEqual(expectedActivityFormUrl);
+        });
+      });
+    });
+  });
+})(CRM._, CRM.url);

--- a/ang/test/civicase/activity/activity-forms/services/draft-email-or-pdf-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/draft-email-or-pdf-activity-form.service.spec.js
@@ -1,0 +1,43 @@
+/* eslint-env jasmine */
+((_, getCrmUrl) => {
+  describe('DraftEmailOrPdfActivityForm', () => {
+    let activity, activityFormUrl, checkIfDraftEmailOrPDFActivity,
+      DraftEmailOrPdfActivityForm, expectedActivityFormUrl;
+
+    beforeEach(module('civicase', 'civicase-base', 'civicase.data'));
+
+    beforeEach(inject((_activitiesMockData_, _checkIfDraftEmailOrPDFActivity_,
+      _DraftEmailOrPdfActivityForm_) => {
+      checkIfDraftEmailOrPDFActivity = _checkIfDraftEmailOrPDFActivity_;
+      DraftEmailOrPdfActivityForm = _DraftEmailOrPdfActivityForm_;
+      activity = _.chain(_activitiesMockData_.get())
+        .first()
+        .cloneDeep()
+        .value();
+    }));
+
+    describe('handling activity forms', () => {
+      it('uses the check if draft email or pdf activity service to determine if it can handle the activity', () => {
+        expect(DraftEmailOrPdfActivityForm.canHandleActivity)
+          .toBe(checkIfDraftEmailOrPDFActivity);
+      });
+    });
+
+    describe('when getting the form url', () => {
+      beforeEach(() => {
+        activityFormUrl = DraftEmailOrPdfActivityForm.getActivityFormUrl(activity);
+        expectedActivityFormUrl = getCrmUrl('civicrm/activity/email/add', {
+          action: 'add',
+          caseId: activity.case_id,
+          context: 'standalone',
+          draft_id: activity.id,
+          reset: '1'
+        });
+      });
+
+      it('returns the popup form url for the draft activity', () => {
+        expect(activityFormUrl).toEqual(expectedActivityFormUrl);
+      });
+    });
+  });
+})(CRM._, CRM.url);

--- a/ang/test/civicase/activity/activity-forms/services/view-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/view-activity-form.service.spec.js
@@ -1,0 +1,75 @@
+/* eslint-env jasmine */
+((_, getCrmUrl) => {
+  describe('ViewActivityForm', () => {
+    let activity, activityFormUrl, expectedActivityFormUrl, canHandle, ViewActivityForm;
+
+    beforeEach(module('civicase', 'civicase-base', 'civicase.data'));
+
+    beforeEach(inject((_activitiesMockData_, _ViewActivityForm_) => {
+      ViewActivityForm = _ViewActivityForm_;
+      activity = _.chain(_activitiesMockData_.get())
+        .first()
+        .cloneDeep()
+        .value();
+    }));
+
+    describe('handling activity forms', () => {
+      describe('when handling an existing activity', () => {
+        beforeEach(() => {
+          canHandle = ViewActivityForm.canHandleActivity(activity);
+        });
+
+        it('can handle the activity', () => {
+          expect(canHandle).toBe(true);
+        });
+      });
+
+      describe('when handling an activity that has not been saved', () => {
+        beforeEach(() => {
+          delete activity.id;
+          canHandle = ViewActivityForm.canHandleActivity(activity);
+        });
+
+        it('cannot handle the activity', () => {
+          expect(canHandle).toBe(false);
+        });
+      });
+    });
+
+    describe('getting the activity form url', () => {
+      describe('when getting the form url for a stand alone activity', () => {
+        beforeEach(() => {
+          delete activity.case_id;
+
+          activityFormUrl = ViewActivityForm.getActivityFormUrl(activity);
+          expectedActivityFormUrl = getCrmUrl('civicrm/activity', {
+            action: 'view',
+            id: activity.id,
+            reset: 1,
+            context: 'activity'
+          });
+        });
+
+        it('returns the form url for the stand alone activity', () => {
+          expect(activityFormUrl).toEqual(expectedActivityFormUrl);
+        });
+      });
+
+      describe('when getting the form url for a case activity', () => {
+        beforeEach(() => {
+          activityFormUrl = ViewActivityForm.getActivityFormUrl(activity);
+          expectedActivityFormUrl = getCrmUrl('civicrm/activity', {
+            action: 'view',
+            id: activity.id,
+            reset: 1,
+            context: 'case'
+          });
+        });
+
+        it('returns the form url for the case activity', () => {
+          expect(activityFormUrl).toEqual(expectedActivityFormUrl);
+        });
+      });
+    });
+  });
+})(CRM._, CRM.url);

--- a/ang/test/civicase/activity/factories/check-if-draft-email-or-pdf.factory.spec.js
+++ b/ang/test/civicase/activity/factories/check-if-draft-email-or-pdf.factory.spec.js
@@ -1,0 +1,74 @@
+/* eslint-env jasmine */
+((_) => {
+  describe('checkIfDraftEmailOrPDFActivity', () => {
+    let activity, checkIfDraftEmailOrPDFActivity, emailActivityTypeId,
+      isDraftEmailOrPdf, pdfActivityTypeId;
+
+    beforeEach(module('civicase.data', 'civicase'));
+
+    beforeEach(inject((_activitiesMockData_, _ActivityTypesData_,
+      _checkIfDraftEmailOrPDFActivity_) => {
+      checkIfDraftEmailOrPDFActivity = _checkIfDraftEmailOrPDFActivity_;
+      emailActivityTypeId = _.chain(_ActivityTypesData_.values)
+        .findKey({ name: 'Email' })
+        .cloneDeep()
+        .value();
+      pdfActivityTypeId = _.chain(_ActivityTypesData_.values)
+        .findKey({ name: 'Print PDF Letter' })
+        .cloneDeep()
+        .value();
+      activity = _.chain(_activitiesMockData_.get())
+        .first()
+        .cloneDeep()
+        .value();
+    }));
+
+    describe('when checking an email draft', () => {
+      beforeEach(() => {
+        activity.activity_type_id = emailActivityTypeId;
+        activity.status_name = 'Draft';
+        isDraftEmailOrPdf = checkIfDraftEmailOrPDFActivity(activity);
+      });
+
+      it('returns true', () => {
+        expect(isDraftEmailOrPdf).toBe(true);
+      });
+    });
+
+    describe('when checking a non draft email', () => {
+      beforeEach(() => {
+        activity.activity_type_id = emailActivityTypeId;
+        activity.status_name = 'Completed';
+        isDraftEmailOrPdf = checkIfDraftEmailOrPDFActivity(activity);
+      });
+
+      it('returns false', () => {
+        expect(isDraftEmailOrPdf).toBe(false);
+      });
+    });
+
+    describe('when checking a PDF draft', () => {
+      beforeEach(() => {
+        activity.activity_type_id = pdfActivityTypeId;
+        activity.status_name = 'Draft';
+        isDraftEmailOrPdf = checkIfDraftEmailOrPDFActivity(activity);
+      });
+
+      it('returns true', () => {
+        expect(isDraftEmailOrPdf).toBe(true);
+      });
+    });
+
+    describe('when checking a non draft PDF', () => {
+      beforeEach(() => {
+        activity.activity_type_id = pdfActivityTypeId;
+        activity.status_name = 'Completed';
+        isDraftEmailOrPdf = checkIfDraftEmailOrPDFActivity(activity);
+      });
+
+      it('returns false', () => {
+        expect(isDraftEmailOrPdf).toBe(false);
+      });
+    });
+  });
+})(CRM._);


### PR DESCRIPTION
## Overview
This PR allows other extensions to define the URL to use when viewing an activity depending on its type and the way the form should be shown.

For before and after please check https://github.com/compucorp/uk.co.compucorp.civiawards/pull/51

## Technical Details

A new activity form provider has been added. It can be used to define the services that will return the form URLs. For example:

```js
ActivityForms. addActivityForms([
  {
    name: 'MyCustomForm',
    weight: 1
  }
]);
```

The `name` should be the name of the service to inject, and the `weight is the priority compared to other services. Only one service will be used to determine the URL.

The services themselves should define 2 functions:

* `canHandleActivity` which should return `true` if the service can return the form URL taking into consideration the activity (any property of the activity including its type, status, if it belongs to a case or not, etc.) and the form options (for example, if the form will be shown on a popup or not).
* `getActivityFormUrl` returns the actual form URL for the activity.

We defined 3 new activity form services by taking into consideration the previous way to get these URLs:

* `DraftEmailOrPdfActivityForm` for draft emails and PDF activitities.
* `ActivityPopupForm` for viewing activity details in a edit popup.
* `ViewActivityForm` for viewing any kind of activities.

As a note the `checkIfDraftEmailOrPDFActivity` was moved into a factory since it was being used in different places.

Finally, we have also updated the `activity-panel.directive.html` so custom styles can be applied to the forms depending on their activity type.