### PR TITLE
RSE-1031: Fix translation in Move/Copy Activity Popup

### DIFF
--- a/ang/civicase/activity/actions/services/move-copy-activity-action.service.js
+++ b/ang/civicase/activity/actions/services/move-copy-activity-action.service.js
@@ -9,10 +9,9 @@
    * @param {object} $rootScope rootscope object
    * @param {object} crmApi service to call civicrm api
    * @param {object} dialogService service for opening dialog box
+   * @param {Function} ts the translation service
    */
-  function MoveCopyActivityAction ($rootScope, crmApi, dialogService) {
-    var ts = CRM.ts('civicase');
-
+  function MoveCopyActivityAction ($rootScope, crmApi, dialogService, ts) {
     /**
      * Perform the action
      *


### PR DESCRIPTION
## Overview
The Move/Copy Activity Popup had translation issues in Case Type categories, this PR fixes the same.

## Before
![2020-03-19 at 8 00 PM](https://user-images.githubusercontent.com/5058867/77078218-49529980-6a1c-11ea-91bd-753a7e03d397.jpg)

## After
![2020-03-19 at 7 59 PM](https://user-images.githubusercontent.com/5058867/77078164-38a22380-6a1c-11ea-8a96-302df1e67a47.jpg)

## Technical Details
Using `ts` angular service in `move-copy-activity-action.service.js`.