### PR TITLE
RSE-745:  Fix Case Category Menu/Tabs Issues

### DIFF
--- a/CRM/Civicase/Hook/PostProcess/CaseCategoryMenuLinksProcessor.php
+++ b/CRM/Civicase/Hook/PostProcess/CaseCategoryMenuLinksProcessor.php
@@ -24,6 +24,7 @@ class CRM_Civicase_Hook_PostProcess_CaseCategoryMenuLinksProcessor {
     }
 
     $caseCategoryMenu = new CaseCategoryMenuService();
+    $formValues = $form->_submitValues;
     $formAction = $form->getVar('_action');
     if ($formAction == CRM_Core_Action::DELETE) {
       $caseCategoryValues = $form->getVar('_values');
@@ -31,9 +32,35 @@ class CRM_Civicase_Hook_PostProcess_CaseCategoryMenuLinksProcessor {
     }
 
     if ($formAction == CRM_Core_Action::ADD) {
-      $formValues = $form->_submitValues;
       $caseCategoryMenu->createItems($formValues['label']);
     }
+
+    if ($formAction == CRM_Core_Action::UPDATE && !empty($formValues['is_active'])) {
+      $caseCategoryMenu->toggleStatus($this->getOptionValueName($form->getVar('_id')), TRUE);
+    }
+
+    if ($formAction == CRM_Core_Action::UPDATE && empty($formValues['is_active'])) {
+      $caseCategoryMenu->toggleStatus($this->getOptionValueName($form->getVar('_id')), FALSE);
+    }
+  }
+
+  /**
+   * Returns the option value name given it's id.
+   *
+   * @param int $id
+   *   Option value id.
+   *
+   * @return string
+   *   Option value name.
+   */
+  private function getOptionValueName($id) {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'case_type_categories',
+      'id' => $id,
+      'return' => ['name'],
+    ]);
+
+    return $result['values'][$id]['name'];
   }
 
   /**

--- a/CRM/Civicase/Hook/Tabset/CaseCategoryTabAdd.php
+++ b/CRM/Civicase/Hook/Tabset/CaseCategoryTabAdd.php
@@ -41,6 +41,7 @@ class CRM_Civicase_Hook_Tabset_CaseCategoryTabAdd {
   private function addCaseCategoryContactTabs(array &$tabs, $contactID, &$useAng) {
     $result = civicrm_api3('OptionValue', 'get', [
       'option_group_id' => 'case_type_categories',
+      'is_active' => 1,
     ]);
 
     if (empty($result['values'])) {

--- a/CRM/Civicase/Hook/alterAPIPermissions/Case.php
+++ b/CRM/Civicase/Hook/alterAPIPermissions/Case.php
@@ -146,7 +146,7 @@ class CRM_Civicase_Hook_alterAPIPermissions_Case {
       return $this->getCaseCategoryNameFromCaseId($params, 'id');
     }
 
-    if ($entity == 'case' && $action == 'getrelations') {
+    if ($entity == 'case' && in_array($action, ['getrelations', 'getfiles'])) {
       return $this->getCaseCategoryNameFromCaseId($params, 'case_id');
     }
 
@@ -154,7 +154,7 @@ class CRM_Civicase_Hook_alterAPIPermissions_Case {
       return $this->getCaseCategoryNameFromCaseType($params, 'case_type_id');
     }
 
-    if ($entity == 'case' && $action != 'delete') {
+    if ($entity == 'case' && !in_array($action, ['delete', 'getfiles'])) {
       return $this->getCaseCategoryNameFromCaseTypeCategory($params, 'case_type_id.case_type_category');
     }
 

--- a/CRM/Civicase/Service/CaseCategoryMenu.php
+++ b/CRM/Civicase/Service/CaseCategoryMenu.php
@@ -129,4 +129,22 @@ class CRM_Civicase_Service_CaseCategoryMenu {
     civicrm_api3('Navigation', 'delete', ['id' => $parentMenu['id']]);
   }
 
+  /**
+   * Disables/Enables the Case Category Main menu.
+   *
+   * @param string $caseTypeCategoryName
+   *   Case category name.
+   * @param bool $status
+   *   Status.
+   */
+  public function toggleStatus($caseTypeCategoryName, $status) {
+    $parentMenu = civicrm_api3('Navigation', 'get', ['name' => $caseTypeCategoryName]);
+
+    if ($parentMenu['count'] == 0) {
+      return;
+    }
+
+    civicrm_api3('Navigation', 'create', ['id' => $parentMenu['id'], 'is_active' => $status ? 1 : 0]);
+  }
+
 }

--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.js
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.js
@@ -18,9 +18,10 @@
 
   /**
    * @param {object} $scope the scope reference.
+   * @param {Function} CaseTypeCategory case type category service.
    * @param {Function} ts translation service
    */
