### PR TITLE
CATL-1221: Accept URL values for the case relationship type filter

### DIFF
--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -62,6 +62,7 @@
       initSubscribers();
       setCustomSearchFieldsAsSearchFilters();
       requestCaseRoles().then(addCaseRolesToContactRoles);
+      setRelationshipTypeByFilterValues();
     }());
 
     /**
@@ -308,6 +309,22 @@
     }
 
     /**
+     * Checks if the given filter property contains a value referencing
+     * the logged in user ID. It could either be through the direct ID (ex: 2)
+     * or by using the "user_contact_id" placeholder.
+     *
+     * @param {string} filterName the name of the filter property.
+     * @returns {boolean} true when the filter contains the logged in user ID.
+     */
+    function isFilterEqualToLoggedInUser (filterName) {
+      var filterValue = $scope.filters[filterName];
+      var isEqualToUserContactId = filterValue === 'user_contact_id';
+      var isSelectingLoggedInUser = _.isEqual(filterValue, [CRM.config.user_contact_id]);
+
+      return isEqualToUserContactId || isSelectingLoggedInUser;
+    }
+
+    /**
      * Map the option parameter from API
      * to show up correctly on the UI.
      *
@@ -404,6 +421,18 @@
 
       if (hasTotalCount) {
         $scope.pageTitle += ' (' + totalCount + ')';
+      }
+    }
+
+    /**
+     * Sets the relationship type filter according to values coming from the
+     * case manager or contact involved URL parameters.
+     */
+    function setRelationshipTypeByFilterValues () {
+      if (isFilterEqualToLoggedInUser('case_manager')) {
+        $scope.relationshipType = ['is_case_manager'];
+      } else if (isFilterEqualToLoggedInUser('contact_involved')) {
+        $scope.relationshipType = ['is_involved'];
       }
     }
   });

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -168,6 +168,48 @@
       });
     });
 
