### PR TITLE
RSE-714: Fix Award/Case Category Page Translation Issues

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/CaseCategoryFormLabelTranslationForChangeCase.php
+++ b/CRM/Civicase/Hook/BuildForm/CaseCategoryFormLabelTranslationForChangeCase.php
@@ -6,6 +6,17 @@
 class CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslationForChangeCase {
 
   /**
+   * Elements names that needs label translation.
+   *
+   * @var array
+   */
+  private $elementsToTranslateLabel = [
+    'case_status_id',
+    'case_type_id',
+    'link_to_case_id',
+  ];
+
+  /**
    * Translate some case form labels that Civi did not run translation for.
    *
    * @param CRM_Core_Form $form
@@ -31,21 +42,23 @@ class CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslationForChangeCase 
    *   Page class.
    */
   private function translateFormLabels(CRM_Core_Form $form) {
-    $caseTypeIdElement = &$form->getElement('case_type_id');
-    $this->translateLabel([$caseTypeIdElement]);
+    foreach ($this->elementsToTranslateLabel as $elementName) {
+      if ($form->elementExists($elementName)) {
+        $element = &$form->getElement($elementName);
+        $this->translateLabel($element);
+      }
+    }
   }
 
   /**
-   * Translate the form labels for an array of form elements.
+   * Translate the form labels for a form elements.
    *
-   * @param array $elements
+   * @param object $element
    *   For Elements array.
    */
-  private function translateLabel(array $elements) {
-    foreach ($elements as $element) {
-      $label = ts($element->getLabel());
-      $element->setLabel($label);
-    }
+  private function translateLabel($element) {
+    $label = ts($element->getLabel());
+    $element->setLabel($label);
   }
 
   /**
@@ -64,7 +77,11 @@ class CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslationForChangeCase 
       return FALSE;
     }
 
-    return $form->_activityTypeName == 'Change Case Type';
+    return in_array($form->_activityTypeName, [
+      'Change Case Type',
+      'Change Case Status',
+      'Link Cases',
+    ]);
   }
 
 }

--- a/ang/civicase/case/actions/services/email-managers-case-action.service.js
+++ b/ang/civicase/case/actions/services/email-managers-case-action.service.js
@@ -5,8 +5,10 @@
 
   /**
    * EmailManagersCaseAction service callback function.
+   *
+   * @param {object} ts translation service
    */
-  function EmailManagersCaseAction () {
+  function EmailManagersCaseAction (ts) {
     /**
      * Returns the configuration options to open up a mail popup to
      * communicate with the case managers. Displays an error message
@@ -28,7 +30,11 @@
       });
 
       if (managers.length === 0) {
-        CRM.alert('Please add a contact as a case manager.', 'No case managers available', 'error');
+        CRM.alert(
+          ts('Please add a contact as a case manager.'),
+          ts('No case managers available'),
+          'error'
+        );
 
         return;
       }


### PR DESCRIPTION
## Overview
There were some screens on Awards where the case category translation were not working as expected. Also an issue with Notification when trying to trigger “Email application manager“ action from the actions menu if there’s no application manager assigned. This PR fixes that.

## Before
The following screens were not translated as expected:
![image-20200326-181057](https://user-images.githubusercontent.com/6951813/77773181-884ea380-7049-11ea-8c9d-d039c5d4b648.png)
![image-20200326-180924](https://user-images.githubusercontent.com/6951813/77773202-91d80b80-7049-11ea-887e-c3748f27b362.png)
![image-20200326-191413](https://user-images.githubusercontent.com/6951813/77773207-943a6580-7049-11ea-8b7d-7e9cad13793a.png)

- Updating Application Status Screen
- Link applications screen
- Milestone activity edit screen.

## After
- The screens above were properly translated. Note that the fix is a generic fix that works for all case type categories including Prospect, Awards and other categories created

<img width="1280" alt="Manage Applications  CiviAwards 2020-03-27 16-42-45" src="https://user-images.githubusercontent.com/6951813/77773755-568a0c80-704a-11ea-953c-f0b24ad1036b.png">
<img width="1280" alt="Manage Applications  CiviAwards 2020-03-27 16-41-28" src="https://user-images.githubusercontent.com/6951813/77773774-5c7fed80-704a-11ea-9984-7a11b25da968.png">
<img width="1280" alt="Manage Prospects  CiviAwards 2020-03-27 16-43-37" src="https://user-images.githubusercontent.com/6951813/77773719-4e31d180-704a-11ea-8bba-e0a122fefcdc.png">




