### PR TITLE
RSE-1033: Allow filtering by disabled case types

### DIFF
--- a/ang/civicase-base.ang.php
+++ b/ang/civicase-base.ang.php
@@ -74,10 +74,15 @@ function get_base_js_files() {
 function set_case_types_to_js_vars(&$options) {
   $caseTypes = civicrm_api3('CaseType', 'get', [
     'return' => [
-      'id', 'name', 'title', 'description', 'definition', 'case_type_category',
+      'id',
+      'name',
+      'title',
+      'description',
+      'definition',
+      'case_type_category',
+      'is_active',
     ],
     'options' => ['limit' => 0, 'sort' => 'weight'],
-    'is_active' => 1,
   ]);
   foreach ($caseTypes['values'] as &$item) {
     CRM_Utils_Array::remove($item, 'is_forkable', 'is_forked');

--- a/ang/civicase-base/providers/case-type.provider.js
+++ b/ang/civicase-base/providers/case-type.provider.js
@@ -8,6 +8,9 @@
    */
   function CaseTypeServiceProvider () {
     var caseTypes = CRM['civicase-base'].caseTypes;
+    var DEFAULT_GET_ALL_OPTIONS = {
+      includeInactive: false
+    };
 
     this.$get = $get;
     this.getAll = getAll;
@@ -40,10 +43,23 @@
     }
 
     /**
+     * @param {object} options configuration options to use for filtering
+     *   the case types.
      * @returns {object[]} a list of case types.
      */
-    function getAll () {
-      return caseTypes;
+    function getAll (options) {
+      options = _.defaults({}, options, DEFAULT_GET_ALL_OPTIONS);
+
+      return options.includeInactive
+        ? caseTypes
+        : getAllActive();
+    }
+
+    /**
+     * @returns {object[]} all active case types.
+     */
+    function getAllActive () {
+      return _.pick(caseTypes, _.matches({ is_active: '1' }));
     }
 
     /**

--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -168,7 +168,7 @@
         sequential: 1,
         case_type_category: $scope.caseFilter['case_type_id.case_type_category'],
         id: $scope.caseFilter.case_type_id,
-        is_active: 1
+        is_active: $scope.caseFilter['case_type_id.is_active'] || '1'
       };
 
       return crmApi('CaseType', 'get', params)

--- a/ang/civicase/case/factories/format-case.factory.js
+++ b/ang/civicase/case/factories/format-case.factory.js
@@ -2,7 +2,7 @@
   var module = angular.module('civicase');
 
   module.factory('formatCase', function (formatActivity, ContactsCache, CaseStatus, CaseType) {
-    var caseTypes = CaseType.getAll();
+    var caseTypes = CaseType.getAll({ includeInactive: true });
     var caseStatuses = CaseStatus.getAll();
 
     return function (item) {

--- a/ang/test/civicase-base/services/case-type.service.spec.js
+++ b/ang/test/civicase-base/services/case-type.service.spec.js
@@ -42,7 +42,7 @@
         returnedCaseTypes = CaseType.getAll({ includeInactive: true });
       });
 
-      it('returns all the active case types', () => {
+      it('returns all the case types including inactive ones', () => {
         expect(returnedCaseTypes).toEqual(CaseTypesData);
       });
     });

--- a/ang/test/civicase-base/services/case-type.service.spec.js
+++ b/ang/test/civicase-base/services/case-type.service.spec.js
@@ -1,24 +1,48 @@
 /* eslint-env jasmine */
 
-(() => {
+((_) => {
   describe('Case Type', () => {
-    let CaseType, CaseTypesData;
+    let CaseType, CaseTypesData, CaseTypesMockDataProvider;
 
-    beforeEach(module('civicase', 'civicase.data'));
+    beforeEach(module('civicase', 'civicase.data', (_CaseTypesMockDataProvider_) => {
+      CaseTypesMockDataProvider = _CaseTypesMockDataProvider_;
+
+      CaseTypesMockDataProvider.add({
+        title: 'inactive case type',
+        is_active: '0'
+      });
+    }));
+
+    afterEach(() => {
+      CaseTypesMockDataProvider.restore();
+    });
 
     beforeEach(inject((_CaseType_, _CaseTypesMockData_) => {
       CaseType = _CaseType_;
       CaseTypesData = _CaseTypesMockData_.get();
     }));
 
-    describe('when getting all case types', () => {
-      let returnedCaseTypes;
+    describe('when getting all active case types', () => {
+      let activeCaseTypes, returnedCaseTypes;
 
       beforeEach(() => {
+        activeCaseTypes = _.pick(CaseTypesData, (caseType) => caseType.is_active === '1');
         returnedCaseTypes = CaseType.getAll();
       });
 
-      it('returns all the case types', () => {
+      it('returns all the active case types', () => {
+        expect(returnedCaseTypes).toEqual(activeCaseTypes);
+      });
+    });
+
+    describe('when getting all case including inactive ones', () => {
+      let returnedCaseTypes;
+
+      beforeEach(() => {
+        returnedCaseTypes = CaseType.getAll({ includeInactive: true });
+      });
+
+      it('returns all the active case types', () => {
         expect(returnedCaseTypes).toEqual(CaseTypesData);
       });
     });
@@ -41,4 +65,4 @@
       });
     });
   });
-})();
+})(CRM._);

--- a/ang/test/civicase/case/directives/case-overview.directive.spec.js
+++ b/ang/test/civicase/case/directives/case-overview.directive.spec.js
@@ -57,7 +57,7 @@
           sequential: 1,
           case_type_category: 'cases',
           id: [1, 2],
-          is_active: 1
+          is_active: '1'
         });
       });
     });

