### PR TITLE
RSE-746: Fix Open Issues With New Case Category Contact Tab

### DIFF
--- a/CRM/Civicase/Helper/CaseCategory.php
+++ b/CRM/Civicase/Helper/CaseCategory.php
@@ -158,7 +158,6 @@ class CRM_Civicase_Helper_CaseCategory {
     $params = [
       'is_deleted' => 0,
       'contact_id' => $contactId,
-      'check_permissions' => TRUE,
       'case_type_id.case_type_category' => $caseTypeCategoryName,
     ];
     try {

--- a/CRM/Civicase/Hook/PermissionCheck/CaseCategory.php
+++ b/CRM/Civicase/Hook/PermissionCheck/CaseCategory.php
@@ -137,6 +137,7 @@ class CRM_Civicase_Hook_PermissionCheck_CaseCategory {
     $isCaseActivityPage = $url == 'civicrm/case/activity';
     $isPrintActivityReportPage = $url == 'civicrm/case/customreport/print';
     $isActivityPage = $url == 'civicrm/activity';
+    $isCaseContactTabPage = $url == 'civicrm/case/contact-case-tab';
 
     if ($isViewCase) {
       return $this->getCaseCategoryForViewCase();
@@ -162,6 +163,9 @@ class CRM_Civicase_Hook_PermissionCheck_CaseCategory {
       return $this->getCaseCategoryFromActivityIdInUrl('id');
     }
 
+    if ($isCaseContactTabPage) {
+      return $this->getCaseCategoryFromUrl();
+    }
   }
 
   /**
@@ -171,10 +175,15 @@ class CRM_Civicase_Hook_PermissionCheck_CaseCategory {
    *   Category URL.
    */
   private function getCaseCategoryFromUrl() {
-    $caseCategoryName = CRM_Utils_Request::retrieve('case_type_category', 'String');
+    $caseCategory = CRM_Utils_Request::retrieve('case_type_category', 'String');
+    if ($caseCategory) {
+      if (is_numeric($caseCategory)) {
+        $caseTypeCategories = CaseType::buildOptions('case_type_category', 'validate');
 
-    if ($caseCategoryName) {
-      return $caseCategoryName;
+        return isset($caseTypeCategories[$caseCategory]) ? $caseTypeCategories[$caseCategory] : NULL;
+      }
+
+      return $caseCategory;
     }
 
     $entryURL = CRM_Utils_Request::retrieve('entryURL', 'String');

--- a/CRM/Civicase/Hook/PermissionCheck/CaseCategory.php
+++ b/CRM/Civicase/Hook/PermissionCheck/CaseCategory.php
@@ -140,14 +140,14 @@ class CRM_Civicase_Hook_PermissionCheck_CaseCategory {
     $isCaseContactTabPage = $url == 'civicrm/case/contact-case-tab';
 
     if ($isViewCase) {
-      return $this->getCaseCategoryForViewCase();
+      return $this->getCaseCategoryNameFromCaseIdInUrl('id');
     }
 
     if ($isAjaxRequest) {
       return $this->getCaseCategoryForAjaxRequest();
     }
 
-    if ($isCasePage) {
+    if ($isCasePage || $isCaseContactTabPage) {
       return $this->getCaseCategoryFromUrl();
     }
 
@@ -161,10 +161,6 @@ class CRM_Civicase_Hook_PermissionCheck_CaseCategory {
 
     if ($isActivityPage) {
       return $this->getCaseCategoryFromActivityIdInUrl('id');
-    }
-
-    if ($isCaseContactTabPage) {
-      return $this->getCaseCategoryFromUrl();
     }
   }
 
@@ -226,20 +222,6 @@ class CRM_Civicase_Hook_PermissionCheck_CaseCategory {
 
       return NULL;
     }
-  }
-
-  /**
-   * Get case category name for view case.
-   *
-   * The view case page is the page civi redirects to after
-   * adding a new case. It does not have the case type category
-   * parameter in the URL since it's an internal civi page but we
-   * can use the just created Case Id to get the case type category.
-   */
-  private function getCaseCategoryForViewCase() {
-    $caseId = CRM_Utils_Request::retrieve('id', 'Integer');
-
-    return CaseCategoryHelper::getCategoryName($caseId);
   }
 
   /**

--- a/CRM/Civicase/Hook/Tabset/CaseCategoryTabAdd.php
+++ b/CRM/Civicase/Hook/Tabset/CaseCategoryTabAdd.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
 
 /**
  * Class CRM_Civicase_Hook_TabsetCaseCategoryTabAdd.
@@ -46,11 +47,15 @@ class CRM_Civicase_Hook_Tabset_CaseCategoryTabAdd {
       return;
     }
 
+    $permissionService = new CaseCategoryPermission();
     $caseTabWeight = $this->getCaseTabWeight($tabs);
     foreach ($result['values'] as $caseCategory) {
-      if ($caseCategory['name'] == CaseCategoryHelper::CASE_TYPE_CATEGORY_NAME) {
+      $caseCategoryPermissions = $permissionService->get($caseCategory['name']);
+      $permissionsToCheck = $this->getBasicCaseCategoryPermissions($caseCategoryPermissions);
+      if ($caseCategory['name'] == CaseCategoryHelper::CASE_TYPE_CATEGORY_NAME || !CRM_Core_Permission::check($permissionsToCheck)) {
         continue;
       }
+
       $caseTabWeight++;
       $useAng = TRUE;
       $icon = !empty($caseCategory['icon']) ? "crm-i {$caseCategory['icon']}" : '';
@@ -99,6 +104,23 @@ class CRM_Civicase_Hook_Tabset_CaseCategoryTabAdd {
     }
 
     return 0;
+  }
+
+  /**
+   * The basic Case category permission set.
+   *
+   * @param array $caseCategoryPermissions
+   *   Case category permissions.
+   *
+   * @return array
+   *   The basic permission set.
+   */
+  private function getBasicCaseCategoryPermissions(array $caseCategoryPermissions) {
+    return [
+      $caseCategoryPermissions['ACCESS_MY_CASE_CATEGORY_AND_ACTIVITIES']['name'],
+      $caseCategoryPermissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name'],
+      $caseCategoryPermissions['BASIC_CASE_CATEGORY_INFO']['name'],
+    ];
   }
 
 }

--- a/ang/civicase.ang.php
+++ b/ang/civicase.ang.php
@@ -14,7 +14,11 @@ use CRM_Civicase_Helper_NewCaseWebform as NewCaseWebform;
 
 load_resources();
 $caseCategoryName = CRM_Utils_Request::retrieve('case_type_category', 'String');
-CRM_Civicase_Hook_Helper_CaseTypeCategory::addWordReplacements($caseCategoryName);
+
+// Word replacements are already loaded for the contact tab ContactCaseTab.
+if (CRM_Utils_System::currentPath() !== 'civicrm/case/contact-case-tab') {
+  CRM_Civicase_Hook_Helper_CaseTypeCategory::addWordReplacements($caseCategoryName);
+}
 
 $permissionService = new CaseCategoryPermission();
 $caseCategoryPermissions = $permissionService->get($caseCategoryName);

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
@@ -8,7 +8,7 @@
   <div class="civicase__contact-cases-tab clearfix">
     <a ng-if="checkPerm('add cases') && !newCaseWebformUrl"
       class="btn-primary btn civicase__contact-cases-tab-add"
-      ng-href="{{ 'civicrm/case/add' | civicaseCrmUrl:{civicase_cid: contactId, reset: 1, action: 'add', context: 'standalone'} }}"
+      ng-href="{{ 'civicrm/case/add' | civicaseCrmUrl:{civicase_cid: contactId, reset: 1, action: 'add', context: 'standalone', case_type_category: caseTypeCategoryName } }}"
       crm-popup-form-success="refresh()">
       <i class="material-icons">add_circle</i>
       {{ ts('Add case') }}

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
@@ -17,6 +17,7 @@
   /**
    * @param {object} $scope the controller scope
    * @param {Function} ts translation service
+   * @param {Function} CaseTypeCategory the case type category service
    * @param {Function} CaseTypeCategoryTranslationService the case type category translation service
    * @param {Function} crmApi the crm api service
    * @param {Function} formatCase the format case service
@@ -25,8 +26,9 @@
    * @param {string} newCaseWebformClient the new case web form client configuration value
    * @param {string} newCaseWebformUrl the new case web form url configuration value
    */
-  function CivicaseContactCaseTabController ($scope, ts, CaseTypeCategoryTranslationService,
-    crmApi, formatCase, Contact, ContactsCache, newCaseWebformClient, newCaseWebformUrl) {
+  function CivicaseContactCaseTabController ($scope, ts, CaseTypeCategory,
+    CaseTypeCategoryTranslationService, crmApi, formatCase, Contact,
+    ContactsCache, newCaseWebformClient, newCaseWebformUrl) {
     var commonConfigs = {
       isLoaded: false,
       showSpinner: false,
@@ -38,7 +40,7 @@
     };
 
     $scope.caseDetailsLoaded = false;
-    $scope.caseTypeCategoryName = CRM['civicase-base'].caseTypeCategories[$scope.caseTypeCategory].name;
+    $scope.caseTypeCategoryName = CaseTypeCategory.getAll()[$scope.caseTypeCategory].name;
     $scope.contactId = Contact.getCurrentContactID();
     $scope.newCaseWebformUrl = newCaseWebformUrl;
     $scope.newCaseWebformClient = newCaseWebformClient;

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
@@ -38,6 +38,7 @@
     };
 
     $scope.caseDetailsLoaded = false;
+    $scope.caseTypeCategoryName = CRM['civicase-base'].caseTypeCategories[$scope.caseTypeCategory].name;
     $scope.contactId = Contact.getCurrentContactID();
     $scope.newCaseWebformUrl = newCaseWebformUrl;
     $scope.newCaseWebformClient = newCaseWebformClient;

--- a/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
+++ b/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
@@ -5,7 +5,7 @@
     var $controller, $rootScope, $scope, CaseTypeCategoryTranslationService,
       crmApi, mockContactId, mockContactService;
 
-    beforeEach(module('civicase', ($provide) => {
+    beforeEach(module('civicase.data', 'civicase', ($provide) => {
       mockContactService = jasmine.createSpyObj('Contact', ['getCurrentContactID']);
 
       $provide.value('Contact', mockContactService);
@@ -37,6 +37,11 @@
       it('stores the current case type category translation', () => {
         expect(CaseTypeCategoryTranslationService.storeTranslation)
           .toHaveBeenCalledWith($scope.caseTypeCategory);
+      });
+
+      it('stores the case type category name', () => {
+        expect($scope.caseTypeCategoryName)
+          .toBe(CRM['civicase-base'].caseTypeCategories[$scope.caseTypeCategory].name);
       });
     });
 


### PR DESCRIPTION
## Overview
This PR fixes the following issues with the New case category contact tabs. 
(1) A permission issue that does not allow the Award manager to view the case category contact tab
(2) The Add New Case [Category] button on the case category tab is pointing to the generic add case page rather than the Add New Case [Category] page.

## Before
- The issues described above exists.

## After
- The Case contact tab page was added to the list of pages where logic for case category permissions is applied.
- Also Case category contact tabs are only shown when user has the corresponding case category permission.
- The Add New Case [Category] button now leads to the Add New Case [Category] page

