### PR TITLE
CPS-115: Fix [Case Type Category / Attachments] Unable to download all attachments from files tab with enough permissions.

### DIFF
--- a/CRM/Civicase/Hook/PermissionCheck/CaseCategory.php
+++ b/CRM/Civicase/Hook/PermissionCheck/CaseCategory.php
@@ -138,6 +138,7 @@ class CRM_Civicase_Hook_PermissionCheck_CaseCategory {
     $isPrintActivityReportPage = $url == 'civicrm/case/customreport/print';
     $isActivityPage = $url == 'civicrm/activity' || $url == 'civicrm/activity/add';
     $isCaseContactTabPage = $url == 'civicrm/case/contact-case-tab';
+    $isDownloadAllActivityFilesPage = $url == 'civicrm/case/activity/download-all-files';
 
     if ($isViewCase) {
       return $this->getCaseCategoryNameFromCaseIdInUrl('id');
@@ -161,6 +162,10 @@ class CRM_Civicase_Hook_PermissionCheck_CaseCategory {
 
     if ($isActivityPage) {
       return $this->getCaseCategoryFromActivityIdInUrl('id');
+    }
+
+    if ($isDownloadAllActivityFilesPage) {
+      return $this->getCaseCategoryFromActivityIdInUrl('activity_id');
     }
   }
 
@@ -205,9 +210,8 @@ class CRM_Civicase_Hook_PermissionCheck_CaseCategory {
    */
   private function getCaseCategoryFromActivityIdInUrl($activityIdParamName) {
     $activityId = CRM_Utils_Request::retrieve($activityIdParamName, 'Integer');
-    $context = CRM_Utils_Request::retrieve('context', 'String');
 
-    if ($activityId && strtolower($context) == 'case') {
+    if ($activityId) {
       $result = civicrm_api3('Activity', 'get', [
         'sequential' => 1,
         'return' => ['case_id'],


### PR DESCRIPTION
## Overview
Currently a user with enough permissions is unable to use the download all action for files on the files tab of the manage case category page. When the user tries to, an access denied error page is gotten.

## Before
- The issue above exists.

## After
- The permissions required for the Download all files page is `access all cases and activities` and `access my cases and activities`, the fix is to add this page to the case category permission logic so that the equivalent case type category permission can be used when acessing this page.

