### PR TITLE
RSE-896: Fix Case tags

### DIFF
--- a/ang/civicase/shared/directives/tags-container.directive.js
+++ b/ang/civicase/shared/directives/tags-container.directive.js
@@ -18,6 +18,8 @@
 
   /**
    * Controller function
+   *
+   * @param {object} $scope a reference to the scope object.
    */
   function civicaseTagsContainerController ($scope) {
     $scope.tagsArray = [];

--- a/ang/civicase/shared/directives/tags-container.directive.js
+++ b/ang/civicase/shared/directives/tags-container.directive.js
@@ -26,9 +26,9 @@
 
     (function init () {
       $scope.$watch('tags', function () {
-        if ($scope.tags) {
-          $scope.tagsArray = Object.values($scope.tags);
-        }
+        $scope.tagsArray = $scope.tags
+          ? _.values($scope.tags)
+          : [];
       });
     }());
   }

--- a/ang/test/civicase/shared/directives/tags-container.directive.spec.js
+++ b/ang/test/civicase/shared/directives/tags-container.directive.spec.js
@@ -36,7 +36,7 @@
     /**
      * Initialise the controller
      *
-     * @param {Object} tags
+     * @param {object} tags a list of tags to include in the scrope.
      */
     function initController (tags) {
       $scope = $rootScope.$new();

--- a/ang/test/civicase/shared/directives/tags-container.directive.spec.js
+++ b/ang/test/civicase/shared/directives/tags-container.directive.spec.js
@@ -33,10 +33,21 @@
       });
     });
 
+    describe('when passing an empty object of tags', () => {
+      beforeEach(() => {
+        initController({});
+        $scope.$digest();
+      });
+
+      it('sets the tags array as empty', () => {
+        expect($scope.tagsArray).toEqual([]);
+      });
+    });
+
     /**
      * Initialise the controller
      *
-     * @param {object} tags a list of tags to include in the scrope.
+     * @param {object} tags a list of tags to include in the scope.
      */
     function initController (tags) {
       $scope = $rootScope.$new();

--- a/ang/test/civicase/shared/directives/tags-container.directive.spec.js
+++ b/ang/test/civicase/shared/directives/tags-container.directive.spec.js
@@ -1,8 +1,8 @@
 /* eslint-env jasmine */
 
-(function () {
-  describe('civicaseTag', function () {
-    var $controller, $rootScope, $scope, mockTags;
+(() => {
+  describe('civicaseTag', () => {
+    let $controller, $rootScope, $scope, mockTags;
 
     beforeEach(module('civicase'));
 
@@ -22,13 +22,13 @@
       };
     }));
 
-    describe('on init', function () {
-      beforeEach(function () {
+    describe('on init', () => {
+      beforeEach(() => {
         initController(mockTags);
         $scope.$digest();
       });
 
-      it('converts the tags object into an array', function () {
+      it('converts the tags object into an array', () => {
         expect($scope.tagsArray).toEqual(Object.values(mockTags));
       });
     });


### PR DESCRIPTION
## Overview
This PR fixes an issue with tags displayed on case details. When switching from a case with tags to another case without them the tags from the previous case would be displayed in the current one.

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/78607741-a5dff200-782d-11ea-8f49-e001b97944d6.gif)

## After
![pr-after](https://user-images.githubusercontent.com/1642119/78607750-aa0c0f80-782d-11ea-8047-b29ecd50c437.gif)

## Technical Details

When the tags container directive was first introduced in https://github.com/compucorp/uk.co.compucorp.civicase/pull/173 we used a condition to update the values of the tags from an object input to an array of objects. Since this was added conditionally when we switched from a case with tags to another without the tags of the previous one would still persist. To fix this we removed the condition and set the tags array to empty if no tags were provided to the directive.

We also removed `Object.values` in favour of `_.values` since the former is [not supported by Internet Explorer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Object/values)