### PR TITLE
CPS-140: [Backstop JS] - Dashboard section - Add logic for opening filter dropdown and add open case modal screen

### DIFF
--- a/tests/backstop_data/Readme.md
+++ b/tests/backstop_data/Readme.md
@@ -16,11 +16,11 @@ The backstop test suite for Civicase 5.1 extension covers following screens
 
 ## Dashboard
 - [x] Dashboard Main screen - With overview table expanded and tooltip visible on one of the titles
-- [x] Dashboard Overview table with gear icon opened
+- [x] Dashboard Main screen - With overview table expanded, gear icon opened and case filter dropdown opened
 - [x] Dashboard Main screen - with loading screens
 - [x] Dashboard Main screen - Calendar - Acitivity card
 - [x] Dashboard Main screen - Calendar - Acitivity card - Loading State
-- [ ] Dashboard Main screen  - Empty State
+- [x] Dashboard Main screen - Add case modal
 
 ## Activities Feed Panel
 - [ ] Activities Feed Panel - Main screen
@@ -31,7 +31,6 @@ The backstop test suite for Civicase 5.1 extension covers following screens
 - [ ] Activities Feed Panel - with one filter enabled
 - [ ] Activities Feed Panel - one activity selected
 - [ ] Activities Feed Panel - Activity card menu on case overview
-- [ ] Activities Feed Panel - Empty State
 - [ ] Activities Feed Panel - Detail - Edit state
 - [ ] Activities Feed Panel - Detail - Delete state
 - [ ] Activities Feed Panel - Under Manage Cases
@@ -43,7 +42,7 @@ The backstop test suite for Civicase 5.1 extension covers following screens
 - [ ] Manage Cases List - Loading screen
 - [ ] Manage Cases List - selected case
 - [ ] Manage Cases List - Case Overview - with drawer closed
-- [ ] Manage Cases List - Case Overview - Empty States
+
 - [ ] Manage Cases List - Case Overview - with calendar activity opened
 - [ ] Manage Cases List - Case Overview - Loading
 - [ ] Manage Cases List - Case Overview - Edit custom Data
@@ -69,6 +68,11 @@ The backstop test suite for Civicase 5.1 extension covers following screens
 - [ ] Modals - Manage Cases - Case Detail - Actions Menu
 - [ ] Modals - Manage Cases - Case Detail - Actions Menu - Edit Tags
 - [ ] Modals - Manage Cases List - Files - menu actions
+
+## Empty States
+- [ ] Dashboard Main screen - Empty State
+- [ ] Activities Feed Panel - Empty State
+- [ ] Manage Cases List - Case Overview - Empty States
 
 # Developer Guide
 

