### PR TITLE
CPS-114: Fix case details link

### DIFF
--- a/ang/civicase/activity/card/directives/activity-card-long.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-long.directive.html
@@ -139,7 +139,7 @@
     </div>
     <!-- Case information -->
     <div class="panel-footer" ng-if="activity.case">
-      <a ng-href="{{ 'civicrm/case/a/#/case/list' | civicaseCrmUrl:{ caseId: activity.case_id } }}">
+      <a ng-href="{{ caseDetailUrl }}">
         <div class="civicase__activity-card-row civicase__activity-card-row--case-info" >
           <span>
             <span class="civicase__activity-card__case-id__label">{{ ts("Case ID:") }}</span>

--- a/ang/civicase/activity/card/directives/activity-card-short.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-short.directive.html
@@ -94,7 +94,7 @@
       </div>
     </div>
     <div class="panel-footer" ng-if="activity.case">
-      <a ng-href="{{ 'civicrm/case/a/#/case/list' | civicaseCrmUrl:{ caseId: activity.case_id } }}">
+      <a ng-href="{{ caseDetailUrl }}">
         <div class="civicase__activity-card-row civicase__activity-card-row--case-info" >
           <span>
             <span class="civicase__activity-card__case-id__label">{{ ts("Case ID:") }}</span>

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -48,7 +48,7 @@
     $scope.caseRelationshipOptions = caseRelationshipConfig;
     $scope.checkPerm = CRM.checkPerm;
     $scope.filterDescription = buildDescription();
