### PR TITLE
CPS-146: Remove "To:" field from PDF activity

### DIFF
--- a/ang/civicase/activity/card/directives/activity-card-long.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-long.directive.html
@@ -106,7 +106,10 @@
         <div ng-if="activity.type !== 'File Upload'" class="civicase__activity-subject">{{ activity.subject }}</div>
         <!-- End - Subject -->
       </div>
-      <div class="civicase__activity-card-row civicase__activity-card-row--communication" ng-if="activity.category.indexOf('communication') > -1">
+      <div
+        class="civicase__activity-card-row civicase__activity-card-row--communication"
+        ng-if="isToFieldVisible"
+      >
         <div>
           <span>To:&nbsp;</span>
           <span ng-if="activity.target_contact_name" civicase-contact-card contacts="activity.target_contact_name"></span>

--- a/ang/civicase/activity/card/directives/activity-card-long.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-long.directive.html
@@ -108,7 +108,7 @@
       </div>
       <div
         class="civicase__activity-card-row civicase__activity-card-row--communication"
-        ng-if="isToFieldVisible"
+        ng-if="areFromAndToFieldsVisible"
       >
         <div>
           <span>To:&nbsp;</span>

--- a/ang/civicase/activity/card/directives/activity-card.directive.js
+++ b/ang/civicase/activity/card/directives/activity-card.directive.js
@@ -59,14 +59,14 @@
     var caseTypes = CaseType.getAll();
     var caseTypeCategories = CaseTypeCategory.getAll();
 
-    $scope.isToFieldVisible = false;
+    $scope.areFromAndToFieldsVisible = false;
     $scope.ts = ts;
     $scope.formatDate = DateHelper.formatDate;
 
     (function init () {
       var hasCase = $scope.activity && !_.isEmpty($scope.activity.case);
 
-      $scope.isToFieldVisible = getToFieldVisibilityStatus();
+      $scope.areFromAndToFieldsVisible = getFromAndToFieldsVisibilityStatus();
 
       if (hasCase) {
         $scope.caseDetailUrl = getCaseDetailUrl();
@@ -193,10 +193,12 @@
     }
 
     /**
+     * Determines whether to show or hide the "From" and "To" fields from the view.
+     *
      * @returns {boolean} true when the current activity belongs to the communication group,
      *   but it's not a Print/Merge Document activity.
      */
-    function getToFieldVisibilityStatus () {
+    function getFromAndToFieldsVisibilityStatus () {
       var isNotPrintPdfActivity = $scope.activity && $scope.activity.type !== 'Print/Merge Document';
       var isCommunicationActivity = (($scope.activity && $scope.activity.category) || [])
         .indexOf('communication') >= 0;

--- a/ang/civicase/activity/card/directives/activity-card.directive.js
+++ b/ang/civicase/activity/card/directives/activity-card.directive.js
@@ -59,11 +59,14 @@
     var caseTypes = CaseType.getAll();
     var caseTypeCategories = CaseTypeCategory.getAll();
 
+    $scope.isToFieldVisible = false;
     $scope.ts = ts;
     $scope.formatDate = DateHelper.formatDate;
 
     (function init () {
       var hasCase = $scope.activity && !_.isEmpty($scope.activity.case);
+
+      $scope.isToFieldVisible = getToFieldVisibilityStatus();
 
       if (hasCase) {
         $scope.caseDetailUrl = getCaseDetailUrl();
@@ -187,6 +190,18 @@
       var angularParams = $.param({ caseId: $scope.activity.case_id });
 
       return $filter('civicaseCrmUrl')(caseDetailUrl) + '?' + angularParams;
+    }
+
+    /**
+     * @returns {boolean} true when the current activity belongs to the communication group,
+     *   but it's not a Print/Merge Document activity.
+     */
+    function getToFieldVisibilityStatus () {
+      var isNotPrintPdfActivity = $scope.activity && $scope.activity.type !== 'Print/Merge Document';
+      var isCommunicationActivity = (($scope.activity && $scope.activity.category) || [])
+        .indexOf('communication') >= 0;
+
+      return isCommunicationActivity && isNotPrintPdfActivity;
     }
   }
 })(angular, CRM.$, CRM._);

--- a/ang/test/civicase/activity/card/directives/activity-card.directive.spec.js
+++ b/ang/test/civicase/activity/card/directives/activity-card.directive.spec.js
@@ -43,8 +43,8 @@
         expect(activityCard.isolateScope().bootstrapThemeElement.is('#bootstrap-theme')).toBe(true);
       });
 
-      it('defines the to field visibility as false', () => {
-        expect(activityCard.isolateScope().isToFieldVisible).toBe(false);
+      it('defines the "From" and "To" fields visibility as false', () => {
+        expect(activityCard.isolateScope().areFromAndToFieldsVisible).toBe(false);
       });
 
       describe('when the activity does not belong to a case', () => {
@@ -98,7 +98,7 @@
       });
     });
 
-    describe('"To:" field visibility', () => {
+    describe('"From" and "To" fields visibility', () => {
       beforeEach(() => {
         $scope.activity = activitiesMockData.get()[0];
       });
@@ -111,8 +111,8 @@
           initDirective();
         });
 
-        it('does not show the "To:" field', () => {
-          expect(activityCard.isolateScope().isToFieldVisible).toBe(false);
+        it('does not show the "From" and "To" fields', () => {
+          expect(activityCard.isolateScope().areFromAndToFieldsVisible).toBe(false);
         });
       });
 
@@ -124,8 +124,8 @@
           initDirective();
         });
 
-        it('shows the "To:" field', () => {
-          expect(activityCard.isolateScope().isToFieldVisible).toBe(true);
+        it('shows the "From" and "To" fields', () => {
+          expect(activityCard.isolateScope().areFromAndToFieldsVisible).toBe(true);
         });
       });
 
@@ -137,8 +137,8 @@
           initDirective();
         });
 
