### PR TITLE
RSE-953: Recalculate scrollbar when case types are fetched

### DIFF
--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -175,6 +175,7 @@
         .then(function (data) {
           $scope.caseTypes = data.values;
           $scope.caseTypesLength = _.size($scope.caseTypes);
+          $scope.$emit('civicase::custom-scrollbar::recalculate');
         });
     }
 


### PR DESCRIPTION
## Overview
When the Case overview breakdowns are expanded, and "More Filters" are applied in Awards Dashboard resulting in no Awards. There is a visible blank section, which is fixed in this PR.

## Before
![before](https://user-images.githubusercontent.com/5058867/75752117-0cb14d80-5d4e-11ea-9f4d-2e17c28de574.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/75752033-e25f9000-5d4d-11ea-87c7-7eb158a9f02d.gif)

## Technical Details
When Case Types are updated by filtering, the SimpleBar Scrollbar was not rerendering, and caused the bug. To fix this, `civicase::custom-scrollbar::recalculate` event has been emitted when Case Types are fetched.
```javascript
return crmApi('CaseType', 'get', params)
  .then(function (data) {
    $scope.caseTypes = data.values;
    $scope.caseTypesLength = _.size($scope.caseTypes);
    $scope.$emit('civicase::custom-scrollbar::recalculate');
  });
```

Unit tests could not be written, because `civicase::custom-scrollbar::recalculate` is being fired multiple times(count is not the same, sometimes its 4 or 8). So there is no way know that the event is fired from `CaseType` api callback.