### PR TITLE
RSE-882: Fix Issue With Other Relationships Tab Not Showing Up For awards

### DIFF
--- a/CRM/Civicase/Hook/alterAPIPermissions/Case.php
+++ b/CRM/Civicase/Hook/alterAPIPermissions/Case.php
@@ -146,6 +146,10 @@ class CRM_Civicase_Hook_alterAPIPermissions_Case {
       return $this->getCaseCategoryNameFromCaseId($params, 'id');
     }
 
+    if ($entity == 'case' && $action == 'getrelations') {
+      return $this->getCaseCategoryNameFromCaseId($params, 'case_id');
+    }
+
     if ($entity == 'case' && $action == 'create') {
       return $this->getCaseCategoryNameFromCaseType($params, 'case_type_id');
     }

--- a/CRM/Civicase/Hook/alterAPIPermissions/Case.php
+++ b/CRM/Civicase/Hook/alterAPIPermissions/Case.php
@@ -143,84 +143,77 @@ class CRM_Civicase_Hook_alterAPIPermissions_Case {
    */
   private function getCaseCategoryName($entity, $action, array $params) {
     if ($entity == 'case' && $action == 'delete') {
-      return $this->getCaseCategoryNameForCaseWhenActionIsDelete($params);
+      return $this->getCaseCategoryNameFromCaseId($params, 'id');
     }
 
     if ($entity == 'case' && $action == 'create') {
-      return $this->getCaseCategoryNameForCaseWhenActionIsCreate($params);
+      return $this->getCaseCategoryNameFromCaseType($params, 'case_type_id');
     }
 
     if ($entity == 'case' && $action != 'delete') {
-      return $this->getCaseCategoryNameForCaseWhenActionNotDelete($params);
+      return $this->getCaseCategoryNameFromCaseTypeCategory($params, 'case_type_id.case_type_category');
     }
 
     if ($entity == 'case_type' && $action != 'delete') {
-      return $this->getCaseCategoryNameForCaseTypeWhenActionNotDelete($params);
+      return $this->getCaseCategoryNameFromCaseTypeCategory($params, 'case_type_category');
     }
   }
 
   /**
-   * Returns the case category name when action is delete.
+   * Returns the case category name when case type is known.
    *
    * @param array $params
    *   API parameters.
+   * @param string $key
+   *   Case Type key.
    *
    * @return string|null
    *   Case category name.
    */
-  private function getCaseCategoryNameForCaseWhenActionIsDelete(array $params) {
-    return CaseCategoryHelper::getCategoryName($params['id']);
-  }
-
-  /**
-   * Returns the case category name when action is create.
-   *
-   * @param array $params
-   *   API parameters.
-   *
-   * @return string|null
-   *   Case category name.
-   */
-  private function getCaseCategoryNameForCaseWhenActionIsCreate(array $params) {
-    if (empty($params['case_type_id'])) {
+  private function getCaseCategoryNameFromCaseType(array $params, $key) {
+    if (empty($params[$key])) {
       return;
     }
 
-    return CaseCategoryHelper::getCategoryNameForCaseType($params['case_type_id']);
+    return CaseCategoryHelper::getCategoryNameForCaseType($params[$key]);
   }
 
   /**
-   * Returns the case category name when action is not delete.
+   * Returns the case category name when case Id is known.
    *
    * @param array $params
    *   API parameters.
+   * @param string $key
+   *   Case ID key.
    *
    * @return string|null
    *   Case category name.
    */
-  private function getCaseCategoryNameForCaseWhenActionNotDelete(array $params) {
-    if (empty($params['case_type_id.case_type_category'])) {
+  private function getCaseCategoryNameFromCaseId(array $params, $key) {
+    if (empty($params[$key])) {
       return;
     }
 
-    return $this->getCaseTypeCategoryNameFromOptions($params['case_type_id.case_type_category']);
+    return CaseCategoryHelper::getCategoryName($params[$key]);
   }
 
   /**
-   * Returns the case category name when action is not delete.
+   * Returns the case category name when case type category is known.
    *
    * @param array $params
    *   API parameters.
+   * @param string $key
+   *   Case type category key.
    *
    * @return string|null
    *   Case category name.
    */
-  private function getCaseCategoryNameForCaseTypeWhenActionNotDelete(array $params) {
-    if (empty($params['case_type_category'])) {
+  private function getCaseCategoryNameFromCaseTypeCategory(array $params, $key) {
+    if (empty($params[$key])) {
       return;
     }
 
-    return $this->getCaseTypeCategoryNameFromOptions($params['case_type_category']);
+    return $this->getCaseTypeCategoryNameFromOptions($params[$key]);
   }
 
   /**


### PR DESCRIPTION
## Overview
The other relationship tab was not showing up for Award manger viewing an award application. Normally the view should have shown `None Found` if there were no relationships.

## Before
The other relationship tab was not showing up for Award manger viewing an award application. 
<img width="1280" alt="Manage Awards  CiviAwards 2020-02-14 12-57-07" src="https://user-images.githubusercontent.com/6951813/74530135-a5ac3000-4f29-11ea-8be0-569095819295.png">



## After
The other relationship tab was is now showing up for Award manger viewing an award application. 
When there are no relationship, it shows `None found`.

<img width="1280" alt="Manage Awards  CiviAwards 2020-02-14 12-53-22" src="https://user-images.githubusercontent.com/6951813/74529889-130b9100-4f29-11ea-9266-f5683af15d4c.png">


## Technical Details
The issue was because the Case.getrelations API used to fetch contents for this tab required the permissions: `API permission check failed for Case\/getrelations call; insufficient permission: require ( access my cases and activities or access all cases and activities or basic case information )`.
Since we can't give the Award manager case related permissions, this API is added to the list of API's that will use case category equivalent permission depending on the case category, so the API will now require the `access my awards and activities or access all awards and activities or basic awards information` for cases belonging to awards category.

