### PR TITLE
CPS-113: Fix Permission Issues With Case Category Contact tabs

### DIFF
--- a/CRM/Civicase/Hook/PermissionCheck/CaseCategory.php
+++ b/CRM/Civicase/Hook/PermissionCheck/CaseCategory.php
@@ -136,7 +136,7 @@ class CRM_Civicase_Hook_PermissionCheck_CaseCategory {
     $isAjaxRequest = $url == 'civicrm/ajax/rest';
     $isCaseActivityPage = $url == 'civicrm/case/activity';
     $isPrintActivityReportPage = $url == 'civicrm/case/customreport/print';
-    $isActivityPage = $url == 'civicrm/activity' || $url = 'civicrm/activity/add';
+    $isActivityPage = $url == 'civicrm/activity' || $url == 'civicrm/activity/add';
     $isCaseContactTabPage = $url == 'civicrm/case/contact-case-tab';
 
     if ($isViewCase) {


### PR DESCRIPTION
## Overview
There is a permission error when accessing the case category contact tabs even if user has sufficient permissions

## Before
- Issue exists
## After
- Issue is fixed
There is a bug in the permission logic caused by using the assignment operator instead of the comparison operator.

