### PR TITLE
RSE-944: Improve Get Stats API - handle no case_type_id corner case

### DIFF
--- a/api/v3/Case/Getstats.php
+++ b/api/v3/Case/Getstats.php
@@ -87,12 +87,9 @@ function civicrm_api3_case_getstats(array $params) {
     $caseTypesParams['id'] = $params['case_type_id'];
     $caseTypes = civicrm_api3('CaseType', 'get', $caseTypesParams);
 
-    _civicrm_api3_case_add_case_category_query_filter($query, $caseTypes);
-  }
-  // Handle no value for case_type_id param case.
-  elseif ($params['case_type_id'] === "") {
-    // Pass an invalid id to get no response.
-    $caseTypes = ['values' => ['0' => ['id' => '0']]];
+    if (!empty($caseTypesParams['id']['IS NULL'])) {
+      $caseTypes = ['values' => ['0' => ['id' => 'IS NULL']]];
+    }
 
     _civicrm_api3_case_add_case_category_query_filter($query, $caseTypes);
   }
@@ -136,10 +133,15 @@ function _civicrm_api3_case_add_case_category_query_filter($query, array $caseTy
   if (empty($caseTypeIds)) {
     return;
   }
+
+  $param = ['IN' => $caseTypeIds];
+
+  if (isset($caseTypeIds[0]) && $caseTypeIds[0] === 'IS NULL') {
+    $param = ['IS NULL' => []];
+  }
+
   $query->join('ct', 'JOIN civicrm_case_type AS ct ON ct.id = a.case_type_id');
-  $query->where(CRM_Core_DAO::createSQLFilter('ct.id', [
-    'IN' => $caseTypeIds,
-  ]));
+  $query->where(CRM_Core_DAO::createSQLFilter('ct.id', $param));
 }
 
 /**

--- a/api/v3/Case/Getstats.php
+++ b/api/v3/Case/Getstats.php
@@ -89,6 +89,13 @@ function civicrm_api3_case_getstats(array $params) {
 
     _civicrm_api3_case_add_case_category_query_filter($query, $caseTypes);
   }
+  // Handle no value for case_type_id param case.
+  elseif ($params['case_type_id'] === "") {
+    // Pass an invalid id to get no response.
+    $caseTypes = ['values' => ['0' => ['id' => '0']]];
+
+    _civicrm_api3_case_add_case_category_query_filter($query, $caseTypes);
+  }
 
   $query->groupBy('a.case_type_id, a.status_id');
   if (!empty($params['check_permissions'])) {


### PR DESCRIPTION
## Overview
This PR fixes the count issue on the overview tab for civiawards extension when the more filters search box filters yields no results.

When awards filter (`More filters`) filter criterion is changed in a way which results in no awards, the count on the overview section for the total application doesn't get updated to 0. See before screen grab. However, it was showing count of all the awards count. 

## Before
![RSE-944-before](https://user-images.githubusercontent.com/3340537/77429848-4aab0a00-6e00-11ea-8519-faa1b1889f1d.gif)

## After
![RSE-944-after](https://user-images.githubusercontent.com/3340537/77430054-965db380-6e00-11ea-83bf-994e4c1357e3.gif)

## Technical Details
The reason behind this issue is that the API for getstats for the Cases was not returning the correct value when `case_type_id` passed is set to empty or null (which mean selecting no case types), the PHP code is considering it as no param (in the logic) at all and returning all the cases expecting this as an empty param.

So, to fix this we need to handle this corner case and pass different param to the SQL query.So, if now the value `IS NULL` we know returns correct value when the value by passing the correct SQL query for this corner case. See `_civicrm_api3_case_add_case_category_query_filter` function.

#### Initially
<img width="1074" alt="Screenshot 2020-03-24 at 6 24 21 PM" src="https://user-images.githubusercontent.com/3340537/77430884-e38e5500-6e01-11ea-8583-3d3299426f13.png">

#### Finally
<img width="1678" alt="Screenshot 2020-03-24 at 9 21 01 PM" src="https://user-images.githubusercontent.com/3340537/77447210-6d93e900-6e15-11ea-9066-6519aca7e660.png">
