### PR TITLE
CPS-109: Fix [Case Type Category / Case] User with relevant permissions is unable to edit case subject

### DIFF
--- a/CRM/Civicase/Hook/alterAPIPermissions/Case.php
+++ b/CRM/Civicase/Hook/alterAPIPermissions/Case.php
@@ -67,6 +67,7 @@ class CRM_Civicase_Hook_alterAPIPermissions_Case {
     ];
 
     $permissions['case']['get'] = $permissions['custom_value']['gettreevalues'] = [$basicCasePermissions];
+    $permissions['case']['update'] = [$basicCasePermissions];
     $locationTypePermissions = array_merge($permissions['default']['default'], ['access CiviCRM']);
     $permissions['location_type']['get'] = [$locationTypePermissions];
     $permissions['relationship_type']['getcaseroles'] = $permissions['relationship_type']['get'];
@@ -152,6 +153,10 @@ class CRM_Civicase_Hook_alterAPIPermissions_Case {
 
     if ($entity == 'case' && $action == 'create') {
       return $this->getCaseCategoryNameFromCaseType($params, 'case_type_id');
+    }
+
+    if ($entity == 'case' && $action == 'update') {
+      return $this->getCaseCategoryNameFromCaseId($params, 'id');
     }
 
     if ($entity == 'case' && !in_array($action, ['delete', 'getfiles'])) {


### PR DESCRIPTION
## Overview
A user with relevant permissions related to a created case type category cannot edit the case category subject on manage case type category.

## Before
- The issue above exists.

## After
- The case update API is added to the list of API's that allows the equivalent case type category permission to be used.
