### PR TITLE
CPS-85: Make Case Category URL's Consistent With Other Case Type Categories

### DIFF
--- a/CRM/Civicase/Setup/UpdateMenuLinks.php
+++ b/CRM/Civicase/Setup/UpdateMenuLinks.php
@@ -6,6 +6,11 @@
 class CRM_Civicase_Setup_UpdateMenuLinks {
 
   /**
+   * Manage case URL.
+   */
+  const MANAGE_CASE_URL = 'civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B"case_type_category":"cases"%7D';
+
+  /**
    * Updates the Manage Cases Menu URLs.
    */
   public function apply() {
@@ -32,7 +37,7 @@ class CRM_Civicase_Setup_UpdateMenuLinks {
     if ($manageCasesMenuItem['id']) {
       civicrm_api3('Navigation', 'create', [
         'id' => $manageCasesMenuItem['id'],
-        'url' => 'civicrm/case/a/#/case/list?cf=%7B"case_type_category":"cases"%7D',
+        'url' => self::MANAGE_CASE_URL,
       ]);
     }
 

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -7,6 +7,7 @@ use CRM_Civicase_Setup_AddCaseCategoryWordReplacementOptionGroup as AddCaseCateg
 use CRM_Civicase_Setup_MoveCaseTypesToCasesCategory as MoveCaseTypesToCasesCategory;
 use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 use CRM_Civicase_Setup_CreateSafeFileExtensionOptionValue as CreateSafeFileExtensionOptionValue;
+use CRM_Civicase_Setup_UpdateMenuLinks as MenuLinksSetup;
 
 /**
  * Collection of upgrade steps.
@@ -145,7 +146,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     $this->addNav([
       'label' => ts('Manage Cases', ['domain' => 'uk.co.compucorp.civicase']),
       'name' => 'Manage Cases',
-      'url' => 'civicrm/case/a/#/case/list',
+      'url' => MenuLinksSetup::MANAGE_CASE_URL,
       'permission' => 'access my cases and activities,access all cases and activities',
       'operator' => 'OR',
       'separator' => 0,

--- a/CRM/Civicase/Upgrader/Steps/Step0009.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0009.php
@@ -5,7 +5,7 @@ use CRM_Civicase_Setup_UpdateMenuLinks as UpdateMenuLinks;
 /**
  * Updates the Manage Cases Menu URLs.
  */
-class CRM_Civicase_Upgrader_Steps_Step0006 {
+class CRM_Civicase_Upgrader_Steps_Step0009 {
 
   /**
    * Updates the Manage Cases Menu URLs.

--- a/civicase.php
+++ b/civicase.php
@@ -588,7 +588,7 @@ function civicase_civicrm_navigationMenu(&$menu) {
    *   Array(string $oldUrl => string $newUrl).
    */
   $rewriteMap = [
-    'civicrm/case?reset=1' => 'civicrm/case/a/#/case?case_type_category=cases',
+    'civicrm/case?reset=1' => 'civicrm/case/a/?case_type_category=cases#/case?case_type_category=cases',
     'civicrm/case/search?reset=1' => 'civicrm/case/a/#/case/list?sx=1',
   ];
 


### PR DESCRIPTION
## Overview
This PR fixes some issues with the Case Dashboard and Manage Case URL.
(1) The Manage Case URL has the case type category parameter missing from the URL in a newly built site despite adding it in a upgrader earlier. 
(2) The Case Dashboard URL is not consistent with other case type category URL's because it's missing the case category URL parameter

## Before
The above stated issues were present.
## After
- The Manage Case URL has the case type category parameter missing from the URL in a newly built site because the new URL with the case type category parameter was only added in an upgrader and not in the extension install. Since upgraders won't run in a freshly installed site, the URL is not updated to the new one. 
The fix for this was to update the Manage case URL in the extension install and also to bump the upgrader number for the previous upgrader because the URL needs to be updated too.
- The Case Dashboard URL was also updated to the one with case type category parameter similar to the other case type category menu links


