### PR TITLE
RSE-754: Dynamically Set Variable Used For Add Case Category Button on Dashboard

### DIFF
--- a/CRM/Civicase/Helper/NewCaseWebform.php
+++ b/CRM/Civicase/Helper/NewCaseWebform.php
@@ -1,5 +1,8 @@
 <?php
 
+use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+use CRM_Civicase_Service_CaseCategorySetting as CaseCategorySetting;
+
 /**
  * CRM_Civicase_Helper_NewCaseWebform class.
  */
@@ -7,14 +10,20 @@ class CRM_Civicase_Helper_NewCaseWebform {
 
   /**
    * Adds new case webform URL and client data to the options array.
+   *
+   * @param array $options
+   *   Options array.
+   * @param string $caseTypeCategory
+   *   Case type category name.
+   * @param CRM_Civicase_Service_CaseCategorySetting $caseCategorySetting
+   *   CaseCategorySetting service.
    */
-  public static function addWebformDataToOptions(&$options) {
+  public static function addWebformDataToOptions(array &$options, $caseTypeCategory, CaseCategorySetting $caseCategorySetting) {
+    $caseTypeCategory = !empty($caseTypeCategory) ? $caseTypeCategory : 'Cases';
+    $newCaseWebformUrl = CaseTypeCategoryHelper::getNewCaseCategoryWebformUrl($caseTypeCategory, $caseCategorySetting);
     // Retrieve civicase webform URL.
-    $allowCaseWebform = Civi::settings()->get('civicaseAllowCaseWebform');
     $options['newCaseWebformClient'] = 'cid';
-    $options['newCaseWebformUrl'] = $allowCaseWebform
-      ? Civi::settings()->get('civicaseWebformUrl')
-      : NULL;
+    $options['newCaseWebformUrl'] = $newCaseWebformUrl;
 
     if ($options['newCaseWebformUrl']) {
       $path = explode('/', $options['newCaseWebformUrl']);

--- a/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
+++ b/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+use CRM_Civicase_Service_CaseCategorySetting as CaseCategorySetting;
 
 /**
  * CRM_Civicase_Hook_Helper_CaseTypeCategory class.
@@ -85,6 +86,38 @@ class CRM_Civicase_Hook_Helper_CaseTypeCategory {
         ],
       ]
     );
+  }
+
+  /**
+   * Returns the new case category webform URL if it's is set.
+   *
+   * @param string $caseCategoryName
+   *   Case category name.
+   * @param CRM_Civicase_Service_CaseCategorySetting $caseCategorySetting
+   *   CaseCategorySetting service.
+   *
+   * @return string|null
+   *   Webform URL.
+   */
+  public static function getNewCaseCategoryWebformUrl($caseCategoryName, CaseCategorySetting $caseCategorySetting) {
+    $webformSetting = $caseCategorySetting->getCaseWebformSetting($caseCategoryName);
+    $webformSetting = array_column($webformSetting, 'is_webform_url', 'name');
+    if (empty($webformSetting)) {
+      return;
+    }
+
+    foreach ($webformSetting as $key => $value) {
+      if ($value) {
+        $caseCategoryWebformUrl = $key;
+      }
+      else {
+        $allowCaseCategoryWebform = $key;
+      }
+    }
+
+    $allowCaseCategoryWebform = Civi::settings()->get($allowCaseCategoryWebform);
+
+    return $allowCaseCategoryWebform ? Civi::settings()->get($caseCategoryWebformUrl) : NULL;
   }
 
 }

--- a/CRM/Civicase/Hook/NavigationMenu/AlterForCaseMenu.php
+++ b/CRM/Civicase/Hook/NavigationMenu/AlterForCaseMenu.php
@@ -1,11 +1,20 @@
 <?php
 
 use CRM_Civicase_Service_CaseCategorySetting as CaseCategorySetting;
+use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
 
 /**
  * Class CRM_Civicase_Hook_Navigation_AlterForCaseMenu.
  */
 class CRM_Civicase_Hook_NavigationMenu_AlterForCaseMenu {
+
+  /**
+   * Case category Setting.
+   *
+   * @var CRM_Civicase_Service_CaseCategorySetting
+   *   CaseCategorySetting service.
+   */
+  private $caseCategorySetting;
 
   /**
    * Modifies the navigation menu.
@@ -17,6 +26,7 @@ class CRM_Civicase_Hook_NavigationMenu_AlterForCaseMenu {
    *   Menu Array.
    */
   public function run(array &$menu) {
+    $this->caseCategorySetting = new CaseCategorySetting();
     $this->rewriteCaseUrls($menu);
     $this->addCaseWebformUrl($menu);
   }
@@ -49,7 +59,7 @@ class CRM_Civicase_Hook_NavigationMenu_AlterForCaseMenu {
 
       if (strpos($item['url'], $addCaseUrl) !== FALSE) {
         $caseCategoryName = $this->getCaseCategoryName($item['url']);
-        $webformUrl = $this->getNewCaseCategoryWebformUrl($caseCategoryName);
+        $webformUrl = CaseTypeCategoryHelper::getNewCaseCategoryWebformUrl($caseCategoryName, $this->caseCategorySetting);
 
         if (!empty($webformUrl)) {
           $item['url'] = $webformUrl;
@@ -97,37 +107,6 @@ class CRM_Civicase_Hook_NavigationMenu_AlterForCaseMenu {
         'active' => 1,
       ],
     ];
-  }
-
-  /**
-   * Returns the new case category webform URL if it's is set.
-   *
-   * @param string $caseCategoryName
-   *   Case category name.
-   *
-   * @return string|null
-   *   Webform URL.
-   */
-  private function getNewCaseCategoryWebformUrl($caseCategoryName) {
-    $caseCategorySetting = new CaseCategorySetting();
-    $webformSetting = $caseCategorySetting->getCaseWebformSetting($caseCategoryName);
-    $webformSetting = array_column($webformSetting, 'is_webform_url', 'name');
-    if (empty($webformSetting)) {
-      return;
-    }
-
-    foreach ($webformSetting as $key => $value) {
-      if ($value) {
-        $caseCategoryWebformUrl = $key;
-      }
-      else {
-        $allowCaseCategoryWebform = $key;
-      }
-    }
-
-    $allowCaseCategoryWebform = Civi::settings()->get($allowCaseCategoryWebform);
-
-    return $allowCaseCategoryWebform ? Civi::settings()->get($caseCategoryWebformUrl) : NULL;
   }
 
   /**

--- a/ang/civicase-base.ang.php
+++ b/ang/civicase-base.ang.php
@@ -13,6 +13,9 @@ use CRM_Civicase_Helper_OptionValues as OptionValuesHelper;
 use CRM_Civicase_Helper_GlobRecursive as GlobRecursive;
 use CRM_Civicase_Helper_NewCaseWebform as NewCaseWebform;
 
+$caseCategoryName = CRM_Utils_Request::retrieve('case_type_category', 'String');
+$caseCategorySetting = new CRM_Civicase_Service_CaseCategorySetting();
+
 $options = [
   'activityTypes' => 'activity_type',
   'activityStatuses' => 'activity_status',
@@ -24,7 +27,7 @@ $options = [
 
 OptionValuesHelper::setToJsVariables($options);
 expose_settings($options);
-NewCaseWebform::addWebformDataToOptions($options);
+NewCaseWebform::addWebformDataToOptions($options, $caseCategoryName, $caseCategorySetting);
 set_case_types_to_js_vars($options);
 set_relationship_types_to_js_vars($options);
 set_file_categories_to_js_vars($options);


### PR DESCRIPTION
## Overview
In https://github.com/compucorp/uk.co.compucorp.civicase/pull/350, the URL for the Add New [Case category] was replaced with what is set in the webform settings for the Case category. This PR uses the URL to set a variable that is used in the frontend for the Add New [Case category] button on the dashboard.

## Before
- Currently the Add New [Case category] button on the dashboard is only set based on Civicase webform settings.

## After
- Currently the Add New [Case category] button on the dashboard is only set based on Case type category for the dashboard being viewed.

The `newCaseWebformUrl` variable set at the BE [here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/RSE-44-awards-management/CRM/Civicase/Helper/NewCaseWebform.php#L15) is used to determine the value of the Add new Case Category button on the [dashboard](https://github.com/compucorp/uk.co.compucorp.civicase/blob/3e074d8dbfd12b173a6be1a13e0341c7efbd57de/ang/civicase/dashboard/directives/add-case-dashboard-action-button.controller.js#L27-L33). Setting the right value for the variable based on the case category ensures that the value is used for the dashboard button.
