### PR TITLE
RSE-774: Fix issue with Changing Case Activity Status For Award Manager

### DIFF
--- a/CRM/Civicase/Hook/PermissionCheck/CaseCategory.php
+++ b/CRM/Civicase/Hook/PermissionCheck/CaseCategory.php
@@ -59,7 +59,7 @@ class CRM_Civicase_Hook_PermissionCheck_CaseCategory {
    * civicase component. To fix such issues, we check that the user has at least
    * any of the equivalent civicase permissions.
    *
-   * @param string$permission
+   * @param string $permission
    *   Permission String.
    * @param bool $granted
    *   Whether permission is granted or not.
@@ -134,6 +134,7 @@ class CRM_Civicase_Hook_PermissionCheck_CaseCategory {
     $isViewCase = $url == 'civicrm/contact/view/case';
     $isCasePage = ($url == 'civicrm/case/add' || $url == 'civicrm/case/a');
     $isAjaxRequest = $url == 'civicrm/ajax/rest';
+    $isCaseActivityPage = 'civicrm/case/activity';
 
     if ($isViewCase) {
       return $this->getCaseCategoryForViewCase();
@@ -146,6 +147,11 @@ class CRM_Civicase_Hook_PermissionCheck_CaseCategory {
     if ($isCasePage) {
       return $this->getCaseCategoryFromUrl();
     }
+
+    if ($isCaseActivityPage) {
+      return $this->getCaseCategoryForCaseActivity();
+    }
+
   }
 
   /**
@@ -183,6 +189,20 @@ class CRM_Civicase_Hook_PermissionCheck_CaseCategory {
    */
   private function getCaseCategoryForViewCase() {
     $caseId = CRM_Utils_Request::retrieve('id', 'Integer');
+
+    return CaseCategoryHelper::getCategoryName($caseId);
+  }
+
+  /**
+   * Get case category name for case activity page.
+   *
+   * The view case activity page is the page for changing the status of
+   * a case activity or editing a case activity. It does not have the
+   * case type category parameter in the URL since it's an internal civi
+   * page but we can use the Case Id to get the case type category.
+   */
+  private function getCaseCategoryForCaseActivity() {
+    $caseId = CRM_Utils_Request::retrieve('caseid', 'Integer');
 
     return CaseCategoryHelper::getCategoryName($caseId);
   }


### PR DESCRIPTION
## Overview
When the Award Manager tries to change a Case or Application status, An error occurs

## Before
![image-20200116-164111 (1)](https://user-images.githubusercontent.com/6951813/72629425-93ea6380-3950-11ea-9961-cf35b3c3c04a.png)



## After
When the Award Manager tries to change a Case or Application status, the case status is changed successfully.

## Technical Details
The permissions required to access the `civicrm/case/activity`  i.e the page for changing the case activity status are civicase permissions ([See](https://github.com/civicrm/civicrm-core/blob/master/CRM/Case/Form/Activity.php#L88)). The Award manager does not have these permissions but have the award case category equivalent for these permissions.

The fix was to add this page to the list of pages that will translate civicase permission to the equivalent case category permissions based on the Case ID parameter in the URL.

