### PR TITLE
CPS-57: [Cases / Reports] Aggregate function gets saved as "Count" in "Case with Activity Pivot Chart" report

### DIFF
--- a/CRM/Civicase/Form/Report/BaseExtendedReport.php
+++ b/CRM/Civicase/Form/Report/BaseExtendedReport.php
@@ -880,11 +880,14 @@ abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_
    */
   public function setDefaultValues($freeze = TRUE) {
     parent::setDefaultValues();
-    $this->_defaults['data_function'] = 'COUNT';
-    $this->_defaults['aggregate_column_date_grouping'] = 'month';
-    $suffix = $this->_aliases[$this->_baseTable] == 'civicrm_contact' ? '_contact_id' : '_id';
-    $this->_defaults['data_function_field'] = $this->_aliases[$this->_baseTable] . $suffix;
-    $this->_defaults['charts'] = TRUE;
+    if (empty($this->_id)) {
+      $this->_defaults['data_function'] = 'COUNT';
+      $this->_defaults['aggregate_column_date_grouping'] = 'month';
+      $suffix = $this->_aliases[$this->_baseTable] == 'civicrm_contact' ? '_contact_id' : '_id';
+      $this->_defaults['data_function_field'] = $this->_aliases[$this->_baseTable] . $suffix;
+      $this->_defaults['charts'] = TRUE;
+    }
+
 
     return $this->_defaults;
   }


### PR DESCRIPTION
## Overview
When saving a report instance for the "Case with Activity Pivot Chart" report the filters are not displayed correcting next time when viewing the saved report. For example the Aggregate function gets displayed as 'COUNT' even if SUM or COUNT UNIQUE was used in creating the report instance

## Before
The scenario described in overview exists.

## After
The filters used in creating a report instance are saved and displays correctly when viewing the saved report.

The "Case with Activity Pivot Chart" report sets some defaults that override the saved form values for the instance in the db as seen [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Report/Form.php#L1040) that the defaults take precedence in displaying form values.

To fix this. The defaults are only set for viewing a fresh form report only and not when viewing a saved form instance.
