### PR TITLE
RSE-1050: Fix Contact Tab Case Actions

### DIFF
--- a/CRM/Civicase/Page/ContactCaseTab.php
+++ b/CRM/Civicase/Page/ContactCaseTab.php
@@ -22,13 +22,26 @@ class CRM_Civicase_Page_ContactCaseTab extends CRM_Core_Page {
     $this->assign('case_type_category', $caseTypeCategory);
     $caseCategoryName = CRM_Civicase_Helper_CaseCategory::getCaseCategoryNameFromOptionValue($caseTypeCategory);
     CRM_Civicase_Hook_Helper_CaseTypeCategory::addWordReplacements($caseCategoryName);
-    $translated = [];
-    if (strtolower($caseCategoryName) != 'cases') {
-      $manager = new Manager(CRM_Core_Resources::singleton());
-      $translated = $manager->getTranslatedStrings('civicase');
+
+    // Skip translations for default case category:
+    if (strtolower($caseCategoryName) == 'cases') {
+      CRM_Core_Resources::singleton()->addSetting([
+        'strings::uk.co.compucorp.civicase' => [],
+      ]);
+
+      return parent::run();
     }
+
+    $angularManager = new Manager(CRM_Core_Resources::singleton());
+    $civicaseModule = $angularManager->getModule('civicase');
+    $translations = $angularManager->getTranslatedStrings('civicase');
+
+    // Adds translated civicase settings and strings to global CRM var:
     CRM_Core_Resources::singleton()->addSetting([
-      'strings::uk.co.compucorp.civicase' => $translated,
+      'civicase' => $civicaseModule['settings'],
+    ]);
+    CRM_Core_Resources::singleton()->addSetting([
+      'strings::uk.co.compucorp.civicase' => $translations,
     ]);
 
     return parent::run();

--- a/ang/civicase-base/services/case-actions.service.js
+++ b/ang/civicase-base/services/case-actions.service.js
@@ -1,0 +1,23 @@
+(function (angular, $, _, CivicaseSettings) {
+  var module = angular.module('civicase-base');
+
+  module.service('CaseActions', CaseActions);
+
+  /**
+   * Case Actions Service
+   */
+  function CaseActions () {
+    var allCaseActions = _.cloneDeep(CivicaseSettings.caseActions);
+
+    this.getAll = getAll;
+
+    /**
+     * Get all Case actions
+     *
+     * @returns {object[]} all case actions
+     */
+    function getAll () {
+      return allCaseActions;
+    }
+  }
+})(angular, CRM.$, CRM._, CRM.civicase);

--- a/ang/civicase/case/actions/directives/case-actions.directive.js
+++ b/ang/civicase/case/actions/directives/case-actions.directive.js
@@ -2,7 +2,7 @@
   var module = angular.module('civicase');
 
   module.directive('civicaseCaseActions', function ($window, $rootScope, $injector, allowCaseLocks,
-    dialogService, PrintMergeCaseAction) {
+    CaseActions, dialogService, PrintMergeCaseAction) {
     return {
       restrict: 'A',
       templateUrl: '~/civicase/case/actions/directives/case-actions.directive.html',
@@ -22,6 +22,7 @@
      * @param {object} attributes the element attributes
      */
     function civicaseCaseActionsLink ($scope, element, attributes) {
+      var CASE_ACTIONS = CaseActions.getAll();
       var ts = CRM.ts('civicase');
       var isBulkMode = attributes.isBulkMode;
 
@@ -99,7 +100,7 @@
             { action: 'DeleteCases', type: 'restore', title: ts('Restore from Trash') }
           ];
         } else {
-          $scope.caseActions = _.cloneDeep(CRM.civicase.caseActions);
+          $scope.caseActions = _.cloneDeep(CASE_ACTIONS);
 
           if (!isBulkMode) {
             _.remove($scope.caseActions, { action: 'changeStatus(cases)' });

--- a/ang/test/civicase-base/services/case-actions.service.spec.js
+++ b/ang/test/civicase-base/services/case-actions.service.spec.js
@@ -1,0 +1,26 @@
+/* eslint-env jasmine */
+
+(() => {
+  describe('Case Actions', () => {
+    let CaseActions, CaseActionsData;
+
+    beforeEach(module('civicase.data', 'civicase'));
+
+    beforeEach(inject((_CaseActions_, _CaseActionsData_) => {
+      CaseActions = _CaseActions_;
+      CaseActionsData = _CaseActionsData_.values;
+    }));
+
+    describe('when getting all case actions', () => {
+      let returnedCaseActions;
+
+      beforeEach(() => {
+        returnedCaseActions = CaseActions.getAll();
+      });
+
+      it('returns all the case actions', () => {
+        expect(returnedCaseActions).toEqual(CaseActionsData);
+      });
+    });
+  });
+})();

--- a/ang/test/civicase/case/actions/directives/case-actions.directive.spec.js
+++ b/ang/test/civicase/case/actions/directives/case-actions.directive.spec.js
@@ -14,9 +14,6 @@ describe('Action', function () {
     var element;
 
     beforeEach(function () {
-      CRM.civicase.caseActions = [{
-        action: 'EditTags'
-      }];
       element = $compile('<div civicase-case-actions=[]></div>')($rootScope);
       $rootScope.$digest();
     });


### PR DESCRIPTION
## Overview
This PR fixes the following issues related to case actions on the contact's case tab:

* It uses the right translation for each action depending on the case category the tab belongs to (ie: Print Application instead of Print Case)
* It uses the right case actions as provided by other extensions. Previously we were adding repeated actions for the same extension

## Before
![Screen Shot 2020-03-31 at 12 40 13 AM](https://user-images.githubusercontent.com/1642119/77987927-185e4880-72e9-11ea-8d20-de0c3d425ef7.png)
* Notice the menu on the right: there are repeated actions, and the "Case" word is not translated

## After
![Screen Shot 2020-03-31 at 12 37 40 AM](https://user-images.githubusercontent.com/1642119/77987980-37f57100-72e9-11ea-92a5-b2f79496f62e.png)

It also works when switching tabs:
![gif](https://user-images.githubusercontent.com/1642119/77988094-7c810c80-72e9-11ea-80ca-b92a16e1b59f.gif)

## Technical Details

The issue is that the case actions are defined in the `civicase.ang.php` file, and we use `Civi\Angular\Manager` to get the translations. It seems this class only gets the translations from JS files when running `$angularManager->getTranslatedStrings('civicase');`.

We took advantage of this same class, since it returns the settings defined for `civicase` and restored them for the contact page by doing the following:

```js
$civicaseModule = $angularManager->getModule('civicase');

CRM_Core_Resources::singleton()->addSetting([
  'civicase' => $civicaseModule['settings'],
]);
```
This will update the right settings (with translations included) into the civicase object.

We have also created a `CaseActions` JS service since we need to store the value of the case actions since they are overridden when switching tabs.

There are some notes:

* We should move the case actions to `civicase-base` and only update the `civicase-base` settings here. This was not done for lack of time.