### PR TITLE
CATL-1171: Exclude deleted cases from search

### DIFF
--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -277,6 +277,10 @@
           search[key] = val;
         }
       });
+
+      // Force 'false' value for empty boolean fields.
+      search.is_deleted = search.is_deleted === undefined ? false : search.is_deleted;
+
       return search;
     }
 


### PR DESCRIPTION
## Overview
There was an issue with filters on **Manage Cases** page (`/civicrm/case/a/?case_type_category=cases`) - when filtering case by id - it was displayed in results even if it was deleted. It should not be displayed int this case unless **Deleted Cases** checkbox is ticked.
Now it's fixed.

## Before
![before](https://user-images.githubusercontent.com/39520000/78151259-14ddd500-7441-11ea-92f2-a8044fc0bf36.gif)

## After
![after](https://user-images.githubusercontent.com/39520000/78151276-1c04e300-7441-11ea-89dc-9de62b3f786c.gif)

## Technical Details
The search filters values are used to send an api request to get the data here. But if checkbox (boolean field) had no value it was not included into filters list - as a result both deleted / not deleted entities where displayed.
Now we force `false` value for empty `is_deleted` field and search works as expected.