### PR TITLE
CPS-81: Fix case subject saving

### DIFF
--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
@@ -60,7 +60,7 @@
     <div class="civicase__contact-cases-tab__panel-row civicase__contact-cases-tab__panel-row--dark  clearfix">
       <div class="pull-left">
         <div class="civicase__contact-card--client" civicase-contact-card contacts="item.client"></div>
-        <div class="civicase__summary-tab__subject">
+        <div class="civicase__summary-tab__subject crm-entity" data-entity="Case" data-id="{{ item.id }}">
           <p
             crm-editable="item"
             data-field="subject"


### PR DESCRIPTION
## Overview
There was an issue with case subject saving: when user clicks it and textarea appears allowing user to edit it. But when user clicks Save button - nothing happend.
This PR fixes it and now subject is saved.

## Before
![before](https://user-images.githubusercontent.com/39520000/77312676-7e5c3600-6d13-11ea-96fa-37d1a001a625.gif)

## After
![after](https://user-images.githubusercontent.com/39520000/77312672-7bf9dc00-6d13-11ea-87f7-594e28d9e05e.gif)

## Technical Details
There was js error in the console: Uncaught TypeError: Cannot read property 'id' of undefined (jquery.crmEditable.js).
After some investigation it turned out that editor requires a parent container to have `.crm-entity` class and 2 attributes (data-entity and data-id) in order to work as expected.
So in this PR we've added everything necessary to the parent container.