### PR TITLE
RSE-363: Filter by Award Status

### DIFF
--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -147,7 +147,12 @@
     function loadStatsData () {
       var apiCalls = [];
 
-      apiCalls.push(['Case', 'getstats', $scope.caseFilter || {}]);
+      var params = angular.copy($scope.caseFilter || {});
+      // status id should not be added to getstats,
+      // because case overview section shows all statuses
+      delete params.status_id;
+
+      apiCalls.push(['Case', 'getstats', params]);
       crmApi(apiCalls).then(function (response) {
         $scope.summaryData = response[0].values;
       });

--- a/ang/civicase/dashboard/directives/dashboard.directive.js
+++ b/ang/civicase/dashboard/directives/dashboard.directive.js
@@ -1,4 +1,4 @@
-(function (angular, $) {
+(function (angular, $, _) {
   var module = angular.module('civicase');
 
   module.directive('civicaseDashboard', function () {
@@ -120,7 +120,7 @@
      * @param {object} data data sent from the broadcaster
      */
     function updateFilterParams (event, data) {
-      $scope.activityFilters.case_filter.case_type_id = data.case_type_id;
+      _.extend($scope.activityFilters.case_filter, data);
     }
   }
-})(angular, CRM.$);
+})(angular, CRM.$, CRM._);

--- a/ang/test/civicase/case/directives/case-overview.directive.spec.js
+++ b/ang/test/civicase/case/directives/case-overview.directive.spec.js
@@ -62,6 +62,24 @@
       });
     });
 
+    describe('Case Status Data', function () {
+      beforeEach(function () {
+        crmApi.and.returnValue($q.resolve([CasesOverviewStats]));
+        compileDirective({
+          caseTypeCategory: 'cases',
+          caseTypeID: [1, 2],
+          status_id: '1'
+        });
+      });
+
+      it('fetches the case statistics, but shows all case statuses', function () {
+        expect(crmApi).toHaveBeenCalledWith([['Case', 'getstats', {
+          'case_type_id.case_type_category': 'cases',
+          case_type_id: [1, 2]
+        }]]);
+      });
+    });
+
     describe('Case Status', function () {
       describe('when the component loads', function () {
         it('requests the case status that are hidden stored in the browser cache', function () {

--- a/ang/test/civicase/dashboard/directives/dashboard.directive.spec.js
+++ b/ang/test/civicase/dashboard/directives/dashboard.directive.spec.js
@@ -89,11 +89,17 @@
     describe('when the dashboard filters changed event is fired', () => {
       beforeEach(() => {
         initController();
-        $rootScope.$broadcast('civicase::dashboard-filters::updated', { case_type_id: 2 });
+        $rootScope.$broadcast('civicase::dashboard-filters::updated', {
+          case_type_id: 2,
+          status_id: { IN: [1, 2] }
+        });
       });
 
       it('reloads the data of the page', () => {
-        expect($scope.activityFilters.case_filter.case_type_id).toBe(2);
+        expect($scope.activityFilters.case_filter).toEqual(jasmine.objectContaining({
+          case_type_id: 2,
+          status_id: { IN: [1, 2] }
+        }));
       });
     });
 


### PR DESCRIPTION
## Overview
As part of this PR, the Award Status filter functionality is fixed.
Related to https://github.com/compucorp/uk.co.compucorp.civiawards/pull/58

## Before/After
See https://github.com/compucorp/uk.co.compucorp.civiawards/pull/58

## Technical Details
In `dashboard.directive.js`, applying all the parameters broadcasted, instead of just `case_type_id`.

In `case-overview.directive.js`, removing the `status_id` parameter, because case overview section should not filter by Award Status and show all statuses.
![2020-02-17 at 1 07 PM](https://user-images.githubusercontent.com/5058867/74632958-9118a380-5186-11ea-8a36-2dfb60c32ea1.jpg)

