### PR TITLE
RSE-830: Fix: Activity Report Should Reflect Correct Case Type Category

### DIFF
--- a/CRM/Civicase/XMLProcessor/Report.php
+++ b/CRM/Civicase/XMLProcessor/Report.php
@@ -430,6 +430,9 @@ AND    ac.case_id = %1
       $report,
       $selectedActivities
     );
+
+    $caseCategoryName = CRM_Civicase_Helper_CaseCategory::getCategoryName($caseID);
+    CRM_Civicase_Hook_Helper_CaseTypeCategory::addWordReplacements($caseCategoryName);
     $printReport = CRM_Case_Audit_Audit::run($contents, $clientID, $caseID, TRUE);
     echo $printReport;
     CRM_Utils_System::civiExit();


### PR DESCRIPTION
## Overview
This PR allows the activity report for each case type category to be translated based on the translation config for each case type category.

## Before
Sample report for prospect category before
<img width="1280" alt="Monosnap 2020-02-18 18-06-14" src="https://user-images.githubusercontent.com/6951813/74759666-707d4600-5279-11ea-93b6-f4baf26315c5.png">

## After
Sample report for prospect category after
<img width="1286" alt="Standard Timeline 2020-02-18 18-04-44" src="https://user-images.githubusercontent.com/6951813/74759556-3f9d1100-5279-11ea-8cbb-549bf35ef214.png">

The Word replacement function is used to add translation strings  just before the output of the print report is rendered so that the template [here](https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/Case/Audit/Report.tpl) will be translated
