### PR TITLE
CPS-124: Remove special characters from case type category name

### DIFF
--- a/CRM/Civicase/Hook/ValidateForm/SaveActivityDraft.php
+++ b/CRM/Civicase/Hook/ValidateForm/SaveActivityDraft.php
@@ -11,8 +11,8 @@ class CRM_Civicase_Hook_ValidateForm_SaveActivityDraft {
    * @var array
    */
   private $specialForms = [
-    'email' => 'CRM_Contact_Form_Task_PDF',
-    'pdf' => 'CRM_Contact_Form_Task_Email',
+    'pdf' => 'CRM_Contact_Form_Task_PDF',
+    'email' => 'CRM_Contact_Form_Task_Email',
   ];
 
   /**

--- a/CRM/Civicase/Hook/ValidateForm/SaveCaseTypeCategory.php
+++ b/CRM/Civicase/Hook/ValidateForm/SaveCaseTypeCategory.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Class CRM_Civicase_Hook_ValidateForm_SaveCaseTypeCategory.
+ */
+class CRM_Civicase_Hook_ValidateForm_SaveCaseTypeCategory {
+
+  /**
+   * Validates case type category.
+   *
+   * @param string $formName
+   *   Form Name.
+   * @param array $fields
+   *   Fields List.
+   * @param array $files
+   *   Files list.
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   * @param array $errors
+   *   Errors.
+   */
+  public function run($formName, array &$fields, array &$files, CRM_Core_Form &$form, array &$errors) {
+    if (!$this->shouldRun($form, $formName)) {
+      return;
+    }
+
+    // Validate the label (category name).
+    $field_name = 'label';
+    if (!empty($fields[$field_name]) && !preg_match('!^[a-zA-Z0-9 -]+$!', $fields[$field_name])) {
+      $errors[$field_name] = ts('Allowed characters: letters (a-z), numbers, space and hyphen.');
+    }
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * @param CRM_Core_Form $form
+   *   Form object class.
+   * @param string $formName
+   *   Form name.
+   *
+   * @return bool
+   *   TRUE if hook should run, FALSE otherwise.
+   */
+  private function shouldRun(CRM_Core_Form $form, $formName) {
+    return $formName == 'CRM_Admin_Form_Options' && $form->getVar('_gName') == 'case_type_categories';
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -375,6 +375,7 @@ function civicase_civicrm_alterContent(&$content, $context, $templateName, $form
 function civicase_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
   $hooks = [
     new CRM_Civicase_Hook_ValidateForm_SaveActivityDraft(),
+    new CRM_Civicase_Hook_ValidateForm_SaveCaseTypeCategory(),
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview
Currently, when user saves case type category special characters in it's name would be saved as well. We need to prevent the name to have special characters such as quotes, ampersand.
So this PR adds validation for case type category.

## Before
Any characters are allowed for category name (label).

## After
Following characters are allowed for category name (label): letters (a-z), numbers, space and hyphen. Respective error is displayed in case if validation failed:
![image](https://user-images.githubusercontent.com/39520000/77765409-47598d80-704f-11ea-8e28-72077b3b5b66.png)


## Technical Details
1. To validate the case type category form (which is the option group form) we created `CRM_Civicase_Hook_ValidateForm_SaveCaseTypeCategory` class, which is then used in `civicase_civicrm_validateForm()` hook.
2. Also as part of this PR wrong array key names where fixed in the sibling `CRM_Civicase_Hook_ValidateForm_SaveActivityDraft` class.