### PR TITLE
CP-67: Fix "Case with Activity Pivot Chart" Report not showing data on civicrm dashboard

### DIFF
--- a/CRM/Civicase/Form/Report/BaseExtendedReport.php
+++ b/CRM/Civicase/Form/Report/BaseExtendedReport.php
@@ -885,7 +885,7 @@ abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_
       $this->_defaults['aggregate_column_date_grouping'] = 'month';
       $suffix = $this->_aliases[$this->_baseTable] == 'civicrm_contact' ? '_contact_id' : '_id';
       $this->_defaults['data_function_field'] = $this->_aliases[$this->_baseTable] . $suffix;
-      $this->_defaults['charts'] = TRUE;
+      $this->_defaults['charts'] = FALSE;
     }
 
 


### PR DESCRIPTION
## Overview
When saving a Case with Activity Pivot Chart report and selecting the option to include in civicrm dashboard. When this report added as a dashlet to the dashboard, it simply does not show any data.

## Before
Case with Activity Pivot Chart report does not show in dashlet.
<img width="1280" alt="CiviCRM Home  CiviAwards 2020-01-27 13-15-28" src="https://user-images.githubusercontent.com/6951813/73174108-3a7bf480-4107-11ea-87f9-0ee12148e5c3.png">

## After
It turned out that setting the chart parameter to TRUE for the Case with Activity Pivot Chart caused this issue. This has always been an existing issue and is not a regression.
Setting the parameter to FALSE fixed the issue.

<img width="1279" alt="CiviCRM Home  CiviAwards 2020-01-27 13-07-55 (2)" src="https://user-images.githubusercontent.com/6951813/73174181-67300c00-4107-11ea-9b40-19aefc1c8d48.png">


When the chart parameter is TRUE,  the section to be shown on the report is set [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Report/BAO/ReportInstance.php#L194-L200), This section means that the Chart template will be used to display the report on the dashlet, [See](https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/Report/Form.tpl#L11-L15). The chart template will not work for the report, hence the reason for setting the Chart parameter to FALSE so that the table layout can be used instead.
