### PR TITLE
Fix reference to undefined variable $caseTypes

### DIFF
--- a/ang/civicase-base.ang.php
+++ b/ang/civicase-base.ang.php
@@ -137,7 +137,7 @@ function set_custom_fields_info_to_js_vars(&$options) {
     if (!empty($group['api.CustomField.get']['values'])) {
       if ($group['extends'] == 'Case') {
         if (!empty($group['extends_entity_column_value'])) {
-          $group['caseTypes'] = CRM_Utils_Array::collect('name', array_values(array_intersect_key($caseTypes['values'], array_flip($group['extends_entity_column_value']))));
+          $group['caseTypes'] = CRM_Utils_Array::collect('name', array_values(array_intersect_key($options['caseTypes'], array_flip($group['extends_entity_column_value']))));
         }
         foreach ($group['api.CustomField.get']['values'] as $field) {
           $group['fields'][] = Utils::formatCustomSearchField($field);


### PR DESCRIPTION
## Overview
This fixes an issue in civicase-base.ang.php where an undefined variable `$caseTypes` is referenced, which leads to notices and warnings in some scenarios.

## Before
Various case screens (e.g. Dashboard) show messages like `Notice: Undefined variable: caseTypes in set_custom_fields_info_to_js_vars()`, `Warning: array_intersect_key(): Argument #1 is not an array in set_custom_fields_info_to_js_vars()`, etc.

## After
No notices or warnings are shown.

## Comments
The issue is only present when case type specific custom fields exist.
