### PR TITLE
RSE-341: Updated Mock files related to Unit Tests

### DIFF
--- a/ang/test/mocks/data/option-value.data.js
+++ b/ang/test/mocks/data/option-value.data.js
@@ -1,0 +1,40 @@
+(function (angular, _) {
+  var module = angular.module('civicase.data');
+
+  module.service('OptionValuesMockData', [function () {
+    var optionValueMockData = [{
+      id: '1',
+      option_group_id: '1',
+      label: 'Phone',
+      value: '1',
+      name: 'Phone',
+      filter: '0',
+      weight: '1',
+      is_optgroup: '0',
+      is_reserved: '0',
+      is_active: '1'
+    }, {
+      id: '2',
+      option_group_id: '1',
+      label: 'Email',
+      value: '2',
+      name: 'Email',
+      filter: '0',
+      weight: '2',
+      is_optgroup: '0',
+      is_reserved: '0',
+      is_active: '1'
+    }];
+
+    return {
+      /**
+       * Returns a list of mocked cases
+       *
+       * @returns {Array} each array contains an object with the activity data.
+       */
+      get: function () {
+        return angular.copy(optionValueMockData);
+      }
+    };
+  }]);
+})(angular, CRM._);

--- a/ang/test/mocks/services/crm-status.factory.mock.js
+++ b/ang/test/mocks/services/crm-status.factory.mock.js
@@ -6,7 +6,9 @@
   module.factory('crmStatus', ['$q', function ($q) {
     var crmStatus = jasmine.createSpy('crmStatus');
 
-    crmStatus.and.returnValue($q.resolve());
+    crmStatus.and.callFake(function (options, promise) {
+      return $q.resolve(promise);
+    });
 
     return crmStatus;
   }]);

--- a/api/v3/CustomValue/Gettreevalues.php
+++ b/api/v3/CustomValue/Gettreevalues.php
@@ -70,6 +70,7 @@ function _civicrm_api3_custom_value_gettreevalues_spec(array &$spec) {
  */
 function civicrm_api3_custom_value_gettreevalues(array $params) {
   $ret = [];
+  $groupID = NULL;
   $options = _civicrm_api3_get_options_from_params($params);
   $toReturn = [
     'custom_group' => [],

--- a/api/v3/CustomValue/Gettreevalues.php
+++ b/api/v3/CustomValue/Gettreevalues.php
@@ -143,7 +143,15 @@ function civicrm_api3_custom_value_gettreevalues(array $params) {
     $treeParams['entityType'] = 'AwardsCaseTypes';
   }
 
-  $groupID = !empty($params['custom_group.id']) ? $params['custom_group.id'] : NULL;
+  if (!empty($params['custom_group.name']) && !is_array($params['custom_group.name'])) {
+    $result = civicrm_api3('CustomGroup', 'getsingle', [
+      'return' => ['id'],
+      'name' => $params['custom_group.name'],
+    ]);
+
+    $groupID = !empty($result['id']) ? $result['id'] : NULL;
+  }
+
   $tree = CRM_Core_BAO_CustomGroup::getTree($treeParams['entityType'], $toReturn, $params['entity_id'], $groupID, $treeParams['subTypes'], $treeParams['subName'], TRUE, NULL, FALSE, CRM_Utils_Array::value('check_permissions', $params, TRUE));
   unset($tree['info']);
   $result = [];

--- a/api/v3/CustomValue/Gettreevalues.php
+++ b/api/v3/CustomValue/Gettreevalues.php
@@ -144,12 +144,16 @@ function civicrm_api3_custom_value_gettreevalues(array $params) {
   }
 
   if (!empty($params['custom_group.name']) && !is_array($params['custom_group.name'])) {
-    $result = civicrm_api3('CustomGroup', 'getsingle', [
-      'return' => ['id'],
-      'name' => $params['custom_group.name'],
-    ]);
+    try {
+      $result = civicrm_api3('CustomGroup', 'getsingle', [
+        'return' => ['id'],
+        'name' => $params['custom_group.name'],
+      ]);
 
-    $groupID = !empty($result['id']) ? $result['id'] : NULL;
+      $groupID = !empty($result['id']) ? $result['id'] : NULL;
+    }
+    catch (CiviCRM_API3_Exception $e) {
+    }
   }
 
   $tree = CRM_Core_BAO_CustomGroup::getTree($treeParams['entityType'], $toReturn, $params['entity_id'], $groupID, $treeParams['subTypes'], $treeParams['subName'], TRUE, NULL, FALSE, CRM_Utils_Array::value('check_permissions', $params, TRUE));

--- a/api/v3/CustomValue/Gettreevalues.php
+++ b/api/v3/CustomValue/Gettreevalues.php
@@ -143,7 +143,8 @@ function civicrm_api3_custom_value_gettreevalues(array $params) {
     $treeParams['entityType'] = 'AwardsCaseTypes';
   }
 
-  $tree = CRM_Core_BAO_CustomGroup::getTree($treeParams['entityType'], $toReturn, $params['entity_id'], NULL, $treeParams['subTypes'], $treeParams['subName'], TRUE, NULL, FALSE, CRM_Utils_Array::value('check_permissions', $params, TRUE));
+  $groupID = !empty($params['custom_group.id']) ? $params['custom_group.id'] : NULL;
+  $tree = CRM_Core_BAO_CustomGroup::getTree($treeParams['entityType'], $toReturn, $params['entity_id'], $groupID, $treeParams['subTypes'], $treeParams['subName'], TRUE, NULL, FALSE, CRM_Utils_Array::value('check_permissions', $params, TRUE));
   unset($tree['info']);
   $result = [];
   foreach ($tree as $group) {


### PR DESCRIPTION
## Overview
Related to https://github.com/compucorp/uk.co.compucorp.civiawards/pull/53

## Technical Details
**CustomValue.gettreevalues api**
CustomValue.gettreevalues api now supports `custom_group.name` parameter, this is used in https://github.com/compucorp/uk.co.compucorp.civiawards/pull/53/files#diff-c845698ec2554abeeceb8861cbdc5f25R70

**Other Changes**
1. Added `option-value.data.js` mock data file.
2. Updated `crm-status.factory.mock.js` file to resolve with the sent promise.