### PR TITLE
RSE-1028: Fix Add Case link

### DIFF
--- a/CRM/Civicase/Helper/NewCaseWebform.php
+++ b/CRM/Civicase/Helper/NewCaseWebform.php
@@ -1,5 +1,6 @@
 <?php
 
+use CRM_Case_BAO_CaseType as CaseType;
 use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
 use CRM_Civicase_Service_CaseCategorySetting as CaseCategorySetting;
 
@@ -13,25 +14,24 @@ class CRM_Civicase_Helper_NewCaseWebform {
    *
    * @param array $options
    *   Options array.
-   * @param string $caseTypeCategory
-   *   Case type category name.
    * @param CRM_Civicase_Service_CaseCategorySetting $caseCategorySetting
    *   CaseCategorySetting service.
    */
-  public static function addWebformDataToOptions(array &$options, $caseTypeCategory, CaseCategorySetting $caseCategorySetting) {
-    $caseTypeCategory = !empty($caseTypeCategory) ? $caseTypeCategory : 'Cases';
-    $newCaseWebformUrl = CaseTypeCategoryHelper::getNewCaseCategoryWebformUrl($caseTypeCategory, $caseCategorySetting);
-    // Retrieve civicase webform URL.
-    $options['newCaseWebformClient'] = 'cid';
-    $options['newCaseWebformUrl'] = $newCaseWebformUrl;
-
-    if ($options['newCaseWebformUrl']) {
-      $path = explode('/', $options['newCaseWebformUrl']);
-      $webformId = array_pop($path);
-      $clientId = self::getCaseWebformClientId($webformId);
-
-      if ($clientId) {
-        $options['newCaseWebformClient'] = 'cid' . $clientId;
+  public static function addWebformDataToOptions(array &$options, CaseCategorySetting $caseCategorySetting) {
+    $caseTypeCategories = CaseType::buildOptions('case_type_category', 'validate');
+    $options['caseCategoryWebformSettings'] = [];
+    foreach ($caseTypeCategories as $caseTypeCategoryName) {
+      $caseTypeCategoryNameLowerCase = strtolower($caseTypeCategoryName);
+      $newCaseWebformUrl = CaseTypeCategoryHelper::getNewCaseCategoryWebformUrl($caseTypeCategoryName, $caseCategorySetting);
+      $options['caseCategoryWebformSettings'][$caseTypeCategoryNameLowerCase]['newCaseWebformClient'] = 'cid';
+      $options['caseCategoryWebformSettings'][$caseTypeCategoryNameLowerCase]['newCaseWebformUrl'] = $newCaseWebformUrl;
+      if ($newCaseWebformUrl) {
+        $path = explode('/', $newCaseWebformUrl);
+        $webformId = array_pop($path);
+        $clientId = self::getCaseWebformClientId($webformId);
+        if ($clientId) {
+          $options['caseCategoryWebformSettings'][$caseTypeCategoryNameLowerCase]['newCaseWebformClient'] = 'cid' . $clientId;
+        }
       }
     }
   }

--- a/ang/civicase-base.ang.php
+++ b/ang/civicase-base.ang.php
@@ -26,7 +26,7 @@ $options = [
 ];
 
 OptionValuesHelper::setToJsVariables($options);
-NewCaseWebform::addWebformDataToOptions($options, $caseCategoryName, $caseCategorySetting);
+NewCaseWebform::addWebformDataToOptions($options, $caseCategorySetting);
 set_case_types_to_js_vars($options);
 set_relationship_types_to_js_vars($options);
 set_file_categories_to_js_vars($options);
@@ -52,7 +52,7 @@ function expose_settings(array &$options, array $defaults) {
   $options['allowMultipleCaseClients'] = (bool) Civi::settings()->get('civicaseAllowMultipleClients');
   $options['allowCaseLocks'] = (bool) Civi::settings()->get('civicaseAllowCaseLocks');
   $options['currentCaseCategory'] = $defaults['caseCategoryName']
-    ? $defaults['caseCategoryName']
+    ? strtolower($defaults['caseCategoryName'])
     : strtolower(CRM_Civicase_Helper_CaseCategory::CASE_TYPE_CATEGORY_NAME);
 }
 

--- a/ang/civicase-base/constants.js
+++ b/ang/civicase-base/constants.js
@@ -4,7 +4,5 @@
   module
     .constant('allowCaseLocks', configuration.allowCaseLocks)
     .constant('allowMultipleCaseClients', configuration.allowMultipleCaseClients)
-    .constant('currentCaseCategory', configuration.currentCaseCategory)
-    .constant('newCaseWebformClient', configuration.newCaseWebformClient)
-    .constant('newCaseWebformUrl', configuration.newCaseWebformUrl);
+    .constant('currentCaseCategory', configuration.currentCaseCategory);
 })(angular, CRM['civicase-base']);

--- a/ang/civicase-base/services/case-category-webform-settings.service.js
+++ b/ang/civicase-base/services/case-category-webform-settings.service.js
@@ -16,7 +16,7 @@
      * @returns {object} settings for given case category
      */
     function getSettingsFor (caseCategoryName) {
-      return caseCategoryWebformSettings[caseCategoryName];
+      return caseCategoryWebformSettings[caseCategoryName.toLowerCase()];
     }
   }
 })(angular, CRM._, CRM['civicase-base']);

