### PR TITLE
RSE-659: Fix Bulk Action Error with Tags

### DIFF
--- a/ang/civicase/activity/actions/services/tags-activity-action.html
+++ b/ang/civicase/activity/actions/services/tags-activity-action.html
@@ -1,7 +1,7 @@
 <div id="bootstrap-theme" class="civicase__tags-modal">
   <form class="form-horizontal">
     <civicase-tags-selector
-      model-object="model.selectedTags"
+      model="model.selectedTags"
       all-tags="model.allTags">
     </civicase-tags-selector>
 


### PR DESCRIPTION
## Overview
When "Tag - add to activities" or " Tag - remove from activities" bulk actions were performed in Activity Feed, the tags were not visible and there were console errors. This PR fixes the same.

## Before
![before](https://user-images.githubusercontent.com/5058867/77724777-d0ee6880-7019-11ea-92cc-5594b37a5cad.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/77724822-ec597380-7019-11ea-8a50-de45c34a34d0.gif)

## Technical Details
This is a regression issue, as part of https://github.com/compucorp/uk.co.compucorp.civicase/pull/405, a new directive `civicase-tags-selector` was created, but the markup was wrong in `tags-activity-action.html`.
The attribute name is changed to `model` from `model-object`.