### PR TITLE
RSE-858: Fix view award application details

### DIFF
--- a/ang/civicase-base.ang.php
+++ b/ang/civicase-base.ang.php
@@ -26,7 +26,6 @@ $options = [
 ];
 
 OptionValuesHelper::setToJsVariables($options);
-expose_settings($options);
 NewCaseWebform::addWebformDataToOptions($options, $caseCategoryName, $caseCategorySetting);
 set_case_types_to_js_vars($options);
 set_relationship_types_to_js_vars($options);
@@ -34,20 +33,26 @@ set_file_categories_to_js_vars($options);
 set_activity_status_types_to_js_vars($options);
 set_custom_fields_info_to_js_vars($options);
 set_tags_to_js_vars($options);
+expose_settings($options, [
+  'caseCategoryName' => $caseCategoryName,
+]);
 
 /**
  * Expose settings.
  *
  * The default case category is taken from URL first,
  * or uses `case` as the default.
+ *
+ * @param array $options
+ *   The options that will store the exposed settings.
+ * @param array $defaults
+ *   Default values to use when exposing settings.
  */
-function expose_settings(&$options) {
-  $urlCaseCategory = CRM_Utils_Request::retrieveValue('case_type_category', 'String');
-
+function expose_settings(array &$options, array $defaults) {
   $options['allowMultipleCaseClients'] = (bool) Civi::settings()->get('civicaseAllowMultipleClients');
   $options['allowCaseLocks'] = (bool) Civi::settings()->get('civicaseAllowCaseLocks');
-  $options['defaultCaseCategory'] = $urlCaseCategory
-    ? $urlCaseCategory
+  $options['defaultCaseCategory'] = $defaults['caseCategoryName']
+    ? $defaults['caseCategoryName']
     : strtolower(CRM_Civicase_Helper_CaseCategory::CASE_TYPE_CATEGORY_NAME);
 }
 

--- a/ang/civicase-base.ang.php
+++ b/ang/civicase-base.ang.php
@@ -51,7 +51,7 @@ expose_settings($options, [
 function expose_settings(array &$options, array $defaults) {
   $options['allowMultipleCaseClients'] = (bool) Civi::settings()->get('civicaseAllowMultipleClients');
   $options['allowCaseLocks'] = (bool) Civi::settings()->get('civicaseAllowCaseLocks');
-  $options['defaultCaseCategory'] = $defaults['caseCategoryName']
+  $options['currentCaseCategory'] = $defaults['caseCategoryName']
     ? $defaults['caseCategoryName']
     : strtolower(CRM_Civicase_Helper_CaseCategory::CASE_TYPE_CATEGORY_NAME);
 }

--- a/ang/civicase-base.ang.php
+++ b/ang/civicase-base.ang.php
@@ -37,11 +37,18 @@ set_tags_to_js_vars($options);
 
 /**
  * Expose settings.
+ *
+ * The default case category is taken from URL first,
+ * or uses `case` as the default.
  */
 function expose_settings(&$options) {
+  $urlCaseCategory = CRM_Utils_Request::retrieveValue('case_type_category', 'String');
+
   $options['allowMultipleCaseClients'] = (bool) Civi::settings()->get('civicaseAllowMultipleClients');
   $options['allowCaseLocks'] = (bool) Civi::settings()->get('civicaseAllowCaseLocks');
-  $options['defaultCaseCategory'] = strtolower(CRM_Civicase_Helper_CaseCategory::CASE_TYPE_CATEGORY_NAME);
+  $options['defaultCaseCategory'] = $urlCaseCategory
+    ? $urlCaseCategory
+    : strtolower(CRM_Civicase_Helper_CaseCategory::CASE_TYPE_CATEGORY_NAME);
 }
 
 /**

--- a/ang/civicase-base/constants.js
+++ b/ang/civicase-base/constants.js
@@ -4,7 +4,7 @@
   module
     .constant('allowCaseLocks', configuration.allowCaseLocks)
     .constant('allowMultipleCaseClients', configuration.allowMultipleCaseClients)
-    .constant('defaultCaseCategory', configuration.defaultCaseCategory)
+    .constant('currentCaseCategory', configuration.currentCaseCategory)
     .constant('newCaseWebformClient', configuration.newCaseWebformClient)
     .constant('newCaseWebformUrl', configuration.newCaseWebformUrl);
 })(angular, CRM['civicase-base']);

--- a/ang/civicase/case/factories/get-case-query-params.factory.js
+++ b/ang/civicase/case/factories/get-case-query-params.factory.js
@@ -1,9 +1,9 @@
 (function (angular, $, _, CRM) {
   var module = angular.module('civicase');
 
-  module.factory('getCaseQueryParams', function () {
+  module.factory('getCaseQueryParams', function (defaultCaseCategory) {
     var DEFAULT_FILTERS = {
-      caseTypeCategory: CRM.civicase.defaultCaseCategory,
+      caseTypeCategory: defaultCaseCategory,
       panelLimit: 5
     };
 

--- a/ang/civicase/case/factories/get-case-query-params.factory.js
+++ b/ang/civicase/case/factories/get-case-query-params.factory.js
@@ -1,9 +1,9 @@
 (function (angular, $, _, CRM) {
   var module = angular.module('civicase');
 
-  module.factory('getCaseQueryParams', function (defaultCaseCategory) {
+  module.factory('getCaseQueryParams', function (currentCaseCategory) {
     var DEFAULT_FILTERS = {
-      caseTypeCategory: defaultCaseCategory,
+      caseTypeCategory: currentCaseCategory,
       panelLimit: 5
     };
 

--- a/ang/civicase/case/list/directives/case-list-table.directive.js
+++ b/ang/civicase/case/list/directives/case-list-table.directive.js
@@ -52,7 +52,7 @@
 
   module.controller('CivicaseCaseListTableController', function ($rootScope,
     $scope, $window, BulkActions, crmApi, crmStatus, crmUiHelp,
-    crmThrottle, defaultCaseCategory, $timeout, formatCase, ContactsCache, CasesUtils, ts,
+    crmThrottle, currentCaseCategory, $timeout, formatCase, ContactsCache, CasesUtils, ts,
     ActivityCategory, ActivityType, CaseStatus) {
     var firstLoad = true;
     var allCases;
@@ -325,7 +325,7 @@
       }
       var params = {
         'case_type_id.is_active': 1,
-        'case_type_id.case_type_category': defaultCaseCategory
+        'case_type_id.case_type_category': currentCaseCategory
       };
       _.each(filters, function (val, filter) {
         if (val || typeof val === 'boolean') {

--- a/ang/civicase/case/list/directives/case-list-table.directive.js
+++ b/ang/civicase/case/list/directives/case-list-table.directive.js
@@ -52,7 +52,7 @@
 
   module.controller('CivicaseCaseListTableController', function ($rootScope,
     $scope, $window, BulkActions, crmApi, crmStatus, crmUiHelp,
-    crmThrottle, $timeout, formatCase, ContactsCache, CasesUtils, ts,
+    crmThrottle, defaultCaseCategory, $timeout, formatCase, ContactsCache, CasesUtils, ts,
     ActivityCategory, ActivityType, CaseStatus) {
     var firstLoad = true;
     var allCases;
@@ -325,7 +325,7 @@
       }
       var params = {
         'case_type_id.is_active': 1,
-        'case_type_id.case_type_category': CRM.civicase.defaultCaseCategory
+        'case_type_id.case_type_category': defaultCaseCategory
       };
       _.each(filters, function (val, filter) {
         if (val || typeof val === 'boolean') {

--- a/ang/civicase/dashboard/directives/add-case-dashboard-action-button.controller.js
+++ b/ang/civicase/dashboard/directives/add-case-dashboard-action-button.controller.js
@@ -10,7 +10,7 @@
    * @param {object} ts ts
    * @param {object} $location the location service.
    * @param {object} $window the window service.
-   * @param {string} currentCaseCategory the default case type category configuration value.
+   * @param {string} currentCaseCategory the current case type category configuration value.
    * @param {string} newCaseWebformUrl the new case web form url configuration value.
    */
   function AddCaseDashboardActionButtonController ($scope, ts, $location, $window,

--- a/ang/civicase/dashboard/directives/add-case-dashboard-action-button.controller.js
+++ b/ang/civicase/dashboard/directives/add-case-dashboard-action-button.controller.js
@@ -10,11 +10,11 @@
    * @param {object} ts ts
    * @param {object} $location the location service.
    * @param {object} $window the window service.
-   * @param {string} defaultCaseCategory the default case type category configuration value.
+   * @param {string} currentCaseCategory the default case type category configuration value.
    * @param {string} newCaseWebformUrl the new case web form url configuration value.
    */
   function AddCaseDashboardActionButtonController ($scope, ts, $location, $window,
-    defaultCaseCategory, newCaseWebformUrl) {
+    currentCaseCategory, newCaseWebformUrl) {
     $scope.ts = ts;
 
     $scope.clickHandler = clickHandler;
@@ -63,7 +63,7 @@
 
       var formUrl = getCrmUrl('civicrm/case/add', {
         action: 'add',
-        case_type_category: caseTypeCategory || defaultCaseCategory,
+        case_type_category: caseTypeCategory || currentCaseCategory,
         context: 'standalone',
         reset: 1
       });

--- a/ang/civicase/dashboard/directives/dashboard.directive.js
+++ b/ang/civicase/dashboard/directives/dashboard.directive.js
@@ -16,13 +16,13 @@
    *
    * @param {object} $scope controller's scope.
    * @param {Function} crmApi CRM API service reference.
+   * @param {string} currentCaseCategory default case type category setting value.
    * @param {object[]} DashboardActionItems Dashboard action items list.
-   * @param {string} defaultCaseCategory default case type category setting value.
    * @param {Function} formatActivity Format Activity service reference.
    * @param {Function} $timeout timeout service reference.
    * @param {Function} ts translate service reference.
    */
-  function civicaseDashboardController ($scope, crmApi, DashboardActionItems, defaultCaseCategory,
+  function civicaseDashboardController ($scope, crmApi, currentCaseCategory, DashboardActionItems,
     formatActivity, $timeout, ts) {
     $scope.checkPerm = CRM.checkPerm;
     $scope.actionBarItems = DashboardActionItems;
@@ -38,7 +38,7 @@
       initWatchers();
       prepareCaseFilterOption();
       $scope.caseTypeCategoryName = getCaseTypeCategoryName();
-      $scope.defaultCaseCategory = defaultCaseCategory;
+      $scope.currentCaseCategory = currentCaseCategory;
       $scope.ts = ts;
     }());
 

--- a/ang/civicase/dashboard/directives/dashboard.directive.js
+++ b/ang/civicase/dashboard/directives/dashboard.directive.js
@@ -16,7 +16,7 @@
    *
    * @param {object} $scope controller's scope.
    * @param {Function} crmApi CRM API service reference.
-   * @param {string} currentCaseCategory default case type category setting value.
+   * @param {string} currentCaseCategory current case type category setting value.
    * @param {object[]} DashboardActionItems Dashboard action items list.
    * @param {Function} formatActivity Format Activity service reference.
    * @param {Function} $timeout timeout service reference.

--- a/ang/test/civicase/case/list/directives/case-list-table.directive.spec.js
+++ b/ang/test/civicase/case/list/directives/case-list-table.directive.spec.js
@@ -138,14 +138,14 @@
             ],
             options: jasmine.any(Object),
             'case_type_id.is_active': 1,
-            'case_type_id.case_type_category': CRM.civicase.defaultCaseCategory,
+            'case_type_id.case_type_category': CRM['civicase-base'].defaultCaseCategory,
             id: { LIKE: '%' + $scope.filters.id + '%' },
             contact_is_deleted: 0
           })],
           ['Case', 'getdetailscount', jasmine.objectContaining({
             'case_type_id.is_active': 1,
             id: { LIKE: '%' + $scope.filters.id + '%' },
-            'case_type_id.case_type_category': CRM.civicase.defaultCaseCategory,
+            'case_type_id.case_type_category': CRM['civicase-base'].defaultCaseCategory,
             contact_is_deleted: 0
           })],
           ['Case', 'getcaselistheaders']

--- a/ang/test/civicase/case/list/directives/case-list-table.directive.spec.js
+++ b/ang/test/civicase/case/list/directives/case-list-table.directive.spec.js
@@ -138,14 +138,14 @@
             ],
             options: jasmine.any(Object),
             'case_type_id.is_active': 1,
