### PR TITLE
BASWSPRT-98: Apply Relationship Filter to Manage Cases link from Dashboard

### DIFF
--- a/ang/civicase/case/directives/case-overview.directive.html
+++ b/ang/civicase/case/directives/case-overview.directive.html
@@ -44,7 +44,7 @@
           popover-append-to-body="true"
           popover-class="civicase__tooltip-popup-list">
           <div class="civicase__case-overview__flow-status__count">
-            <a ng-href="{{ caseListLink(null, status.value) }}">
+            <a ng-href="{{ linkToManageCase(null, status.value) }}">
               {{ summaryData.all[status.value] || '0' }}
             </a>
           </div>
@@ -73,7 +73,7 @@
           popover-placement="bottom"
           popover-append-to-body="true"
           popover-class="civicase__tooltip-popup-list">
-          <a ng-href="{{ caseListLink(caseType.name) }}">
+          <a ng-href="{{ linkToManageCase(caseType.name) }}">
             {{ caseType.title }}
           </a>
           <span
@@ -84,7 +84,7 @@
           class="civicase__case-overview__breakdown-field"
           ng-if="!status.isHidden"
           ng-repeat="status in caseStatuses">
-          <a ng-href="{{ caseListLink(caseType.name, status.value) }}">
+          <a ng-href="{{ linkToManageCase(caseType.name, status.value) }}">
             {{ summaryData[caseType.id][status.value] || '0' }}
           </a>
         </div>

--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -8,7 +8,8 @@
       templateUrl: '~/civicase/case/directives/case-overview.directive.html',
       controller: civicaseCaseOverviewController,
       scope: {
-        caseFilter: '<'
+        caseFilter: '<',
+        linkToManageCase: '='
       },
       link: civicaseCaseOverviewLink
     };
@@ -75,31 +76,6 @@
       return _.filter($scope.caseStatuses, function (status) {
         return !status.isHidden;
       }).length === 0;
-    };
-
-    /**
-     * Creates link to the filtered cases list
-     *
-     * @param {string} type the case type
-     * @param {string} status the case's status.
-     * @returns {string} link to the filtered list of cases
-     */
-    $scope.caseListLink = function (type, status) {
-      var cf = {};
-
-      if (type) {
-        cf.case_type_id = [type];
-      }
-
-      if (status) {
-        cf.status_id = [status];
-      }
-
-      if ($scope.myCasesOnly) {
-        cf.case_manager = [CRM.config.user_contact_id];
-      }
-
-      return '#/case/list?' + $.param({ cf: JSON.stringify(cf) });
     };
 
     /**

--- a/ang/civicase/dashboard/directives/dashboard-tab.directive.html
+++ b/ang/civicase/dashboard/directives/dashboard-tab.directive.html
@@ -2,6 +2,7 @@
   <div class="civicase__dashboard__tab__top">
     <civicase-case-overview
       case-filter="activityFilters.case_filter"
+      link-to-manage-case="linkToManageCase"
     ></civicase-case-overview>
   </div>
   <div class="civicase__dashboard__tab__main">

--- a/ang/civicase/dashboard/directives/dashboard.directive.js
+++ b/ang/civicase/dashboard/directives/dashboard.directive.js
@@ -42,17 +42,31 @@
       $scope.ts = ts;
     }());
 
-    $scope.caseListLink = function (type, status) {
-      var cf = {};
+    /**
+     * Creates link to the filtered cases list
+     *
+     * @param {string} type the case type
+     * @param {string} status the case's status.
+     * @returns {string} link to the filtered list of cases
+     */
+    $scope.linkToManageCase = function (type, status) {
+      var cf = { case_type_category: $scope.caseTypeCategoryName };
+      var userContactId = [CRM.config.user_contact_id];
+
       if (type) {
         cf.case_type_id = [type];
       }
+
       if (status) {
         cf.status_id = [status];
       }
-      if ($scope.myCasesOnly) {
-        cf.case_manager = CRM.config.user_contact_id;
+
+      if ($scope.filters.caseRelationshipType === 'is_case_manager') {
+        cf.case_manager = userContactId;
+      } else if ($scope.filters.caseRelationshipType === 'is_involved') {
+        cf.contact_involved = userContactId;
       }
+
       return '#/case/list?' + $.param({ cf: JSON.stringify(cf) });
     };
 

--- a/ang/test/civicase/case/directives/case-overview.directive.spec.js
+++ b/ang/test/civicase/case/directives/case-overview.directive.spec.js
@@ -40,12 +40,6 @@
       });
     });
 
