### PR TITLE
BASWSPRT-114:  Show the Display values of Custom fields on Case Activities 'Print Report'

### DIFF
--- a/CRM/Civicase/Form/Report/BaseExtendedReport.php
+++ b/CRM/Civicase/Form/Report/BaseExtendedReport.php
@@ -885,7 +885,7 @@ abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_
       $this->_defaults['aggregate_column_date_grouping'] = 'month';
       $suffix = $this->_aliases[$this->_baseTable] == 'civicrm_contact' ? '_contact_id' : '_id';
       $this->_defaults['data_function_field'] = $this->_aliases[$this->_baseTable] . $suffix;
-      $this->_defaults['charts'] = TRUE;
+      $this->_defaults['charts'] = FALSE;
     }
 
 

--- a/CRM/Civicase/XMLProcessor/Report.php
+++ b/CRM/Civicase/XMLProcessor/Report.php
@@ -460,12 +460,33 @@ AND    ac.case_id = %1
       }
       foreach ($caseCustomGroup['fields'] as $customField) {
         if (isset($customField['value']['id'])) {
-          $customValues[$customField['id']] = $customField['value']['display'];
+          $displayField = $customField['value']['display'];
+          if ($customField['data_type'] === 'Money' && in_array($customField['html_type'], ['Radio', 'Select'])) {
+            $displayField = $customField['value']['data'];
+          }
+          if ($customField['data_type'] === 'File') {
+            $displayField = self::getFileLink($customField);
+          }
+
+          $customValues[$customField['id']] = $displayField;
         }
       }
     }
 
     return $customValues;
+  }
+
+  /**
+   * Returns the formatted file link.
+   *
+   * @param string $customData
+   *   Custom data.
+   *
+   * @return string
+   *   The file link.
+   */
+  private static function getFileLink($customData) {
+    return CRM_Utils_System::href($customData['value']['fileName'], $customData['value']['fileURL']);
   }
 
   /**

--- a/CRM/Civicase/XMLProcessor/Report.php
+++ b/CRM/Civicase/XMLProcessor/Report.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+
 /**
  * Class CRM_Civicase_XMLProcessor_Report.
  */
@@ -401,7 +403,7 @@ AND    ac.case_id = %1
 
     // Retrieve custom values for cases.
     $customValues = self::getCaseCustomValues($caseID);
-    $extends = ['case'];
+    $extends = self::getEntityToExtend($caseID);
     $groupTree = CRM_Core_BAO_CustomGroup::getGroupDetail(NULL, NULL, $extends);
     $caseCustomFields = [];
     foreach ($groupTree as $gid => $group_values) {
@@ -464,6 +466,25 @@ AND    ac.case_id = %1
     }
 
     return $customValues;
+  }
+
+  /**
+   * Returns the entity to fetch custom fields for.
+   *
+   * @param int $caseId
+   *   Case ID.
+   *
+   * @return array
+   *   Entity Name.
+   */
+  private static function getEntityToExtend($caseId) {
+    $entityToExtend = ['Case'];
+    $caseCategoryName = CaseCategoryHelper::getCategoryName($caseId);
+    if ($caseCategoryName && $caseCategoryName != 'Cases') {
+      $entityToExtend = [$caseCategoryName];
+    }
+
+    return $entityToExtend;
   }
 
 }


### PR DESCRIPTION
## Overview
On the Print Reports page for a case, the values of case custom fields shown are numerical values rather than the actual display values for these fields. This is observed with fields like 
- Field type - radio
- Field type - Select
- Field type - Checkbox
- Field type - Multi-Select
- Field Type - Autocomplete-select
- Field Type - File

## Before
<img width="1292" alt="Standard Timeline 2020-01-27 17-04-43" src="https://user-images.githubusercontent.com/6951813/73191206-67d89a80-4127-11ea-8d87-bbce9d87275f.png">


## After

<img width="1280" alt="Standard Timeline 2020-01-27 17-05-50" src="https://user-images.githubusercontent.com/6951813/73191236-732bc600-4127-11ea-8158-fb3d11c047e2.png">

The core `CRM_Core_BAO_CustomValueTable::getEntityValues` function was used to fetch the custom values for a case. This function returns the values for the custom fields but sometimes these values are not meaningful to the user viewing the report especially for the fields mentioned in the overview. For example a custom field having a select list options of `Yes => 1, No => 2 `, If the value selected is Yes, what is displayed to the user is `1`. 
The function to fetch the case custom values is replaced with the `Customvalue.gettreevalues` API. This API is a civicase version of the original `Customvalue.gettree` API . The reason for using this api is because:

1. The API returns the data display for the custom field value. This is equivalent to what the user should see when viewing the values of these fields on the UI.
2. The API is case type category compatible, i.e this will work for prospect, awards print report.

```php  
 $result = civicrm_api3('CustomValue', 'gettreevalues', [
      'entity_id' => $caseId,
      'entity_type' => 'Case',
    ]);
```

## Comment
- Some issues were discovered during testing related for file fields and money select and radio fields. Appropriate data was not displayed for these fields. For the file field we need to display the link to the file rather than just the name, A new function was added to fix this. 
For money select and radio fields, the field values itself are what needs to be displayed rather than the labels(An exception to other select and radio fields).
This PR also makes the Print functionality to be Case category compatible. Before the print screen for a prospect case will not display the custom fields because the entity to extend is `Case`. 
A new function was added to fetch the appropriate case category and the Entity to fetch custom fields for.