### PR TITLE
RSE-753: Replace Add New [Case category] Menu URL with Webform URL.

### DIFF
--- a/CRM/Civicase/Hook/NavigationMenu/AlterForCaseMenu.php
+++ b/CRM/Civicase/Hook/NavigationMenu/AlterForCaseMenu.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * Class CRM_Civicase_Hook_Navigation_AlterForCaseMenu.
+ */
+class CRM_Civicase_Hook_NavigationMenu_AlterForCaseMenu {
+
+  /**
+   * Modifies the navigation menu.
+   *
+   * Modifies the menu so that some memnu URL's can be changed
+   * or some menu's dynamically inserted.
+   *
+   * @param array $menu
+   *   Menu Array.
+   */
+  public function run(array &$menu) {
+    $this->rewriteCaseUrls($menu);
+    $this->addCaseWebformUrl($menu);
+  }
+
+  /**
+   * Rewrite some case menu URL's.
+   *
+   * @param array $menu
+   *   Menu Array.
+   */
+  private function rewriteCaseUrls(array &$menu) {
+    // Array(string $oldUrl => string $newUrl).
+    $rewriteMap = [
+      'civicrm/case?reset=1' => 'civicrm/case/a/#/case?case_type_category=cases',
+      'civicrm/case/search?reset=1' => 'civicrm/case/a/#/case/list?sx=1',
+    ];
+
+    // For URLS that have hardcoded values that may change per system.
+    // or for adding dynamic menu url mappings.
+    $otherUrlsMap = [];
+    $this->addNewCaseUrlMap($otherUrlsMap);
+
+    $this->menuWalk($menu, function (&$item) use ($rewriteMap, $otherUrlsMap) {
+      if (!isset($item['url'])) {
+        return;
+      }
+
+      if (isset($rewriteMap[$item['url']])) {
+        $item['url'] = $rewriteMap[$item['url']];
+
+        return;
+      }
+
+      foreach ($otherUrlsMap as $oldUrl => $newUrl) {
+        if (strpos($item['url'], $oldUrl) !== FALSE) {
+          $item['url'] = $newUrl;
+
+          return;
+        }
+      }
+    });
+  }
+
+  /**
+   * Adds the civicase Webform menu to the Adminsiter Civicase Menu.
+   *
+   * @param array $menu
+   *   Menu Array.
+   */
+  private function addCaseWebformUrl(array &$menu) {
+    // Add new menu item
+    // Check that our item doesn't already exist.
+    $menu_item_search = ['url' => 'civicrm/case/webforms'];
+    $menu_items = [];
+    CRM_Core_BAO_Navigation::retrieve($menu_item_search, $menu_items);
+
+    if (!empty($menu_items)) {
+      return;
+    }
+
+    $navId = CRM_Core_DAO::singleValueQuery("SELECT max(id) FROM civicrm_navigation");
+    if (is_int($navId)) {
+      $navId++;
+    }
+    // Find the Civicase menu.
+    $caseID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'CiviCase', 'id', 'name');
+    $administerID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Administer', 'id', 'name');
+    $menu[$administerID]['child'][$caseID]['child'][$navId] = [
+      'attributes' => [
+        'label' => ts('CiviCase Webforms'),
+        'name' => 'CiviCase Webforms',
+        'url' => 'civicrm/case/webforms',
+        'permission' => 'access CiviCase',
+        'operator' => 'OR',
+        'separator' => 1,
+        'parentID' => $caseID,
+        'navID' => $navId,
+        'active' => 1,
+      ],
+    ];
+  }
+
+  /**
+   * Civicase Add new case URL map.
+   *
+   * Adds the add case URL mapping to the array depending on
+   * the case settings config for the system. IF an alternate add Case
+   * URL is set, the url mapping is added.
+   *
+   * @param array $urlMapArray
+   *   URL Map array.
+   */
+  private function addNewCaseUrlMap(array &$urlMapArray) {
+    $allowCaseWebform = Civi::settings()->get('civicaseAllowCaseWebform');
+    $newCaseWebformUrl = $allowCaseWebform ? Civi::settings()
+      ->get('civicaseWebformUrl') : NULL;
+
+    if ($newCaseWebformUrl) {
+      $urlMapArray['civicrm/case/add?reset=1'] = $newCaseWebformUrl;
+    }
+  }
+
+  /**
+   * Visit every link in the navigation menu, and alter it using $callback.
+   *
+   * @param array $menu
+   *   Tree of menu items, per hook_civicrm_navigationMenu.
+   * @param callable $callback
+   *   Function(&$item).
+   */
+  private function menuWalk(array &$menu, callable $callback) {
+    foreach (array_keys($menu) as $key) {
+      if (isset($menu[$key]['attributes'])) {
+        $callback($menu[$key]['attributes']);
+      }
+
+      if (isset($menu[$key]['child'])) {
+        $this->menuWalk($menu[$key]['child'], $callback);
+      }
+    }
+  }
+
+}