--- a/ang/civicase-base/services/case-category-webform-settings.service.js
+++ b/ang/civicase-base/services/case-category-webform-settings.service.js
@@ -1,0 +1,22 @@
+(function (angular, _, configuration) {
+  var module = angular.module('civicase-base');
+
+  module.service('CaseCategoryWebformSettings', CaseCategoryWebformSettings);
+
+  /**
+   * CaseCategoryWebformSettings Service
+   */
+  function CaseCategoryWebformSettings () {
+    var caseCategoryWebformSettings = configuration.caseCategoryWebformSettings;
+
+    this.getSettingsFor = getSettingsFor;
+
+    /**
+     * @param {string} caseCategoryName name of the case category
+     * @returns {object} settings for given case category
+     */
+    function getSettingsFor (caseCategoryName) {
+      return caseCategoryWebformSettings[caseCategoryName];
+    }
+  }
+})(angular, CRM._, CRM['civicase-base']);

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
@@ -6,16 +6,16 @@
   <!-- Added for SEO purpose (This will be hidden through css) -->
   <h1 crm-page-title class="element-invisible"> {{ ts('Related cases to the user') }} </h1>
   <div class="civicase__contact-cases-tab clearfix">
-    <a ng-if="checkPerm('add cases') && !newCaseWebformUrl"
+    <a ng-if="checkPerm('add cases') && !webformSettings.newCaseWebformUrl"
       class="btn-primary btn civicase__contact-cases-tab-add"
       ng-href="{{ 'civicrm/case/add' | civicaseCrmUrl:{civicase_cid: contactId, reset: 1, action: 'add', context: 'standalone', case_type_category: caseTypeCategoryName } }}"
       crm-popup-form-success="refresh()">
       <i class="material-icons">add_circle</i>
       {{ ts('Add case') }}
     </a>
-    <a ng-if="checkPerm('add cases') && newCaseWebformUrl"
+    <a ng-if="checkPerm('add cases') && webformSettings.newCaseWebformUrl"
       class="btn-primary btn"
-      ng-href="{{ newCaseWebformUrl | civicaseCrmUrl:{[newCaseWebformClient]: contactId} }}">
+      ng-href="{{ webformSettings.newCaseWebformUrl | civicaseCrmUrl:{[webformSettings.newCaseWebformClient]: contactId} }}">
       <i class="material-icons">add_circle</i>
       {{ ts('Add case') }}
     </a>

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
@@ -23,12 +23,11 @@
    * @param {Function} formatCase the format case service
    * @param {object} Contact the contact service
    * @param {object} ContactsCache the contacts cache service
