### PR TITLE
RSE-790:  Allow Icon Field For Case Categories

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/EnableCaseCategoryIconField.php
+++ b/CRM/Civicase/Hook/BuildForm/EnableCaseCategoryIconField.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Class CRM_Civicase_Hook_BuildForm_EnableCaseCategoryIconField.
+ */
+class CRM_Civicase_Hook_BuildForm_EnableCaseCategoryIconField {
+
+  /**
+   * Shows the icon field for case category option value.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   * @param string $formName
+   *   Form Name.
+   */
+  public function run(CRM_Core_Form &$form, $formName) {
+    if (!$this->shouldRun($form, $formName)) {
+      return;
+    }
+
+    $form->add('text',
+      'icon',
+      ts('Icon'),
+      [
+        'class' => 'crm-icon-picker',
+        'title' => ts('Choose Icon'),
+        'allowClear' => TRUE,
+      ]
+    );
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * @param CRM_Core_Form $form
+   *   Form object class.
+   * @param string $formName
+   *   Form name.
+   *
+   * @return bool
+   *   returns TRUE or FALSE.
+   */
+  private function shouldRun(CRM_Core_Form $form, $formName) {
+    $optionGroupName = $form->getVar('_gName');
+    return $formName == 'CRM_Admin_Form_Options' && $optionGroupName == 'case_type_categories';
+  }
+
+}

--- a/CRM/Civicase/Hook/Tabset/CaseCategoryTabAdd.php
+++ b/CRM/Civicase/Hook/Tabset/CaseCategoryTabAdd.php
@@ -1,6 +1,5 @@
 <?php
 
-use CRM_Case_BAO_CaseType as CaseType;
 use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 
 /**
@@ -39,28 +38,33 @@ class CRM_Civicase_Hook_Tabset_CaseCategoryTabAdd {
    *   Whether to use angular.
    */
   private function addCaseCategoryContactTabs(array &$tabs, $contactID, &$useAng) {
-    $caseTypeCategories = CaseType::buildOptions('case_type_category', 'match');
-    if (empty($caseTypeCategories)) {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'case_type_categories',
+    ]);
+
+    if (empty($result['values'])) {
       return;
     }
 
     $caseTabWeight = $this->getCaseTabWeight($tabs);
-    foreach ($caseTypeCategories as $categoryName => $categoryLabel) {
-      if ($categoryName == CaseCategoryHelper::CASE_TYPE_CATEGORY_NAME) {
+    foreach ($result['values'] as $caseCategory) {
+      if ($caseCategory['name'] == CaseCategoryHelper::CASE_TYPE_CATEGORY_NAME) {
         continue;
       }
       $caseTabWeight++;
       $useAng = TRUE;
+      $icon = !empty($caseCategory['icon']) ? "crm-i {$caseCategory['icon']}" : '';
       $tabs[] = [
-        'id' => $categoryName,
+        'id' => $caseCategory['name'],
         'url' => CRM_Utils_System::url('civicrm/case/contact-case-tab', [
           'cid' => $contactID,
-          'case_type_category' => $categoryName,
+          'case_type_category' => $caseCategory['name'],
         ]),
-        'title' => ts($categoryLabel),
+        'title' => ts($caseCategory['label']),
         'weight' => $caseTabWeight,
-        'count' => CaseCategoryHelper::getCaseCount($categoryName, $contactID),
+        'count' => CaseCategoryHelper::getCaseCount($caseCategory['name'], $contactID),
         'class' => 'livePage',
+        'icon' => $icon,
       ];
     }
   }

--- a/civicase.php
+++ b/civicase.php
@@ -183,6 +183,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_FilterByCaseCategoryOnChangeCaseType(),
     new CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslationForNewCase(),
     new CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslationForChangeCase(),
+    new CRM_Civicase_Hook_BuildForm_EnableCaseCategoryIconField(),
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview
Currently Civi only allows icons to be set for Activity Type option group icons in the UI([See](https://github.com/civicrm/civicrm-core/blob/master/CRM/Admin/Form/Options.php#L159-L174)). We need to be able to set these icons for Case type category option group values also. This PR makes that happen. Also when generating case contact tabs for case categories, these icon set for the case categories are used.

## Before
- Icons can not be set for case type categories in the UI
<img width="1239" alt="Option Groups  CiviAwards 2020-01-28 14-47-16" src="https://user-images.githubusercontent.com/6951813/73269478-2d313980-41dd-11ea-97d5-5662bda03068.png">
- Case contact tabs for case categories uses default icons
<img width="1281" alt="adminexample com  CiviAwards 2020-01-28 14-48-09" src="https://user-images.githubusercontent.com/6951813/73269518-4803ae00-41dd-11ea-8b9e-11f0538f4f9f.png">


## After
- Icons can now be set for case type categories in the UI
<img width="1206" alt="Option Groups  CiviAwards 2020-01-28 14-44-27 (1)" src="https://user-images.githubusercontent.com/6951813/73269306-dcb9dc00-41dc-11ea-972b-b81bb182ad1e.png">

- Case contact tabs for case categories uses icons set in the icon field for the option value.
<img width="1164" alt="Option Groups  CiviAwards 2020-01-28 14-42-02" src="https://user-images.githubusercontent.com/6951813/73269329-eba08e80-41dc-11ea-82e9-19ba32cf10f0.png">
<img width="1283" alt="adminexample com  CiviAwards 2020-01-28 14-42-34" src="https://user-images.githubusercontent.com/6951813/73269349-f2c79c80-41dc-11ea-9421-2d8c63381068.png">

## Comments
- The [PR](https://github.com/compucorp/uk.co.compucorp.civicase/pull/331) for generating the menus dynamically when a case type category option is created will also be updated to use these icon for the menu once the ticket is unblocked. 
- Default icons will also be set for Award and Prospect category upon the installation of these extensions.