-  function CivicaseContactCaseTabCaseDetailsController ($scope, ts) {
+  function CivicaseContactCaseTabCaseDetailsController ($scope, CaseTypeCategory, ts) {
     $scope.getCaseDetailsUrl = getCaseDetailsUrl;
     $scope.ts = ts;
 
@@ -33,7 +34,11 @@
      * @returns {string} the case details page url.
      */
     function getCaseDetailsUrl (caseItem) {
-      return '/civicrm/case/a/#/case/list?caseId=' + caseItem.id +
+      var caseTypeCategoryId = caseItem['case_type_id.case_type_category'];
+      var caseTypeCategoryName = CaseTypeCategory.getAll()[caseTypeCategoryId].name;
+
+      return '/civicrm/case/a/?case_type_category=' + caseTypeCategoryName +
+        '#/case/list?caseId=' + caseItem.id +
         '&cf={"status_id":[' + caseItem.status_id + ']}';
     }
   }

--- a/ang/civicase/case/details/summary-tab/case-summary-tasks.html
+++ b/ang/civicase/case/details/summary-tab/case-summary-tasks.html
@@ -28,7 +28,7 @@
   <div ng-if="item.tasks.length === 0" class="civicase__activity-card--big--empty civicase__activity-card--big--empty--list-view">
     <div class="civicase__activity-no-result-icon civicase__activity-no-result-icon--tasks"></div>
     <div class="civicase__activity-card--big--empty-title"> No new tasks </div>
-    <div class="civicase__activity-card--big--empty-description"> Click on the button below to add a task to this case </div>
+    <div class="civicase__activity-card--big--empty-description"> {{ ts('Click on the button below to add a task to this case') }} </div>
     <span civicase-dropdown>
       <div class="civicase__activity-card--big--empty-button btn"
         civicase-dropdown-toggle>

--- a/ang/test/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.spec.js
+++ b/ang/test/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.spec.js
@@ -1,14 +1,15 @@
 /* eslint-env jasmine */
 
-(() => {
+((_) => {
   describe('Contact Case Tab Case Details', () => {
-    let $controller, $rootScope, $scope, mockCase;
+    let $controller, $rootScope, $scope, CaseTypeCategory, mockCase;
 
     beforeEach(module('civicase', 'civicase.data'));
 
-    beforeEach(inject((_$controller_, _$rootScope_, _CasesData_, _crmApi_) => {
+    beforeEach(inject((_$controller_, _$rootScope_, _CasesData_, _CaseTypeCategory_, _crmApi_) => {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
+      CaseTypeCategory = _CaseTypeCategory_;
       mockCase = _CasesData_.get().values[0];
 
       initController();
@@ -18,8 +19,14 @@
       let expectedUrl, returnedUrl;
 
       beforeEach(() => {
-        expectedUrl = '/civicrm/case/a/#/case/list' +
-          `?caseId=${mockCase.id}&cf={"status_id":[${mockCase.status_id}]}`;
+        var caseTypeCategory = _.chain(CaseTypeCategory.getAll())
+          .values()
+          .sample()
+          .value();
+        mockCase['case_type_id.case_type_category'] = caseTypeCategory.value;
+        expectedUrl = '/civicrm/case/a/' +
+          `?case_type_category=${caseTypeCategory.name}` +
+          `#/case/list?caseId=${mockCase.id}&cf={"status_id":[${mockCase.status_id}]}`;
         returnedUrl = $scope.getCaseDetailsUrl(mockCase);
       });
 
@@ -37,4 +44,4 @@
       $controller('CivicaseContactCaseTabCaseDetailsController', { $scope: $scope });
     }
   });
-})();
+})(CRM._);

--- a/api/v3/Case/Getfiles.php
+++ b/api/v3/Case/Getfiles.php
@@ -62,9 +62,6 @@ function _civicrm_api3_case_getfiles_spec(&$spec) {
  * @throws API_Exception
  */
 function civicrm_api3_case_getfiles($params) {
-  // Check authorization.
-  // WISHLIST: would be nice to incorporate addSelectWhere() instead?
-  _civicrm_api3_case_getfiles_assert_access($params);
   $params = _civicrm_api3_case_getfiles_format_params($params);
   $options = _civicrm_api3_get_options_from_params($params);
 
@@ -218,28 +215,6 @@ function _civicrm_api3_case_getfiles_select($params) {
 
   $select->orderBy(array('act.activity_date_time DESC, act.id DESC, f.id DESC'));
   return $select;
-}
-
-/**
- * Assert that this request is authorized to access the given Case.
- * @param array $params
- * @throws API_Exception
- */
-function _civicrm_api3_case_getfiles_assert_access($params) {
-  if (empty($params['check_permissions'])) {
-    return; // OK
-  }
-
-  if (empty($params['case_id'])) {
-    throw new API_Exception("Blank case_id cannot be validated");
-  }
-
-  // Delegate to Case.get to determine if the ID is accessible.
-  civicrm_api3('Case', 'getsingle', array(
-    'id' => $params['case_id'],
-    'check_permissions' => $params['check_permissions'],
-    'return' => 'id',
-  ));
 }
 
 /**


### PR DESCRIPTION
## Overview
This PR fixes issues found when testing the Case Category Menu/Tabs Issues functionality.
- An issue with not being able to upload files for a case category on manage case category.
- Issue with disabled case tabs still active
- Menu items not getting deleted after disabling the case category option value.
- Word replacements on Manage Cases task block
- GO TO [Case Category] button on case category contact tab was giving an access denied error.

## Before
- These issues exist

## After
These Issues were fixed.
- The issue with not being able to upload the files for a case category was due to a call to Case.getsingle API. This call will invoke the `civicase_civicrm_selectWhereClause` which is already overriden [here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/civicase.php#L700-L704) to basically check for permission access. Since the case category user already have the case category equivalent of this permission, this check is un-necessary here and the `_civicrm_api3_case_getfiles_assert_access` function was removed.
- Issue with disabled case tabs still active was fixed by fetching only active case type categories when generating the case category tabs.
- Menu items not getting deleted after disabling the case category option value was fixed by adding a function to disable the case category menu's in the `CaseCategoryMenu` service and then using this function in the `CaseCategoryMenuLinksProcessor` class.
- Word replacements on Manage Cases task block was fixed by using the ts function to translate the string.
- Issue with Go TO [Case Category] button on case category contact tab was fixed by appending the case_type_category to the page URL so that the appropriate permission can be used for the page.