-    $scope.filters = angular.extend({}, $scope.defaults);
+    $scope.filters = {};
     $scope.contactRoles = [
       { id: 'all-case-roles', text: ts('All Case Roles') },
       { id: 'client', text: ts('Client') }
@@ -60,6 +60,7 @@
 
     (function init () {
       bindRouteParamsToScope();
+      applyDefaultFilters();
       setCaseTypesBasedOnCategory();
       initiateWatchers();
       initSubscribers();
@@ -145,11 +146,29 @@
     }
 
     /**
+     * Sets default case filters based on this priority:
+     *
+     * 1 - the filters coming from the URL through the `cf` parameter.
+     * 2 - the default filters coming the `filters` directive's attribute.
+     * 3 - default filter values defined in this directive.
+     */
+    function applyDefaultFilters () {
+      var filtersComingFromUrl = $scope.filters;
+
+      $scope.filters = _.defaults(
+        {},
+        filtersComingFromUrl,
+        $scope.defaults,
+        DEFAULT_CASE_FILTERS
+      );
+    }
+
+    /**
      * Binds all route parameters to scope
      */
     function bindRouteParamsToScope () {
       $scope.$bindToRoute({ expr: 'expanded', param: 'sx', format: 'bool', default: false });
-      $scope.$bindToRoute({ expr: 'filters', param: 'cf', default: DEFAULT_CASE_FILTERS });
+      $scope.$bindToRoute({ expr: 'filters', param: 'cf', default: {} });
       $scope.$bindToRoute({ expr: 'contactRoleFilter', param: 'crf', default: $scope.contactRoleFilter });
     }
 

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -20,10 +20,6 @@
    */
   module.controller('civicaseSearchController', function ($scope, $rootScope, $timeout,
     crmApi, getSelect2Value, ts, CaseStatus, CaseTypeCategory, CaseType, currentCaseCategory, CustomSearchField) {
-    var DEFAULT_CASE_FILTERS = {
-      case_type_category: currentCaseCategory
-    };
-    $scope.ts = ts;
     var caseTypes = CaseType.getAll();
     var caseStatuses = CaseStatus.getAll();
     var caseTypeCategories = CaseTypeCategory.getAll();
@@ -41,22 +37,26 @@
       { text: ts('My cases'), id: 'is_case_manager' },
       { text: ts('Cases I am involved'), id: 'is_involved' }
     ];
+    var DEFAULT_CASE_FILTERS = {
+      case_type_category: currentCaseCategory
+    };
 
-    $scope.pageTitle = '';
-    $scope.caseStatusOptions = _.map(caseStatuses, mapSelectOptions);
-    $scope.customGroups = CustomSearchField.getAll();
     $scope.caseRelationshipOptions = caseRelationshipConfig;
+    $scope.caseStatusOptions = _.map(caseStatuses, mapSelectOptions);
     $scope.checkPerm = CRM.checkPerm;
+    $scope.customGroups = CustomSearchField.getAll();
     $scope.filterDescription = buildDescription();
     $scope.filters = {};
-    $scope.contactRoles = [
-      { id: 'all-case-roles', text: ts('All Case Roles') },
-      { id: 'client', text: ts('Client') }
-    ];
+    $scope.pageTitle = '';
+    $scope.ts = ts;
     $scope.contactRoleFilter = {
       selectedContacts: null,
       selectedContactRoles: ['all-case-roles']
     };
+    $scope.contactRoles = [
+      { id: 'all-case-roles', text: ts('All Case Roles') },
+      { id: 'client', text: ts('Client') }
+    ];
 
     (function init () {
       bindRouteParamsToScope();

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -19,7 +19,10 @@
    * Controller Function for civicase-search directive
    */
   module.controller('civicaseSearchController', function ($scope, $rootScope, $timeout,
-    crmApi, getSelect2Value, ts, CaseStatus, CaseTypeCategory, CaseType, CustomSearchField) {
+    crmApi, getSelect2Value, ts, CaseStatus, CaseTypeCategory, CaseType, currentCaseCategory, CustomSearchField) {
+    var DEFAULT_CASE_FILTERS = {
+      case_type_category: currentCaseCategory
+    };
     $scope.ts = ts;
     var caseTypes = CaseType.getAll();
     var caseStatuses = CaseStatus.getAll();
@@ -146,7 +149,7 @@
      */
     function bindRouteParamsToScope () {
       $scope.$bindToRoute({ expr: 'expanded', param: 'sx', format: 'bool', default: false });
-      $scope.$bindToRoute({ expr: 'filters', param: 'cf', default: {} });
+      $scope.$bindToRoute({ expr: 'filters', param: 'cf', default: DEFAULT_CASE_FILTERS });
       $scope.$bindToRoute({ expr: 'contactRoleFilter', param: 'crf', default: $scope.contactRoleFilter });
     }
 

--- a/ang/test/civicase/activity/card/directives/activity-card.directive.spec.js
+++ b/ang/test/civicase/activity/card/directives/activity-card.directive.spec.js
@@ -1,15 +1,15 @@
 /* eslint-env jasmine */
 
-(function ($, _) {
-  describe('ActivityCard', function () {
-    var $compile, $filter, $rootScope, $scope, viewInPopup, activityCard,
+(($, _) => {
+  describe('ActivityCard', () => {
+    let $compile, $filter, $rootScope, $scope, viewInPopup, activityCard,
       activitiesMockData, CaseType, CaseTypeCategory,
       viewInPopupMockReturn, crmFormSuccessCallback;
 
-    beforeEach(module('civicase', 'civicase.templates', 'civicase.data', function ($provide) {
-      var viewInPopupMock = jasmine.createSpy('viewInPopupMock');
+    beforeEach(module('civicase', 'civicase.templates', 'civicase.data', ($provide) => {
+      const viewInPopupMock = jasmine.createSpy('viewInPopupMock');
       viewInPopupMockReturn = jasmine.createSpyObj('viewInPopupMockObj', ['on']);
-      viewInPopupMockReturn.on.and.callFake(function (event, fn) {
+      viewInPopupMockReturn.on.and.callFake((event, fn) => {
         crmFormSuccessCallback = fn;
       });
       viewInPopupMock.and.returnValue(viewInPopupMockReturn);
@@ -34,12 +34,12 @@
       initDirective();
     }));
 
-    afterEach(function () {
+    afterEach(() => {
       $('#bootstrap-theme').remove();
     });
 
-    describe('on init', function () {
-      it('stores a reference to the bootstrap theme element', function () {
+    describe('on init', () => {
+      it('stores a reference to the bootstrap theme element', () => {
         expect(activityCard.isolateScope().bootstrapThemeElement.is('#bootstrap-theme')).toBe(true);
       });
 
@@ -94,29 +94,29 @@
       });
     });
 
-    describe('when editing an activity in the popup', function () {
-      var activity;
+    describe('when editing an activity in the popup', () => {
+      let activity;
 
-      beforeEach(function () {
+      beforeEach(() => {
         activity = activitiesMockData.get()[0];
 
         activityCard.isolateScope().viewInPopup(null, activity);
       });
 
-      it('opens the modal to edit the activity', function () {
+      it('opens the modal to edit the activity', () => {
         expect(viewInPopup).toHaveBeenCalledWith(null, activity);
       });
 
-      it('listenes for the the form to be saved', function () {
+      it('listenes for the the form to be saved', () => {
         expect(viewInPopupMockReturn.on).toHaveBeenCalledWith('crmFormSuccess', jasmine.any(Function));
       });
 
-      describe('when activity is saved', function () {
-        beforeEach(function () {
+      describe('when activity is saved', () => {
+        beforeEach(() => {
           crmFormSuccessCallback();
         });
 
-        it('refreshes the data when activity is saved', function () {
+        it('refreshes the data when activity is saved', () => {
           expect(activityCard.isolateScope().refresh).toHaveBeenCalled();
         });
       });

--- a/ang/test/civicase/activity/card/directives/activity-card.directive.spec.js
+++ b/ang/test/civicase/activity/card/directives/activity-card.directive.spec.js
@@ -1,9 +1,10 @@
 /* eslint-env jasmine */
 
-(function ($) {
+(function ($, _) {
   describe('ActivityCard', function () {
-    var $compile, $rootScope, $scope, viewInPopup, activityCard,
-      activitiesMockData, viewInPopupMockReturn, crmFormSuccessCallback;
+    var $compile, $filter, $rootScope, $scope, viewInPopup, activityCard,
+      activitiesMockData, CaseType, CaseTypeCategory,
+      viewInPopupMockReturn, crmFormSuccessCallback;
 
     beforeEach(module('civicase', 'civicase.templates', 'civicase.data', function ($provide) {
       var viewInPopupMock = jasmine.createSpy('viewInPopupMock');
@@ -16,11 +17,18 @@
       $provide.value('viewInPopup', viewInPopupMock);
     }));
 
-    beforeEach(inject(function (_$compile_, _$rootScope_, _activitiesMockData_, _viewInPopup_) {
+    beforeEach(inject(function (_$compile_, _$filter_, _$rootScope_, _activitiesMockData_,
+      _CaseType_, _CaseTypeCategory_, _viewInPopup_) {
       $compile = _$compile_;
+      $filter = _$filter_;
       $rootScope = _$rootScope_;
       activitiesMockData = _activitiesMockData_;
+      CaseType = _CaseType_;
+      CaseTypeCategory = _CaseTypeCategory_;
       viewInPopup = _viewInPopup_;
+
+      $scope = $rootScope.$new();
+      $scope.activity = {};
 
       $('<div id="bootstrap-theme"></div>').appendTo('body');
       initDirective();
@@ -33,6 +41,56 @@
     describe('on init', function () {
       it('stores a reference to the bootstrap theme element', function () {
         expect(activityCard.isolateScope().bootstrapThemeElement.is('#bootstrap-theme')).toBe(true);
+      });
+
+      describe('when the activity does not belong to a case', () => {
+        it('does not store a link to a case details page', () => {
+          expect($scope.caseDetailUrl).not.toBeDefined();
+        });
+      });
+
+      describe('when the activity belongs to a case', () => {
+        let expectedCaseDetailsUrl;
+
+        beforeEach(() => {
+          const caseTypes = CaseType.getAll();
+          const caseTypeId = _.chain(caseTypes).keys().sample().value();
+          const caseType = caseTypes[caseTypeId];
+          const caseTypeCategory = _.find(CaseTypeCategory.getAll(), {
+            value: caseType.case_type_category
+          });
+          $scope.activity = _.sample(activitiesMockData.get());
+          $scope.activity.case_id = _.uniqueId();
+          $scope.activity.case = {
+            case_id: $scope.activity.case_id,
+            case_type_id: caseTypeId
+          };
+
+          expectedCaseDetailsUrl = getExpectedCaseDetailsUrl(
+            $scope.activity.case_id,
+            caseTypeCategory.name
+          );
+
+          initDirective();
+        });
+
+        it('stores the URL to the case details for the case associated to the activity', () => {
+          expect(activityCard.isolateScope().caseDetailUrl).toEqual(expectedCaseDetailsUrl);
+        });
+
+        /**
+         * @param {number} caseId the case id.
+         * @param {number} caseTypeCategoryName the category the case belongs to.
+         * @returns {string} the expected URL to the case details for the given case.
+         */
+        function getExpectedCaseDetailsUrl (caseId, caseTypeCategoryName) {
+          const caseDetailUrl = 'civicrm/case/a/?' +
+            $.param({ case_type_category: caseTypeCategoryName }) +
+            '#/case/list';
+          const angularParams = $.param({ caseId });
+
+          return $filter('civicaseCrmUrl')(caseDetailUrl) + '?' + angularParams;
+        }
       });
     });
 
@@ -68,12 +126,10 @@
      * Initializes the ActivityCard directive
      */
     function initDirective () {
-      $scope = $rootScope.$new();
-      $scope.activity = {};
       $scope.refreshCallback = jasmine.createSpy('refreshCallback');
 
       activityCard = $compile('<div case-activity-card="activity" refresh-callback="refreshCallback"></div>')($scope);
       $rootScope.$digest();
     }
   });
-})(CRM.$);
+})(CRM.$, CRM._);

--- a/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
@@ -32,8 +32,8 @@ describe('Case Details People Tab', () => {
     CRM.$.fn.select2 = jasmine.createSpy('select2').and.callFake(function (option) {
       if (option === 'data') {
         return caseRoleSelectorContact;
-      } else {
-        return crmConfirmDialog;
+      } else if (option === 'container') {
+        return crmConfirmDialog.find('[name=caseRoleSelector]');
       }
     });
   }));

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -1,8 +1,8 @@
 /* eslint-env jasmine */
 (($, _) => {
   describe('civicaseSearch', () => {
-    let $controller, $rootScope, $scope, CaseFilters, CaseStatuses, CaseTypes, crmApi, affixOriginalFunction,
-      offsetOriginalFunction, originalDoSearch, originalParentScope, affixReturnValue,
+    let $controller, $rootScope, $scope, CaseFilters, CaseStatuses, CaseTypes, crmApi, currentCaseCategory,
+      affixOriginalFunction, offsetOriginalFunction, originalDoSearch, originalParentScope, affixReturnValue,
       originalBindToRoute;
 
     beforeEach(module('civicase.templates', 'civicase', 'civicase.data', ($provide) => {
@@ -11,13 +11,15 @@
       $provide.value('crmApi', crmApi);
     }));
 
-    beforeEach(inject((_$controller_, $q, _$rootScope_, _CaseFilters_, _CaseStatuses_, _CaseTypesMockData_) => {
+    beforeEach(inject((_$controller_, $q, _$rootScope_, _CaseFilters_, _CaseStatuses_, _CaseTypesMockData_,
+      _currentCaseCategory_) => {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       $scope = $rootScope.$new();
       CaseFilters = _CaseFilters_;
       CaseStatuses = _CaseStatuses_.values;
       CaseTypes = _CaseTypesMockData_.get();
+      currentCaseCategory = _currentCaseCategory_;
 
       crmApi.and.returnValue($q.resolve({ values: [] }));
     }));
@@ -71,6 +73,18 @@
 
       it('checks $scope.filters', () => {
         expect($scope.filterDescription).toEqual(jasmine.any(Object));
+      });
+    });
+
+    describe('when no case filters are passed through the URL', () => {
+      it('sets the case type category filter equal to the current case type category', () => {
+        expect($scope.$bindToRoute).toHaveBeenCalledWith({
+          expr: 'filters',
+          param: 'cf',
+          default: jasmine.objectContaining({
+            case_type_category: currentCaseCategory
+          })
+        });
       });
     });
 

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -76,14 +76,29 @@
       });
     });
 
-    describe('when no case filters are passed through the URL', () => {
-      it('sets the case type category filter equal to the current case type category', () => {
-        expect($scope.$bindToRoute).toHaveBeenCalledWith({
-          expr: 'filters',
-          param: 'cf',
-          default: jasmine.objectContaining({
+    describe('default case filters', () => {
+      describe('when no case filters are passed through the URL', () => {
+        it('sets the case type category category equal to the current case type category', () => {
+          expect($scope.filters).toEqual({
             case_type_category: currentCaseCategory
-          })
+          });
+        });
+      });
+
+      describe('when a case filter is passed through the URL', () => {
+        beforeEach(() => {
+          $scope.$bindToRoute.and.callFake((options) => {
+            if (options.param === 'cf') {
+              $scope.filters.case_type_category = 'custom-category';
+              $scope.$digest();
+            }
+          });
+
+          initController();
+        });
+
+        it('uses the case type category passed from the URL', () => {
+          expect($scope.filters.case_type_category).toEqual('custom-category');
         });
       });
     });


### PR DESCRIPTION
## Overview
This PR fixes the links to the case details. There are two fixes involved:

* Links to case details from activity cards did not have the `case_type_category` parameter. This made permission checking impossible.
* The list of case types were not being properly filtered according to the category the user was currently in.

## Before & After

<table>
  <tr>
    <th></th>
    <th>Before</th>
    <th>After</th>
    <th>Notes</th>
  </tr>
  <tr>
    <th>Contact Case Tab</th>
    <td><img src="https://user-images.githubusercontent.com/1642119/76762529-d620fd00-6767-11ea-9b69-3191dc9a9227.gif" /></td>
    <td><img src="https://user-images.githubusercontent.com/1642119/76712639-0e392900-66f1-11ea-85ee-c7d218880716.gif" /></td>
    <td>The case type filter showed all case types.</td>
  </tr>
  <tr>
    <th>Activity Card</th>
    <td><img src="https://user-images.githubusercontent.com/1642119/76716272-03d55a00-6706-11ea-88c2-39ce4dcce89b.gif" /></td>
    <td><img src="https://user-images.githubusercontent.com/1642119/76711996-0bd3d080-66eb-11ea-90fe-c21092b416b5.gif" /></td>
    <td>The case details were not shown and the case type filter showed all case types.</td>
  </tr>
</table>

## Technical Details

### Contact Case Tab

The case details page was being loaded correctly, but the list of case types on the filter were not right. The issue was that we were not passing the `case_type_category` parameter through the `cf` URL parameter (ie: `cf={"case_type_category": "cases"}`). What we have done is that the we only require the `case_type_category` URL parameter to be defined. Since this parameter is provided through `CRM['civicase-base'].currentCaseCategory` (via PHP) we use this value as a default if none is passed through the URL. The flow of case filter values is now as follows:

```js
    var DEFAULT_CASE_FILTERS = {
      case_type_category: currentCaseCategory
    };

    (function init () {
      bindRouteParamsToScope(); // the filters from the URL are injected into `$scope.filters`
      applyDefaultFilters();
      // ...
    })();

    function applyDefaultFilters () {
      var filtersComingFromUrl = $scope.filters;

      // we re apply the filters with the following priority:
      $scope.filters = _.defaults(
        {},
        filtersComingFromUrl, // 1 - values coming from the URL
        $scope.defaults,  // 2 - values coming from the directive's filter attribute binding
        DEFAULT_CASE_FILTERS // 3 - values defined at the top of this directive
      );
    }
```

### Activity card

We needed to add the `case_type_category` parameter to the case details URL. This parameter is needed by PHP to determine if the user has the right permissions to view the case.

It's important to note that not all activities are related to a case, but when they are we get their case type, and from the case type we know the category. So to prepare the URL we do the following:

```js

    var caseTypes = CaseType.getAll();
    var caseTypeCategories = CaseTypeCategory.getAll();

    // ...

    (function init () {
      // we use _.isEmpty because sometimes the `activity.case` parameter would contain an empty object:
      var hasCase = $scope.activity && !_.isEmpty($scope.activity.case);

      if (hasCase) {
        $scope.caseDetailUrl = getCaseDetailUrl();
      }
    })();

    // ...

    function getCaseDetailUrl () {
      var caseTypeId = $scope.activity.case.case_type_id;
      var caseType = caseTypes[caseTypeId]; // we get the case type
      var caseTypeCategory = caseTypeCategories[caseType.case_type_category]; // we get the category
      // we manually build the URL because `civicaseCrmUrl` (`CRM.url`) appends the URL parameters wrong, so by appending them manually we have more control:
      var caseDetailUrl = 'civicrm/case/a/?' +
        $.param({ case_type_category: caseTypeCategory.name }) +
        '#/case/list';
      var angularParams = $.param({ caseId: $scope.activity.case_id });

      
      return $filter('civicaseCrmUrl')(caseDetailUrl) + '?' + angularParams;
    }
```

### Fixing Unit tests

We fixed the `case-details-people-tab.directive.spec.js` spec file. Tests were failing because the `select2` mock function was returning the wrong selector when used for finding a wrapper container. We send the input element instead of the modal and this fixes the issue. The test was not implement right in the first place.