### PR TITLE
CPS-68: Activity Calendar Refactor

### DIFF
--- a/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
+++ b/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
@@ -5,6 +5,7 @@
     return {
       scope: {
         caseId: '=',
+        caseParams: '=',
         refresh: '=refreshCallback'
       },
       controller: 'civicaseActivitiesCalendarController',
@@ -265,20 +266,11 @@
     function formatActivityCardData (activity) {
       activity = formatActivity(activity);
 
-      if ($scope.caseId && (!_.isArray($scope.caseId) || $scope.caseId.length === 1)) {
+      if (!$scope.caseParams) {
         delete activity.case;
       }
 
       return activity;
-    }
-
-    /**
-     * Prepares the value of the case_id api param based on the $scope.caseId property
-     *
-     * @returns {number/object} case id api param
-     */
-    function getCaseIdApiParam () {
-      return _.isArray($scope.caseId) ? { IN: $scope.caseId } : $scope.caseId;
     }
 
     /**
@@ -438,7 +430,11 @@
       params = params || {};
 
       if ($scope.caseId) {
-        params.case_id = getCaseIdApiParam();
+        params.case_id = $scope.caseId;
+      }
+
+      if ($scope.caseParams) {
+        params.case_filter = $scope.caseParams;
       }
 
       return crmApi('Activity', 'get', _.assign(params, {
@@ -530,7 +526,11 @@
       };
 
       if ($scope.caseId) {
-        params.case_id = getCaseIdApiParam();
+        params.case_id = $scope.caseId;
+      }
+
+      if ($scope.caseParams) {
+        params.case_params = $scope.caseParams;
       }
 
       return crmApi('Activity', 'getdayswithactivities', params)

--- a/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
+++ b/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
@@ -377,6 +377,9 @@
       $scope.$watch('caseId', function (newValue, oldValue) {
         newValue !== oldValue && reload();
       });
+      $scope.$watch('caseParams', function (newValue, oldValue) {
+        newValue !== oldValue && reload();
+      });
     }
 
     /**

--- a/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
+++ b/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
@@ -533,7 +533,7 @@
       }
 
       if ($scope.caseParams) {
-        params.case_params = $scope.caseParams;
+        params.case_filter = $scope.caseParams;
       }
 
       return crmApi('Activity', 'getdayswithactivities', params)

--- a/ang/civicase/dashboard/directives/dashboard-tab.directive.html
+++ b/ang/civicase/dashboard/directives/dashboard-tab.directive.html
@@ -7,8 +7,8 @@
   <div class="civicase__dashboard__tab__main">
     <div class="civicase__dashboard__tab__col-wrapper">
       <div class="civicase__dashboard__tab__col civicase__dashboard__tab__col--left">
-        <civicase-activities-calendar case-id="caseIds" refresh-callback="activityCardRefreshCalendar" ng-if="caseIds"></civicase-activities-calendar>
-        <civicase-activities-calendar-placeholder ng-if="!caseIds" style="padding-top: 0;"></civicase-activities-calendar-placeholder>
+        <civicase-activities-calendar case-params="calendarCaseParams" refresh-callback="activityCardRefreshCalendar" ng-if="calendarCaseParams"></civicase-activities-calendar>
+        <civicase-activities-calendar-placeholder ng-if="!calendarCaseParams" style="padding-top: 0;"></civicase-activities-calendar-placeholder>
       </div>
       <div class="civicase__dashboard__tab__col civicase__dashboard__tab__col--right">
         <!-- New Cases -->

--- a/ang/civicase/dashboard/directives/dashboard-tab.directive.js
+++ b/ang/civicase/dashboard/directives/dashboard-tab.directive.js
@@ -74,7 +74,7 @@
     };
 
     $scope.ts = ts;
-    $scope.caseIds = null;
+    $scope.calendarCaseParams = null;
     $scope.activitiesPanel = {
       name: 'activities',
       query: {
@@ -128,7 +128,7 @@
 
     (function init () {
       initWatchers();
-      loadCaseIds();
+      setCalendarParams();
     }());
 
     /**
@@ -226,7 +226,7 @@
         $scope.newCasesPanel.query.params = getQueryParams('cases');
         $scope.newCasesPanel.custom.viewCasesLink = viewCasesLink();
 
-        loadCaseIds();
+        setCalendarParams();
       });
 
       // When the involvement filters change, broadcast the event that will be
@@ -269,18 +269,10 @@
      *
      * The ids are used for the activities calendar
      */
-    function loadCaseIds () {
-      crmApi('Case', 'getcaselist', _.assign({
-        'status_id.grouping': 'Opened',
-        return: 'id',
-        sequential: 1,
-        options: { limit: 0 }
-      }, $scope.activityFilters.case_filter))
-        .then(function (result) {
-          $scope.caseIds = result.values.map(function (caseObj) {
-            return caseObj.id;
-          });
-        });
+    function setCalendarParams () {
+      $scope.calendarCaseParams = _.assign({
+        'status_id.grouping': 'Opened'
+      }, $scope.activityFilters.case_filter);
     }
 
     /**

--- a/ang/test/civicase/activity/calendar/directives/activities-calendar.directive.spec.js
+++ b/ang/test/civicase/activity/calendar/directives/activities-calendar.directive.spec.js
@@ -128,7 +128,7 @@
         it('loads the days with activities from all the given cases', function () {
           var apiParams1 = crmApi.calls.argsFor(0)[2];
 
-          expect(apiParams1.case_params).toEqual({ a: 'b' });
+          expect(apiParams1.case_filter).toEqual({ a: 'b' });
         });
 
         describe('when selecting a date with activities', function () {

--- a/ang/test/civicase/activity/calendar/directives/activities-calendar.directive.spec.js
+++ b/ang/test/civicase/activity/calendar/directives/activities-calendar.directive.spec.js
@@ -86,40 +86,6 @@
     });
 
     describe('case id', function () {
-      describe('when none is passed', function () {
-        beforeEach(function () {
-          commonControllerSetup(null);
-        });
-
-        it('loads the days with activities from all cases', function () {
-          var apiParams1 = crmApi.calls.argsFor(0)[2];
-          var apiParams2 = crmApi.calls.argsFor(1)[2];
-
-          expect(apiParams1.case_id).toBeUndefined();
-          expect(apiParams2.case_id).toBeUndefined();
-        });
-
-        describe('when selecting a date with activities', function () {
-          beforeEach(function () {
-            commonDateSelectSetup();
-          });
-
-          it('loads activities from all cases when selecting a day', function () {
-            var apiParams = crmApi.calls.argsFor(0)[2];
-
-            expect(apiParams.case_id).toBeUndefined();
-          });
-
-          describe('case info footer on activity card', function () {
-            it('keeps the `case` property on the activities to display the footer', function () {
-              expect($scope.selectedActivites.every(function (activity) {
-                return typeof activity.case !== 'undefined';
-              })).toBe(true);
-            });
-          });
-        });
-      });
-
       describe('when one is passed', function () {
         beforeEach(function () {
           commonControllerSetup();
@@ -154,25 +120,15 @@
         });
       });
 
-      describe('when multiple ids are passed', function () {
+      describe('when case parameters are passed', function () {
         beforeEach(function () {
-          commonControllerSetup([_.uniqueId(), _.uniqueId(), _.uniqueId()]);
+          commonControllerSetup({ caseParams: { a: 'b' } });
         });
 
         it('loads the days with activities from all the given cases', function () {
           var apiParams1 = crmApi.calls.argsFor(0)[2];
-          var apiParams2 = crmApi.calls.argsFor(1)[2];
 
-          expect(apiParams1.case_id).toEqual({
-            IN: [
-              $scope.caseId[0], $scope.caseId[1], $scope.caseId[2]
-            ]
-          });
-          expect(apiParams2.case_id).toEqual({
-            IN: [
-              $scope.caseId[0], $scope.caseId[1], $scope.caseId[2]
-            ]
-          });
+          expect(apiParams1.case_params).toEqual({ a: 'b' });
         });
 
         describe('when selecting a date with activities', function () {
@@ -183,11 +139,7 @@
           it('loads activities from all the given cases when selecting a day', function () {
             var apiParams = crmApi.calls.argsFor(0)[2];
 
-            expect(apiParams.case_id).toEqual({
-              IN: [
-                $scope.caseId[0], $scope.caseId[1], $scope.caseId[2]
-              ]
-            });
+            expect(apiParams.case_filter).toEqual({ a: 'b' });
           });
 
           describe('case info footer on activity card', function () {
@@ -226,15 +178,14 @@
           });
         });
       });
+
       /**
        * Common controller setup logic for the "case id" tests
        *
-       * @param {*} caseIds The case ids to set on the $scope.caseId property
+       * @param {*} scopeProps properties to add to the scope
        */
-      function commonControllerSetup (caseIds) {
-        var caseIdsParam = typeof caseIds !== 'undefined' ? { caseId: caseIds } : null;
-
-        initController(caseIdsParam);
+      function commonControllerSetup (scopeProps) {
+        initController(scopeProps);
         returnDateForStatus(dates.today, 'any');
 
         $rootScope.$emit('civicase::uibDaypicker::compiled');

--- a/ang/test/civicase/dashboard/directives/dashboard-tab.directive.spec.js
+++ b/ang/test/civicase/dashboard/directives/dashboard-tab.directive.spec.js
@@ -37,26 +37,15 @@
       }));
     }));
 
