### PR TITLE
CPS-128: Fix "add new case" link for contact case tab

### DIFF
--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
@@ -129,7 +129,7 @@
     <div class="civicase__activity-card--big--empty-description"> {{ ts('Click the button below to create a new case for this contact') }} </div>
     <a ng-if="checkPerm('add cases')"
       class="civicase__activity-card--big--empty-button btn"
-      ng-href="{{ 'civicrm/case/add' | civicaseCrmUrl:{reset: 1, action: 'add', context: 'standalone'} }}"
+      ng-href="{{ 'civicrm/case/add' | civicaseCrmUrl:{civicase_cid: contactId, reset: 1, action: 'add', context: 'standalone', case_type_category: caseTypeCategoryName } }}"
       crm-popup-form-success="refresh()">
       {{ ts('Add new case') }}
     </a>


### PR DESCRIPTION
## Overview
This PR fixes the link to create a new case from the contact's case tab. The issues fixed were:

* The case type category was not being passed to the case form so the right list of case types is not displayed. This also causes permission issues.
* The contact was not being preselected.

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/76655151-13587580-6543-11ea-8f66-7d3505d8a34a.gif)

## After
![pr-after](https://user-images.githubusercontent.com/1642119/76655412-94b00800-6543-11ea-800a-134b6e5e3522.gif)

## Technical Details

The issue happens because we were not passing the case type category name to the form. We were also not passing the contact id. To fix this issue we pass these parameter which are the same ones passed to the "Add Case" button on the top:

```html
    <a ng-if="checkPerm('add cases')"
      class="civicase__activity-card--big--empty-button btn"
      ng-href="{{ 'civicrm/case/add' | civicaseCrmUrl:{civicase_cid: contactId, reset: 1, action: 'add', context: 'standalone', case_type_category: caseTypeCategoryName } }}"
      crm-popup-form-success="refresh()">
      {{ ts('Add new case') }}
    </a>
```