-        it('does not show the "To:" field', () => {
-          expect(activityCard.isolateScope().isToFieldVisible).toBe(false);
+        it('does not show the "From" and "To" fields', () => {
+          expect(activityCard.isolateScope().areFromAndToFieldsVisible).toBe(false);
         });
       });
     });

--- a/ang/test/civicase/activity/card/directives/activity-card.directive.spec.js
+++ b/ang/test/civicase/activity/card/directives/activity-card.directive.spec.js
@@ -43,6 +43,10 @@
         expect(activityCard.isolateScope().bootstrapThemeElement.is('#bootstrap-theme')).toBe(true);
       });
 
+      it('defines the to field visibility as false', () => {
+        expect(activityCard.isolateScope().isToFieldVisible).toBe(false);
+      });
+
       describe('when the activity does not belong to a case', () => {
         it('does not store a link to a case details page', () => {
           expect($scope.caseDetailUrl).not.toBeDefined();
@@ -91,6 +95,51 @@
 
           return $filter('civicaseCrmUrl')(caseDetailUrl) + '?' + angularParams;
         }
+      });
+    });
+
+    describe('"To:" field visibility', () => {
+      beforeEach(() => {
+        $scope.activity = activitiesMockData.get()[0];
+      });
+
+      describe('when the activity is a communication of the "Print/Merge Document" type', () => {
+        beforeEach(() => {
+          $scope.activity.category = 'communication';
+          $scope.activity.type = 'Print/Merge Document';
+
+          initDirective();
+        });
+
+        it('does not show the "To:" field', () => {
+          expect(activityCard.isolateScope().isToFieldVisible).toBe(false);
+        });
+      });
+
+      describe('when the activity is any communication other than the "Print/Merge Document" type', () => {
+        beforeEach(() => {
+          $scope.activity.category = 'communication';
+          $scope.activity.type = 'Email';
+
+          initDirective();
+        });
+
+        it('shows the "To:" field', () => {
+          expect(activityCard.isolateScope().isToFieldVisible).toBe(true);
+        });
+      });
+
+      describe('when the activity is not a communication', () => {
+        beforeEach(() => {
+          $scope.activity.category = 'milestone';
+          $scope.activity.type = 'Open Case';
+
+          initDirective();
+        });
+
+        it('does not show the "To:" field', () => {
+          expect(activityCard.isolateScope().isToFieldVisible).toBe(false);
+        });
       });
     });
 

--- a/ang/test/civicase/activity/card/directives/activity-card.directive.spec.js
+++ b/ang/test/civicase/activity/card/directives/activity-card.directive.spec.js
@@ -156,7 +156,7 @@
         expect(viewInPopup).toHaveBeenCalledWith(null, activity);
       });
 
-      it('listenes for the the form to be saved', () => {
+      it('listens for the the form to be saved', () => {
         expect(viewInPopupMockReturn.on).toHaveBeenCalledWith('crmFormSuccess', jasmine.any(Function));
       });
 


### PR DESCRIPTION
## Overview
This PR hides the "To:" field from the activity card for "Print/Merge Document" (PDF Letter) activity types.

## Before
![Screen Shot 2020-04-06 at 5 15 15 PM](https://user-images.githubusercontent.com/1642119/78605810-374d6500-782a-11ea-803d-3664dcbf5487.png)

## After
![Screen Shot 2020-04-06 at 5 14 52 PM](https://user-images.githubusercontent.com/1642119/78605817-3ae0ec00-782a-11ea-8ead-8b6e9eb62789.png)

## Technical Details

Since the logic to display the "To" field became more complex we moved it from the view to the controller. The view only checks whether `isToFieldVisible` is true or false. When the activity card is initialized we set the visibility value using the newly introduced `getToFieldVisibilityStatus` function:

```js
    function getToFieldVisibilityStatus () {
      var isNotPrintPdfActivity = $scope.activity && $scope.activity.type !== 'Print/Merge Document';
      var isCommunicationActivity = (($scope.activity && $scope.activity.category) || [])
        .indexOf('communication') >= 0;

      return isCommunicationActivity && isNotPrintPdfActivity;
    }
```