--- a/ang/test/mocks/data/cases-types.data.js
+++ b/ang/test/mocks/data/cases-types.data.js
@@ -195,7 +195,8 @@
       },
       icon: 'icon',
       color: 'color',
-      case_type_category: '1'
+      case_type_category: '1',
+      is_active: '1'
     },
     2: {
       name: 'adult_day_care_referral',
@@ -322,7 +323,8 @@
           }
         ]
       },
-      case_type_category: '2'
+      case_type_category: '2',
+      is_active: '1'
     }
   };
 
@@ -335,7 +337,16 @@
      * @param {object} newCaseTypes a map of case types indexed by their id.
      */
     this.add = function (newCaseTypes) {
-      caseTypesMock = _.assign({}, caseTypesMock, newCaseTypes);
+      var newCaseTypesMock = _.assign({}, caseTypesMock, newCaseTypes);
+
+      CRM['civicase-base'].caseTypes = _.clone(newCaseTypesMock);
+    };
+
+    /**
+     * Restores the mock case types to the default ones. This avoids different
+     * spec files from overriding values to other files.
+     */
+    this.restore = function () {
       CRM['civicase-base'].caseTypes = _.clone(caseTypesMock);
     };
 


### PR DESCRIPTION
## Overview
This PR allows filters to request cases belonging to disabled case types and to show disabled case types in the overview section.

**Note:** this PR is linked to https://github.com/compucorp/uk.co.compucorp.civiawards/pull/75

## Before & After
For before and after screens please refer to https://github.com/compucorp/uk.co.compucorp.civiawards/pull/75

## Technical Details

In `civicase-base.ang.php` we made so that all case types are appended to the global JS variable regardless of its active status. We also added the `is_active` parameter to determine if a particular case type should be shown or not.

The `CaseType` provider now can return all case types (including disabled ones) when the `{ includeInactive: true }` property is passed, otherwise it will only return active ones.

The `case-overview.directive.js` directive will display active case types by default, but can be configured to display disabled ones.

Finally, the case types mock data now has a `restore` method which should be used to restore the case types to its original values after adding new ones. This is done to avoid contaminating other tests.