### PR TITLE
RSE-752:  Generate Case Webform Setting Fields For Case Type Categories

### DIFF
--- a/CRM/Civicase/Hook/PreProcess/AddCaseAdminSettings.php
+++ b/CRM/Civicase/Hook/PreProcess/AddCaseAdminSettings.php
@@ -1,0 +1,63 @@
+<?php
+
+use CRM_Civicase_Service_CaseCategorySetting as CaseCategorySetting;
+
+/**
+ * Class CRM_Civicase_Hook_PreProcess_AddCaseAdminSettings.
+ */
+class CRM_Civicase_Hook_PreProcess_AddCaseAdminSettings {
+
+  /**
+   * Sets the case admin settings.
+   *
+   * @param string $formName
+   *   Form name.
+   * @param CRM_Core_Form $form
+   *   Form object class.
+   */
+  public function run($formName, CRM_Core_Form &$form) {
+    if (!$this->shouldRun($formName)) {
+      return;
+    }
+
+    $settings = $form->getVar('_settings');
+    $settings['civicaseAllowCaseLocks'] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;
+    $this->setCaseCategoryWebformSettings($form, $settings);
+
+    $form->setVar('_settings', $settings);
+  }
+
+  /**
+   * Sets webform settings for case categories.
+   *
+   * @param CRM_Core_Form $form
+   *   Form object class.
+   * @param array $settings
+   *   Settings array.
+   */
+  private function setCaseCategoryWebformSettings(CRM_Core_Form &$form, array &$settings) {
+    $caseSetting = new CaseCategorySetting();
+    $caseCategoryWebFormSetting = $caseSetting->getForWebform();
+    $settingKeys = array_keys($caseCategoryWebFormSetting);
+
+    foreach ($settingKeys as $settingKey) {
+      $settings[$settingKey] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;
+    }
+
+    $form->assign('caseCategoryWebFormSetting', $caseCategoryWebFormSetting);
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * @param string $formName
+   *   Form class object.
+   *
+   * @return bool
+   *   returns TRUE or FALSE.
+   */
+  private function shouldRun($formName) {
+    return $formName == 'CRM_Admin_Form_Setting_Case';
+  }
+
+}

--- a/CRM/Civicase/Service/CaseCategorySetting.php
+++ b/CRM/Civicase/Service/CaseCategorySetting.php
@@ -1,0 +1,106 @@
+<?php
+
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+use CRM_Case_BAO_CaseType as CaseType;
+
+/**
+ * Class CRM_Civicase_Service_CaseCategorySetting.
+ */
+class CRM_Civicase_Service_CaseCategorySetting {
+
+  /**
+   * Returns the settings set for all case categories.
+   *
+   * @return array
+   *   Array of webform settings.
+   */
+  public function getForWebform() {
+    $caseTypeCategories = CaseType::buildOptions('case_type_category', 'validate');
+    $caseCategorySettings = [];
+    foreach ($caseTypeCategories as $caseCategoryName) {
+      $caseCategorySettings = array_merge($caseCategorySettings, $this->getCaseWebformSetting($caseCategoryName));
+    }
+
+    return $caseCategorySettings;
+  }
+
+  /**
+   * Returns the case category webform settings.
+   *
+   * @param string $caseCategoryName
+   *   Case category name.
+   *
+   * @return array
+   *   Case webform setting for category.
+   */
+  private function getCaseWebformSetting($caseCategoryName) {
+    return [
+      str_replace(' ', '', $this->replaceWords('civicaseAllowCaseWebform', $caseCategoryName)) => [
+        'group_name' => 'CiviCRM Preferences',
+        'group' => 'core',
+        'name' => $this->replaceWords('civicaseAllowCaseWebform', $caseCategoryName),
+        'type' => 'Boolean',
+        'quick_form_type' => 'YesNo',
+        'default' => FALSE,
+        'html_type' => 'radio',
+        'add' => '4.7',
+        'title' => $this->replaceWords('Trigger webform on Add Case', $caseCategoryName),
+        'is_domain' => 1,
+        'is_contact' => 0,
+        'description' => $this->replaceWords('This setting allows the user to set a webform to be triggered when clicking the `Add Case` button on the Cases tab on the Contact.', $caseCategoryName),
+        'help_text' => '',
+        'is_webform_url' => FALSE,
+        'webform_url_name' => str_replace(' ', '', $this->replaceWords('civicaseWebformUrl', $caseCategoryName)),
+      ],
+      str_replace(' ', '', $this->replaceWords('civicaseWebformUrl', $caseCategoryName)) => [
+        'group_name' => 'CiviCRM Preferences',
+        'group' => 'core',
+        'name' => $this->replaceWords('civicaseWebformUrl', $caseCategoryName),
+        'type' => 'String',
+        'quick_form_type' => 'Element',
+        'html_attributes' => [
+          'size' => 64,
+          'maxlength' => 64,
+        ],
+        'html_type' => 'text',
+        'default' => '',
+        'add' => '4.7',
+        'title' => ' URL of the Webform',
+        'is_domain' => 1,
+        'is_contact' => 0,
+        'description' => '',
+        'help_text' => '',
+        'is_webform_url' => TRUE,
+      ],
+    ];
+  }
+
+  /**
+   * Returns the appropriate string after proper word replacements.
+   *
+   * @param string $stringToReplace
+   *   String for word replacements.
+   * @param string $caseCategoryName
+   *   Case category name.
+   *
+   * @return string
+   *   Word replaced string.
+   */
+  public function replaceWords($stringToReplace, $caseCategoryName) {
+    if ($caseCategoryName == CaseCategoryHelper::CASE_TYPE_CATEGORY_NAME) {
+      return $stringToReplace;
+    }
+
+    return str_replace(
+      ['civicaseAllowCaseWebform', 'civicaseWebformUrl', 'Case', 'Cases'],
+      [
+        "civi{$caseCategoryName}Allow{$caseCategoryName}Webform",
+        "civi{$caseCategoryName}WebformUrl",
+        ucfirst($caseCategoryName),
+        ucfirst($caseCategoryName) . 's',
+      ],
+      $stringToReplace
+    );
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -684,21 +684,11 @@ function civicase_civicrm_preProcess($formName, &$form) {
     new CRM_Civicase_Hook_PreProcess_ProcessCaseCategoryCustomFieldsForEdit(),
     new CRM_Civicase_Hook_PreProcess_CaseCategoryWordReplacementsForNewCase(),
     new CRM_Civicase_Hook_PreProcess_CaseCategoryWordReplacementsForChangeCase(),
+    new CRM_Civicase_Hook_PreProcess_AddCaseAdminSettings(),
   ];
 
   foreach ($hooks as $hook) {
     $hook->run($formName, $form);
-  }
-
-  // TODO: We need to move this function into it's own class
-  // and implement as above.
-  if ($formName == 'CRM_Admin_Form_Setting_Case') {
-    $settings = $form->getVar('_settings');
-    $settings['civicaseAllowCaseLocks'] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;
-    $settings['civicaseAllowCaseWebform'] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;
-    $settings['civicaseWebformUrl'] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;
-
-    $form->setVar('_settings', $settings);
   }
 }
 

--- a/settings/CiviCase.setting.php
+++ b/settings/CiviCase.setting.php
@@ -1,6 +1,11 @@
 <?php
 
-return [
+/**
+ * @file
+ * CiviCase Setting file.
+ */
+
+$setting = [
   'civicaseAllowCaseLocks' => [
     'group_name' => 'CiviCRM Preferences',
     'group' => 'core',
@@ -16,38 +21,9 @@ return [
     'description' => 'This will allow cases to be locked for certain contacts.',
     'help_text' => '',
   ],
-  'civicaseAllowCaseWebform' => [
-    'group_name' => 'CiviCRM Preferences',
-    'group' => 'core',
-    'name' => 'civicaseAllowCaseWebform',
-    'type' => 'Boolean',
-    'quick_form_type' => 'YesNo',
-    'default' => FALSE,
-    'html_type' => 'radio',
-    'add' => '4.7',
-    'title' => 'Trigger webform on Add Case',
-    'is_domain' => 1,
-    'is_contact' => 0,
-    'description' => 'This setting allows the user to set a webform to be triggered when clicking the `Add Case` button on the Cases tab on the Contact.',
-    'help_text' => '',
-  ],
-  'civicaseWebformUrl' => [
-    'group_name' => 'CiviCRM Preferences',
-    'group' => 'core',
-    'name' => 'civicaseWebformUrl',
-    'type' => 'String',
-    'quick_form_type' => 'Element',
-    'html_attributes' => [
-      'size' => 64,
-      'maxlength' => 64,
-    ],
-    'html_type' => 'text',
-    'default' => '',
-    'add' => '4.7',
-    'title' => ' URL of the Webform',
-    'is_domain' => 1,
-    'is_contact' => 0,
-    'description' => '',
-    'help_text' => '',
-  ],
 ];
+
+$caseSetting = new CRM_Civicase_Service_CaseCategorySetting();
+$caseCategoryWebFormSetting = $caseSetting->getForWebform();
+
+return array_merge($setting, $caseCategoryWebFormSetting);

--- a/templates/CRM/Civicase/Admin/Form/Settings.tpl
+++ b/templates/CRM/Civicase/Admin/Form/Settings.tpl
@@ -4,39 +4,45 @@
     <span class="description">{ts}This will allow cases to be locked for certain contacts.{/ts}</span>
   </td>
 </tr>
-<tr class="crm-case-form-block-allowCaseLocks">
-  <td class="label">{$form.civicaseAllowCaseWebform.label}</td>
-  <td>{$form.civicaseAllowCaseWebform.html}<br />
-    <span class="description">{ts}This setting allows the user to set a webform to be triggered when clicking the "Add Case" button on the Cases tab on the Contact{/ts}</span>
-  </td>
-</tr>
-<tr class="crm-case-form-block-webformUrl">
-  <td class="label">{$form.civicaseWebformUrl.label}</td>
-  <td>{$form.civicaseWebformUrl.html}<br />
-    <span class="description">{ts}A Webform url e.g /node/233{/ts}</span>
-  </td>
-</tr>
+
+{foreach from=$caseCategoryWebFormSetting key=settingKey item=setting}
+  <tr class="crm-case-form-block-{$settingKey}">
+    <td class="label">{$form.$settingKey.label}</td>
+    <td>{$form.$settingKey.html}<br />
+      <span class="description">{ts}This setting allows the user to set a webform to be triggered when clicking the "Add Case" button on the Cases tab on the Contact{/ts}</span>
+    </td>
+  </tr>
+{/foreach}
 
 <script type="text/javascript">
+  var caseCategoryWebFormSetting = {$caseCategoryWebFormSetting|@json_encode};
   {literal}
+
     CRM.$(function($) {
-      allowCaseWebformToggle();
-      cj('input[name="civicaseAllowCaseWebform"]').click(function() {
-        allowCaseWebformToggle();
+      cj.each(caseCategoryWebFormSetting, function(key, val){
+        if (!val.is_webform_url) {
+          allowCaseWebformToggle(key, val.webform_url_name);
+          cj('input[name="' + key + '"]').click(function() {
+            allowCaseWebformToggle(key, val.webform_url_name);
+          });
+        }
       });
     });
 
   /**
    * Logic for what happens when the allow case webform radio button is
    * toggled.
+   *
+   * @param string settingKey the webform setting key
+   * @param string corresponding webform Url setting name
    */
-  function allowCaseWebformToggle() {
-    var allowCaseWebform = cj('input[name="civicaseAllowCaseWebform"]:checked').val();
+  function allowCaseWebformToggle(settingKey, webformUrl) {
+    var allowCaseWebform = cj('input[name="' + settingKey + '"]:checked').val();
     if (allowCaseWebform === '0') {
-      cj('.crm-case-form-block-webformUrl').hide();
+      cj('.crm-case-form-block-' + webformUrl).hide();
     }
     else if (allowCaseWebform === '1') {
-      cj('.crm-case-form-block-webformUrl').show();
+      cj('.crm-case-form-block-' + webformUrl).show();
     }
   }
   {/literal}


### PR DESCRIPTION
## Overview
Currently, in the Civicase settings, An administrator can choose to set an alternative URL which is to be used when creating new cases both on the case dashboard and the navigation menu. 
This setting is only available for cases but we need it to be available for other case type categories in the system. This PR makes that possible.

## Before
<img width="1271" alt="Settings - CiviCase  compuclient-cps-71-a4g compubox co uk 2020-01-30 16-02-43" src="https://user-images.githubusercontent.com/6951813/73461179-03614980-437a-11ea-810c-930a53f79714.png">


## After

<img width="1234" alt="Settings - CiviCase  CiviAwards 2020-01-30 16-03-56" src="https://user-images.githubusercontent.com/6951813/73461397-5cc97880-437a-11ea-94d6-e0bed710a246.png">

## Technical Details
The `CRM_Civicase_Service_CaseCategorySetting` was created to dynamically generate webform settings for all case type categories. 

```php
  public function getForWebform() {
    $caseTypeCategories = CaseType::buildOptions('case_type_category', 'validate');
    $caseCategorySettings = [];
    foreach ($caseTypeCategories as $caseCategoryName) {
      $caseCategorySettings = array_merge($caseCategorySettings, $this->getCaseWebformSetting($caseCategoryName));
    }

    return $caseCategorySettings;
  }
```