### PR TITLE
RSE-747: Update and Translate Case Category Form Settings Description For  CiviCase Settings

### DIFF
--- a/CRM/Civicase/Service/CaseCategorySetting.php
+++ b/CRM/Civicase/Service/CaseCategorySetting.php
@@ -47,7 +47,7 @@ class CRM_Civicase_Service_CaseCategorySetting {
         'title' => $this->replaceWords('Trigger webform on Add Case', $caseCategoryName),
         'is_domain' => 1,
         'is_contact' => 0,
-        'description' => $this->replaceWords('This setting allows the user to set a webform to be triggered when clicking the `Add Case` button on the Cases tab on the Contact.', $caseCategoryName),
+        'description' => $this->replaceWords('This setting allows the user to set a webform to be triggered when clicking the "Add Case" button on the Cases tab on the Contact.', $caseCategoryName),
         'help_text' => '',
         'is_webform_url' => FALSE,
         'webform_url_name' => str_replace(' ', '', $this->replaceWords('civicaseWebformUrl', $caseCategoryName)),
@@ -68,7 +68,7 @@ class CRM_Civicase_Service_CaseCategorySetting {
         'title' => ' URL of the Webform',
         'is_domain' => 1,
         'is_contact' => 0,
-        'description' => '',
+        'description' => 'A Webform url e.g /node/233',
         'help_text' => '',
         'is_webform_url' => TRUE,
       ],
@@ -92,12 +92,12 @@ class CRM_Civicase_Service_CaseCategorySetting {
     }
 
     return str_replace(
-      ['civicaseAllowCaseWebform', 'civicaseWebformUrl', 'Case', 'Cases'],
+      ['civicaseAllowCaseWebform', 'civicaseWebformUrl', 'Cases', 'Case'],
       [
         "civi" . ucfirst($caseCategoryName) . "Allow" . ucfirst($caseCategoryName) . "Webform",
         "civi" . ucfirst($caseCategoryName) . "WebformUrl",
         ucfirst($caseCategoryName),
-        ucfirst($caseCategoryName) . 's',
+        ucfirst($caseCategoryName),
       ],
       $stringToReplace
     );

--- a/templates/CRM/Civicase/Admin/Form/Settings.tpl
+++ b/templates/CRM/Civicase/Admin/Form/Settings.tpl
@@ -9,7 +9,7 @@
   <tr class="crm-case-form-block-{$settingKey}">
     <td class="label">{$form.$settingKey.label}</td>
     <td>{$form.$settingKey.html}<br />
-      <span class="description">{$setting.description}</span>
+      <span class="description">{ts}{$setting.description}{/ts}</span>
     </td>
   </tr>
 {/foreach}

--- a/templates/CRM/Civicase/Admin/Form/Settings.tpl
+++ b/templates/CRM/Civicase/Admin/Form/Settings.tpl
@@ -9,7 +9,7 @@
   <tr class="crm-case-form-block-{$settingKey}">
     <td class="label">{$form.$settingKey.label}</td>
     <td>{$form.$settingKey.html}<br />
-      <span class="description">{ts}This setting allows the user to set a webform to be triggered when clicking the "Add Case" button on the Cases tab on the Contact{/ts}</span>
+      <span class="description">{$setting.description}</span>
     </td>
   </tr>
 {/foreach}


### PR DESCRIPTION
## Overview
The Civicase settings page  allows an administrator to choose to set an alternative URL which is to be used when creating new case category case both on the case category dashboard and the navigation menu. These form fields descriptions are updated in this PR as they are not translated (i.e  `Case` should be replaced by the appropriate case category name), also the `URL webform ` field description is updated to reflect what can be added for the field.

## Before
<img width="1280" alt="Settings - CiviCase  CiviAwards 2020-02-18 17-00-09" src="https://user-images.githubusercontent.com/6951813/74754222-969ee800-5271-11ea-85f6-ce64acc58204.png">


## After
<img width="1280" alt="Settings - CiviCase  CiviAwards 2020-02-18 16-59-22" src="https://user-images.githubusercontent.com/6951813/74754259-a4546d80-5271-11ea-95f9-dd0e38e24801.png">
