### PR TITLE
RSE-751: Contact Cases Tab Word Replacement

### DIFF
--- a/CRM/Civicase/Page/ContactCaseTab.php
+++ b/CRM/Civicase/Page/ContactCaseTab.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Angular\Manager;
+
 /**
  * Class CRM_Civicase_Page_ContactActivityTab.
  *
@@ -18,6 +20,16 @@ class CRM_Civicase_Page_ContactCaseTab extends CRM_Core_Page {
   public function run() {
     $caseTypeCategory = CRM_Utils_Request::retrieveValue('case_type_category', 'String');
     $this->assign('case_type_category', $caseTypeCategory);
+    $caseCategoryName = CRM_Civicase_Helper_CaseCategory::getCaseCategoryNameFromOptionValue($caseTypeCategory);
+    CRM_Civicase_Hook_Helper_CaseTypeCategory::addWordReplacements($caseCategoryName);
+    $translated = [];
+    if (strtolower($caseCategoryName) != 'cases') {
+      $manager = new Manager(CRM_Core_Resources::singleton());
+      $translated = $manager->getTranslatedStrings('civicase');
+    }
+    CRM_Core_Resources::singleton()->addSetting([
+      'strings::uk.co.compucorp.civicase' => $translated,
+    ]);
 
     return parent::run();
   }

--- a/ang/civicase-base/factories/parse-url-parameters.factory.js
+++ b/ang/civicase-base/factories/parse-url-parameters.factory.js
@@ -1,0 +1,23 @@
+(function (_, angular) {
+  var module = angular.module('civicase-base');
+
+  module.factory('parseUrlParameters', function () {
+    return parseUrlParameters;
+
+    /**
+     * @param {string} url the URL to use for parsing its parameter
+     * @returns {object} returns the given URL's parameters as an object.
+     */
+    function parseUrlParameters (url) {
+      var urlParamPairs = url.split('?')
+        .slice(1)
+        .join('')
+        .split('&')
+        .map(function (paramNameAndValue) {
+          return paramNameAndValue.split('=');
+        });
+
+      return _.zipObject(urlParamPairs);
+    }
+  });
+})(CRM._, angular);

--- a/ang/civicase-base/services/case-type-category-translation.service.js
+++ b/ang/civicase-base/services/case-type-category-translation.service.js
@@ -2,7 +2,7 @@
   var module = angular.module('civicase-base');
 
   module.service('CaseTypeCategoryTranslationService', function ($rootScope) {
-    var civicaseTranslationDomainName = 'strings::uk.co.compucorp.civicase';
+    var CIVICASE_TRANSLATION_DOMAIN_NAME = 'strings::uk.co.compucorp.civicase';
 
     this.restoreTranslation = restoreTranslation;
     this.storeTranslation = storeTranslation;
@@ -26,7 +26,7 @@
      * @param {number} caseTypeCategoryId the case type category id.
      */
     function restoreTranslation (caseTypeCategoryId) {
-      CRM[civicaseTranslationDomainName] =
+      CRM[CIVICASE_TRANSLATION_DOMAIN_NAME] =
         $rootScope.caseTypeCategoryTranslations[caseTypeCategoryId];
     }
 
@@ -37,7 +37,7 @@
      */
     function storeTranslation (caseTypeCategoryId) {
       $rootScope.caseTypeCategoryTranslations[caseTypeCategoryId] =
-        _.clone(CRM[civicaseTranslationDomainName]);
+        _.clone(CRM[CIVICASE_TRANSLATION_DOMAIN_NAME]);
     }
   });
 })(CRM._, angular);