-    describe('caseListLink', function () {
-      it('checks the output of caseListLink function', function () {
-        expect(element.isolateScope().caseListLink('type', 'status')).toEqual('#/case/list?cf=%7B%22case_type_id%22%3A%5B%22type%22%5D%2C%22status_id%22%3A%5B%22status%22%5D%7D');
-      });
-    });
-
     describe('Case Types', function () {
       beforeEach(function () {
         crmApi.and.returnValue($q.resolve([CasesOverviewStats]));

--- a/ang/test/civicase/dashboard/directives/dashboard.directive.spec.js
+++ b/ang/test/civicase/dashboard/directives/dashboard.directive.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env jasmine */
 
-(function (_) {
+(function (_, $) {
   describe('civicaseDashboardController', function () {
     var $controller, $rootScope, $scope, DashboardActionItems;
 
@@ -116,9 +116,15 @@
           returnedLink = $scope.linkToManageCase('type', 'status');
         });
 
-        it('returns url to manage cases page with case type and case status preselected', () => {
+        it('returns the url to manage cases page with case type and case status preselected', () => {
           expect(returnedLink)
-            .toBe('#/case/list?cf=%7B%22case_type_category%22%3A%22cases%22%2C%22case_type_id%22%3A%5B%22type%22%5D%2C%22status_id%22%3A%5B%22status%22%5D%7D');
+            .toBe('#/case/list?' + $.param({
+              cf: JSON.stringify({
+                case_type_category: 'cases',
+                case_type_id: ['type'],
+                status_id: ['status']
+              })
+            }));
         });
       });
 
@@ -130,9 +136,16 @@
           returnedLink = $scope.linkToManageCase('type', 'status');
         });
 
-        it('returns url to manage cases page with "my cases" filter selected', () => {
+        it('returns the url to manage cases page with "my cases" filter selected', () => {
           expect(returnedLink)
-            .toBe('#/case/list?cf=%7B%22case_type_category%22%3A%22cases%22%2C%22case_type_id%22%3A%5B%22type%22%5D%2C%22status_id%22%3A%5B%22status%22%5D%2C%22case_manager%22%3A%5B203%5D%7D');
+            .toBe('#/case/list?' + $.param({
+              cf: JSON.stringify({
+                case_type_category: 'cases',
+                case_type_id: ['type'],
+                status_id: ['status'],
+                case_manager: [CRM.config.user_contact_id]
+              })
+            }));
         });
       });
 
@@ -144,9 +157,16 @@
           returnedLink = $scope.linkToManageCase('type', 'status');
         });
 
-        it('returns url to manage cases page with "cases I am involved in" filter selected', () => {
+        it('returns the url to manage cases page with "cases I am involved in" filter selected', () => {
           expect(returnedLink)
-            .toBe('#/case/list?cf=%7B%22case_type_category%22%3A%22cases%22%2C%22case_type_id%22%3A%5B%22type%22%5D%2C%22status_id%22%3A%5B%22status%22%5D%2C%22contact_involved%22%3A%5B203%5D%7D');
+            .toBe('#/case/list?' + $.param({
+              cf: JSON.stringify({
+                case_type_category: 'cases',
+                case_type_id: ['type'],
+                status_id: ['status'],
+                contact_involved: [CRM.config.user_contact_id]
+              })
+            }));
         });
       });
     });
@@ -160,4 +180,4 @@
       });
     }
   });