--- a/CRM/Civicase/Service/CaseCategorySetting.php
+++ b/CRM/Civicase/Service/CaseCategorySetting.php
@@ -33,12 +33,12 @@ class CRM_Civicase_Service_CaseCategorySetting {
    * @return array
    *   Case webform setting for category.
    */
-  private function getCaseWebformSetting($caseCategoryName) {
+  public function getCaseWebformSetting($caseCategoryName) {
     return [
       str_replace(' ', '', $this->replaceWords('civicaseAllowCaseWebform', $caseCategoryName)) => [
         'group_name' => 'CiviCRM Preferences',
         'group' => 'core',
-        'name' => $this->replaceWords('civicaseAllowCaseWebform', $caseCategoryName),
+        'name' => str_replace(' ', '', $this->replaceWords('civicaseAllowCaseWebform', $caseCategoryName)),
         'type' => 'Boolean',
         'quick_form_type' => 'YesNo',
         'default' => FALSE,
@@ -55,7 +55,7 @@ class CRM_Civicase_Service_CaseCategorySetting {
       str_replace(' ', '', $this->replaceWords('civicaseWebformUrl', $caseCategoryName)) => [
         'group_name' => 'CiviCRM Preferences',
         'group' => 'core',
-        'name' => $this->replaceWords('civicaseWebformUrl', $caseCategoryName),
+        'name' => str_replace(' ', '', $this->replaceWords('civicaseWebformUrl', $caseCategoryName)),
         'type' => 'String',
         'quick_form_type' => 'Element',
         'html_attributes' => [
@@ -94,8 +94,8 @@ class CRM_Civicase_Service_CaseCategorySetting {
     return str_replace(
       ['civicaseAllowCaseWebform', 'civicaseWebformUrl', 'Case', 'Cases'],
       [
-        "civi{$caseCategoryName}Allow{$caseCategoryName}Webform",
-        "civi{$caseCategoryName}WebformUrl",
+        "civi" . ucfirst($caseCategoryName) . "Allow" . ucfirst($caseCategoryName) . "Webform",
+        "civi" . ucfirst($caseCategoryName) . "WebformUrl",
         ucfirst($caseCategoryName),
         ucfirst($caseCategoryName) . 's',
       ],


### PR DESCRIPTION
## Overview
#347 allows the case webform settings to be set per case type category. This PR allows these setting to reflect in the New [Case category] Menu url in the navigation menu. Whatever is set for the webform URL in the case category is the URL that will be used for adding a new case of that category in the navigation menu.

## Before
This functionality is not available

## After
 Whatever is set for the webform URL in the case category is the URL that will be used for adding a new case of that category in the navigation menu.

```php

      if (strpos($item['url'], $addCaseUrl) !== FALSE) {
        $caseCategoryName = $this->getCaseCategoryName($item['url']);
        $webformUrl = $this->getNewCaseCategoryWebformUrl($caseCategoryName);

        if (!empty($webformUrl)) {
          $item['url'] = $webformUrl;
        }

        return;
      }
```