--- a/ang/civicase-base/services/case-type-category-translation.service.js
+++ b/ang/civicase-base/services/case-type-category-translation.service.js
@@ -1,0 +1,43 @@
+(function (_, angular) {
+  var module = angular.module('civicase-base');
+
+  module.service('CaseTypeCategoryTranslationService', function ($rootScope) {
+    var civicaseTranslationDomainName = 'strings::uk.co.compucorp.civicase';
+
+    this.restoreTranslation = restoreTranslation;
+    this.storeTranslation = storeTranslation;
+
+    (function init () {
+      createTranslationStore();
+    })();
+
+    /**
+     * Creates a map used to store translations for a particular case type category.
+     */
+    function createTranslationStore () {
+      if (!$rootScope.caseTypeCategoryTranslations) {
+        $rootScope.caseTypeCategoryTranslations = {};
+      }
+    }
+
+    /**
+     * Restores the translation for the given case type category.
+     *
+     * @param {number} caseTypeCategoryId the case type category id.
+     */
+    function restoreTranslation (caseTypeCategoryId) {
+      CRM[civicaseTranslationDomainName] =
+        $rootScope.caseTypeCategoryTranslations[caseTypeCategoryId];
+    }
+
+    /**
+     * Stores the translation for the given case type category.
+     *
+     * @param {number} caseTypeCategoryId the case type category id.
+     */
+    function storeTranslation (caseTypeCategoryId) {
+      $rootScope.caseTypeCategoryTranslations[caseTypeCategoryId] =
+        _.clone(CRM[civicaseTranslationDomainName]);
+    }
+  });
+})(CRM._, angular);

--- a/ang/civicase/case/card/directives/case-card-contact-record.directive.html
+++ b/ang/civicase/case/card/directives/case-card-contact-record.directive.html
@@ -9,12 +9,12 @@
     <div class="civicase__case-card__row civicase__case-card__row--primary clearfix">
       <div class="pull-left civicase__case-card-subject">{{ data.subject }}</div>
       <div class="pull-right">
-        <span>Case ID : </span>
+        <span> {{ ts('Case ID :') }} </span>
         <strong> {{ data.id }} </strong>
         <span class="civicase__pipe" ng-if="data.status !== 'Resolved'"> | </span>
         <span ng-if="data.status !== 'Resolved'">
           <span>Next Milestone: </span>
-          <span 
+          <span
             class="civicase__case-card__date"
             ng-class="{'civicase__overdue-activity-icon': data.activity_summary.milestone[0].is_overdue}"
             >

--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
@@ -2,7 +2,7 @@
   <div class="panel-body panel-body-extra" ng-controller="civicaseCaseDetailsController" ng-if="item">
     <div class="civicase__contact-cases-tab__panel-row civicase__contact-cases-tab__panel-row--dark  clearfix">
       <div class="pull-left civicase__contact-cases-tab__panel-field-emphasis civicase__contact-cases-tab-details__title">
-        <span>Case ID: <strong> {{item.id}} </strong></span>
+        <span> {{ ts('Case ID:') }} <strong> {{item.id}} </strong></span>
       </div>
       <div class="pull-right">
         <div class="btn-group btn-group-md">
@@ -109,7 +109,7 @@
         </civicase-tags-container>
       </div>
       <span class="pull-right civicase__contact-cases-tab__panel-fields--inline">
-        <span class="civicase__contact-cases-tab__panel-field-emphasis">Case Manager:</span>
+        <span class="civicase__contact-cases-tab__panel-field-emphasis"> {{ ts('Case Manager:') }} </span>
         <span>
           <span
             class="civicase__contact-card civicase__contact-card--manager"
@@ -207,7 +207,7 @@
       <!-- Case Status -->
       <div class="civicase__contact-cases-tab__panel-fields">
         <div class="civicase__contact-cases-tab__panel-field-title">
-          Case Status
+          {{ ts('Case Status') }}
         </div>
         <span
           class="crm_notification-badge ng-binding ng-scope"
@@ -247,7 +247,7 @@
     </div>
     <div class="civicase__contact-cases-tab__panel-row civicase__contact-cases-tab__panel-actions">
       <a ng-href="{{getCaseDetailsUrl(item)}}" class="btn btn-primary">
-        Go To Case
+        {{ ts('Go To Case') }}
       </a>
     </div>
   </div>

--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.js
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.js
@@ -18,9 +18,11 @@
 
   /**
    * @param {object} $scope the scope reference.
+   * @param {Function} ts translation service
    */