-})(CRM._);
+})(CRM._, CRM.$);

--- a/ang/test/civicase/dashboard/directives/dashboard.directive.spec.js
+++ b/ang/test/civicase/dashboard/directives/dashboard.directive.spec.js
@@ -103,6 +103,54 @@
       });
     });
 
+    describe('link to manage screen page', () => {
+      beforeEach(() => {
+        initController();
+        $scope.caseTypeCategoryName = 'cases';
+      });
+
+      describe('when case type and case status is sent ', () => {
+        let returnedLink;
+
+        beforeEach(() => {
+          returnedLink = $scope.linkToManageCase('type', 'status');
+        });
+
+        it('returns url to manage cases page with case type and case status preselected', () => {
+          expect(returnedLink)
+            .toBe('#/case/list?cf=%7B%22case_type_category%22%3A%22cases%22%2C%22case_type_id%22%3A%5B%22type%22%5D%2C%22status_id%22%3A%5B%22status%22%5D%7D');
+        });
+      });
+
+      describe('when "my cases" filter is selected ', () => {
+        let returnedLink;
+
+        beforeEach(() => {
+          $scope.filters.caseRelationshipType = 'is_case_manager';
+          returnedLink = $scope.linkToManageCase('type', 'status');
+        });
+
+        it('returns url to manage cases page with "my cases" filter selected', () => {
+          expect(returnedLink)
+            .toBe('#/case/list?cf=%7B%22case_type_category%22%3A%22cases%22%2C%22case_type_id%22%3A%5B%22type%22%5D%2C%22status_id%22%3A%5B%22status%22%5D%2C%22case_manager%22%3A%5B203%5D%7D');
+        });
+      });
+
+      describe('when "cases I am involved in" filter is selected ', () => {
+        let returnedLink;
+
+        beforeEach(() => {
+          $scope.filters.caseRelationshipType = 'is_involved';
+          returnedLink = $scope.linkToManageCase('type', 'status');
+        });
+
+        it('returns url to manage cases page with "cases I am involved in" filter selected', () => {
+          expect(returnedLink)
+            .toBe('#/case/list?cf=%7B%22case_type_category%22%3A%22cases%22%2C%22case_type_id%22%3A%5B%22type%22%5D%2C%22status_id%22%3A%5B%22status%22%5D%2C%22contact_involved%22%3A%5B203%5D%7D');
+        });
+      });
+    });
+
     /**
      * Initializes the dashboard controller.
      */


### PR DESCRIPTION
## Overview
This PR fixed the following things,
1. When clicking on any 'Case Status' or the 'Case Status Count' in the Case Overview of Dashboard section, browser redirected to Manage Cases page, but the "Relationship" filter was not sent to the Manage Cases page. 
![2020-03-11 at 12 58 PM](https://user-images.githubusercontent.com/5058867/76392668-03e8f900-6398-11ea-8621-b3546ec15f7a.jpg)

2. When clicking on any 'Case Status' or the 'Case Status Count' in the Case Overview of Dashboard section the Case Type Category filter was not sent to the Manage Cases page, which resulted in showing cases from all Case Categories. 

## Before
![before](https://user-images.githubusercontent.com/5058867/76392855-693cea00-6398-11ea-8d89-f9dc23c50c00.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/76392806-52969300-6398-11ea-873b-e95edbdaad2d.gif)

## Technical Details
1. As the Relationship Filter is available on the `civicaseDashboard` directive, and not in `civicaseCaseOverview`, the `$scope.caseListLink` function has been moved to `civicaseDashboard`, and then the same is passed down to `civicaseCaseOverview` using attributes.

2. In `civicaseDashboard`, there was an unused and duplicate `caseListLink` function, which has been removed now.