### PR TITLE
RSE-757: Filter contact tabs by case category

### DIFF
--- a/CRM/Civicase/Hook/Tabset/CaseCategoryTabAdd.php
+++ b/CRM/Civicase/Hook/Tabset/CaseCategoryTabAdd.php
@@ -58,7 +58,7 @@ class CRM_Civicase_Hook_Tabset_CaseCategoryTabAdd {
         'id' => $caseCategory['name'],
         'url' => CRM_Utils_System::url('civicrm/case/contact-case-tab', [
           'cid' => $contactID,
-          'case_type_category' => $caseCategory['name'],
+          'case_type_category' => $caseCategory['value'],
         ]),
         'title' => ts($caseCategory['label']),
         'weight' => $caseTabWeight,

--- a/CRM/Civicase/Hook/Tabset/CaseTabModifier.php
+++ b/CRM/Civicase/Hook/Tabset/CaseTabModifier.php
@@ -57,9 +57,10 @@ class CRM_Civicase_Hook_Tabset_CaseTabModifier {
    *   The URL.
    */
   private function getCaseTabUrl($contactId) {
+    $caseCategoryOptions = array_flip(CRM_Case_BAO_CaseType::buildOptions('case_type_category', 'validate'));
     return CRM_Utils_System::url('civicrm/case/contact-case-tab', [
       'cid' => $contactId,
-      'case_type_category' => CaseCategoryHelper::CASE_TYPE_CATEGORY_NAME,
+      'case_type_category' => $caseCategoryOptions[CaseCategoryHelper::CASE_TYPE_CATEGORY_NAME],
     ]);
   }
 

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
@@ -6,7 +6,9 @@
       restrict: 'EA',
       controller: 'CivicaseContactCaseTabController',
       templateUrl: '~/civicase/contact-case-tab/directives/contact-case-tab.directive.html',
-      scope: {}
+      scope: {
+        caseTypeCategory: '='
+      }
     };
   });
 
@@ -43,6 +45,7 @@
         title: 'Open Cases',
         filterParams: {
           'status_id.grouping': 'Opened',
+          'case_type_id.case_type_category': $scope.caseTypeCategory,
           contact_id: $scope.contactId,
           is_deleted: 0
         },
@@ -52,6 +55,7 @@
         title: 'Resolved cases',
         filterParams: {
           'status_id.grouping': 'Closed',
+          'case_type_id.case_type_category': $scope.caseTypeCategory,
           contact_id: $scope.contactId,
           is_deleted: 0
         },
@@ -61,6 +65,7 @@
         title: 'Other cases for this contact',
         filterParams: {
           case_manager: $scope.contactId,
+          'case_type_id.case_type_category': $scope.caseTypeCategory,
           is_deleted: 0
         },
         showContactRole: true

--- a/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
+++ b/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
@@ -35,6 +35,7 @@
           jasmine.objectContaining({
             cases: ['Case', 'getcaselist', jasmine.objectContaining({
               'status_id.grouping': 'Opened',
+              'case_type_id.case_type_category': 2,
               contact_id: mockContactId,
               is_deleted: 0
             })]
@@ -47,6 +48,7 @@
           jasmine.objectContaining({
             cases: ['Case', 'getcaselist', jasmine.objectContaining({
               'status_id.grouping': 'Closed',
+              'case_type_id.case_type_category': 2,
               contact_id: mockContactId,
               is_deleted: 0
             })]
@@ -59,6 +61,7 @@
           jasmine.objectContaining({
             cases: ['Case', 'getcaselist', jasmine.objectContaining({
               case_manager: mockContactId,
+              'case_type_id.case_type_category': 2,
               is_deleted: 0
             })]
           })
@@ -71,7 +74,7 @@
      */
     function initController () {
       $scope = $rootScope.$new();
-
+      $scope.caseTypeCategory = 2;
       $controller('CivicaseContactCaseTabController', { $scope: $scope });
     }
   });

--- a/templates/CRM/Civicase/Page/ContactCaseTab.tpl
+++ b/templates/CRM/Civicase/Page/ContactCaseTab.tpl
@@ -1,4 +1,4 @@
-<div id="civicaseContactTab" >
+<div id="civicaseContactTab-{$case_type_category}">
   <div class="container" ng-view></div>
 </div>
 {literal}
@@ -8,13 +8,13 @@
       angular.module('civicaseContactTab').config(function($routeProvider) {
         $routeProvider.when('/', {
           reloadOnSearch: false,
-          template: '<civicase-contact-case-tab></civicase-contact-case-tab>'
+          template: '<civicase-contact-case-tab case-type-category="{/literal}{$case_type_category}{literal}"></civicase-contact-case-tab>'
         });
       });
     })(angular, CRM.$, CRM._);
 
     CRM.$(document).one('crmLoad', function(){
-      angular.bootstrap(document.getElementById('civicaseContactTab'), ['civicaseContactTab']);
+      angular.bootstrap(document.getElementById('civicaseContactTab-{/literal}{$case_type_category}{literal}'), ['civicaseContactTab']);
     });
   </script>
 {/literal}


### PR DESCRIPTION
## Overview
As part of this PR, the ability to filter contact case tabs by case type category has been added.

## Before
![a](https://user-images.githubusercontent.com/5058867/73834807-5e8bb400-4832-11ea-8821-978b3885f843.gif)

## After
![before](https://user-images.githubusercontent.com/5058867/73834742-49af2080-4832-11ea-8928-e4a6380a54bc.gif)

## Technical Details
**`civicaseContactCaseTab` now accepts case type category parameter**
`civicaseContactCaseTab` now accepts case type category parameter and uses the same to filter the cases.

In `ContactCaseTab.tpl`, `case-type-category` is set as an attribute.
```javascript
$routeProvider.when('/', {
  reloadOnSearch: false,
  template: '<civicase-contact-case-tab case-type-category="{/literal}{$case_type_category}{literal}"></civicase-contact-case-tab>'
});
```

Also the container for Contact Case tab is assigned an unique id for every Case type Category. Otherwise angular throws, `App already bootstrapped with this element '<div id="civicaseContactTab" class="ng-scope">'` error.