-   * @param {string} newCaseWebformClient the new case web form client configuration value
-   * @param {string} newCaseWebformUrl the new case web form url configuration value
+   * @param {string} CaseCategoryWebformSettings service to fetch case category webform settings
    */
   function CivicaseContactCaseTabController ($scope, ts, CaseTypeCategory,
     CaseTypeCategoryTranslationService, crmApi, formatCase, Contact,
-    ContactsCache, newCaseWebformClient, newCaseWebformUrl) {
+    ContactsCache, CaseCategoryWebformSettings) {
     var commonConfigs = {
       isLoaded: false,
       showSpinner: false,
@@ -42,8 +41,7 @@
     $scope.caseDetailsLoaded = false;
     $scope.caseTypeCategoryName = CaseTypeCategory.getAll()[$scope.caseTypeCategory].name;
     $scope.contactId = Contact.getCurrentContactID();
-    $scope.newCaseWebformUrl = newCaseWebformUrl;
-    $scope.newCaseWebformClient = newCaseWebformClient;
+    $scope.webformSettings = CaseCategoryWebformSettings.getSettingsFor($scope.caseTypeCategoryName);
     $scope.casesListConfig = [
       {
         name: 'opened',

--- a/ang/civicase/dashboard/directives/add-case-dashboard-action-button.controller.js
+++ b/ang/civicase/dashboard/directives/add-case-dashboard-action-button.controller.js
@@ -11,10 +11,12 @@
    * @param {object} $location the location service.
    * @param {object} $window the window service.
    * @param {string} currentCaseCategory the current case type category configuration value.
-   * @param {string} newCaseWebformUrl the new case web form url configuration value.
+   * @param {string} CaseCategoryWebformSettings service to fetch case category webform settings
    */
   function AddCaseDashboardActionButtonController ($scope, ts, $location, $window,
-    currentCaseCategory, newCaseWebformUrl) {
+    currentCaseCategory, CaseCategoryWebformSettings) {
+    var webformSettings = CaseCategoryWebformSettings.getSettingsFor(currentCaseCategory);
+
     $scope.ts = ts;
 
     $scope.clickHandler = clickHandler;
@@ -25,7 +27,7 @@
      * it will redirect to it. Otherwise it will open a CRM form popup to add a new case.
      */
     function clickHandler () {
-      var hasCustomNewCaseWebformUrl = !!newCaseWebformUrl;
+      var hasCustomNewCaseWebformUrl = !!webformSettings.newCaseWebformUrl;
 
       hasCustomNewCaseWebformUrl
         ? redirectToCustomNewCaseWebformUrl()
@@ -75,7 +77,7 @@
      * Redirects the user to the custom webform URL as defined in the configuration.
      */
     function redirectToCustomNewCaseWebformUrl () {
-      $window.location.href = newCaseWebformUrl;
+      $window.location.href = webformSettings.newCaseWebformUrl;
     }
   }
 })(CRM._, angular, CRM.checkPerm, CRM.loadForm, CRM.url);

--- a/ang/civicase/dashboard/directives/dashboard.directive.js
+++ b/ang/civicase/dashboard/directives/dashboard.directive.js
@@ -31,7 +31,6 @@
     $scope.activityFilters = {
       case_filter: { 'case_type_id.is_active': 1, contact_is_deleted: 0 }
     };
-    $scope.newCaseWebformUrl = CRM.civicase.newCaseWebformUrl;
 
     (function init () {
       bindRouteParamsToScope();

--- a/ang/test/civicase/dashboard/directives/add-case-dashboard-action-button.controller.spec.js
+++ b/ang/test/civicase/dashboard/directives/add-case-dashboard-action-button.controller.spec.js
@@ -3,7 +3,7 @@
 (($, loadForm, getCrmUrl) => {
   describe('AddCaseDashboardActionButtonController', () => {
     let $location, $window, $rootScope, $scope, $controller, currentCaseCategory,
-      mockedFormPopUp;
+      mockedFormPopUp, CaseCategoryWebformSettings;
 
     beforeEach(() => {
       $window = { location: { href: '' } };
@@ -43,12 +43,15 @@
     });
 
     describe('click handler', () => {
-      describe('when the new case web form url configuration value is defined', () => {
-        const newCaseWebformUrl = 'http://example.com/';
+      beforeEach(module('civicase', ($provide) => {
+        CaseCategoryWebformSettings = jasmine.createSpyObj('CaseCategoryWebformSettings', ['getSettingsFor']);
+        $provide.value('CaseCategoryWebformSettings', CaseCategoryWebformSettings);
+      }));
 
+      describe('when the new case web form url configuration value is defined', () => {
         beforeEach(module('civicase', ($provide) => {
-          $provide.constant('newCaseWebformUrl', newCaseWebformUrl);
           $provide.value('$window', $window);
+          CaseCategoryWebformSettings.getSettingsFor.and.returnValue({ newCaseWebformUrl: '/someurl' });
         }));
 
         beforeEach(() => {
@@ -57,13 +60,13 @@
         });
 
         it('redirects the user to the configured web form url value', () => {
-          expect($window.location.href).toBe(newCaseWebformUrl);
+          expect($window.location.href).toBe('/someurl');
         });
       });
 
       describe('when the new case web form url configuration value is not defined', () => {
         beforeEach(module('civicase-base', 'civicase', ($provide) => {
-          $provide.constant('newCaseWebformUrl', null);
+          CaseCategoryWebformSettings.getSettingsFor.and.returnValue({ newCaseWebformUrl: null });
           $provide.value('$window', $window);
         }));
 
@@ -81,7 +84,9 @@
       describe('opening a new case form popup', () => {
         let expectedFormUrl;
 
-        beforeEach(module('civicase', 'civicase.data'));
+        beforeEach(module('civicase', 'civicase.data', ($provide) => {
+          CaseCategoryWebformSettings.getSettingsFor.and.returnValue({ newCaseWebformUrl: null });
+        }));
 
         beforeEach(() => {
           injectDependencies();

--- a/ang/test/mocks/data/constants.data.js
+++ b/ang/test/mocks/data/constants.data.js
@@ -4,14 +4,15 @@
   CRM['civicase-base'].allowMultipleCaseClients = true;
   CRM['civicase-base'].allowCaseLocks = false;
   CRM['civicase-base'].currentCaseCategory = 'cases';
-  CRM['civicase-base'].newCaseWebformClient = 'cid';
-  CRM['civicase-base'].newCaseWebformUrl = null;
+  CRM['civicase-base'].caseCategoryWebformSettings = {
+    cases: { newCaseWebformClient: 'cid', newCaseWebformUrl: '/cases' },
+    Prospecting: { newCaseWebformClient: 'cid', newCaseWebformUrl: '/prospects' }
+  };
 
   module.config(($provide) => {
     $provide.constant('allowMultipleCaseClients', CRM['civicase-base'].allowMultipleCaseClients);
     $provide.constant('allowCaseLocks', CRM['civicase-base'].allowCaseLocks);
     $provide.constant('currentCaseCategory', CRM['civicase-base'].currentCaseCategory);
-    $provide.constant('newCaseWebformClient', CRM['civicase-base'].newCaseWebformClient);
-    $provide.constant('newCaseWebformUrl', CRM['civicase-base'].newCaseWebformUrl);
+    $provide.constant('caseCategoryWebformSettings', CRM['civicase-base'].caseCategoryWebformSettings);
   });
 })(angular);


### PR DESCRIPTION
## Overview
Previously the Add <Case Category Name>, link in Contact Case tabs always redirected to "Case" webform. This PR fixes the same.

## Before
![before](https://user-images.githubusercontent.com/5058867/77069444-71d39700-6a0e-11ea-93f6-a865093966a3.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/77069327-3933bd80-6a0e-11ea-9d9a-50250dd77449.gif)

## Technical Details
1. `newCaseWebformClient` and `newCaseWebformUrl` set from Backend, always had Cases values inside the Contact Case Category Tabs. As angular loads only once for these tabs, it was always Cases. So to fix these, now all the webform settings are exposed to FE in `NewCaseWebform.php`
![2020-03-19 at 6 25 PM](https://user-images.githubusercontent.com/5058867/77069759-0938ea00-6a0f-11ea-9d6f-5499514d96a7.jpg)

2. Removed `newCaseWebformClient` and `newCaseWebformUrl` angular constants. And added `case-category-webform-settings.service.js`, which exposes `getSettingsFor` function to get settings for a specific case category.


 
