### PR TITLE
RSE-957: Fix Clicking on "Case Category Dashboard" Breadcrumb Takes User to Cases Dashboard

### DIFF
--- a/CRM/Civicase/Helper/CaseCategory.php
+++ b/CRM/Civicase/Helper/CaseCategory.php
@@ -62,7 +62,7 @@ class CRM_Civicase_Helper_CaseCategory {
         return $caseTypeCategories[$caseCategoryId];
       }
     }
-    catch(Exception $e) {
+    catch (Exception $e) {
       return NULL;
     }
 
@@ -222,6 +222,37 @@ class CRM_Civicase_Helper_CaseCategory {
     }
 
     return $caseCategoryAccess;
+  }
+
+  /**
+   * Updates breadcrumb for a case category page.
+   *
+   * The breadcrumb is updated so that the necessary words can be replaced and
+   * also so that the dashboard leads to the case category dashboard page
+   * depending on the case category.
+   *
+   * @param string $caseCategoryName
+   *   Case category name.
+   */
+  public static function updateBreadcrumbs($caseCategoryName) {
+    CRM_Utils_System::resetBreadCrumb();
+    $breadcrumb = [
+      [
+        'title' => ts('Home'),
+        'url' => CRM_Utils_System::url(),
+      ],
+      [
+        'title' => ts('CiviCRM'),
+        'url' => CRM_Utils_System::url('civicrm', 'reset=1'),
+      ],
+      [
+        'title' => ts('Case Dashboard'),
+        'url' => CRM_Utils_System::url('civicrm/case/a/', ['case_type_category' => $caseCategoryName], TRUE,
+          "/case?case_type_category={$caseCategoryName}"),
+      ],
+    ];
+
+    CRM_Utils_System::appendBreadCrumb($breadcrumb);
   }
 
 }

--- a/CRM/Civicase/Hook/PreProcess/CaseCategoryWordReplacementsForNewCase.php
+++ b/CRM/Civicase/Hook/PreProcess/CaseCategoryWordReplacementsForNewCase.php
@@ -1,5 +1,6 @@
 <?php
 
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
 
 /**
@@ -46,39 +47,7 @@ class CRM_Civicase_Hook_PreProcess_CaseCategoryWordReplacementsForNewCase {
     // through the ts function.
     $pageTitle = $form->get_template_vars('activityType');
     CRM_Utils_System::setTitle(ts($pageTitle));
-    $this->updateBreadcrumbs($caseCategoryName);
-  }
-
-  /**
-   * Updates the New Case page breadcrumb.
-   *
-   * The breadcrumb is updated so that the necessary words can be replaced and
-   * also so that the dashboard leads to the case category dashboard page
-   * depending on the case category.
-   *
-   * @param string $caseCategoryName
-   *   Case category name.
-   */
-  private function updateBreadcrumbs($caseCategoryName) {
-    $caseCategoryName = strtolower($caseCategoryName);
-    CRM_Utils_System::resetBreadCrumb();
-    $breadcrumb = [
-      [
-        'title' => ts('Home'),
-        'url' => CRM_Utils_System::url(),
-      ],
-      [
-        'title' => ts('CiviCRM'),
-        'url' => CRM_Utils_System::url('civicrm', 'reset=1'),
-      ],
-      [
-        'title' => ts('Case Dashboard'),
-        'url' => CRM_Utils_System::url('civicrm/case/a/', ['case_type_category' => $caseCategoryName], TRUE,
-          "/case?case_type_category={$caseCategoryName}"),
-      ],
-    ];
-
-    CRM_Utils_System::appendBreadCrumb($breadcrumb);
+    CaseCategoryHelper::updateBreadcrumbs($caseCategoryName);
   }
 
   /**

--- a/ang/civicase.ang.php
+++ b/ang/civicase.ang.php
@@ -11,6 +11,7 @@
 use CRM_Civicase_Helper_GlobRecursive as GlobRecursive;
 use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
 use CRM_Civicase_Helper_NewCaseWebform as NewCaseWebform;
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 
 load_resources();
 $caseCategoryName = CRM_Utils_Request::retrieve('case_type_category', 'String');
@@ -26,7 +27,7 @@ $caseCategoryPermissions = $permissionService->get($caseCategoryName);
 // The following changes are only relevant to the full-page app.
 if (CRM_Utils_System::getUrlPath() == 'civicrm/case/a') {
   adds_shoreditch_css();
-  update_breadcrumbs();
+  CaseCategoryHelper::updateBreadcrumbs($caseCategoryName);
 }
 
 $options = [];
@@ -76,28 +77,6 @@ function adds_shoreditch_css() {
     Civi::resources()
       ->addStyleFile('org.civicrm.shoreditch', 'css/custom-civicrm.css', 99, 'html-header');
   }
-}
-
-/**
- * Update Breadcrumbs.
- */
-function update_breadcrumbs() {
-  CRM_Utils_System::resetBreadCrumb();
-  $breadcrumb = [
-    [
-      'title' => ts('Home'),
-      'url' => CRM_Utils_System::url(),
-    ],
-    [
-      'title' => ts('CiviCRM'),
-      'url' => CRM_Utils_System::url('civicrm', 'reset=1'),
-    ],
-    [
-      'title' => ts('Case Dashboard'),
-      'url' => CRM_Utils_System::url('civicrm/case/a/#/case'),
-    ],
-  ];
-  CRM_Utils_System::appendBreadCrumb($breadcrumb);
 }
 
 /**


### PR DESCRIPTION
## Overview
When a user clicks on the Case category dashboard link on the breadcrumbs, either for Awards or any other case category, it takes the user to the default Case dashboard. The user should be taken to the dashboard for that case category and not the case dashboard.

## Before
The issue described above exists
![BreadcrumbBefore](https://user-images.githubusercontent.com/6951813/77541089-7a135280-6ea4-11ea-8bb2-575743acef4c.gif)


## After
Issue is fixed.
The function for updating the Case category breadcrumbs was moved to a central function and used from there for the New case page and the angular related case category pages.

![Breadcrumb](https://user-images.githubusercontent.com/6951813/77541232-aaf38780-6ea4-11ea-80b2-0af6c394e8bc.gif)

