### PR TITLE
RSE-956: Use form service when adding new activities

### DIFF
--- a/ang/civicase/activity/activity-forms/activity-forms.config.js
+++ b/ang/civicase/activity/activity-forms/activity-forms.config.js
@@ -12,20 +12,28 @@
   function activityFormsConfiguration (ActivityFormsProvider) {
     var addActivityFormConfigs = [
       {
-        name: 'DraftPdfActivityForm',
+        name: 'AddCustomPathActivityForm',
         weight: 0
       },
       {
-        name: 'DraftEmailActivityForm',
+        name: 'AddActivityForm',
         weight: 1
       },
       {
-        name: 'ActivityPopupForm',
+        name: 'DraftPdfActivityForm',
         weight: 2
       },
       {
-        name: 'ViewActivityForm',
+        name: 'DraftEmailActivityForm',
         weight: 3
+      },
+      {
+        name: 'UpdateActivityForm',
+        weight: 4
+      },
+      {
+        name: 'ViewActivityForm',
+        weight: 5
       }
     ];
 

--- a/ang/civicase/activity/activity-forms/services/add-activity-form.service.js
+++ b/ang/civicase/activity/activity-forms/services/add-activity-form.service.js
@@ -1,0 +1,41 @@
+(function (_, angular, getCrmUrl) {
+  var module = angular.module('civicase');
+
+  module.service('AddActivityForm', AddActivityForm);
+
+  /**
+   * Add Activity Form service.
+   */
+  function AddActivityForm () {
+    this.canChangeStatus = true;
+    this.canHandleActivity = canHandleActivity;
+    this.getActivityFormUrl = getActivityFormUrl;
+
+    /**
+     * The service can handle any activity that needs to be added.
+     *
+     * @param {object} activity an activity object.
+     * @param {object} options form options.
+     * @returns {boolean} true when the service can handle the given activity.
+     */
+    function canHandleActivity (activity, options) {
+      return options && options.action === 'add';
+    }
+
+    /**
+     * @param {object} activity an activity object.
+     * @param {object} overridingOptions form options.
+     * @returns {string} the URL for the form to add the given activity.
+     */
+    function getActivityFormUrl (activity, overridingOptions) {
+      var options = _.defaults({}, overridingOptions, {
+        action: 'add',
+        reset: 1,
+        caseid: activity.case_id,
+        atype: activity.activity_type_id
+      });
+
+      return getCrmUrl('civicrm/case/activity', options);
+    }
+  }
+})(CRM._, angular, CRM.url);

--- a/ang/civicase/activity/activity-forms/services/add-custom-path-activity-form.service.js
+++ b/ang/civicase/activity/activity-forms/services/add-custom-path-activity-form.service.js
@@ -1,0 +1,51 @@
+(function (_, angular, getCrmUrl) {
+  var module = angular.module('civicase');
+
+  module.service('AddCustomPathActivityForm', AddCustomPathActivityForm);
+
+  /**
+   * Add Custom Path Activity Form service.
+   */
+  function AddCustomPathActivityForm () {
+    var ACTIVITY_TYPES_CUSTOM_PATHS = {
+      Email: 'civicrm/activity/email/add',
+      'Print PDF Letter': 'civicrm/activity/pdf/add'
+    };
+
+    this.canChangeStatus = true;
+    this.canHandleActivity = canHandleActivity;
+    this.getActivityFormUrl = getActivityFormUrl;
+
+    /**
+     * The service can handle the creation of activities with custom save paths.
+     *
+     * @param {object} activity an activity object.
+     * @param {object} options form options.
+     * @returns {boolean} true when the service can handle the given activity.
+     */
+    function canHandleActivity (activity, options) {
+      var isAddAction = options && options.action === 'add';
+      var hasCustomPath = !!ACTIVITY_TYPES_CUSTOM_PATHS[activity.type];
+
+      return isAddAction && hasCustomPath;
+    }
+
+    /**
+     * @param {object} activity an activity object.
+     * @param {object} overridingOptions form options.
+     * @returns {string} the URL for the form to add the given activity.
+     */
+    function getActivityFormUrl (activity, overridingOptions) {
+      var path = ACTIVITY_TYPES_CUSTOM_PATHS[activity.type];
+      var options = _.defaults({}, overridingOptions, {
+        action: 'add',
+        reset: 1,
+        caseid: activity.case_id,
+        atype: activity.activity_type_id,
+        context: 'standalone'
+      });
+
+      return getCrmUrl(path, options);
+    }
+  }
+})(CRM._, angular, CRM.url);

--- a/ang/civicase/activity/activity-forms/services/update-activity-form.service.js
+++ b/ang/civicase/activity/activity-forms/services/update-activity-form.service.js
@@ -1,18 +1,18 @@
 (function (angular, getCrmUrl) {
   var module = angular.module('civicase');
 
-  module.service('ActivityPopupForm', ActivityPopupForm);
+  module.service('UpdateActivityForm', UpdateActivityForm);
 
   /**
-   * Activity Popup Form service.
+   * Update Activity Form service.
    */
-  function ActivityPopupForm () {
+  function UpdateActivityForm () {
     this.canChangeStatus = true;
     this.canHandleActivity = canHandleActivity;
     this.getActivityFormUrl = getActivityFormUrl;
 
     /**
-     * Only handles activity forms that will be displayed in a popup.
+     * Only handles activity forms that will be updated.
      * It supports both stand-alone activities and case activities.
      *
      * @param {object} activity an activity object.
@@ -20,12 +20,12 @@
      * @returns {boolean} true when it can handle the activity and form options.
      */
     function canHandleActivity (activity, options) {
-      return (options && options.formType === 'popup') || false;
+      return (options && options.action === 'update') || false;
     }
 
     /**
      * @param {object} activity an activity object.
-     * @returns {string} the URL for the activity form that will be displayed in a popup.
+     * @returns {string} the URL for the activity form that will be updated.
      */
     function getActivityFormUrl (activity) {
       var urlPath = 'civicrm/activity';

--- a/ang/civicase/activity/directives/add-activity-menu.directive.js
+++ b/ang/civicase/activity/directives/add-activity-menu.directive.js
@@ -15,7 +15,8 @@
     };
   });
 
-  module.controller('civicaseAddActivityMenuController', function ($scope, getCaseQueryParams, CaseType, ActivityType) {
+  module.controller('civicaseAddActivityMenuController', function ($scope, getCaseQueryParams, CaseType, ActivityType,
+    ActivityForms) {
     var definition = CaseType.getAll()[$scope.case.case_type_id].definition;
 
     (function init () {
@@ -107,28 +108,22 @@
      */
     $scope.newActivityUrl = function (actType) {
       var caseQueryParams = JSON.stringify(getCaseQueryParams({ caseId: $scope.case.id }));
-      var path = 'civicrm/case/activity';
-      var args = {
+      var newActivity = {
+        activity_type_id: actType.id,
+        case_id: $scope.case.id,
+        type: actType.name
+      };
+      var options = {
         action: 'add',
-        reset: 1,
-        caseid: $scope.case.id,
-        atype: actType.id,
         civicase_reload: caseQueryParams
       };
+      var activityForm = ActivityForms.getActivityFormService(newActivity, options);
 
-      // CiviCRM requires nonstandard urls for a couple special activity types
-      if (actType.name === 'Email') {
-        path = 'civicrm/activity/email/add';
-        args.context = 'standalone';
-        delete args.cid;
+      if (!activityForm) {
+        return;
       }
 
-      if (actType.name === 'Print PDF Letter') {
-        path = 'civicrm/activity/pdf/add';
-        args.context = 'standalone';
-      }
-
-      return CRM.url(path, args);
+      return activityForm.getActivityFormUrl(newActivity, options);
     };
   });
 })(CRM.$, CRM._, angular);

--- a/ang/civicase/activity/factories/view-in-popup.factory.js
+++ b/ang/civicase/activity/factories/view-in-popup.factory.js
@@ -12,7 +12,7 @@
     function viewInPopup ($event, activity) {
       var isClickingAButton = $event && $($event.target).is('a, a *, input, button, button *');
       var activityForm = ActivityForms.getActivityFormService(activity, {
-        formType: 'popup'
+        action: 'update'
       });
 
       if (!activityForm || isClickingAButton) {

--- a/ang/test/civicase/activity/activity-forms/activity-forms.config.spec.js
+++ b/ang/test/civicase/activity/activity-forms/activity-forms.config.spec.js
@@ -17,8 +17,24 @@
       it('adds the draft pdf activity form service', () => {
         expect(ActivityFormsProvider.addActivityForms)
           .toHaveBeenCalledWith(jasmine.arrayContaining([{
-            name: 'DraftPdfActivityForm',
+            name: 'AddCustomPathActivityForm',
             weight: 0
+          }]));
+      });
+
+      it('adds the draft pdf activity form service', () => {
+        expect(ActivityFormsProvider.addActivityForms)
+          .toHaveBeenCalledWith(jasmine.arrayContaining([{
+            name: 'AddActivityForm',
+            weight: 1
+          }]));
+      });
+
+      it('adds the draft pdf activity form service', () => {
+        expect(ActivityFormsProvider.addActivityForms)
+          .toHaveBeenCalledWith(jasmine.arrayContaining([{
+            name: 'DraftPdfActivityForm',
+            weight: 2
           }]));
       });
 
@@ -26,15 +42,15 @@
         expect(ActivityFormsProvider.addActivityForms)
           .toHaveBeenCalledWith(jasmine.arrayContaining([{
             name: 'DraftEmailActivityForm',
-            weight: 1
+            weight: 3
           }]));
       });
 
       it('adds the activity popup form service', () => {
         expect(ActivityFormsProvider.addActivityForms)
           .toHaveBeenCalledWith(jasmine.arrayContaining([{
-            name: 'ActivityPopupForm',
-            weight: 2
+            name: 'UpdateActivityForm',
+            weight: 4
           }]));
       });
 
@@ -42,7 +58,7 @@
         expect(ActivityFormsProvider.addActivityForms)
           .toHaveBeenCalledWith(jasmine.arrayContaining([{
             name: 'ViewActivityForm',
-            weight: 3
+            weight: 5
           }]));
       });
     });

--- a/ang/test/civicase/activity/activity-forms/services/add-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/add-activity-form.service.spec.js
@@ -1,0 +1,66 @@
+/* eslint-env jasmine */
+((_, getCrmUrl) => {
+  describe('AddActivityForm', () => {
+    let AddActivityForm, activity, activityFormUrl, expectedActivityFormUrl, canHandle;
+
+    beforeEach(module('civicase', 'civicase-base', 'civicase.data'));
+
+    beforeEach(inject((_activitiesMockData_, _AddActivityForm_) => {
+      AddActivityForm = _AddActivityForm_;
+      activity = _.chain(_activitiesMockData_.get())
+        .first()
+        .cloneDeep()
+        .value();
+    }));
+
+    describe('allowing activity status change', () => {
+      it('allows for activity status change', () => {
+        expect(AddActivityForm.canChangeStatus).toBe(true);
+      });
+    });
+
+    describe('handling activity forms', () => {
+      describe('when handling a new activity', () => {
+        beforeEach(() => {
+          canHandle = AddActivityForm.canHandleActivity(activity, {
+            action: 'add'
+          });
+        });
+
+        it('can handle the activity', () => {
+          expect(canHandle).toBe(true);
+        });
+      });
+
+      describe('when handling an existing activity', () => {
+        beforeEach(() => {
+          canHandle = AddActivityForm.canHandleActivity(activity, {
+            action: 'update'
+          });
+        });
+
+        it('cannot handle the activity', () => {
+          expect(canHandle).toBe(false);
+        });
+      });
+    });
+
+    describe('getting the activity form url', () => {
+      describe('when getting the form url to create a new activity', () => {
+        beforeEach(() => {
+          activityFormUrl = AddActivityForm.getActivityFormUrl(activity);
+          expectedActivityFormUrl = getCrmUrl('civicrm/case/activity', {
+            action: 'add',
+            reset: 1,
+            caseid: activity.case_id,
+            atype: activity.activity_type_id
+          });
+        });
+
+        it('returns the form url to create a new activity', () => {
+          expect(activityFormUrl).toEqual(expectedActivityFormUrl);
+        });
+      });
+    });
+  });
+})(CRM._, CRM.url);

--- a/ang/test/civicase/activity/activity-forms/services/add-custom-path-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/add-custom-path-activity-form.service.spec.js
@@ -1,0 +1,127 @@
+/* eslint-env jasmine */
+((_, getCrmUrl) => {
+  describe('AddCustomPathActivityForm', () => {
+    let AddCustomPathActivityForm, activity, activityFormUrl, expectedActivityFormUrl, canHandle;
+
+    beforeEach(module('civicase', 'civicase-base', 'civicase.data'));
+
+    beforeEach(inject((_activitiesMockData_, _AddCustomPathActivityForm_) => {
+      AddCustomPathActivityForm = _AddCustomPathActivityForm_;
+      activity = _.chain(_activitiesMockData_.get())
+        .first()
+        .cloneDeep()
+        .value();
+    }));
+
+    describe('allowing activity status change', () => {
+      it('allows for activity status change', () => {
+        expect(AddCustomPathActivityForm.canChangeStatus).toBe(true);
+      });
+    });
+
+    describe('handling activity forms', () => {
+      describe('when handling a new Email activity', () => {
+        beforeEach(() => {
+          activity.type = 'Email';
+          canHandle = AddCustomPathActivityForm.canHandleActivity(activity, {
+            action: 'add'
+          });
+        });
+
+        it('can handle the activity', () => {
+          expect(canHandle).toBe(true);
+        });
+      });
+
+      describe('when handling a new Print PDF Letter activity', () => {
+        beforeEach(() => {
+          activity.type = 'Print PDF Letter';
+          canHandle = AddCustomPathActivityForm.canHandleActivity(activity, {
+            action: 'add'
+          });
+        });
+
+        it('can handle the activity', () => {
+          expect(canHandle).toBe(true);
+        });
+      });
+
+      describe('when handling an existing Email activity', () => {
+        beforeEach(() => {
+          activity.type = 'Email';
+          canHandle = AddCustomPathActivityForm.canHandleActivity(activity, {
+            action: 'update'
+          });
+        });
+
+        it('cannot handle the activity', () => {
+          expect(canHandle).toBe(false);
+        });
+      });
+
+      describe('when handling an existing Print PDF Letter activity', () => {
+        beforeEach(() => {
+          activity.type = 'Print PDF Letter';
+          canHandle = AddCustomPathActivityForm.canHandleActivity(activity, {
+            action: 'update'
+          });
+        });
+
+        it('cannot handle the activity', () => {
+          expect(canHandle).toBe(false);
+        });
+      });
+
+      describe('when handling a new activity', () => {
+        beforeEach(() => {
+          activity.type = 'Another Type';
+          canHandle = AddCustomPathActivityForm.canHandleActivity(activity, {
+            action: 'add'
+          });
+        });
+
+        it('cannot handle the activity', () => {
+          expect(canHandle).toBe(false);
+        });
+      });
+    });
+
+    describe('getting the activity form url', () => {
+      describe('when getting the form url to create a new Email activity', () => {
+        beforeEach(() => {
+          activity.type = 'Email';
+          activityFormUrl = AddCustomPathActivityForm.getActivityFormUrl(activity);
+          expectedActivityFormUrl = getCrmUrl('civicrm/activity/email/add', {
+            action: 'add',
+            reset: 1,
+            caseid: activity.case_id,
+            atype: activity.activity_type_id,
+            context: 'standalone'
+          });
+        });
+
+        it('returns the form url to create a new activity', () => {
+          expect(activityFormUrl).toEqual(expectedActivityFormUrl);
+        });
+      });
+
+      describe('when getting the form url to create a new Print PDF Letter activity', () => {
+        beforeEach(() => {
+          activity.type = 'Print PDF Letter';
+          activityFormUrl = AddCustomPathActivityForm.getActivityFormUrl(activity);
+          expectedActivityFormUrl = getCrmUrl('civicrm/activity/pdf/add', {
+            action: 'add',
+            reset: 1,
+            caseid: activity.case_id,
+            atype: activity.activity_type_id,
+            context: 'standalone'
+          });
+        });
+
+        it('returns the form url to create a new activity', () => {
+          expect(activityFormUrl).toEqual(expectedActivityFormUrl);
+        });
+      });
+    });
+  });
+})(CRM._, CRM.url);

--- a/ang/test/civicase/activity/activity-forms/services/update-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/update-activity-form.service.spec.js
@@ -1,12 +1,12 @@
 /* eslint-env jasmine */
 ((_, getCrmUrl) => {
-  describe('ActivityPopupForm', () => {
-    let activity, activityFormUrl, ActivityPopupForm, expectedActivityFormUrl, canHandle;
+  describe('UpdateActivityForm', () => {
+    let activity, activityFormUrl, UpdateActivityForm, expectedActivityFormUrl, canHandle;
 
     beforeEach(module('civicase', 'civicase-base', 'civicase.data'));
 
-    beforeEach(inject((_activitiesMockData_, _ActivityPopupForm_) => {
-      ActivityPopupForm = _ActivityPopupForm_;
+    beforeEach(inject((_activitiesMockData_, _UpdateActivityForm_) => {
+      UpdateActivityForm = _UpdateActivityForm_;
       activity = _.chain(_activitiesMockData_.get())
         .first()
         .cloneDeep()
@@ -15,26 +15,26 @@
 
     describe('allowing activity status change', () => {
       it('allows for activity status change', () => {
-        expect(ActivityPopupForm.canChangeStatus).toBe(true);
+        expect(UpdateActivityForm.canChangeStatus).toBe(true);
       });
     });
 
     describe('handling activity forms', () => {
-      describe('when handling a popup form', () => {
+      describe('when handling an update form', () => {
         beforeEach(() => {
-          canHandle = ActivityPopupForm.canHandleActivity(activity, {
-            formType: 'popup'
+          canHandle = UpdateActivityForm.canHandleActivity(activity, {
+            action: 'update'
           });
         });
 
-        it('can handle the popup form', () => {
+        it('can handle the update form', () => {
           expect(canHandle).toBe(true);
         });
       });
 
       describe('when handling any other form type', () => {
         beforeEach(() => {
-          canHandle = ActivityPopupForm.canHandleActivity(activity);
+          canHandle = UpdateActivityForm.canHandleActivity(activity);
         });
 
         it('cannot handle the form', () => {
@@ -48,7 +48,7 @@
         beforeEach(() => {
           delete activity.case_id;
 
-          activityFormUrl = ActivityPopupForm.getActivityFormUrl(activity);
+          activityFormUrl = UpdateActivityForm.getActivityFormUrl(activity);
           expectedActivityFormUrl = getCrmUrl('civicrm/activity', {
             action: 'update',
             id: activity.id,
@@ -56,7 +56,7 @@
           });
         });
 
-        it('returns the popup form url for the stand alone activity', () => {
+        it('returns the update form url for the stand alone activity', () => {
           expect(activityFormUrl).toEqual(expectedActivityFormUrl);
         });
       });
@@ -64,7 +64,7 @@
       describe('when getting the form url for a case activity', () => {
         beforeEach(() => {
           activity.case_id = _.uniqueId();
-          activityFormUrl = ActivityPopupForm.getActivityFormUrl(activity);
+          activityFormUrl = UpdateActivityForm.getActivityFormUrl(activity);
           expectedActivityFormUrl = getCrmUrl('civicrm/case/activity', {
             action: 'update',
             id: activity.id,
@@ -73,7 +73,7 @@
           });
         });
 
-        it('returns the popup form url for the case activity', () => {
+        it('returns the update form url for the case activity', () => {
           expect(activityFormUrl).toEqual(expectedActivityFormUrl);
         });
       });


### PR DESCRIPTION
## Overview
This PR implements the form service introduced in https://github.com/compucorp/uk.co.compucorp.civicase/pull/329 and uses it when creating new activities. This allows other extensions to define the form to display when creating new activities.

**Note:** this PR is linked to https://github.com/compucorp/uk.co.compucorp.civiawards/pull/80

## Before & After
Please refer to https://github.com/compucorp/uk.co.compucorp.civiawards/pull/80 for before and after screenshots

## Technical Details

* Divided the logic that was in `add-activity-menu.directive.js`'s `newActivityUrl` method into two new form services: `AddCustomPathActivityForm` and `AddActivityForm`.
* `AddCustomPathActivityForm` is used for activities that have a custom path to save the activity such as `Email` and `Print PDF Letter`.
* `AddActivityForm` is used for all other activities.
* `ActivityPopupForm` was refactored into `UpdateActivityForm` so users of the activity form service can override the values of the form instead of having custom ones for each operation.
