### PR TITLE
CPS-101: Fix Unable to Edit an Activity For Newly Created Case Type Category

### DIFF
--- a/CRM/Civicase/Hook/PermissionCheck/CaseCategory.php
+++ b/CRM/Civicase/Hook/PermissionCheck/CaseCategory.php
@@ -136,7 +136,7 @@ class CRM_Civicase_Hook_PermissionCheck_CaseCategory {
     $isAjaxRequest = $url == 'civicrm/ajax/rest';
     $isCaseActivityPage = $url == 'civicrm/case/activity';
     $isPrintActivityReportPage = $url == 'civicrm/case/customreport/print';
-    $isActivityPage = $url == 'civicrm/activity';
+    $isActivityPage = $url == 'civicrm/activity' || $url = 'civicrm/activity/add';
     $isCaseContactTabPage = $url == 'civicrm/case/contact-case-tab';
 
     if ($isViewCase) {


### PR DESCRIPTION
## Overview
When a user with all permissions associated to new case type category tries to edit an activity for that case category, an error is thrown.

## Before
Issue exist.

## After
The activity add/edit page is added to the list of pages where we check for case category permission equivalent.