-    describe('case ids', function () {
+    describe('case parameters', function () {
       beforeEach(function () {
         initController();
       });
 
-      it('queries the API for the ids of all the cases that match the relationship filter', function () {
-        expect(crmApi).toHaveBeenCalledWith('Case', 'getcaselist', jasmine.objectContaining(_.assign({
-          'status_id.grouping': 'Opened',
-          return: 'id',
-          sequential: 1,
-          options: {
-            limit: 0
-          }
-        }, $scope.activityFilters.case_filter)));
-      });
-
-      it('stores the list of ids', function () {
-        expect($scope.caseIds).toEqual(mockedCases.map(function (caseObj) {
-          return caseObj.id;
-        }));
+      it('fetches the activities from the cases that match the relationship filter', function () {
+        expect($scope.calendarCaseParams).toEqual(_.assign({
+          'status_id.grouping': 'Opened'
+        }, $scope.activityFilters.case_filter));
       });
 
       describe('when the relationship type changes', function () {
@@ -73,7 +62,9 @@
         });
 
         it('adds the properties of the `case_filter` object to the query params', function () {
-          expect(crmApi).toHaveBeenCalledWith('Case', 'getcaselist', jasmine.objectContaining({
+          expect($scope.calendarCaseParams).toEqual(_.assign({
+            'status_id.grouping': 'Opened'
+          }, {
             foo: newFilterValue
           }));
         });

--- a/api/v3/Activity/Getdayswithactivities.php
+++ b/api/v3/Activity/Getdayswithactivities.php
@@ -35,8 +35,8 @@ function civicrm_api3_activity_getdayswithactivities(array $params) {
   $query = CRM_Utils_SQL_Select::from('civicrm_activity a');
   $query->select(['a.activity_date_time']);
 
-  if (!empty($params['case_id']) && !empty($params['case_params'])) {
-    throw new API_Exception("case_id and case_params cannot be present at the same time.");
+  if (!empty($params['case_id']) && !empty($params['case_filter'])) {
+    throw new API_Exception("case_id and case_filter cannot be present at the same time.");
   }
 
   if (!empty($params['activity_type_id'])) {
@@ -52,15 +52,17 @@ function civicrm_api3_activity_getdayswithactivities(array $params) {
   }
 
   if (!empty($params['case_id'])) {
-    print('<pre>' . print_r($params['case_id'], TRUE) . '</pre>');
-
-    $query->join('ca', "INNER JOIN civicrm_case_activity AS ca ON a.id = ca.activity_id");
-    _civicrm_api3_activity_getdayswithactivities_handle_id_param($params['case_id'], 'ca.case_id', $query);
+    _join_to_case($query, $params['case_id']);
   }
 
-  if (!empty($params['case_params'])) {
-    $query->join('ca', "INNER JOIN civicrm_case_activity AS ca ON a.id = ca.activity_id");
-    _civicrm_api3_activity_getdayswithactivities_handle_id_param(['IN' => _get_case_ids($params['case_params'])], 'ca.case_id', $query);
+  if (!empty($params['case_filter'])) {
+    $case_ids = _get_case_ids($params['case_filter']);
+
+    if (empty($case_ids)) {
+      return civicrm_api3_create_success([], $params, 'Activity', 'getdayswithactivities');
+    }
+
+    _join_to_case($query, ['IN' => _get_case_ids($params['case_filter'])]);
   }
 
   $query->groupBy('a.activity_date_time');
@@ -90,6 +92,20 @@ function _civicrm_api3_activity_getdayswithactivities_handle_id_param($param, $c
 }
 
 /**
+ * Apply Inner Join for Case related filters.
+ *
+ * @param CRM_Utils_SQL_Select $query
+ *   Query.
+ * @param array $value
+ *   Value of the filter.
+ */
+function _join_to_case(CRM_Utils_SQL_Select $query, array $value) {
+  $query->join('ca', "INNER JOIN civicrm_case_activity AS ca ON a.id = ca.activity_id");
+
+  _civicrm_api3_activity_getdayswithactivities_handle_id_param($value, 'ca.case_id', $query);
+}
+
+/**
  * Get the list of case ids.
  *
  * @param array $caseParams
@@ -101,11 +117,8 @@ function _civicrm_api3_activity_getdayswithactivities_handle_id_param($param, $c
 function _get_case_ids(array $caseParams) {
   $results = civicrm_api3('Case', 'getcaselist', array_merge([
     'return' => 'id',
-    'sequential' => 1,
     'options' => [limit => 0],
   ], $caseParams))['values'];
 
-  return array_map(function ($row) {
-    return $row['id'];
-  }, $results);
+  return array_column($results, 'id');
 }


### PR DESCRIPTION
## Overview
When having a lot of Case, the Calendar in Case Dashboard, does not work, because the `Activity.getdayswithactivities` api threw `414 Request: URI Too Large` error. This PR fixes that problem.

## Before
![2020-01-29 at 2 21 PM](https://user-images.githubusercontent.com/5058867/73341440-a47cd100-42a2-11ea-9d72-46f2f4797a10.jpg)

## After
![2020-01-29 at 2 20 PM](https://user-images.githubusercontent.com/5058867/73341379-8b742000-42a2-11ea-968e-127bc1aa23d8.jpg)

## Technical Details
**Problem**
Previously, all case IDs which matched the 'Relationship' filter where sent to the Back end using `IN` filter(as shown in Before image). So when the number of cases were too many, this resulted in Get Requested being too large.

**Fixes for Activity.getdayswithactivities api**
So now, instead all the Case Filter Parameters are sent to the `Activity.getdayswithactivities` api using `case_params` parameter. And the backend fetches the Case IDs and then applies the same. This way a huge list of Case Ids does not need to be sent to the backend.

```php
if (!empty($params['case_params'])) {
    $query->join('ca', "INNER JOIN civicrm_case_activity AS ca ON a.id = ca.activity_id");
    _civicrm_api3_activity_getdayswithactivities_handle_id_param(['IN' => _get_case_ids($params['case_params'])], 'ca.case_id', $query);
  }

function _get_case_ids(array $caseParams) {
  $results = civicrm_api3('Case', 'getcaselist', array_merge([
    'return' => 'id',
    'sequential' => 1,
    'options' => [limit => 0],
  ], $caseParams))['values'];

  return array_map(function ($row) {
    return $row['id'];
  }, $results);
}
```

**Fixes for Activity.get api**
When clicking on a Calendar date, the system fetches all activities for that date. Here too we had similar issues, where a huge list of IDs were being sent. So this has been replaced with sending the IDs via, exisiting `case_filter` parameter.

**Changes to Front End**
1. In `dashboard-tab.directive.js`, now instead of setting Case Ids, `calendarCaseParams` $scope variable is set. Which is passed to Activity Calendar from `dashboard-tab.directive.html`.

`<civicase-activities-calendar case-params="calendarCaseParams" refresh-callback="activityCardRefreshCalendar" ng-if="calendarCaseParams"></civicase-activities-calendar>`

2. In `activities-calendar.directive.js`, now a new attribute `caseParams` is added, when it is present. It passes to `Activity.get` api using `case_filter` parameter. and to `Activity.getdayswithactivities` api using `case_param` parameter.