### PR TITLE
RSE-1053: Fix create activity

### DIFF
--- a/ang/civicase-base/providers/case-type.provider.js
+++ b/ang/civicase-base/providers/case-type.provider.js
@@ -12,6 +12,7 @@
     this.$get = $get;
     this.getAll = getAll;
     this.getByCategory = getByCategory;
+    this.getById = getById;
     this.getTitlesForNames = getTitlesForNames;
 
     /**
@@ -24,6 +25,7 @@
       return {
         getAll: getAll,
         getByCategory: getByCategory,
+        getById: getById,
         getItemsForCaseType: getItemsForCaseType,
         getTitlesForNames: getTitlesForNames
       };
@@ -56,6 +58,14 @@
       return _.filter(caseTypes, function (caseType) {
         return caseType.case_type_category === categoryValue;
       });
+    }
+
+    /**
+     * @param {number} caseTypeId the id for the case type.
+     * @returns {object} the case type for the given ID.
+     */
+    function getById (caseTypeId) {
+      return caseTypes[caseTypeId];
     }
 
     /**

--- a/ang/civicase/activity/directives/add-activity-menu.directive.js
+++ b/ang/civicase/activity/directives/add-activity-menu.directive.js
@@ -107,7 +107,11 @@
      * @returns {string} url
      */
     $scope.newActivityUrl = function (actType) {
-      var caseQueryParams = JSON.stringify(getCaseQueryParams({ caseId: $scope.case.id }));
+      var caseType = CaseType.getById($scope.case.case_type_id);
+      var caseQueryParams = JSON.stringify(getCaseQueryParams({
+        caseId: $scope.case.id,
+        caseTypeCategory: caseType.case_type_category
+      }));
       var newActivity = {
         activity_type_id: actType.id,
         case_id: $scope.case.id,

--- a/ang/test/civicase-base/services/case-type.service.spec.js
+++ b/ang/test/civicase-base/services/case-type.service.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env jasmine */
 
-(() => {
+((_) => {
   describe('Case Type', () => {
     let CaseType, CaseTypesData;
 
@@ -40,5 +40,19 @@
         ]);
       });
     });
+
+    describe('when getting a case type by id', () => {
+      let expectedCaseType, returnedCaseType;
+
+      beforeEach(() => {
+        const caseTypeId = _.chain(CaseTypesData).keys().sample().value();
+        expectedCaseType = CaseTypesData[caseTypeId];
+        returnedCaseType = CaseType.getById(caseTypeId);
+      });
+
+      it('returns the matching case type', () => {
+        expect(returnedCaseType).toEqual(expectedCaseType);
+      });
+    });
   });
-})();
+})(CRM._);


### PR DESCRIPTION
## Overview
This PR fixes an issue where award managers could not create review activities from the award tab on the contact details due to lack of permissions.

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/78082608-750d4200-7381-11ea-91d0-12d620ebe5c9.gif)


## After
![pr-after](https://user-images.githubusercontent.com/1642119/78082618-7a6a8c80-7381-11ea-9a5b-bdc46877cb11.gif)


## Technical Details

The issue happened because we were not passing the case category parameter to the form.

To pass the parameter we did the following changes:

* Added a `getById` method to the case type service so it's easier to get case types.
* Modified `add-activity-menu.directive.js` so we pass the `case_type_category` parameter to the   award form.