-  function CivicaseContactCaseTabCaseDetailsController ($scope) {
+  function CivicaseContactCaseTabCaseDetailsController ($scope, ts) {
     $scope.getCaseDetailsUrl = getCaseDetailsUrl;
+    $scope.ts = ts;
 
     /**
      * Returns the URL needed to open the case details page for the given case.

--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-list.directive.html
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-list.directive.html
@@ -26,7 +26,7 @@
     <button
       class="btn btn-default"
       ng-if="casesList.isLoadMoreAvailable && casesList.isLoaded && !casesList.showSpinner  && !casesList.disableLoadMore"
-      ng-click="loadMore()">Load More Cases</button>
+      ng-click="loadMore()"> {{ ts('Load More Cases') }} </button>
     <div ng-if="!casesList.isLoadMoreAvailable">
       <span ng-if="casesList.cases.length > 0"> Showing all {{ casesList.cases.length }}</span>
     </div>

--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-list.directive.js
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-list.directive.js
@@ -8,17 +8,26 @@
       controller: CivicaseContactCaseTabCaseListController,
       templateUrl: '~/civicase/case/contact-case-tab/directives/contact-case-tab-case-list.directive.html',
       scope: {
-        'casesList': '=',
-        'viewingCaseId': '='
+        casesList: '=',
+        viewingCaseId: '='
       }
     };
   });
 
-  function CivicaseContactCaseTabCaseListController ($scope, $rootScope, crmApi, formatCase, DateHelper) {
+  /**
+   * @param {object} $scope the controller scope
+   * @param {Function} ts translation service
+   * @param {Function} $rootScope the root scope
+   * @param {Function} crmApi the crm api service
+   * @param {Function} formatCase the format case service
+   * @param {Function} DateHelper the date helper service
+   */
+  function CivicaseContactCaseTabCaseListController ($scope, ts, $rootScope, crmApi, formatCase, DateHelper) {
     var defaultPageSize = 2;
 
     $scope.loadingPlaceholders = _.range($scope.casesList.page.size || defaultPageSize);
     $scope.formatDate = DateHelper.formatDate;
+    $scope.ts = ts;
 
     /**
      * Emits loadmore event
@@ -30,7 +39,7 @@
     /**
      * Emits view-case event
      *
-     * @param {Object} caseObj
+     * @param {object} caseObj the case object
      */
     $scope.viewCase = function (caseObj) {
       $scope.$emit('civicase::contact-record-list::view-case', caseObj);

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
@@ -1,6 +1,6 @@
 <div id="bootstrap-theme" class="clearfix civicase__container">
   <!-- Added for SEO purpose (This will be hidden through css) -->
-  <h1 crm-page-title class="element-invisible">Related cases to the user</h1>
+  <h1 crm-page-title class="element-invisible"> {{ ts('Related cases to the user') }} </h1>
   <div class="civicase__contact-cases-tab clearfix">
     <a ng-if="checkPerm('add cases') && !newCaseWebformUrl"
       class="btn-primary btn civicase__contact-cases-tab-add"
@@ -120,8 +120,8 @@
   </div>
   <div  ng-if="totalCount == 0" class="civicase__contact-cases-tab-empty">
     <div class="civicase__activity-no-result-icon civicase__activity-no-result-icon--case"></div>
-    <div class="civicase__activity-card--big--empty-title"> This contact has no cases </div>
-    <div class="civicase__activity-card--big--empty-description"> Click the button below to create a new case for this contact </div>
+    <div class="civicase__activity-card--big--empty-title"> {{ ts('This contact has no cases') }} </div>
+    <div class="civicase__activity-card--big--empty-description"> {{ ts('Click the button below to create a new case for this contact') }} </div>
     <a ng-if="checkPerm('add cases')"
       class="civicase__activity-card--big--empty-button btn"
       ng-href="{{ 'civicrm/case/add' | civicaseCrmUrl:{reset: 1, action: 'add', context: 'standalone'} }}"

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
@@ -1,4 +1,8 @@
-<div id="bootstrap-theme" class="clearfix civicase__container">
+<div
+  id="bootstrap-theme"
+  class="clearfix civicase__container"
+  civicase-on-contact-tab-change="handleContactTabChange($tabUrlParams)"
+>
   <!-- Added for SEO purpose (This will be hidden through css) -->
   <h1 crm-page-title class="element-invisible"> {{ ts('Related cases to the user') }} </h1>
   <div class="civicase__contact-cases-tab clearfix">
@@ -10,8 +14,8 @@
       {{ ts('Add case') }}
     </a>
     <a ng-if="checkPerm('add cases') && newCaseWebformUrl"
-       class="btn-primary btn"
-       ng-href="{{ newCaseWebformUrl | civicaseCrmUrl:{[newCaseWebformClient]: contactId} }}">
+      class="btn-primary btn"
+      ng-href="{{ newCaseWebformUrl | civicaseCrmUrl:{[newCaseWebformClient]: contactId} }}">
       <i class="material-icons">add_circle</i>
       {{ ts('Add case') }}
     </a>
@@ -66,7 +70,7 @@
                   <div class="civicase__contact-cases-tab__panel-fields" style="margin-bottom: 10px;">
                     <div class="civicase__loading-placeholder__oneline civicase__contact-cases-tab__panel-field-title" style="width: 8em; margin-bottom: 10px;"></div>
                     <div class="civicase__activity-card civicase__activity-card--short">
-                       <div class="panel panel-default">
+                      <div class="panel panel-default">
                         <div class="panel-body">
                           <div class="civicase__activity-card-row" style="margin-bottom: 8px;">
                             <div class="civicase__loading-placeholder__oneline" style="width: 0.8em; font-size: 24px; margin-right: 10px;"></div>

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
@@ -43,7 +43,7 @@
     $scope.casesListConfig = [
       {
         name: 'opened',
-        title: 'Open Cases',
+        title: ts('Open Cases'),
         filterParams: {
           'status_id.grouping': 'Opened',
           'case_type_id.case_type_category': $scope.caseTypeCategory,
@@ -53,7 +53,7 @@
         showContactRole: false
       }, {
         name: 'closed',
-        title: 'Resolved cases',
+        title: ts('Resolved cases'),
         filterParams: {
           'status_id.grouping': 'Closed',
           'case_type_id.case_type_category': $scope.caseTypeCategory,
@@ -63,7 +63,7 @@
         showContactRole: false
       }, {
         name: 'related',
-        title: 'Other cases for this contact',
+        title: ts('Other cases for this contact'),
         filterParams: {
           case_manager: $scope.contactId,
           'case_type_id.case_type_category': $scope.caseTypeCategory,

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
@@ -17,6 +17,7 @@
   /**
    * @param {object} $scope the controller scope
    * @param {Function} ts translation service
+   * @param {Function} CaseTypeCategoryTranslationService the case type category translation service
    * @param {Function} crmApi the crm api service
    * @param {Function} formatCase the format case service
    * @param {object} Contact the contact service
@@ -24,8 +25,8 @@
    * @param {string} newCaseWebformClient the new case web form client configuration value
    * @param {string} newCaseWebformUrl the new case web form url configuration value
    */
-  function CivicaseContactCaseTabController ($scope, ts, crmApi, formatCase, Contact, ContactsCache,
-    newCaseWebformClient, newCaseWebformUrl) {
+  function CivicaseContactCaseTabController ($scope, ts, CaseTypeCategoryTranslationService,
+    crmApi, formatCase, Contact, ContactsCache, newCaseWebformClient, newCaseWebformUrl) {
     var commonConfigs = {
       isLoaded: false,
       showSpinner: false,
@@ -74,12 +75,15 @@
     ];
 
     $scope.checkPerm = CRM.checkPerm;
+    $scope.handleContactTabChange = handleContactTabChange;
     $scope.ts = ts;
 
     (function init () {
       initCasesConfig();
       initSubscribers();
       getCases();
+      CaseTypeCategoryTranslationService
+        .storeTranslation($scope.caseTypeCategory);
     }());
 
     /**
@@ -230,6 +234,25 @@
 
         $scope.totalCount = count;
       });
+    }
+
+    /**
+     * Triggers after the contact tab changes. When changing back to the tab belonging to this case
+     * type category, it restores the translations associated with it. This is done due to CiviCRM
+     * replacing the translation files when a new angular module is loaded. The solution is to manually
+     * restore the translations.
+     *
+     * @param {object} urlParams a map of the URL parameters belonging to the currently active tab.
+     */
+    function handleContactTabChange (urlParams) {
+      var caseTypeCategoryId = parseInt(urlParams.case_type_category, 10);
+      var isChangingToCurrentCaseCategoryTab = caseTypeCategoryId === $scope.caseTypeCategory;
+
+      if (!isChangingToCurrentCaseCategoryTab) {
+        return;
+      }
+
+      CaseTypeCategoryTranslationService.restoreTranslation(caseTypeCategoryId);
     }
 
     /**

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
@@ -16,6 +16,7 @@
 
   /**
    * @param {object} $scope the controller scope
+   * @param {Function} ts translation service
    * @param {Function} crmApi the crm api service
    * @param {Function} formatCase the format case service
    * @param {object} Contact the contact service
@@ -23,7 +24,7 @@
    * @param {string} newCaseWebformClient the new case web form client configuration value
    * @param {string} newCaseWebformUrl the new case web form url configuration value
    */
-  function CivicaseContactCaseTabController ($scope, crmApi, formatCase, Contact, ContactsCache,
+  function CivicaseContactCaseTabController ($scope, ts, crmApi, formatCase, Contact, ContactsCache,
     newCaseWebformClient, newCaseWebformUrl) {
     var commonConfigs = {
       isLoaded: false,
@@ -73,7 +74,7 @@
     ];
 
     $scope.checkPerm = CRM.checkPerm;
-    $scope.ts = CRM.ts('civicase');
+    $scope.ts = ts;
 
     (function init () {
       initCasesConfig();
@@ -180,7 +181,8 @@
         'subject', 'details', 'contact_id', 'case_type_id', 'status_id',
         'contacts', 'start_date', 'end_date', 'is_deleted', 'activity_summary',
         'activity_count', 'category_count', 'tag_id.name', 'tag_id.color',
-        'tag_id.description', 'tag_id.parent_id', 'related_case_ids'
+        'tag_id.description', 'tag_id.parent_id', 'related_case_ids',
+        'case_type_id.case_type_category'
       ];
       var returnCaseParams = {
         sequential: 1,

--- a/ang/civicase/shared/directives/on-contact-tab-change.directive.js
+++ b/ang/civicase/shared/directives/on-contact-tab-change.directive.js
@@ -4,7 +4,7 @@
   module.directive('civicaseOnContactTabChange', function (parseUrlParameters) {
     return {
       restrict: 'A',
-      link: onContactTabChangeLink,
+      link: civicaseOnContactTabChangeLink,
       scope: {
         onContactTabChange: '&civicaseOnContactTabChange'
       }
@@ -17,7 +17,7 @@
      *
      * @param {object} $scope a reference to the directive's scope.
      */
-    function onContactTabChangeLink ($scope) {
+    function civicaseOnContactTabChangeLink ($scope) {
       var contactTabs = $('.page-civicrm-contact #mainTabContainer');
 
       (function init () {

--- a/ang/civicase/shared/directives/on-contact-tab-change.directive.js
+++ b/ang/civicase/shared/directives/on-contact-tab-change.directive.js
@@ -1,0 +1,47 @@
+(function ($, angular) {
+  var module = angular.module('civicase');
+
+  module.directive('civicaseOnContactTabChange', function (parseUrlParameters) {
+    return {
+      restrict: 'A',
+      link: onContactTabChangeLink,
+      scope: {
+        onContactTabChange: '&civicaseOnContactTabChange'
+      }
+    };
+
+    /**
+     * Listens for contact tab change and triggers the handler
+     * passed down to this directive. It provides the URL and URL
+     * parameters (as objects) for the new tab.
+     *
+     * @param {object} $scope a reference to the directive's scope.
+     */
+    function onContactTabChangeLink ($scope) {
+      var contactTabs = $('.page-civicrm-contact #mainTabContainer');
+
+      (function init () {
+        contactTabs.on('tabsactivate', listenToContactTabChange);
+      })();
+
+      /**
+       * Handles the contact tab change.
+       *
+       * @param {document#event:tabsactivate} event the tab change event reference.
+       * @param {object} uiTab a UI Tab event object which contains a reference to the new
+       *   and previous tabs.
+       */
+      function listenToContactTabChange (event, uiTab) {
+        var tabUrl = $(uiTab.newTab).find('a').attr('href');
+        var urlParams = parseUrlParameters(tabUrl);
+
+        $scope.$apply(function () {
+          $scope.onContactTabChange({
+            $tabUrl: tabUrl,
+            $tabUrlParams: urlParams
+          });
+        });
+      }
+    }
+  });
+})(CRM.$, angular);

--- a/ang/test/civicase-base/factories/parse-url-parameters.factory.spec.js
+++ b/ang/test/civicase-base/factories/parse-url-parameters.factory.spec.js
@@ -1,0 +1,30 @@
+/* eslint-env jasmine */
+(() => {
+  describe('parseUrlParameters', () => {
+    let parseUrlParameters;
+
+    beforeEach(module('civicase-base'));
+
+    beforeEach(inject((_parseUrlParameters_) => {
+      parseUrlParameters = _parseUrlParameters_;
+    }));
+
+    describe('when parsing a URL', () => {
+      let parsedUrlResult;
+      const testUrl = '/civicrm/a?cid=999&case_id=888&category=custom-category';
+      const expectedResult = {
+        cid: '999',
+        case_id: '888',
+        category: 'custom-category'
+      };
+
+      beforeEach(() => {
+        parsedUrlResult = parseUrlParameters(testUrl);
+      });
+
+      it('returns the URL parameters as an object', () => {
+        expect(parsedUrlResult).toEqual(expectedResult);
+      });
+    });
+  });
+})();

--- a/ang/test/civicase-base/services/case-type-category-translation.service.spec.js
+++ b/ang/test/civicase-base/services/case-type-category-translation.service.spec.js
@@ -2,7 +2,7 @@
 
 ((_, CRM) => {
   describe('CaseTypeCategoryTranslationService', () => {
-    const civicaseTranslationDomainName = 'strings::uk.co.compucorp.civicase';
+    const CIVICASE_TRANSLATION_DOMAIN_NAME = 'strings::uk.co.compucorp.civicase';
     const mockCaseTypeCategoryId = _.uniqueId();
     const mockTranslation = {
       civicase: 'my custom case name'
@@ -15,7 +15,7 @@
       $rootScope = _$rootScope_;
       CaseTypeCategoryTranslationService = _CaseTypeCategoryTranslationService_;
 
-      CRM[civicaseTranslationDomainName] = mockTranslation;
+      CRM[CIVICASE_TRANSLATION_DOMAIN_NAME] = mockTranslation;
     }));
 
     describe('when it initializes', () => {
@@ -43,12 +43,12 @@
     describe('when restoring a case type category translation', () => {
       beforeEach(() => {
         CaseTypeCategoryTranslationService.storeTranslation(mockCaseTypeCategoryId);
-        CRM[civicaseTranslationDomainName] = {};
+        CRM[CIVICASE_TRANSLATION_DOMAIN_NAME] = {};
         CaseTypeCategoryTranslationService.restoreTranslation(mockCaseTypeCategoryId);
       });
 
       it('replaces the civicase translation object with the one that was previously stored in the root scope', () => {
-        expect(CRM[civicaseTranslationDomainName]).toEqual(mockTranslation);
+        expect(CRM[CIVICASE_TRANSLATION_DOMAIN_NAME]).toEqual(mockTranslation);
       });
     });
   });

--- a/ang/test/civicase-base/services/case-type-category-translation.service.spec.js
+++ b/ang/test/civicase-base/services/case-type-category-translation.service.spec.js
@@ -1,0 +1,55 @@
+/* eslint-env jasmine */
+
+((_, CRM) => {
+  describe('CaseTypeCategoryTranslationService', () => {
+    const civicaseTranslationDomainName = 'strings::uk.co.compucorp.civicase';
+    const mockCaseTypeCategoryId = _.uniqueId();
+    const mockTranslation = {
+      civicase: 'my custom case name'
+    };
+    let $rootScope, CaseTypeCategoryTranslationService;
+
+    beforeEach(module('civicase-base'));
+
+    beforeEach(inject((_$rootScope_, _CaseTypeCategoryTranslationService_) => {
+      $rootScope = _$rootScope_;
+      CaseTypeCategoryTranslationService = _CaseTypeCategoryTranslationService_;
+
+      CRM[civicaseTranslationDomainName] = mockTranslation;
+    }));
+
+    describe('when it initializes', () => {
+      it('creates a store for translations in the root scope object', () => {
+        expect($rootScope.caseTypeCategoryTranslations).toEqual({});
+      });
+    });
+
+    describe('when storing a case type category translation', () => {
+      beforeEach(() => {
+        CaseTypeCategoryTranslationService.storeTranslation(mockCaseTypeCategoryId);
+      });
+
+      it('stores the translation in the root scope object', () => {
+        expect($rootScope.caseTypeCategoryTranslations[mockCaseTypeCategoryId])
+          .toEqual(mockTranslation);
+      });
+
+      it('stores a copy of the translation and not the original one', () => {
+        expect($rootScope.caseTypeCategoryTranslations[mockCaseTypeCategoryId])
+          .not.toBe(mockTranslation);
+      });
+    });
+
+    describe('when restoring a case type category translation', () => {
+      beforeEach(() => {
+        CaseTypeCategoryTranslationService.storeTranslation(mockCaseTypeCategoryId);
+        CRM[civicaseTranslationDomainName] = {};
+        CaseTypeCategoryTranslationService.restoreTranslation(mockCaseTypeCategoryId);
+      });
+
+      it('replaces the civicase translation object with the one that was previously stored in the root scope', () => {
+        expect(CRM[civicaseTranslationDomainName]).toEqual(mockTranslation);
+      });
+    });
+  });
+})(CRM._, CRM);

--- a/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
+++ b/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
@@ -2,7 +2,8 @@
 
 ((_) => {
   describe('Contact Case Tab', () => {
-    var $controller, $rootScope, $scope, crmApi, mockContactId, mockContactService;
+    var $controller, $rootScope, $scope, CaseTypeCategoryTranslationService,
+      crmApi, mockContactId, mockContactService;
 
     beforeEach(module('civicase', ($provide) => {
       mockContactService = jasmine.createSpyObj('Contact', ['getCurrentContactID']);
@@ -10,10 +11,15 @@
       $provide.value('Contact', mockContactService);
     }));
 
-    beforeEach(inject((_$controller_, _$rootScope_, _crmApi_) => {
+    beforeEach(inject((_$controller_, _$rootScope_, _CaseTypeCategoryTranslationService_,
+      _crmApi_) => {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
+      CaseTypeCategoryTranslationService = _CaseTypeCategoryTranslationService_;
       crmApi = _crmApi_;
+
+      spyOn(CaseTypeCategoryTranslationService, 'restoreTranslation');
+      spyOn(CaseTypeCategoryTranslationService, 'storeTranslation');
     }));
 
     beforeEach(() => {
@@ -26,6 +32,11 @@
     describe('on init', () => {
       it('stores the contact id extracted from the URL', () => {
         expect($scope.contactId).toBe(mockContactId);
+      });
+
+      it('stores the current case type category translation', () => {
+        expect(CaseTypeCategoryTranslationService.storeTranslation)
+          .toHaveBeenCalledWith($scope.caseTypeCategory);
       });
     });
 
@@ -66,6 +77,34 @@
             })]
           })
         ]));
+      });
+    });
+
+    describe('when changing contact tabs', () => {
+      describe('when changing back to the current case type category tab', () => {
+        beforeEach(() => {
+          $scope.handleContactTabChange({
+            case_type_category: $scope.caseTypeCategory
+          });
+        });
+
+        it('restores the translations for the current case type category', () => {
+          expect(CaseTypeCategoryTranslationService.restoreTranslation)
+            .toHaveBeenCalledWith($scope.caseTypeCategory);
+        });
+      });
+
+      describe('when changing back to a different case type category tab', () => {
+        beforeEach(() => {
+          $scope.handleContactTabChange({
+            case_type_category: 3
+          });
+        });
+
+        it('does not restore the case type category translation', () => {
+          expect(CaseTypeCategoryTranslationService.restoreTranslation)
+            .not.toHaveBeenCalled();
+        });
       });
     });
 

--- a/ang/test/civicase/shared/directives/on-contact-tab-change.directive.spec.js
+++ b/ang/test/civicase/shared/directives/on-contact-tab-change.directive.spec.js
@@ -1,0 +1,85 @@
+/* eslint-env jasmine */
+
+(($) => {
+  describe('civicaseOnContactTabChange', () => {
+    let $compile, $rootScope, $scope, element;
+    const testUrl = '/civicrm/contact?cid=999&tab=test-tab';
+
+    beforeEach(module('civicase'));
+
+    beforeEach(inject((_$compile_, _$rootScope_) => {
+      $compile = _$compile_;
+      $rootScope = _$rootScope_;
+    }));
+
+    beforeEach(() => {
+      $scope = $rootScope.$new();
+      $scope.contactTabChangeSpy = jasmine.createSpy('contactTabChangeSpy');
+
+      spyOn($scope, '$apply').and.callThrough();
+      initDirective();
+    });
+
+    afterEach(() => {
+      element.remove();
+    });
+
+    describe('when the contact tab changes', () => {
+      beforeEach(() => {
+        const uiTab = {
+          newTab: element.find('li')
+        };
+
+        element.find('#mainTabContainer')
+          .trigger('tabsactivate', uiTab);
+      });
+
+      it('calls the change handler function', () => {
+        expect($scope.contactTabChangeSpy).toHaveBeenCalled();
+      });
+
+      it('passes the new tab URL', () => {
+        expect($scope.contactTabChangeSpy).toHaveBeenCalledWith(jasmine.objectContaining({
+          $tabUrl: testUrl
+        }));
+      });
+
+      it('passes the parsed URL parameters of the new tab', () => {
+        expect($scope.contactTabChangeSpy).toHaveBeenCalledWith(jasmine.objectContaining({
+          $tabUrlParams: {
+            cid: '999',
+            tab: 'test-tab'
+          }
+        }));
+      });
+    });
+
+    /**
+     * Attaches the DOM elements needed to test the directive and initializes
+     * the directive itself. The DOM elements are attached to the body of the DOM
+     * so it needs to be removed on each cicle.
+     */
+    function initDirective () {
+      element = CRM.$(`
+        <div id="civicase-dom-test" class="page-civicrm-contact">
+          <ul id="mainTabContainer">
+            <li>
+              <a href="${testUrl}">
+                Test Tab
+              </a>
+            </li>
+          </ul>
+          <div
+            civicase-on-contact-tab-change="contactTabChangeSpy({
+              $tabUrl: $tabUrl,
+              $tabUrlParams: $tabUrlParams
+            })"
+          ></div>
+        </div>
+      `);
+      element.appendTo('body');
+
+      $compile(element)($scope);
+    }
+  });
+})(CRM.$);


### PR DESCRIPTION
## Overview
This PR adds the translations needed for the case and other case categories tabs in the contact details page.

## Before

![Screen Shot 2020-03-02 at 5 49 05 PM](https://user-images.githubusercontent.com/1642119/75721109-2602bd00-5cae-11ea-9ddf-3a82cafd6562.png)
Using awards as an example. The word "Case" has not been replaced in a few places.

## After
![Screen Shot 2020-03-02 at 6 03 19 PM](https://user-images.githubusercontent.com/1642119/75722236-33b94200-5cb0-11ea-8aa1-37d260fe1a60.png)


## Technical Details
For the most part we simply replaced the "Case" word and printed it using the `ts` service.

Regarding the PHP changes in `CRM/Civicase/Page/ContactCaseTab.php` these are done in order to run the proper word replacements belonging to the case type category.

### Tab change issue

When changing tabs the translations would be replaced from the global object and when coming back to a particular tab the last translation file would be used. This caused the following issue:

![gif](https://user-images.githubusercontent.com/1642119/75721755-497a3780-5caf-11ea-933f-9ffd901a49cf.gif)

As you can see the "cases" tab gets the translations from the last accessed case category tab. This is because when an angular page is loaded it replaces the `CRM['strings::uk.co.compucorp.civicase']` global variable with the translations and word replacements for that particular module. 

To fix this we store the translation for the given case category and restore it after the contact tab changes. 

### New directives and services

`on-contact-tab-change.directive.js` is a directive that listen to a contact tab change and triggers a function passed down to it and it provides the URL and URL parameters for the given tab. Usage example:

```html
<div civicase-on-contact-tab-change="handleContactTabChange($tabUrl, $tabUrlParams)">
  ...
</div>
```

`parse-url-parameters.factory.js` is a service that given a URL string, returns the URL parameters as object. Example:

```js
var urlParams = parseUrlParameters('/civicrm?path=main&category=custom&travel=boat');

/*
{
  path: 'main',
  category: 'custom',
  travel: 'boat'
}
*/
```

This service was added because angular provide a similar behaviour through the `$location` object, but only for the current angular route, not for arbitrary paths.

`case-type-category-translation.service.js` stores and restores the translations contained in the `CRM['strings::uk.co.compucorp.civicase']` object. The stored translations are associated to a given case type category. This service is used to store the translations when switching to a different module that uses a different case category and to restoring the translation when switching back since they both use the `CRM['strings::uk.co.compucorp.civicase']` object and this service helps keep the right translation object in place.
