### PR TITLE
CPS-86: Remove Webforms case action

### DIFF
--- a/ang/civicase.ang.php
+++ b/ang/civicase.ang.php
@@ -220,7 +220,7 @@ function add_webforms_case_action(&$options) {
       }
       $options['caseActions'][] = [
         'title' => ts('Webforms'),
-        'action' => '',
+        'action' => 'Webforms',
         'icon' => 'fa-file-text-o',
         'items' => $items,
       ];

--- a/ang/civicase/case/actions/directives/case-actions.directive.js
+++ b/ang/civicase/case/actions/directives/case-actions.directive.js
@@ -40,7 +40,7 @@
         var caseActionService = getCaseActionService(action.action);
 
         if (caseActionService && caseActionService.isActionAllowed) {
-          isActionAllowed = caseActionService.isActionAllowed(action, $scope.cases);
+          isActionAllowed = caseActionService.isActionAllowed(action, $scope.cases, attributes);
         }
 
         return isActionAllowed && ((isLockCaseAction && isCaseLockAllowed) ||

--- a/ang/civicase/case/actions/services/webforms-case-action.service.js
+++ b/ang/civicase/case/actions/services/webforms-case-action.service.js
@@ -1,0 +1,28 @@
+(function (angular, $, _) {
+  var module = angular.module('civicase');
+
+  module.service('WebformsCaseAction', WebformsCaseAction);
+
+  /**
+   * Webforms action for cases.
+   *
+   * @param {object} $window - window object.
+   *
+   * @class
+   */
+  function WebformsCaseAction ($window) {
+    /**
+     * Check if action is allowed.
+     *
+     * @param {object} action - action data.
+     * @param {object} cases - cases.
+     * @param {object} attributes - item attributes.
+     *
+     * @returns {boolean} - true if action is allowed, false otherwise.
+     */
+    this.isActionAllowed = function (action, cases, attributes) {
+      // Allow this action on Case details page only.
+      return attributes && attributes.mode === 'case-details';
+    };
+  }
+})(angular, CRM.$, CRM._);

--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
@@ -50,6 +50,7 @@
           </button>
           <ul
             class="dropdown-menu dropdown-menu-right"
+            mode="contact-tab-cases"
             civicase-case-actions="[item]"
             refresh-callback="refresh"
             popup-params="caseGetParams"

--- a/ang/civicase/case/details/directives/case-details-header.html
+++ b/ang/civicase/case/details/directives/case-details-header.html
@@ -80,6 +80,7 @@
       </button>
       <ul
         class="dropdown-menu dropdown-menu-right"
+        mode="case-details"
         civicase-case-actions="[item]"
         refresh-callback="refresh"
         popup-params="caseGetParams"

--- a/ang/civicase/case/list/directives/case-list-table-first-column-header.html
+++ b/ang/civicase/case/list/directives/case-list-table-first-column-header.html
@@ -23,7 +23,7 @@
       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       <span class="caret"></span>
     </button>
-    <ul class="dropdown-menu" civicase-case-actions="selectedCases" is-bulk-mode="true" refresh-callback="refresh"></ul>
+    <ul class="dropdown-menu" mode="case-bulk-actions" civicase-case-actions="selectedCases" is-bulk-mode="true" refresh-callback="refresh"></ul>
   </div>
 </span>
 <span class="btn-group btn-group-sm pull-right" ng-if="sort.sortable">

--- a/ang/test/civicase/case/actions/services/webforms-case-action.service.spec.js
+++ b/ang/test/civicase/case/actions/services/webforms-case-action.service.spec.js
@@ -1,0 +1,45 @@
+/* eslint-env jasmine */
+
+(function (_, $) {
+  describe('WebformsCaseAction', function () {
+    var WebformsCaseAction, attributes;
+
+    beforeEach(module('civicase'));
+
+    beforeEach(inject(function (_WebformsCaseAction_) {
+      WebformsCaseAction = _WebformsCaseAction_;
+    }));
+
+    describe('isActionAllowed()', function () {
+      beforeEach(function () {
+        attributes = {};
+      });
+
+      describe('when attribute.mode is set to case-details', function () {
+        beforeEach(function () {
+          attributes.mode = 'case-details';
+        });
+
+        it('should return true', function () {
+          expect(WebformsCaseAction.isActionAllowed(null, null, attributes)).toBeTrue();
+        });
+      });
+
+      describe('when attribute.mode is set to case-bulk-actions', function () {
+        beforeEach(function () {
+          attributes.mode = 'case-bulk-actions';
+        });
+
+        it('should return false', function () {
+          expect(WebformsCaseAction.isActionAllowed(null, null, attributes)).toBeFalse();
+        });
+      });
+
+      describe('when attribute.mode is undefined', function () {
+        it('should return false', function () {
+          expect(WebformsCaseAction.isActionAllowed(null, null, attributes)).toBeFalse();
+        });
+      });
+    });
+  });
+})(CRM._, CRM.$);


### PR DESCRIPTION
## Overview
There is *Webforms* menu item available for cases. According to new requirements we need to keep it on case details view only:
1. Remove the webforms link from contact card actions menu.
2. Remove the webforms link from manage cases > bulk actions menu.
3. Keep the webforms link on manage cases > case details > actions menu.

## Before/After
Contact details - Cases tab before:
![image](https://user-images.githubusercontent.com/39520000/77417158-0e62b400-6dd6-11ea-9114-a5c5c8124a43.png)

Contact details - Cases tab after:
![image](https://user-images.githubusercontent.com/39520000/77417179-13bffe80-6dd6-11ea-9365-3ad49f9b5193.png)

Manage cases - bulk actions before:
![image](https://user-images.githubusercontent.com/39520000/77417299-38b47180-6dd6-11ea-8acb-016fb97a99b0.png)

Manage cases - bulk actions after:
![image](https://user-images.githubusercontent.com/39520000/77417324-3ce08f00-6dd6-11ea-83f5-2b2937765fa8.png)

Case details before and after (no changes):
![image](https://user-images.githubusercontent.com/39520000/77417353-4833ba80-6dd6-11ea-8dc7-bcf2af4be6f0.png)

## Technical Details
The *Webforms* menu item is added in the `add_webforms_case_action()` back-end function, but there are no reliable ways to tweak this function to add this item for case details only.
So it was decided to go ahead with front-end approach:
1. The `isActionAllowed()` method was added for this action which allows this action for case details only. To make it work properly we had to:
1.1. Create a `WebformsCaseAction` service (see `webforms-case-action.service.js`), because there were no service for this action.
1.2. Set a `Webforms` name to the action, because there were no name specified for this action (see `add_webforms_case_action()` in `civicase.ang.php`).
2. The `mode` attribute was added to each action list `<ul>` which defines a name of a place where this list is printed. This attribute then used in `isActionAllowed()` to perform the check.

Also basic tests where added for the new `isActionAllowed()` method (see `webforms-case-action.service.spec.js`).