### PR TITLE
CPS-136: [Backstop JS]Tweak contacts dashboard js and associated readme content

### DIFF
--- a/tests/backstop_data/Readme.md
+++ b/tests/backstop_data/Readme.md
@@ -4,9 +4,10 @@
 ## Dashboard Section
 
 * The current calendar month has at least one day with some activities
+* Have at least that many acitivities on activity panel, so that it shows load more button
 
 ## Contact Section
-* Make sure the civicase is installed with demo data and should have a contact name "Betty Adams" and at least have one activity for the contact.
+* Make sure the civicase is installed with demo data and should have a contact name matching "Betty" and at least have one activity for the contact.
 
 ---
 

--- a/tests/backstop_data/engine_scripts/puppet/contacts/contact-dashboard.js
+++ b/tests/backstop_data/engine_scripts/puppet/contacts/contact-dashboard.js
@@ -5,7 +5,7 @@ const Utility = require('./../utility.js');
 module.exports = async (page, scenario, vp) => {
   const utility = new Utility(page, scenario, vp);
 
-  await page.type('#sort_name', 'Betty Adams');
+  await page.type('#sort_name', 'Betty');
   await utility.clickAndWaitForNavigation('#_qf_Basic_refresh');
   await utility.clickAndWaitForNavigation('.crm-search-results a[title="View Contact Details"]');
 };


### PR DESCRIPTION
## Overview
This PR fixes some part of js code related to capture contact activity dashboard and related readme content

## Before/After
<img width="848" alt="Screenshot 2020-03-20 at 3 20 24 PM" src="https://user-images.githubusercontent.com/3340537/77152686-6e97e400-6abe-11ea-8cec-b374df75f524.png">
<img width="790" alt="Screenshot 2020-03-20 at 3 21 02 PM" src="https://user-images.githubusercontent.com/3340537/77152701-76578880-6abe-11ea-93cc-e615dddcccc2.png">

## Technical Details
For some reason full name (with first and last name) doesn't return correct result for the contact search form
![readme](https://user-images.githubusercontent.com/3340537/77164393-25ec2500-6ad6-11ea-917a-41dcf06c38be.gif)
So, we have changed the logic to only search for the first name. So, inspite of `Betty Adams` now it only search for `Betty` and same has been updated in the readme file.

