### PR TITLE
CATL-1214: Optimize Case Activity Pivot Report

### DIFF
--- a/CRM/Civicase/Form/Report/BaseExtendedReport.php
+++ b/CRM/Civicase/Form/Report/BaseExtendedReport.php
@@ -106,10 +106,11 @@ abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_
     }
     $extendsString = implode("','", $optionGroupIds);
     $ogDAO = CRM_Core_DAO::executeQuery("
-    SELECT ov.value, ov.label, ov.option_group_id
-    FROM civicrm_option_value ov
-    WHERE ov.option_group_id IN ('" . $extendsString . "')
-    ORDER BY ov.weight;");
+      SELECT ov.value, ov.label, ov.option_group_id
+      FROM civicrm_option_value ov
+      WHERE ov.option_group_id IN ('" . $extendsString . "')
+      ORDER BY ov.weight;
+    ");
 
     while ($ogDAO->fetch()) {
       $sortedLists[$ogDAO->option_group_id][$ogDAO->value] = $ogDAO->label;

--- a/CRM/Civicase/Form/Report/BaseExtendedReport.php
+++ b/CRM/Civicase/Form/Report/BaseExtendedReport.php
@@ -1136,10 +1136,10 @@ abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_
         if ($filterExtendsContact) {
           $filtersGroupedByTableKeys[$table][$field['table_key']][$prefix . $fieldName] = $field;
         }
-
-        $this->addFilterFieldsToReport($field, $fieldName, $table, $count, $prefix);
+        if ($filterGroups[$table]['open'] == 'true' || $this->_filterPane && $this->_filterPane == $paneName)  {
+          $this->addFilterFieldsToReport($field, $fieldName, $table, $count, $prefix);
+        }
       }
-
 
       if (!empty($filters) && $filterString == 'filters') {
         $this->tabs['Filters'] = [

--- a/templates/CRM/Report/Form/Tabs/FilterCriteria.tpl
+++ b/templates/CRM/Report/Form/Tabs/FilterCriteria.tpl
@@ -1,0 +1,46 @@
+{* Report form criteria section *}
+{literal}
+  <script type="text/javascript">
+{/literal}
+{foreach from=$table item=field key=fieldName}
+  {literal}var val = "dnc";{/literal}
+  {assign var=fieldOp     value=$fieldName|cat:"_op"}
+  {if !($field.operatorType & 4) && !$field.no_display && $form.$fieldOp.html}
+    {literal}var val = document.getElementById("{/literal}{$fieldOp}{literal}").value;{/literal}
+  {/if}
+  {literal}showHideMaxMinVal( "{/literal}{$fieldName}{literal}", val );{/literal}
+{/foreach}
+
+{literal}
+
+  /**
+   * Show/Hide min value for form filter fields.
+   */
+  function showHideMaxMinVal( field, val ) {
+    var fldVal    = field + "_value_cell";
+    var fldMinMax = field + "_min_max_cell";
+    if ( val == "bw" || val == "nbw" ) {
+      cj('#' + fldVal ).hide();
+      cj('#' + fldMinMax ).show();
+    } else if (val =="nll" || val == "nnll") {
+      cj('#' + fldVal).hide() ;
+      cj('#' + field + '_value').val('');
+      cj('#' + fldMinMax ).hide();
+    } else {
+      cj('#' + fldVal ).show();
+      cj('#' + fldMinMax ).hide();
+    }
+  }
+
+  CRM.$(function($) {
+    $('.crm-report-criteria-groupby input:checkbox').click(function() {
+      $('#fields_' + this.id.substr(10)).prop('checked', this.checked);
+    });
+    {/literal}{if $displayToggleGroupByFields}{literal}
+      $('.crm-report-criteria-field input:checkbox').click(function() {
+        $('#group_bys_' + this.id.substr(7)).prop('checked', this.checked);
+      });
+      {/literal}{/if}{literal}
+    });
+  </script>
+{/literal}

--- a/templates/CRM/Report/Form/Tabs/FilterField.tpl
+++ b/templates/CRM/Report/Form/Tabs/FilterField.tpl
@@ -14,12 +14,12 @@
 
     {if $field.operatorType & 4}
       <tr class="report-contents crm-report crm-report-criteria-filter crm-report-criteria-filter-{$tableName}">
-        <td class="label report-contents">{$fieldLabel}</td>
+        <td class="label report-contents">{ts}{$fieldLabel}{/ts}</td>
         {include file="CRM/Core/DateRange.tpl" fieldName=$fieldName from='_from' to='_to'}
       </tr>
     {elseif $form.$fieldOp.html}
       <tr class="report-contents crm-report crm-report-criteria-filter crm-report-criteria-filter-{$tableName}" {if $field.no_display} style="display: none;"{/if}>
-        <td class="label report-contents">{$fieldLabel}</td>
+        <td class="label report-contents">{ts}{$fieldLabel}{/ts}</td>
         <td class="report-contents">{$form.$fieldOp.html}</td>
         <td>
           <span id="{$filterVal}_cell">{$form.$filterVal.label}&nbsp;{$form.$filterVal.html}</span>

--- a/templates/CRM/Report/Form/Tabs/FilterField.tpl
+++ b/templates/CRM/Report/Form/Tabs/FilterField.tpl
@@ -1,28 +1,31 @@
-{foreach from=$table item=field key=fieldName}
-  {assign var=fieldOp     value=$fieldName|cat:"_op"}
-  {assign var=filterVal   value=$fieldName|cat:"_value"}
-  {assign var=filterMin   value=$fieldName|cat:"_min"}
-  {assign var=filterMax   value=$fieldName|cat:"_max"}
+<table class="report-layout">
+  {foreach from=$table item=field key=fieldName}
 
-  {if $isGroupedByTableSet == 'YES'}
-    {assign var=fieldLabel value=$field.label}
-  {else}
-    {assign var=fieldLabel value=$field.title}
-  {/if}
+    {assign var=fieldOp     value=$fieldName|cat:"_op"}
+    {assign var=filterVal   value=$fieldName|cat:"_value"}
+    {assign var=filterMin   value=$fieldName|cat:"_min"}
+    {assign var=filterMax   value=$fieldName|cat:"_max"}
 
-  {if $field.operatorType & 4}
-    <tr class="report-contents crm-report crm-report-criteria-filter crm-report-criteria-filter-{$tableName}">
-      <td class="label report-contents">{$fieldLabel}</td>
-      {include file="CRM/Core/DateRange.tpl" fieldName=$fieldName from='_from' to='_to'}
-    </tr>
-  {elseif $form.$fieldOp.html}
-    <tr class="report-contents crm-report crm-report-criteria-filter crm-report-criteria-filter-{$tableName}" {if $field.no_display} style="display: none;"{/if}>
-      <td class="label report-contents">{$fieldLabel}</td>
-      <td class="report-contents">{$form.$fieldOp.html}</td>
-      <td>
-        <span id="{$filterVal}_cell">{$form.$filterVal.label}&nbsp;{$form.$filterVal.html}</span>
-        <span id="{$filterMin}_max_cell">{$form.$filterMin.label}&nbsp;{$form.$filterMin.html}&nbsp;&nbsp;{$form.$filterMax.label}&nbsp;{$form.$filterMax.html}</span>
-      </td>
-    </tr>
-  {/if}
-{/foreach}
+    {if $isGroupedByTableSet == 'YES'}
+      {assign var=fieldLabel value=$field.label}
+    {else}
+      {assign var=fieldLabel value=$field.title}
+    {/if}
+
+    {if $field.operatorType & 4}
+      <tr class="report-contents crm-report crm-report-criteria-filter crm-report-criteria-filter-{$tableName}">
+        <td class="label report-contents">{$fieldLabel}</td>
+        {include file="CRM/Core/DateRange.tpl" fieldName=$fieldName from='_from' to='_to'}
+      </tr>
+    {elseif $form.$fieldOp.html}
+      <tr class="report-contents crm-report crm-report-criteria-filter crm-report-criteria-filter-{$tableName}" {if $field.no_display} style="display: none;"{/if}>
+        <td class="label report-contents">{$fieldLabel}</td>
+        <td class="report-contents">{$form.$fieldOp.html}</td>
+        <td>
+          <span id="{$filterVal}_cell">{$form.$filterVal.label}&nbsp;{$form.$filterVal.html}</span>
+          <span id="{$filterMin}_max_cell">{$form.$filterMin.label}&nbsp;{$form.$filterMin.html}&nbsp;&nbsp;{$form.$filterMax.label}&nbsp;{$form.$filterMax.html}</span>
+        </td>
+      </tr>
+    {/if}
+  {/foreach}
+</table>

--- a/templates/CRM/Report/Form/Tabs/FilterPane.tpl
+++ b/templates/CRM/Report/Form/Tabs/FilterPane.tpl
@@ -1,0 +1,15 @@
+{assign var=paneTableName    value=$filterPaneGroups.$filterPane.table_name}
+{assign var=groupExtendsContact   value=$filterPaneGroups.$filterPane.group_extends_contact}
+{if $groupExtendsContact}
+  {foreach from=$filtersGroupedByTableSets.$paneTableName item=table key=tableKey}
+    {include file="CRM/Report/Form/Tabs/FilterCriteria.tpl"}
+    <tr class="report-contents crm-report crm-report-criteria-filter crm-report-criteria-filter-{$tableName}">
+      <td colspan=2 class=""><h5>{$filterExtendsContactGroup.$tableKey.group_field_label}</h5></td>
+    </tr>
+    {include file="CRM/Report/Form/Tabs/FilterField.tpl" isGroupedByTableSet='YES'}
+  {/foreach}
+{else}
+  {assign var=table value=$filters.$paneTableName}
+  {include file="CRM/Report/Form/Tabs/FilterCriteria.tpl"}
+  {include file="CRM/Report/Form/Tabs/FilterField.tpl" isGroupedByTableSet='NO'}
+{/if}

--- a/templates/CRM/Report/Form/Tabs/FiltersCiviCase.tpl
+++ b/templates/CRM/Report/Form/Tabs/FiltersCiviCase.tpl
@@ -1,28 +1,31 @@
-{*
- +--------------------------------------------------------------------+
- | CiviCRM version 5                                                  |
- +--------------------------------------------------------------------+
- | Copyright CiviCRM LLC (c) 2004-2018                                |
- +--------------------------------------------------------------------+
- | This file is a part of CiviCRM.                                    |
- |                                                                    |
- | CiviCRM is free software; you can copy, modify, and distribute it  |
- | under the terms of the GNU Affero General Public License           |
- | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
- |                                                                    |
- | CiviCRM is distributed in the hope that it will be useful, but     |
- | WITHOUT ANY WARRANTY; without even the implied warranty of         |
- | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
- | See the GNU Affero General Public License for more details.        |
- |                                                                    |
- | You should have received a copy of the GNU Affero General Public   |
- | License and the CiviCRM Licensing Exception along                  |
- | with this program; if not, contact CiviCRM LLC                     |
- | at info[AT]civicrm[DOT]org. If you have questions about the        |
- | GNU Affero General Public License or the licensing of CiviCRM,     |
- | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
- +--------------------------------------------------------------------+
-*}
+{literal}
+<script type="text/javascript">
+  CRM.$(function($) {
+    $('.crm-ajax-accordion').on('click', '.crm-accordion-header:not(.active)', function() {
+      loadPanes($(this).attr('id'));
+    });
+    $('.crm-ajax-accordion:not(.collapsed) .crm-accordion-header').each(function() {
+      loadPanes($(this).attr('id'));
+    });
+
+    /**
+     * Loads snippet based on id of crm-accordion-header
+     * @params {String} id
+     */
+    function loadPanes(id) {
+      var url = "{/literal}{crmURL p=`$currentPath` q="qfKey=`$qfKey`&filterPane=" h=0}{literal}" + id;
+      var header = $('#' + id);
+      var body = $('.crm-accordion-body.' + id);
+      if (header.length > 0 && body.length > 0) {
+        body.html('<div class="crm-loading-element"><span class="loading-text">{/literal}{ts escape='js'}Loading{/ts}{literal}...</span></div>');
+        header.append('{/literal}<a href="#" class="crm-close-accordion crm-hover-button css_right" title="{ts escape='js'}Remove from search criteria{/ts}"><i class="crm-i fa-times"></i></a>{literal}');
+        header.addClass('active');
+        CRM.loadPage(url, {target: body, block: false});
+      }
+    }
+  });
+</script>
+{/literal}
 
 <div id="report-tab-set-filters" class="civireport-criteria">
   <div class="crm-accordion-wrapper crm-accordion collapsed">
@@ -45,30 +48,15 @@
     {if $filterGroups.$tableName.group_title and $filterCount gte 1}
     {* we should close table that contains other filter elements before we start building custom group accordion
      *}
-    {if $counter eq 1}
+  {if $counter eq 1}
   </table>
   {assign var="counter" value=0}
   {/if}
-  <div class="crm-accordion-wrapper crm-accordion collapsed">
-    <div class="crm-accordion-header">
+  <div class="crm-accordion-wrapper crm-ajax-accordion crm-{$filterGroups.$tableName.pane_name}-accordion {if $filterGroups.$tableName.open eq 'true'} {else}collapsed{/if}">
+    <div class="crm-accordion-header" id="{$filterGroups.$tableName.pane_name}">
       {$filterGroups.$tableName.group_title}
     </div><!-- /.crm-accordion-header -->
-    <div class="crm-accordion-body">
-      <table class="report-layout">
-        {/if}
-        {if $filterGroups.$tableName.group_extends_contact}
-          {assign var=isGroupeddByTableSet value=TRUE}
-          {foreach from=$filtersGroupedByTableSets.$tableName item=table key=tableKey}
-            <tr class="report-contents crm-report crm-report-criteria-filter crm-report-criteria-filter-{$tableName}">
-              <td colspan=2 class=""><h5>{$filterExtendsContactGroup.$tableKey.group_field_label}</h5></td>
-            </tr>
-            {include file="CRM/Report/Form/Tabs/FilterField.tpl" isGroupedByTableSet='YES'}
-          {/foreach}
-        {else}
-          {include file="CRM/Report/Form/Tabs/FilterField.tpl" isGroupedByTableSet='NO'}
-        {/if}
-        {if $filterGroups.$tableName.group_title}
-      </table>
+    <div class="crm-accordion-body {$filterGroups.$tableName.pane_name}">
     </div><!-- /.crm-accordion-body -->
   </div><!-- /.crm-accordion-wrapper -->
   {assign var=closed value="1"} {*-- ie table tags are closed-- *}

--- a/templates/CRM/Report/Form/Tabs/FiltersCiviCase.tpl
+++ b/templates/CRM/Report/Form/Tabs/FiltersCiviCase.tpl
@@ -18,7 +18,6 @@
       var body = $('.crm-accordion-body.' + id);
       if (header.length > 0 && body.length > 0) {
         body.html('<div class="crm-loading-element"><span class="loading-text">{/literal}{ts escape='js'}Loading{/ts}{literal}...</span></div>');
-        header.append('{/literal}<a href="#" class="crm-close-accordion crm-hover-button css_right" title="{ts escape='js'}Remove from search criteria{/ts}"><i class="crm-i fa-times"></i></a>{literal}');
         header.addClass('active');
         CRM.loadPage(url, {target: body, block: false});
       }


### PR DESCRIPTION
## Overview
The Case Activity pivot reports takes time to load and the page would somehow hang before the reports become usable. 

## Before
The issues described above exist.

## After
The report functionality was optimized in the following areas:
- The `setCaseRolesContactMetaData` function of the `CaseWithActivityPivot` class was optimizes such that it makes a single API call to the Relationship API to fetch available relationship types rather than multiple calls it was making before the change.
- An issue with un-necessary multiple loops in the `setDefaultValues` function of the `ExtendedReport` class was fixed.
- Issue with un-necessary multiple loops when adding Custom fields for entities was also fixed.
- The filter fields could grow really huge and this slows down the report rendering, rather than loading all the filter fields at once, the approach used in advanced search in core was replicated for the reports here such that, the filter fields are loaded only when the relevant filter pane/accordion is opened.