--- a/tests/backstop_data/engine_scripts/puppet/mouse-events-helper.js
+++ b/tests/backstop_data/engine_scripts/puppet/mouse-events-helper.js
@@ -20,12 +20,12 @@ module.exports = async (page, scenario, viewport) => {
 /**
  * Action handler for hover event
  *
- * @param {Object} page pupettter engine object
- * @param {Object} scenario object of each scenario
- * @param {Object} viewport viewport configurations
+ * @param {object} page pupettter engine object
+ * @param {object} scenario object of each scenario
+ * @param {object} viewport viewport configurations
  */
 async function hoverSelectorAction (page, scenario, viewport) {
-  const hoverSelectors = scenario.hoverSelectors || [ scenario.hoverSelector ];
+  const hoverSelectors = scenario.hoverSelectors || [scenario.hoverSelector];
   const utility = new Utility(page, scenario, viewport);
 
   for (const hoverSelector of hoverSelectors) {
@@ -40,12 +40,12 @@ async function hoverSelectorAction (page, scenario, viewport) {
 /**
  * Action handler for click event
  *
- * @param {Object} page pupettter engine object
- * @param {Object} scenario object of each scenario
- * @param {Object} viewport viewport configurations
+ * @param {object} page pupettter engine object
+ * @param {object} scenario object of each scenario
+ * @param {object} viewport viewport configurations
  */
 async function clickSelectorAction (page, scenario, viewport) {
-  const clickSelectors = scenario.clickSelectors || [ scenario.clickSelector ];
+  const clickSelectors = scenario.clickSelectors || [scenario.clickSelector];
   const utility = new Utility(page, scenario, viewport);
 
   for (const clickSelector of clickSelectors) {
@@ -53,6 +53,10 @@ async function clickSelectorAction (page, scenario, viewport) {
 
     if (scenario.waitForAjaxComplete) {
       await utility.waitForLoadingComplete();
+    }
+
+    if (scenario.waitForUIModalLoad) {
+      await utility.waitForUIModalLoad();
     }
   }
 }

--- a/tests/backstop_data/engine_scripts/puppet/utility.js
+++ b/tests/backstop_data/engine_scripts/puppet/utility.js
@@ -10,7 +10,7 @@ module.exports = class CrmPage {
   /**
    * Waits and clicks every element that matches the target selector.
    *
-   * @param {String} selector - the css selector of the target elements to
+   * @param {string} selector - the css selector of the target elements to
    * click.
    */
   async clickAll (selector) {
@@ -22,7 +22,7 @@ module.exports = class CrmPage {
   /**
    * Waits for the Navigation to happens after some link (selector) is clicked.
    *
-   * @param {String} selector - the css selector for the element to click and wait for navigation.
+   * @param {string} selector - the css selector for the element to click and wait for navigation.
    */
   async clickAndWaitForNavigation (selector) {
     await this.engine.waitForSelector(selector);
@@ -43,7 +43,7 @@ module.exports = class CrmPage {
    */
   async cloneUibPopover () {
     await this.engine.evaluate(() => {
-      let uibPopover = document.querySelector('div[uib-popover-popup]');
+      const uibPopover = document.querySelector('div[uib-popover-popup]');
       const uibPopoverClone = uibPopover.cloneNode(true);
 
       // Insert the new node before the reference node
@@ -54,8 +54,8 @@ module.exports = class CrmPage {
   /**
    * Checks if element is visible on screen
    *
-   * @param {String} selector - the css selector for the element to checkfor
-   * @return {Boolean}
+   * @param {string} selector - the css selector for the element to checkfor
+   * @returns {boolean} if the element is visible on the screen
    */
   async isElementVisible (selector) {
     return this.engine.evaluate((selector) => {
@@ -108,7 +108,7 @@ module.exports = class CrmPage {
   /**
    * Waits for all the loading placeholders to vanish
    *
-   * @param {String} parentSelector
+   * @param {string} parentSelector
    *  - for contextual loading checks
    */
   async waitForLoadingComplete (parentSelector) {
@@ -119,13 +119,22 @@ module.exports = class CrmPage {
       const allLoadingElements = document.querySelectorAll(parentSelector + 'div[class*="civicase__loading-placeholder"]');
 
       return allLoadingElements.length === 0;
-    }, {timeout: timeout}, parentSelector);
+    }, { timeout: timeout }, parentSelector);
+  }
+
+  /**
+   * Waits for the UI modal to load the form inside it.
+   */
+  async waitForUIModalLoad () {
+    await this.engine.waitFor('.modal-dialog.crm-ajax-container > form');
+    await this.cleanups();
+    await this.openAllAccordions();
   }
 
   /**
    * Waits for a selector before clicking
    *
-   * @param {String} selector
+   * @param {string} selector to wait for and click on
    */
   async waitForAndClick (selector) {
     await this.engine.waitFor(selector);
@@ -135,7 +144,7 @@ module.exports = class CrmPage {
   /**
    * Waits for a selector before hovering
    *
-   * @param {String} selector
+   * @param {string} selector to wait for and hover on
    */
   async waitForAndHover (selector) {
     await this.engine.waitFor(selector);
@@ -167,7 +176,7 @@ module.exports = class CrmPage {
   /**
    * Waits for the selector to be clearly visible on the screen.
    *
-   * @param {String} selector - the css selector of the target elements to
+   * @param {string} selector - the css selector of the target elements to
    * look for.
    */
   async waitForVisibility (selector) {
@@ -181,7 +190,7 @@ module.exports = class CrmPage {
   /**
    * Waits for an element and then evaluates a function on the browser.
    *
-   * @param {String} selector - the css selector for the element to wait
+   * @param {string} selector - the css selector for the element to wait
    * @param {Function} fn - the callback function to be executed in
    * the browser after the target element is ready.
    * for.

--- a/tests/backstop_data/scenarios/dashboard.json
+++ b/tests/backstop_data/scenarios/dashboard.json
@@ -8,11 +8,12 @@
       "isUIBPopover": true
     },
     {
-      "label": "Civicase - Dashboard - With overview table expanded and gear icon opened",
+      "label": "Civicase - Dashboard - With overview table expanded, gear icon opened and case filter dropdown opened",
       "url": "{url}/civicrm/case/a/#/case",
       "clickSelectors": [
         ".civicase__case-overview__flow-status-settings + .civicase__case-overview__flow-status__icon",
-        ".civicase__case-overview__flow-status-settings"
+        ".civicase__case-overview__flow-status-settings",
+        ".civicase__dashboard__relation-filter .select2-choice"
       ]
     },
     {
@@ -30,6 +31,12 @@
       "label": "Civicase - Dashboard - Calendar - Activity Card - Loading state",
       "url": "{url}/civicrm/case/a/#/case",
       "clickSelector": ".civicase__activities-calendar__day-status"
+    },
+    {
+      "label": "Civicase - Dashboard - Add case modal",
+      "url": "{url}/civicrm/case/a/#/case",
+      "clickSelector": ".civicase__dashboard__action-btn",
+      "waitForUIModalLoad": true
     }
   ]
 }


### PR DESCRIPTION
## Overview
This PR adds screens for the dashboard sections
* Add screen while opening the filter dropdown
* Add screen for opening new case modal

## Screens added
![Civicase51_Civicase_-_Dashboard_-_With_overview_table_expanded_gear_icon_opened_and_case_filter_dropdown_opened_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/77303408-eeb98600-6d18-11ea-86be-5c4382780cb9.png)
![Civicase51_Civicase_-_Dashboard_-_Add_case_modal_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/77303426-f4af6700-6d18-11ea-8422-8d62a8873174.png)


## Technical Details
* Moved all empty state screens in a new group `Empty screens` as this will be handled separately
* Added a new utility function `waitForUIModalLoad` and provided this as a configuration from the scenario building list in `clickSelectorAction` function
* Added an extra click selector to capture civicase filter dropdown with it.

