### PR TITLE
RSE-828: Manage Case Tab header Always Shows Manage Cases Regardless of Case Type category

### DIFF
--- a/ang/civicase/case/list/directives/case-list.html
+++ b/ang/civicase/case/list/directives/case-list.html
@@ -2,7 +2,7 @@
 <div crm-ui-debug="viewingCase"></div>
 <div crm-ui-debug="viewingCaseTab"></div>
 <div id="bootstrap-theme" class="clearfix civicase__container">
-  <h1 crm-page-title>Manage Cases</h1>  <!-- Added for SEO purpose (This will be hidden through css) -->
+  <h1 crm-page-title>{{ ts('Manage Cases') }}</h1>  <!-- Added for SEO purpose (This will be hidden through css) -->
   <civicase-search
     filters="filters" hidden-filters="hiddenFilters"
     expanded="searchIsOpen" on-search="applyAdvSearch(selectedFilters)">


### PR DESCRIPTION
## Overview
The manage case tab header always shows `Manage Cases` regardless of case type category

## Before
<img width="1280" alt="Monosnap 2020-02-11 17-31-26 (1)" src="https://user-images.githubusercontent.com/6951813/74258637-f9830300-4cf6-11ea-808b-0e739ffe5ad3.png">


## After
<img width="1277" alt="Manage Awards  CiviAwards 2020-02-11 17-28-45" src="https://user-images.githubusercontent.com/6951813/74258682-056ec500-4cf7-11ea-8fd5-d85b3ced2b42.png">


- The page title for the Manage Case page is translated based on the word replacement config for the case category by using the `ts` function.
