### PR TITLE
CPS-122: Fix my role not showing

### DIFF
--- a/ang/civicase/case/factories/format-case.factory.js
+++ b/ang/civicase/case/factories/format-case.factory.js
@@ -6,7 +6,6 @@
     var caseStatuses = CaseStatus.getAll();
 
     return function (item) {
-      item.myRole = [];
       item.client = [];
       item.subject = (typeof item.subject === 'undefined') ? '' : item.subject;
       item.status = caseStatuses[item.status_id].label;
@@ -32,10 +31,6 @@
       _.each(item.contacts, function (contact) {
         if (!contact.relationship_type_id) {
           item.client.push(contact);
-        }
-
-        if (contact.contact_id === CRM.config.user_contact_id) {
-          item.myRole.push(contact.role);
         }
 
         if (contact.manager) {


### PR DESCRIPTION
## Overview
The Case List on Manage Cases page, the My Role column does not show anything, this PR fixes the same.

## Before
![2020-03-13 at 12 52 PM](https://user-images.githubusercontent.com/5058867/76598746-805f1180-6529-11ea-9459-1cb0730d5c2e.jpg)

## After
![2020-03-13 at 12 51 PM](https://user-images.githubusercontent.com/5058867/76598695-6ae9e780-6529-11ea-8f69-4986bac66595.jpg)

## Technical Details
The `Case.getcaselist` API already returns `myRole`, 
![2020-03-13 at 12 54 PM](https://user-images.githubusercontent.com/5058867/76598890-cddb7e80-6529-11ea-9c60-c98563e9c395.jpg)

But this was getting reset in `format-case.factory.js`, 
```
 item.myRole = [];
...
if (contact.contact_id === CRM.config.user_contact_id) {	
  item.myRole.push(contact.role);	
}
```

Now the logic could have been fixed, but as the API already returns the My Role, the above logic is not necessary anymore. So it has been removed.