### PR TITLE
RSE-761: Fix Issues With Saving Prospect Custom Field Values Not Saving

### DIFF
--- a/CRM/Civicase/Helper/CaseCategory.php
+++ b/CRM/Civicase/Helper/CaseCategory.php
@@ -101,4 +101,31 @@ class CRM_Civicase_Helper_CaseCategory {
     return [];
   }
 
+  /**
+   * Returns the actual case category name stored in case type category.
+   *
+   * The case type category parameter passed in the URL may have been changed
+   * by user e.g might have been changed to upper case or all lower case while
+   * the actual value stored in db might be different. This might cause issues
+   * because Core uses some function to check if the case category value
+   * (especially for custom field) extends match what is stored in some option
+   * values array, if these don't match, it might cause an issue in the
+   * application behaviour.
+   *
+   * @param string $caseCategoryNameFromUrl
+   *   Case category name passed from URL.
+   *
+   * @return string
+   *   Actual case category name.
+   */
+  public static function getActualCaseCategoryName($caseCategoryNameFromUrl) {
+    $caseCategoryNameFromUrl = strtolower($caseCategoryNameFromUrl);
+    $caseTypeCategories = CaseType::buildOptions('case_type_category', 'validate');
+    $caseTypeCategoriesCombined = array_combine($caseTypeCategories, $caseTypeCategories);
+    $caseTypeCategoriesLower = array_change_key_case($caseTypeCategoriesCombined);
+
+    return !empty($caseTypeCategoriesLower[$caseCategoryNameFromUrl]) ? $caseTypeCategoriesLower[$caseCategoryNameFromUrl] : NULL;
+
+  }
+
 }

--- a/CRM/Civicase/Hook/PostProcess/CaseCategoryCustomFieldsSaver.php
+++ b/CRM/Civicase/Hook/PostProcess/CaseCategoryCustomFieldsSaver.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+
 /**
  * CRM_Civicase_Hook_PostProcess_CaseCategoryCustomFieldsSaver class.
  */
@@ -83,7 +85,12 @@ class CRM_Civicase_Hook_PostProcess_CaseCategoryCustomFieldsSaver {
     $urlParams = parse_url(htmlspecialchars_decode($form->controller->_entryURL), PHP_URL_QUERY);
     parse_str($urlParams, $urlParams);
 
-    return !empty($urlParams['case_type_category']) ? $urlParams['case_type_category'] : NULL;
+    $caseCategory = !empty($urlParams['case_type_category']) ? $urlParams['case_type_category'] : NULL;
+    if (!$caseCategory) {
+      return NULL;
+    }
+
+    return CaseCategoryHelper::getActualCaseCategoryName($caseCategory);
   }
 
 }


### PR DESCRIPTION
## Overview
When you try to edit the custom field values for a prospect and you save, the prospect values does not get saved. This is a random issue and does not happen all the time. This PR fixes the issue so that the prospect custom fields gets saved whenever their values are changed.

## Before
![Beforw](https://user-images.githubusercontent.com/6951813/74022469-e6da9800-499d-11ea-93b7-5c8e4da6e65b.gif)


## After

![After](https://user-images.githubusercontent.com/6951813/74022491-f0640000-499d-11ea-9ff7-3a4888091b6a.gif)

- The issue was initially thought to be a permission related issue but it was not. When you create a new prospect and the prospect is saved, the prospect custom field values are saved [in the cache](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/BAO/CustomField.php#L544) so that when saving the values of these custom fields the next time, the fields meta data can easily be retrieved from the cache. 
When you try to edit prospect custom fields it works fine but when the cache is cleared, the custom fields edited values are not saved again.
This is because, the field meta data is no longer in the cache and the code to regenerate the metadata fails [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/BAO/CustomField.php#L408-L417). The reason is that the case category name for the prospecting case type category is lowercase, i.e `prospecting` but the case category value fetched [here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/0c7626fbaad8f22c94f1ea06879193b6414132d4/CRM/Civicase/Hook/PostProcess/ProcessCaseCategoryCustomFieldsForSave.php#L28) starts with upper case i.e `Prospecting`

- To fix the issue. The case category option value name case is unified at the relevant places, from creating Prospect option value, to adding the option value to the `cg_extend_objects` option group. Also when the value is retrieved from the URL, it is converted to the actual case category option name stored in the case category option group, A new function `getActualCaseCategoryName` was added for this.

