### PR TITLE
BASWSPRT-98: Fix case overview link

### DIFF
--- a/ang/civicase/case/directives/case-overview.directive.html
+++ b/ang/civicase/case/directives/case-overview.directive.html
@@ -44,7 +44,7 @@
           popover-append-to-body="true"
           popover-class="civicase__tooltip-popup-list">
           <div class="civicase__case-overview__flow-status__count">
-            <a ng-href="{{ caseListLink(null, status.name) }}">
+            <a ng-href="{{ caseListLink(null, status.value) }}">
               {{ summaryData.all[status.value] || '0' }}
             </a>
           </div>
@@ -86,7 +86,7 @@
           class="civicase__case-overview__breakdown-field"
           ng-if="!status.isHidden"
           ng-repeat="status in caseStatuses">
-          <a ng-href="{{ caseListLink(caseType.name, status.name) }}">
+          <a ng-href="{{ caseListLink(caseType.name, status.value) }}">
             {{ summaryData[ctid][status.value] || '0' }}
           </a>
         </div>


### PR DESCRIPTION
## Overview
As part of this PR, the link from Case Overview to Manage Cases page has been fixed.
Previously when clicking on any 'Case Status' or the 'Case Status Count' in the Case Overview of Dashboard section, browser redirected to Manage Cases page, but the Clicked Status was not set as a filter. Also there were console errors.
![2020-01-23 at 2 56 PM](https://user-images.githubusercontent.com/5058867/72971942-8de10080-3df0-11ea-95a4-f3f59d30a406.jpg)

This PR fixes the same.

## Before
![before1](https://user-images.githubusercontent.com/5058867/72961194-42215d80-3dd6-11ea-8ff4-158b64b2ff17.gif)
![before2](https://user-images.githubusercontent.com/5058867/72961195-42215d80-3dd6-11ea-9e19-7c63a2276935.gif)

## After
![after1](https://user-images.githubusercontent.com/5058867/72961199-45b4e480-3dd6-11ea-828c-51ec80d772e7.gif)
![after2](https://user-images.githubusercontent.com/5058867/72961200-45b4e480-3dd6-11ea-98c3-d4d153983bca.gif)

## Technical Details
This is a regression issue. As part of https://github.com/compucorp/uk.co.compucorp.civicase/pull/290, the url expects `status_id`s to be set, but in `case-overview.directive.html` this was missed, where still Status Name was being set to the url.