### PR TITLE
BASWSPRT-99: Case Tag Support For Case Activity Pivot Report

### DIFF
--- a/CRM/Civicase/Form/Report/BaseExtendedReport.php
+++ b/CRM/Civicase/Form/Report/BaseExtendedReport.php
@@ -309,6 +309,9 @@ abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_
       ],
       'case_role_contact' => [
         'callback' => 'joinCaseRolesContact',
+      ],
+      'case_tags' => [
+        'callback' => 'joinEntityTagFromCase',
       ]
     ];
 

--- a/CRM/Civicase/Form/Report/Case/CaseWithActivityPivot.php
+++ b/CRM/Civicase/Form/Report/Case/CaseWithActivityPivot.php
@@ -1,30 +1,111 @@
 <?php
 
 /**
- * Class CRM_Extendedreport_Form_Report_Case_CaseWithActivityPivot
+ * Class CRM_Extendedreport_Form_Report_Case_CaseWithActivityPivot.
  */
 class CRM_Civicase_Form_Report_Case_CaseWithActivityPivot extends CRM_Civicase_Form_Report_BaseExtendedReport {
+
   /**
+   * Report base table.
+   *
    * @var string
    */
   protected $_baseTable = 'civicrm_case';
+
+  /**
+   * Whether to Skip ACL.
+   *
+   * @var bool
+   */
   protected $skipACL = FALSE;
+
+  /**
+   * Custom group aggregates.
+   *
+   * @var bool
+   */
   protected $_customGroupAggregates = TRUE;
+
+  /**
+   * Whether aggregates include NULL.
+   *
+   * @var bool
+   */
   protected $_aggregatesIncludeNULL = TRUE;
+
+  /**
+   * Aggregates and Total.
+   *
+   * @var bool
+   */
   protected $_aggregatesAddTotal = TRUE;
+
+  /**
+   * With Rollup.
+   *
+   * @var string
+   */
   protected $_rollup = 'WITH ROLLUP';
+
+  /**
+   * Temp table.
+   *
+   * @var string
+   */
   protected $_temporary = ' TEMPORARY ';
+
+  /**
+   * Aggregate add percentage.
+   *
+   * @var bool
+   */
   protected $_aggregatesAddPercentage = TRUE;
+
+  /**
+   * To drill down report.
+   *
+   * @var array
+   */
   public $_drilldownReport = [];
+
+  /**
+   * If report is Pivot.
+   *
+   * @var bool
+   */
   protected $isPivot = TRUE;
+
+  /**
+   * If no fields.
+   *
+   * @var bool
+   */
   protected $_noFields = TRUE;
+
+  /**
+   * Potential criteria.
+   *
+   * @var array
+   */
   protected $_potentialCriteria = [];
-  protected $tempCaseActivityTableName = '';
-  protected $tempCaseRelationshipTableName;
+
+  /**
+   * Case contact meta data.
+   *
+   * @var array
+   */
   protected $caseRoleContactMetaData = [];
+
+  /**
+   * Tag filter table name.
+   *
+   * @var string
+   */
   protected $_tagFilterTable = 'civicrm_case';
 
-
+  /**
+   * CRM_Civicase_Form_Report_Case_CaseWithActivityPivot constructor.
+   */
   public function __construct() {
     $this->setCaseRolesContactMetaData();
     $this->_customGroupExtended['civicrm_case'] = [
@@ -55,11 +136,11 @@ class CRM_Civicase_Form_Report_Case_CaseWithActivityPivot extends CRM_Civicase_F
     $this->addAdditionFilterFields();
   }
 
-
   /**
    * {@inheritdoc}
    *
    * @return array
+   *   From clauses.
    */
   public function fromClauses() {
     return [
@@ -73,14 +154,14 @@ class CRM_Civicase_Form_Report_Case_CaseWithActivityPivot extends CRM_Civicase_F
 
   /**
    * SQL condition to JOIN to the relationship table.
+   *
    * It takes into consideration active relationships and only
    * joins to a relationship that is still active.
-   *
-   * The as at date parameter when present will only join to case roles that with the as at date
-   * between the case roles start and end dates.
+   * The as at date parameter when present will only join to case roles
+   * that with the as at date between the case roles start and end dates.
    */
   public function joinRelationshipFromCase() {
-    $date = !empty($this->_params['as_at_date']) ? $this->_params['as_at_date'] :date('Y-m-d');
+    $date = !empty($this->_params['as_at_date']) ? $this->_params['as_at_date'] : date('Y-m-d');
     $activeStatus = !empty($this->_params['as_at_date']) ? "0, 1" : "1";
     $this->_from .= "
       LEFT JOIN civicrm_relationship crt
@@ -94,13 +175,14 @@ class CRM_Civicase_Form_Report_Case_CaseWithActivityPivot extends CRM_Civicase_F
   }
 
   /**
-   * SQL query condition to JOIN to the contact table for each of
-   * the case roles contacts based on the relationship the role
-   * has with the case client.
+   * SQL query condition to JOIN to the contact table.
+   *
+   * For each of the case roles contacts based on the
+   * relationship the role has with the case client.
    */
   protected function joinCaseRolesContact() {
     foreach ($this->caseRoleContactMetaData as $data) {
-      $tableAlias = $data['table_prefix'].'civicrm_contact';
+      $tableAlias = $data['table_prefix'] . 'civicrm_contact';
       $this->_from .= "
       LEFT JOIN civicrm_contact $tableAlias
       ON (
@@ -122,9 +204,10 @@ class CRM_Civicase_Form_Report_Case_CaseWithActivityPivot extends CRM_Civicase_F
 
   /**
    * Adds some meta information for Case Roles contacts for case types.
-   * This information will be used to build the columns and add the tables
-   * needed to Join to the contact records for the contacts having these case role
-   * relationship with the case client.
+   *
+   * This information will be used to build the columns and add the
+   * tables needed to Join to the contact records for the contacts
+   * having these case role relationship with the case client.
    */
   protected function setCaseRolesContactMetaData() {
     $result = civicrm_api3('CaseType', 'get', [
@@ -147,7 +230,7 @@ class CRM_Civicase_Form_Report_Case_CaseWithActivityPivot extends CRM_Civicase_F
         $caseRoleData[$tablePrefix] = [
           'relationship_type_id' => $data['id'],
           'relationship_name' => $caseRole['name'],
-          'table_prefix' => $tablePrefix
+          'table_prefix' => $tablePrefix,
         ];
       }
     }
@@ -156,7 +239,7 @@ class CRM_Civicase_Form_Report_Case_CaseWithActivityPivot extends CRM_Civicase_F
   }
 
   /**
-   * Adds additional filter fields
+   * Adds additional filter fields.
    */
   protected function addAdditionFilterFields() {
     $this->add(
@@ -173,33 +256,37 @@ class CRM_Civicase_Form_Report_Case_CaseWithActivityPivot extends CRM_Civicase_F
    * Returns the Db prefix that will be used for Case Roles contact table.
    *
    * @param string $roleName
+   *   The role name.
    *
    * @return string
+   *   Db prefix.
    */
   private function getDbPrefixFromRoleName($roleName) {
     $stringArray = explode(' ', $roleName);
 
     $prefix = '';
     foreach ($stringArray as $value) {
-      $prefix .= strtolower($value)."_";
+      $prefix .= strtolower($value) . "_";
     }
 
     return preg_replace("/[^A-Z0-9_-]/i", '', $prefix);
   }
 
   /**
-   * Returns the contact columns meta data for the case roles for all
-   * case types. This allows to join to the contact table to get contact
+   * Returns the contact columns meta data for the case roles for case types.
+   *
+   * This allows to join to the contact table to get contact
    * and custom field information for contacts having relationships with
    * a case client for.
    *
    * Each case role data is added once and is not duplicated.
    *
    * @return array
+   *   The case role contact columns.
    */
   private function getCaseRolesContactColumns() {
     $contactColumns = [];
-    foreach($this->caseRoleContactMetaData as $data) {
+    foreach ($this->caseRoleContactMetaData as $data) {
       $contactColumns += $this->getColumns(
         'Contact',
         [
@@ -214,8 +301,9 @@ class CRM_Civicase_Form_Report_Case_CaseWithActivityPivot extends CRM_Civicase_F
   }
 
   /**
-   * Function that allows additional filter fields provided by this class to be added to the
-   * where clause for the report.
+   * Function that allows additional filter fields provided by this class.
+   *
+   * To be added to the where clause for the report.
    */
   protected function addAdditionalFiltersToWhereClause() {
     if (!empty($this->_params['as_at_date'])) {
@@ -230,11 +318,12 @@ class CRM_Civicase_Form_Report_Case_CaseWithActivityPivot extends CRM_Civicase_F
    * Returns additional filter fields provided by this report class.
    *
    * @return array
+   *   Additional filter fields.
    */
   protected function getAdditionalFilterFields() {
     $fields = [
       'as_at_date' => [
-        'label' => 'As At Date'
+        'label' => 'As At Date',
       ]
     ];
 
@@ -242,11 +331,13 @@ class CRM_Civicase_Form_Report_Case_CaseWithActivityPivot extends CRM_Civicase_F
   }
 
   /**
-   * Returns the name of template file to use for the filters for this report class.
+   * Returns the name of template file to use for the filters for this class.
    *
    * @return string
+   *   Filters template name.
    */
   protected function getFiltersTemplateName() {
     return 'FiltersCiviCase';
   }
+
 }

--- a/CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+++ b/CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
@@ -629,4 +629,56 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
     return $this->buildColumns($activityFields['civicrm_activity']['fields'], $options['prefix'] . 'civicrm_activity', 'CRM_Activity_DAO_Activity');
   }
 
+  /**
+   * Returns the case tag column.
+   *
+   * @param array $options
+   *   Options for generating the columns.
+   *
+   * @return array
+   *   Generated columns.
+   */
+  public function getCaseTagColumns(array $options) {
+    $defaultOptions = [
+      'prefix' => '',
+      'prefix_label' => '',
+      'fields' => TRUE,
+      'group_by' => FALSE,
+      'order_by' => TRUE,
+      'filters' => TRUE,
+    ];
+    $options = array_merge($defaultOptions, $options);
+    $caseTagFields['civicrm_entity_tag']['fields'] = [
+      'tag_id' => [
+        'title' => ts('Case Tag'),
+        'is_fields' => TRUE,
+        'is_filters' => TRUE,
+        'alter_display' => 'alterGenericSelect',
+        'operatorType' => CRM_Report_Form::OP_MULTISELECT,
+        'options' => $this->getCaseTags(),
+        'name' => 'tag_id',
+        'type' => CRM_Utils_Type::T_INT,
+      ],
+    ];
+    return $this->buildColumns($caseTagFields['civicrm_entity_tag']['fields'], $options['prefix'] . 'civicrm_entity_tag', 'CRM_Core_DAO_EntityTag', NULL, [], $options);
+  }
+
+  /**
+   * Returns tags applicable for cases.
+   *
+   * @return
+   *   The case tags.
+   */
+  private function getCaseTags() {
+    $result = civicrm_api3('Tag', 'get', [
+      'used_for' => 'Cases',
+    ]);
+
+    if (empty($result['values'])) {
+      return [];
+    }
+
+    return array_column($result['values'], 'name', 'id');
+  }
+
 }


### PR DESCRIPTION
## Overview
The Case activity pivot report currently does not support filtering the reports by case tags or selecting case tags as the columns. This PR makes it possible.

## Before
This functionality was not available.

## After
![CaseTags](https://user-images.githubusercontent.com/6951813/75054371-3effb700-54d3-11ea-8fad-b2a9658b6cd4.gif)
