### PR TITLE
Fix activity not loading when status grouping is undefined

### DIFF
--- a/ang/civicase/activity/panel/directives/activity-panel.directive.js
+++ b/ang/civicase/activity/panel/directives/activity-panel.directive.js
@@ -172,8 +172,9 @@
       $scope.allowedActivityStatuses = {};
 
       _.each(ActivityStatus.getAll(), function (activityStatus, activityStatusID) {
-        var ifStatusIsInSameCategory = _.intersection($scope.activity.category, activityStatus.grouping.split(',')).length > 0;
-        var ifStatusIsInNoneCategory = $scope.activity.category.length === 0 && activityStatus.grouping.split(',').indexOf('none') !== -1;
+        var statusGrouping = activityStatus.grouping ? activityStatus.grouping.split(',') : [];
+        var ifStatusIsInSameCategory = _.intersection($scope.activity.category, statusGrouping).length > 0;
+        var ifStatusIsInNoneCategory = $scope.activity.category.length === 0 && statusGrouping.indexOf('none') !== -1;
 
         if (ifStatusIsInSameCategory || ifStatusIsInNoneCategory) {
           $scope.allowedActivityStatuses[activityStatusID] = activityStatus;


### PR DESCRIPTION
## Overview
This fixes an issue where activity details may not load if an activity status has no grouping.

## Before
Opening an activity from the Case > Activity tab may fail with this error if an activity status without `grouping` exists:
```
TypeError: Cannot read property 'split' of undefined
  at setAllowedActivityStatuses
```
(For some reason it typically works when attempting to open another activity.)

## After
Loading activities works.

## Comments
Not sure if this is the preferred fix, or if you'd rather ensure that `activity-status.service.js` preformats the statuses to always include a (possibly empty) grouping.
