### PR TITLE
RSE-1005: Uppercase the case type category name in the filter

### DIFF
--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -34,7 +34,7 @@
     };
     var caseRelationshipConfig = [
       { text: ts('All Cases'), id: 'all' },
-      { text: ts('My cases'), id: 'is_case_manager' },
+      { text: ts('My Cases'), id: 'is_case_manager' },
       { text: ts('Cases I am involved'), id: 'is_involved' }
     ];
     var DEFAULT_CASE_FILTERS = {

--- a/ang/civicase/dashboard/directives/dashboard.directive.js
+++ b/ang/civicase/dashboard/directives/dashboard.directive.js
@@ -115,7 +115,7 @@
      */
     function prepareCaseFilterOption () {
       var options = [
-        { text: ts('My cases'), id: 'is_case_manager' },
+        { text: ts('My Cases'), id: 'is_case_manager' },
         { text: ts('Cases I am involved in'), id: 'is_involved' }
       ];
 


### PR DESCRIPTION
## Overview
There is a relation filter on the cases Dashboard page and we have same filter when we go to the case type category page. And there was a mess with letters upper/lower case - first letter of a category name should be uppercased for all options in that filters, but one option still had lower case.
Now it's fixed.

## Before
![image](https://user-images.githubusercontent.com/39520000/77915525-52572c80-72a0-11ea-9931-5beeb944e868.png)

## After
![image](https://user-images.githubusercontent.com/39520000/77915698-93e7d780-72a0-11ea-9b6b-621716ca2980.png)

## Technical Details
There is `CRM_Civicase_Helper_CaseCategory::getWordReplacements()` which provides word replacing for the following forms of the word: `Case`, `Cases`, `case`, `cases`. In order to have first character uppercased we need to use `Case`, but `case` was used for the filter option. Now we are using correct form of the word and issue is fixed.