+    describe('accepting URL values for the relationship type filter', () => {
+      describe('when setting the case manager as the logged in user', () => {
+        beforeEach(() => {
+          $scope.$bindToRoute.and.callFake(() => {
+            $scope.filters = {
+              case_manager: 'user_contact_id'
+            };
+          });
+          initController();
+          $scope.$digest();
+        });
+
+        it('sets the relationship type filter equal to "My Cases"', () => {
+          expect($scope.relationshipType).toEqual(['is_case_manager']);
+        });
+
+        it('sets the case manager filter equal to the current logged in user id', () => {
+          expect($scope.filters.case_manager).toEqual([CRM.config.user_contact_id]);
+        });
+      });
+
+      describe('when setting the contact involved as the logged in user', () => {
+        beforeEach(() => {
+          $scope.$bindToRoute.and.callFake(() => {
+            $scope.filters = {
+              contact_involved: 'user_contact_id'
+            };
+          });
+          initController();
+          $scope.$digest();
+        });
+
+        it('sets the relationship type filter equal to "Cases I am involved"', () => {
+          expect($scope.relationshipType).toEqual(['is_involved']);
+        });
+
+        it('sets the contact involved filter equal to the current logged in user id', () => {
+          expect($scope.filters.contact_involved).toEqual([CRM.config.user_contact_id]);
+        });
+      });
+    });
+
     describe('doSearch()', () => {
       beforeEach(() => {
         originalParentScope = $scope.$parent;

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -2,7 +2,7 @@
 (($, _) => {
   describe('civicaseSearch', () => {
     let $controller, $rootScope, $scope, CaseFilters, CaseStatuses, CaseTypes, crmApi, affixOriginalFunction,
-      offsetOriginalFunction, originalDoSearch, orginalParentScope, affixReturnValue,
+      offsetOriginalFunction, originalDoSearch, originalParentScope, affixReturnValue,
       originalBindToRoute;
 
     beforeEach(module('civicase.templates', 'civicase', 'civicase.data', ($provide) => {
@@ -170,7 +170,7 @@
 
     describe('doSearch()', () => {
       beforeEach(() => {
-        orginalParentScope = $scope.$parent;
+        originalParentScope = $scope.$parent;
         $scope.$parent = {};
       });
 
@@ -181,7 +181,7 @@
       });
 
       afterEach(() => {
-        $scope.$parent = orginalParentScope;
+        $scope.$parent = originalParentScope;
       });
 
       it('should build filter description', () => {

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -1,17 +1,17 @@
 /* eslint-env jasmine */
-(function ($, _) {
-  describe('civicaseSearch', function () {
-    var $controller, $rootScope, $scope, CaseFilters, CaseStatuses, CaseTypes, crmApi, affixOriginalFunction,
+(($, _) => {
+  describe('civicaseSearch', () => {
+    let $controller, $rootScope, $scope, CaseFilters, CaseStatuses, CaseTypes, crmApi, affixOriginalFunction,
       offsetOriginalFunction, originalDoSearch, orginalParentScope, affixReturnValue,
       originalBindToRoute;
 
-    beforeEach(module('civicase.templates', 'civicase', 'civicase.data', function ($provide) {
+    beforeEach(module('civicase.templates', 'civicase', 'civicase.data', ($provide) => {
       crmApi = jasmine.createSpy('crmApi');
 
       $provide.value('crmApi', crmApi);
     }));
 
-    beforeEach(inject(function (_$controller_, $q, _$rootScope_, _CaseFilters_, _CaseStatuses_, _CaseTypesMockData_) {
+    beforeEach(inject((_$controller_, $q, _$rootScope_, _CaseFilters_, _CaseStatuses_, _CaseTypesMockData_) => {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       $scope = $rootScope.$new();
@@ -22,13 +22,11 @@
       crmApi.and.returnValue($q.resolve({ values: [] }));
     }));
 
-    beforeEach(function () {
+    beforeEach(() => {
       affixOriginalFunction = CRM.$.fn.affix;
       offsetOriginalFunction = CRM.$.fn.offset;
 
-      CRM.$.fn.offset = function () {
-        return { top: 100 };
-      };
+      CRM.$.fn.offset = () => ({ top: 100 });
 
       CRM.$.fn.affix = jasmine.createSpy('affix');
       affixReturnValue = jasmine.createSpyObj('affix', ['on']);
@@ -40,57 +38,57 @@
       initController();
     });
 
-    afterEach(function () {
+    afterEach(() => {
       CRM.$.fn.affix = affixOriginalFunction;
       CRM.$.fn.offset = offsetOriginalFunction;
       $scope.$bindToRoute = originalBindToRoute;
     });
 
-    describe('$scope variables', function () {
-      it('checks $scope.caseTypeOptions', function () {
+    describe('$scope variables', () => {
+      it('checks $scope.caseTypeOptions', () => {
         expect($scope.caseTypeOptions).toEqual(jasmine.any(Object));
       });
 
-      it('checks $scope.caseStatusOptions', function () {
+      it('checks $scope.caseStatusOptions', () => {
         expect($scope.caseStatusOptions).toEqual(jasmine.any(Object));
       });
 
-      it('checks $scope.customGroups', function () {
+      it('checks $scope.customGroups', () => {
         expect($scope.customGroups).toEqual(jasmine.any(Object));
       });
 
-      it('checks $scope.caseRelationshipOptions', function () {
+      it('checks $scope.caseRelationshipOptions', () => {
         expect($scope.caseRelationshipOptions).toEqual(jasmine.any(Object));
       });
 
-      it('checks $scope.checkPerm', function () {
+      it('checks $scope.checkPerm', () => {
         expect($scope.checkPerm).toEqual(jasmine.any(Function));
       });
 
-      it('checks $scope.filterDescription', function () {
+      it('checks $scope.filterDescription', () => {
         expect($scope.filterDescription).toEqual(jasmine.any(Array));
       });
 
-      it('checks $scope.filters', function () {
+      it('checks $scope.filters', () => {
         expect($scope.filterDescription).toEqual(jasmine.any(Object));
       });
     });
 
-    describe('watchers', function () {
-      describe('when updating the relationship types', function () {
-        describe('when I am the case manager', function () {
-          beforeEach(function () {
+    describe('watchers', () => {
+      describe('when updating the relationship types', () => {
+        describe('when I am the case manager', () => {
+          beforeEach(() => {
             $scope.relationshipType = ['is_case_manager'];
             $scope.$digest();
           });
 
-          it('sets the case manager filter equal to my id', function () {
+          it('sets the case manager filter equal to my id', () => {
             expect($scope.filters.case_manager).toEqual([CRM.config.user_contact_id]);
           });
         });
 
-        describe('when I am involved in the case', function () {
-          beforeEach(function () {
+        describe('when I am involved in the case', () => {
+          beforeEach(() => {
             $scope.relationshipType = ['is_involved'];
             $scope.$digest();
           });
@@ -101,120 +99,123 @@
         });
       });
 
-      describe('$scope.filters', function () {
-        beforeEach(function () {
+      describe('$scope.filters', () => {
+        beforeEach(() => {
           originalDoSearch = $scope.doSearch;
           $scope.doSearch = jasmine.createSpy('doSearch');
           $scope.filters = CaseFilters.filter;
         });
 
-        afterEach(function () {
+        afterEach(() => {
           $scope.doSearch = originalDoSearch;
         });
 
-        describe('when $scope.expanded is false', function () {
-          beforeEach(function () {
+        describe('when $scope.expanded is false', () => {
+          beforeEach(() => {
             $scope.expanded = false;
             $scope.$digest();
           });
-          it('calls $scope.doSearch()', function () {
+
+          it('calls $scope.doSearch()', () => {
             expect($scope.doSearch).toHaveBeenCalled();
           });
         });
-        describe('when $scope.expanded is true', function () {
-          beforeEach(function () {
+
+        describe('when $scope.expanded is true', () => {
+          beforeEach(() => {
             $scope.expanded = true;
             $scope.$digest();
           });
-          it('does not calls $scope.doSearch()', function () {
+
+          it('does not calls $scope.doSearch()', () => {
             expect($scope.doSearch).not.toHaveBeenCalled();
           });
         });
       });
     });
 
-    describe('caseManagerIsMe()', function () {
-      describe('when case_manager is me', function () {
-        beforeEach(function () {
+    describe('caseManagerIsMe()', () => {
+      describe('when case_manager is me', () => {
+        beforeEach(() => {
           $scope.filters.case_manager = [203];
         });
 
-        it('should return true', function () {
+        it('should return true', () => {
           expect($scope.caseManagerIsMe()).toBe(true);
         });
       });
 
-      describe('when case_manager is not me', function () {
-        describe('when case id is different', function () {
-          beforeEach(function () {
+      describe('when case_manager is not me', () => {
+        describe('when case id is different', () => {
+          beforeEach(() => {
             $scope.filters.case_manager = [201];
           });
 
-          it('should return false', function () {
+          it('should return false', () => {
             expect($scope.caseManagerIsMe()).toBe(false);
           });
         });
 
-        describe('when case id undefined', function () {
-          beforeEach(function () {
+        describe('when case id undefined', () => {
+          beforeEach(() => {
             $scope.filters.case_manager = undefined;
           });
 
-          it('should return undefined', function () {
+          it('should return undefined', () => {
             expect($scope.caseManagerIsMe()).toBeUndefined();
           });
         });
       });
     });
 
-    describe('doSearch()', function () {
-      beforeEach(function () {
+    describe('doSearch()', () => {
+      beforeEach(() => {
         orginalParentScope = $scope.$parent;
         $scope.$parent = {};
       });
 
-      beforeEach(function () {
+      beforeEach(() => {
         $scope.expanded = true;
         $scope.filters.case_manager = [203];
         $scope.doSearch();
       });
 
-      afterEach(function () {
+      afterEach(() => {
         $scope.$parent = orginalParentScope;
       });
 
-      it('should build filter description', function () {
+      it('should build filter description', () => {
         expect($scope.filterDescription).toEqual([{ label: 'Case Manager', text: 'Me' }]);
       });
 
-      it('should close the dropdown', function () {
+      it('should close the dropdown', () => {
         expect($scope.expanded).toBe(false);
       });
     });
 
-    describe('clearSearch()', function () {
-      beforeEach(function () {
+    describe('clearSearch()', () => {
+      beforeEach(() => {
         originalDoSearch = $scope.doSearch;
         $scope.doSearch = jasmine.createSpy('doSearch');
         $scope.filters = CaseFilters.filter;
         $scope.clearSearch();
       });
 
-      afterEach(function () {
+      afterEach(() => {
         $scope.doSearch = originalDoSearch;
       });
 
-      it('clears filters object', function () {
+      it('clears filters object', () => {
         expect($scope.filters).toEqual({});
       });
 
-      it('calls doSearch()', function () {
+      it('calls doSearch()', () => {
         expect($scope.doSearch).toHaveBeenCalled();
       });
     });
 
-    describe('mapSelectOptions()', function () {
-      it('returns a mapped response', function () {
+    describe('mapSelectOptions()', () => {
+      it('returns a mapped response', () => {
         expect($scope.caseTypeOptions[0]).toEqual(jasmine.objectContaining({ id: jasmine.any(String), text: jasmine.any(String), color: jasmine.any(String), icon: jasmine.any(String) }));
       });
     });
@@ -362,4 +363,4 @@
       });
     }
   });
-}(CRM.$, CRM._));
+})(CRM.$, CRM._);


### PR DESCRIPTION
## Overview
This PR allows to pass a placeholder value to the case relationship type filter through the URL. The placeholder is `user_contact_id` and this value is replaced for the actual user ID (ex: 2). This is needed in order to create URLs that could be used by any user instead of a particular one.

## Before
Accessing `/civicrm/case/a/#/case/list?cf=%7B%22case_type_category%22:%22cases%22,%22case_manager%22:%22user_contact_id%22%7D`
![Screen Shot 2020-03-03 at 9 20 34 PM](https://user-images.githubusercontent.com/1642119/75835290-d77c1e00-5d94-11ea-8eea-fd0446075aa1.png)

The filter is not understood.

## After
Accessing `/civicrm/case/a/#/case/list?cf=%7B%22case_type_category%22:%22cases%22,%22case_manager%22:%22user_contact_id%22%7D`
![Screen Shot 2020-03-03 at 9 14 28 PM](https://user-images.githubusercontent.com/1642119/75834964-fded8980-5d93-11ea-80e0-e3adf5b8239c.png)

## Technical Details

The `user_contact_id` placeholder was used because it's the one used by core. We still translate the value to the direct contact ID because the placeholder only works for direct values (`{ case_manager: 'user_contact_id' }`) and not for IN or other type of statements (`{ case_maanger: { 'IN': ['user_contact_id'] }}`).

In order to apply the placeholder we run the check when the search controller initializes, but after the values have been bound from the URL, and after filter watches have been setup.

The `isFilterEqualToLoggedInUser` function determines if the given filter contains either the `user_contact_id` placeholder, or an array with the current logged in user id. If this is true it then sets the value of the relationship type filter accordingly.
