### PR TITLE
CPS-78: Fix dropdown menu on Firefox

### DIFF
--- a/ang/civicase/shared/directives/dropdown.directive.js
+++ b/ang/civicase/shared/directives/dropdown.directive.js
@@ -87,8 +87,8 @@
         $(document).on('click', closeDropdownOnClickOutside);
 
         if (attrs.civicaseDropdownTrigger === 'hover') {
-          $element.on('mouseover', showDropdown);
-          $element.on('mouseout', hideDropdown);
+          $element.on('mouseenter', showDropdown);
+          $element.on('mouseleave', hideDropdown);
         }
       }
 
@@ -110,8 +110,8 @@
           $toggleElement.unbind('click', toggleDropdown);
           $('body').unbind('keydown', closeDropdownOnEscapeKeyPressed);
           $(document).unbind('click', closeDropdownOnClickOutside);
-          $element.unbind('mouseover', showDropdown);
-          $element.unbind('mouseout', hideDropdown);
+          $element.unbind('mouseenter', showDropdown);
+          $element.unbind('mouseleave', hideDropdown);
         });
       }
 

--- a/ang/civicase/shared/directives/dropdown.directive.js
+++ b/ang/civicase/shared/directives/dropdown.directive.js
@@ -14,9 +14,9 @@
     /**
      * Dropdown Directive's link function definition.
      *
-     * @param {Object} scope the scope the element is linked to.
-     * @param {Object} element a reference to the dropdown element.
-     * @param {Object} attrs attributes and values attached to the dropdown element.
+     * @param {object} scope the scope the element is linked to.
+     * @param {object} $element a reference to the dropdown element.
+     * @param {object} attrs attributes and values attached to the dropdown element.
      */
     function civicaseDropdownLink (scope, $element, attrs) {
       var $toggleElement = $element.find('[civicase-dropdown-toggle]:first');
@@ -30,7 +30,7 @@
       /**
        * Closes the dropdown menu when clicking outside of it or when clicking
        *
-       * @param {Object} event the DOM event that was triggered by the click.
+       * @param {object} event the DOM event that was triggered by the click.
        */
       function closeDropdownOnClickOutside (event) {
         var $dropdownMenu = getChildDropdownMenu();
@@ -48,7 +48,7 @@
       /**
        * Closes the dropdown menu when the Escape key is pressed
        *
-       * @param {Object} event the DOM event that was triggered by the key press.
+       * @param {object} event the DOM event that was triggered by the key press.
        */
       function closeDropdownOnEscapeKeyPressed (event) {
         var $dropdownMenu = getChildDropdownMenu();
@@ -61,6 +61,9 @@
         }
       }
 
+      /**
+       * @returns {object} a reference to the dropdown menu container.
+       */
       function getChildDropdownMenu () {
         return $element.find('.dropdown-menu:first');
       }

--- a/ang/test/civicase/shared/directives/dropdown.directive.spec.js
+++ b/ang/test/civicase/shared/directives/dropdown.directive.spec.js
@@ -1,147 +1,147 @@
 /* eslint-env jasmine */
 
-(function ($) {
-  describe('Dropdown', function () {
+(($) => {
+  describe('Dropdown', () => {
     var $compile, $rootScope, dropdowns, dropdownContainer, scope;
 
     beforeEach(module('civicase'));
 
-    beforeEach(inject(function (_$compile_, _$rootScope_) {
+    beforeEach(inject((_$compile_, _$rootScope_) => {
       $compile = _$compile_;
       $rootScope = _$rootScope_;
     }));
 
-    afterEach(function () {
+    afterEach(() => {
       dropdownContainer.remove();
     });
 
-    describe('opening the dropdown', function () {
-      beforeEach(function () {
+    describe('opening the dropdown', () => {
+      beforeEach(() => {
         initDirective();
       });
 
-      describe('when clicking on the toggle element', function () {
-        beforeEach(function () {
+      describe('when clicking on the toggle element', () => {
+        beforeEach(() => {
           dropdowns.parent.find('[civicase-dropdown-toggle]:first').click();
         });
 
-        it('displays the dropdown menu', function () {
+        it('displays the dropdown menu', () => {
           expect(dropdowns.parent.find('.dropdown-menu:first').is(':visible')).toBe(true);
         });
       });
 
-      describe('when opening the parent menu and then clicking the child toggle element', function () {
-        beforeEach(function () {
+      describe('when opening the parent menu and then clicking the child toggle element', () => {
+        beforeEach(() => {
           dropdowns.parent.find('[civicase-dropdown-toggle]:first').click();
           dropdowns.child.find('[civicase-dropdown-toggle]:first').click();
         });
 
-        it('displays the child dropdown menu', function () {
+        it('displays the child dropdown menu', () => {
           expect(dropdowns.child.find('.dropdown-menu:first').is(':visible')).toBe(true);
         });
       });
     });
 
-    describe('closing the dropdown', function () {
-      beforeEach(function () {
+    describe('closing the dropdown', () => {
+      beforeEach(() => {
         initDirective();
       });
 
-      beforeEach(function () {
+      beforeEach(() => {
         dropdowns.parent.find('[civicase-dropdown-toggle]:first').click();
       });
 
-      describe('when the dropdown is open and the toggle element is clicked again', function () {
-        beforeEach(function () {
+      describe('when the dropdown is open and the toggle element is clicked again', () => {
+        beforeEach(() => {
           dropdowns.parent.find('[civicase-dropdown-toggle]:first').click();
         });
 
-        it('hides the dropdown menu', function () {
+        it('hides the dropdown menu', () => {
           expect(dropdowns.parent.find('.dropdown-menu:first').is(':visible')).toBe(false);
         });
       });
 
-      describe('when the dropdown is open and an element outside of the dropdown is clicked', function () {
-        beforeEach(function () {
+      describe('when the dropdown is open and an element outside of the dropdown is clicked', () => {
+        beforeEach(() => {
           $('body').click();
         });
 
-        it('hides the dropdown menu', function () {
+        it('hides the dropdown menu', () => {
           expect(dropdowns.parent.find('.dropdown-menu:first').is(':visible')).toBe(false);
         });
       });
 
-      describe('when pressing the Escape key', function () {
-        beforeEach(function () {
+      describe('when pressing the Escape key', () => {
+        beforeEach(() => {
           var escapeKeydownEven = new window.KeyboardEvent('keydown', { key: 'Escape' });
 
           $('body')[0].dispatchEvent(escapeKeydownEven);
         });
 
-        it('hides the child dropdown menu', function () {
+        it('hides the child dropdown menu', () => {
           expect(dropdowns.parent.find('.dropdown-menu:first').is(':visible')).toBe(false);
         });
       });
 
-      describe('closing the child dropdown', function () {
-        beforeEach(function () {
+      describe('closing the child dropdown', () => {
+        beforeEach(() => {
           dropdowns.child.find('[civicase-dropdown-toggle]:first').click();
         });
 
-        describe('when the child toggle element is clicked', function () {
-          beforeEach(function () {
+        describe('when the child toggle element is clicked', () => {
+          beforeEach(() => {
             dropdowns.child.find('[civicase-dropdown-toggle]:first').click();
           });
 
-          it('hides the child dropdown menu', function () {
+          it('hides the child dropdown menu', () => {
             expect(dropdowns.child.find('.dropdown-menu:first').is(':visible')).toBe(false);
           });
 
-          it('keeps the parent dropdown menu visible', function () {
+          it('keeps the parent dropdown menu visible', () => {
             expect(dropdowns.parent.find('.dropdown-menu:first').is(':visible')).toBe(true);
           });
         });
 
-        describe('when pressing the Escape key', function () {
-          beforeEach(function () {
+        describe('when pressing the Escape key', () => {
+          beforeEach(() => {
             var escapeKeydownEven = new window.KeyboardEvent('keydown', { key: 'Escape' });
 
             $('body')[0].dispatchEvent(escapeKeydownEven);
           });
 
-          it('hides the child dropdown menu', function () {
+          it('hides the child dropdown menu', () => {
             expect(dropdowns.child.find('.dropdown-menu:first').is(':visible')).toBe(false);
           });
 
-          it('keeps the parent dropdown menu visible', function () {
+          it('keeps the parent dropdown menu visible', () => {
             expect(dropdowns.parent.find('.dropdown-menu:first').is(':visible')).toBe(true);
           });
         });
       });
     });
 
-    describe('when the dropdown menu is triggered by mouse events', function () {
-      beforeEach(function () {
+    describe('when the dropdown menu is triggered by mouse events', () => {
+      beforeEach(() => {
         initDirective({ trigger: 'hover' });
       });
 
-      describe('when the mouse passes over the dropdown element', function () {
-        beforeEach(function () {
+      describe('when the mouse passes over the dropdown element', () => {
+        beforeEach(() => {
           dispatchMouseEvent('mouseover');
         });
 
-        it('displays the dropdown menu', function () {
+        it('displays the dropdown menu', () => {
           expect(dropdowns.parent.find('.dropdown-menu:first').is(':visible')).toBe(true);
         });
       });
 
-      describe('when the mouse passes over and then leaves the dropdown element', function () {
-        beforeEach(function () {
+      describe('when the mouse passes over and then leaves the dropdown element', () => {
+        beforeEach(() => {
           dispatchMouseEvent('mouseover');
           dispatchMouseEvent('mouseout');
         });
 
-        it('hides the dropdown menu', function () {
+        it('hides the dropdown menu', () => {
           expect(dropdowns.parent.find('.dropdown-menu:first').is(':visible')).toBe(false);
         });
       });

--- a/ang/test/civicase/shared/directives/dropdown.directive.spec.js
+++ b/ang/test/civicase/shared/directives/dropdown.directive.spec.js
@@ -73,7 +73,7 @@
 
       describe('when pressing the Escape key', function () {
         beforeEach(function () {
-          var escapeKeydownEven = new window.KeyboardEvent('keydown', {'key': 'Escape'});
+          var escapeKeydownEven = new window.KeyboardEvent('keydown', { key: 'Escape' });
 
           $('body')[0].dispatchEvent(escapeKeydownEven);
         });
@@ -104,7 +104,7 @@
 
         describe('when pressing the Escape key', function () {
           beforeEach(function () {
-            var escapeKeydownEven = new window.KeyboardEvent('keydown', {'key': 'Escape'});
+            var escapeKeydownEven = new window.KeyboardEvent('keydown', { key: 'Escape' });
 
             $('body')[0].dispatchEvent(escapeKeydownEven);
           });
@@ -149,7 +149,7 @@
       /**
        * Dispatches a mouse event to the dropdown toggle element.
        *
-       * @param {String} eventType the mouse event type that is going to be dispatched to the element.
+       * @param {string} eventType the mouse event type that is going to be dispatched to the element.
        */
       function dispatchMouseEvent (eventType) {
         var event = document.createEvent('mouseevent');
@@ -163,7 +163,7 @@
      * Initializes the dropdown directive, stores a reference to the dropdown element
      * and scope.
      *
-     * @param {Object} options a list of configurations to pass to the dropdown directive.
+     * @param {object} options a list of configurations to pass to the dropdown directive.
      */
     function initDirective (options) {
       var defaultOptions = { trigger: 'click' };

--- a/ang/test/civicase/shared/directives/dropdown.directive.spec.js
+++ b/ang/test/civicase/shared/directives/dropdown.directive.spec.js
@@ -127,7 +127,7 @@
 
       describe('when the mouse passes over the dropdown element', () => {
         beforeEach(() => {
-          dispatchMouseEvent('mouseover');
+          dispatchMouseEvent('mouseenter');
         });
 
         it('displays the dropdown menu', () => {
@@ -137,8 +137,8 @@
 
       describe('when the mouse passes over and then leaves the dropdown element', () => {
         beforeEach(() => {
-          dispatchMouseEvent('mouseover');
-          dispatchMouseEvent('mouseout');
+          dispatchMouseEvent('mouseenter');
+          dispatchMouseEvent('mouseleave');
         });
 
         it('hides the dropdown menu', () => {
@@ -147,15 +147,14 @@
       });
 
       /**
-       * Dispatches a mouse event to the dropdown toggle element.
+       * Dispatches the given event type to the dropdown toggle element.
        *
        * @param {string} eventType the mouse event type that is going to be dispatched to the element.
        */
       function dispatchMouseEvent (eventType) {
-        var event = document.createEvent('mouseevent');
+        var event = $.Event(eventType);
 
-        event.initEvent(eventType, true, false);
-        dropdowns.parent.find('[civicase-dropdown-toggle]:first')[0].dispatchEvent(event);
+        dropdowns.parent.find('[civicase-dropdown-toggle]:first').trigger(event);
       }
     });
 


### PR DESCRIPTION
## Overview
This PR fixes the case details' "Add New" Dropdown menu breaks on Firefox since it disappears when trying to access child menu items.

Fixes #152 

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/76371258-1c153580-6310-11ea-93cd-690f8553ead3.gif)

## After
![pr-after](https://user-images.githubusercontent.com/1642119/76371213-ef611e00-630f-11ea-987b-063206cbbc8f.gif)

## Technical Details

The issue happens because the `civicase-dropdown` directive used `mouseover` and `mouseout` events, and these trigger multiple times while the mouse moves which makes Firefox hide the menu because it's the last event triggered out of those two.

To avoid this issue we use `mouseenter` and `mouseleave` events which only trigger once.