### PR TITLE
CPS-94: Fix [Case Type Category] Adding An icon to a Case Type Category Not displaying Icon On Main Menu

### DIFF
--- a/CRM/Civicase/Hook/PostProcess/CaseCategoryMenuLinksProcessor.php
+++ b/CRM/Civicase/Hook/PostProcess/CaseCategoryMenuLinksProcessor.php
@@ -35,12 +35,13 @@ class CRM_Civicase_Hook_PostProcess_CaseCategoryMenuLinksProcessor {
       $caseCategoryMenu->createItems($formValues['label']);
     }
 
-    if ($formAction == CRM_Core_Action::UPDATE && !empty($formValues['is_active'])) {
-      $caseCategoryMenu->toggleStatus($this->getOptionValueName($form->getVar('_id')), TRUE);
-    }
+    if ($formAction == CRM_Core_Action::UPDATE) {
+      $updateParams = [
+        'is_active' => !empty($formValues['is_active']) ? 1 : 0,
+        'icon' => 'crm-i ' . $formValues['icon'],
+      ];
 
-    if ($formAction == CRM_Core_Action::UPDATE && empty($formValues['is_active'])) {
-      $caseCategoryMenu->toggleStatus($this->getOptionValueName($form->getVar('_id')), FALSE);
+      $caseCategoryMenu->updateItems($form->getVar('_id'), $updateParams);
     }
   }
 


### PR DESCRIPTION
## Overview
This PR fixes fixes an issue whereby when a case category is added, the menu for the option value is not reflected on the menu icon for the Navigation menu generated.

## Before
- This issue exist.

## After
Issue is fixed.

The `toggleStatus` function of the `CRM_Civicase_Service_CaseCategoryMenu` was changed to `updateItems` to accommodate for properties of the case category menu that needs to be updated.

