### PR TITLE
CPS-117: Fix Activty Types not shown on Contact Case tab

### DIFF
--- a/ang/civicase/activity/directives/add-activity-menu.directive.js
+++ b/ang/civicase/activity/directives/add-activity-menu.directive.js
@@ -95,7 +95,7 @@
 
       $scope.$watch('case.allActivities', function () {
         $scope.availableActivityTypes = getAvailableActivityTypes(
-          $scope.case.activity_count, $scope.case.definition);
+          $scope.case.activity_count, definition);
       });
     }
 

--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.js
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.js
@@ -9,6 +9,7 @@
       templateUrl: '~/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html',
       scope: {
         item: '=selectedCase',
+        caseTypeCategory: '=',
         refreshCases: '=refreshCallback'
       }
     };

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
@@ -39,7 +39,8 @@
               class="civicase__contact-cases-tab-details"
               selected-case="selectedCase"
               ng-if="caseDetailsLoaded",
-              refresh-callback="refresh">
+              refresh-callback="refresh"
+              case-type-category="caseTypeCategoryName">
             </civicase-contact-case-tab-case-details>
             <!-- Loading placeholder -->
             <div ng-if="!caseDetailsLoaded" class="panel panel-default civicase__contact-cases-tab-details">


### PR DESCRIPTION
## Overview
In Contact Case tab, the Add Activities button inside "Next Activity" block does not show list of available Activity Types. This PR fixes this issue.
This PR also fixes CPS-116.

## Before
![2020-03-13 at 1 29 PM](https://user-images.githubusercontent.com/5058867/76601344-bce13c00-652e-11ea-8d7c-16d3b7f41433.jpg)

## After
![2020-03-13 at 1 28 PM](https://user-images.githubusercontent.com/5058867/76601296-a0dd9a80-652e-11ea-8314-7577f1037912.jpg)

## Technical Details
This is a regression issue introduced by https://github.com/compucorp/uk.co.compucorp.civicase/commit/6eff6b413cbf4f2a59838f116dd573eedda261ea

Where the following code was introduced
```
$scope.$watch('case.allActivities', function () {
  $scope.availableActivityTypes = getAvailableActivityTypes(
    $scope.case.activity_count,  $scope.case.definition);
});
```

But in some scenarios `$scope.case.definition` is undefined, when the case has been fetched, but the definition is not set yet in https://github.com/compucorp/uk.co.compucorp.civicase/blob/6cfbb9772787d73a7204c602090919e141b4c22a/ang/civicase/case/details/directives/case-details.directive.js#L318 .

So to avoid this, the following code is applied
```
$scope.$watch('case.allActivities', function () {
  $scope.availableActivityTypes = getAvailableActivityTypes(
    $scope.case.activity_count, definition);
});
```

Here `definition` variable is already defined and used in similar code across the file.

Also fixed an additional issue, in https://github.com/compucorp/uk.co.compucorp.civicase/blob/6cfbb9772787d73a7204c602090919e141b4c22a/ang/civicase/case/details/directives/case-details.directive.js#L286 , the `$scope.caseTypeCategory` was undefined, inside Contact Case Category tabs. This is because the directive expects the `caseTypeCategory` to be sent as an attribute https://github.com/compucorp/uk.co.compucorp.civicase/blob/6cfbb9772787d73a7204c602090919e141b4c22a/ang/civicase/case/details/directives/case-details.directive.js#L13.

But inside the Contact Case tab, the directive is not used directly, instead the `civicaseCaseDetailsController` is attached to the `civicaseContactCaseTabCaseDetails` directive using `ng-controller` https://github.com/compucorp/uk.co.compucorp.civicase/blob/6cfbb9772787d73a7204c602090919e141b4c22a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html#L2.

To fix this, in `contact-case-tab.directive.html`, added `case-type-category` attribute to `civicase-contact-case-tab-case-details` directive.