-            'case_type_id.case_type_category': CRM['civicase-base'].defaultCaseCategory,
+            'case_type_id.case_type_category': CRM['civicase-base'].currentCaseCategory,
             id: { LIKE: '%' + $scope.filters.id + '%' },
             contact_is_deleted: 0
           })],
           ['Case', 'getdetailscount', jasmine.objectContaining({
             'case_type_id.is_active': 1,
             id: { LIKE: '%' + $scope.filters.id + '%' },
-            'case_type_id.case_type_category': CRM['civicase-base'].defaultCaseCategory,
+            'case_type_id.case_type_category': CRM['civicase-base'].currentCaseCategory,
             contact_is_deleted: 0
           })],
           ['Case', 'getcaselistheaders']

--- a/ang/test/civicase/dashboard/directives/add-case-dashboard-action-button.controller.spec.js
+++ b/ang/test/civicase/dashboard/directives/add-case-dashboard-action-button.controller.spec.js
@@ -2,7 +2,7 @@
 
 (($, loadForm, getCrmUrl) => {
   describe('AddCaseDashboardActionButtonController', () => {
-    let $location, $window, $rootScope, $scope, $controller, defaultCaseCategory,
+    let $location, $window, $rootScope, $scope, $controller, currentCaseCategory,
       mockedFormPopUp;
 
     beforeEach(() => {
@@ -94,7 +94,7 @@
           beforeEach(() => {
             expectedFormUrl = getCrmUrl('civicrm/case/add', {
               action: 'add',
-              case_type_category: defaultCaseCategory,
+              case_type_category: currentCaseCategory,
               context: 'standalone',
               reset: 1
             });
@@ -145,12 +145,12 @@
      */
     function injectDependencies () {
       inject((_$location_, _$rootScope_, _$window_, _$controller_,
-        _defaultCaseCategory_) => {
+        _currentCaseCategory_) => {
         $location = _$location_;
         $window = _$window_;
         $controller = _$controller_;
         $rootScope = _$rootScope_;
-        defaultCaseCategory = _defaultCaseCategory_;
+        currentCaseCategory = _currentCaseCategory_;
 
         initController();
       });

--- a/ang/test/global.js
+++ b/ang/test/global.js
@@ -3,7 +3,7 @@
 (function (CRM) {
   CRM['civicase-base'] = {};
   CRM.civicase = {};
-  CRM.civicase.defaultCaseCategory = 'cases';
+  CRM['civicase-base'].defaultCaseCategory = 'cases';
   CRM.angular = { requires: {} };
   /**
    * Dependency Injection for civicase module, defined in ang/civicase.ang.php

--- a/ang/test/global.js
+++ b/ang/test/global.js
@@ -3,7 +3,7 @@
 (function (CRM) {
   CRM['civicase-base'] = {};
   CRM.civicase = {};
-  CRM['civicase-base'].defaultCaseCategory = 'cases';
+  CRM['civicase-base'].currentCaseCategory = 'cases';
   CRM.angular = { requires: {} };
   /**
    * Dependency Injection for civicase module, defined in ang/civicase.ang.php

--- a/ang/test/mocks/data/constants.data.js
+++ b/ang/test/mocks/data/constants.data.js
@@ -3,14 +3,14 @@
 
   CRM['civicase-base'].allowMultipleCaseClients = true;
   CRM['civicase-base'].allowCaseLocks = false;
-  CRM['civicase-base'].defaultCaseCategory = 'cases';
+  CRM['civicase-base'].currentCaseCategory = 'cases';
   CRM['civicase-base'].newCaseWebformClient = 'cid';
   CRM['civicase-base'].newCaseWebformUrl = null;
 
   module.config(($provide) => {
     $provide.constant('allowMultipleCaseClients', CRM['civicase-base'].allowMultipleCaseClients);
     $provide.constant('allowCaseLocks', CRM['civicase-base'].allowCaseLocks);
-    $provide.constant('defaultCaseCategory', CRM['civicase-base'].defaultCaseCategory);
+    $provide.constant('currentCaseCategory', CRM['civicase-base'].currentCaseCategory);
     $provide.constant('newCaseWebformClient', CRM['civicase-base'].newCaseWebformClient);
     $provide.constant('newCaseWebformUrl', CRM['civicase-base'].newCaseWebformUrl);
   });


### PR DESCRIPTION
## Overview
This PR fixes an issue where trying to view an award application by clicking on an application from the dashboard it would not display the details for them. This issue can only be reproduced when trying to view the details as an award manager.

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/74402850-d1c99300-4dfb-11ea-9760-2addb807abdf.gif)

## After
![pr-after](https://user-images.githubusercontent.com/1642119/74402859-d68e4700-4dfb-11ea-9fff-24ea3710cf47.gif)

## Technical Details

The main issue happens because the award manager does not have permissions to view normal cases, just awards, and the API was being called using `case` as the default category.

To fix this we updated the `expose_settings` function in `ang/civicase-base.ang.php` so it configures the default category depending on the value that is stored in the URL. So for the awards dashboard and manage applications the default category is `awards`.

Some other fixes done:

Also This PR fixed a regression introduced by https://github.com/compucorp/uk.co.compucorp.civicase/pull/309/files#diff-d431593b2ccb21d00d07dcae86eed8acR38-R42
The problem was that the `defaultCaseCategory` var was moved to `civicase-base` but this was not reflected in some files.
