### PR TITLE
CPS-106: Fix undefined activity status grouping

### DIFF
--- a/ang/civicase/activity/panel/directives/activity-panel.directive.js
+++ b/ang/civicase/activity/panel/directives/activity-panel.directive.js
@@ -175,8 +175,9 @@
         var statusGrouping = activityStatus.grouping ? activityStatus.grouping.split(',') : [];
         var ifStatusIsInSameCategory = _.intersection($scope.activity.category, statusGrouping).length > 0;
         var ifStatusIsInNoneCategory = $scope.activity.category.length === 0 && statusGrouping.indexOf('none') !== -1;
+        var ifStatusIsForAllCategories = statusGrouping.length === 0;
 
-        if (ifStatusIsInSameCategory || ifStatusIsInNoneCategory) {
+        if (ifStatusIsInSameCategory || ifStatusIsInNoneCategory || ifStatusIsForAllCategories) {
           $scope.allowedActivityStatuses[activityStatusID] = activityStatus;
         }
       });

--- a/ang/civicase/activity/panel/directives/activity-panel.directive.js
+++ b/ang/civicase/activity/panel/directives/activity-panel.directive.js
@@ -172,8 +172,9 @@
       $scope.allowedActivityStatuses = {};
 
       _.each(ActivityStatus.getAll(), function (activityStatus, activityStatusID) {
-        var ifStatusIsInSameCategory = _.intersection($scope.activity.category, activityStatus.grouping.split(',')).length > 0;
-        var ifStatusIsInNoneCategory = $scope.activity.category.length === 0 && activityStatus.grouping.split(',').indexOf('none') !== -1;
+        var statusGrouping = activityStatus.grouping ? activityStatus.grouping.split(',') : [];
+        var ifStatusIsInSameCategory = _.intersection($scope.activity.category, statusGrouping).length > 0;
+        var ifStatusIsInNoneCategory = $scope.activity.category.length === 0 && statusGrouping.indexOf('none') !== -1;
 
         if (ifStatusIsInSameCategory || ifStatusIsInNoneCategory) {
           $scope.allowedActivityStatuses[activityStatusID] = activityStatus;


### PR DESCRIPTION
## Overview
This PR is a continuation of https://github.com/compucorp/uk.co.compucorp.civicase/pull/375.
When no Activity Category is selected for an Activity Status, now it is considered that all categories are selected. 


## Technical Details
Added a check to see if the Activity Status has no category selected.
```javascript
if (ifStatusIsInSameCategory || ifStatusIsInNoneCategory || ifStatusIsForAllCategories) {
  $scope.allowedActivityStatuses[activityStatusID] = activityStatus;
}
```


