### PR TITLE
CPS-77: Fix for Add Case button in Contact Tab not redirecting to Webforms

### DIFF
--- a/ang/civicase/case/services/add-case.service.js
+++ b/ang/civicase/case/services/add-case.service.js
@@ -6,12 +6,10 @@
   /**
    * Add Case Service
    *
-   * @param {object} ts ts
-   * @param {object} $location the location service.
    * @param {object} $window the window service.
    * @param {string} CaseCategoryWebformSettings service to fetch case category webform settings
    */
-  function AddCaseService (ts, $location, $window, CaseCategoryWebformSettings) {
+  function AddCaseService ($window, CaseCategoryWebformSettings) {
     this.clickHandler = clickHandler;
     this.isVisible = isVisible;
 

--- a/ang/civicase/case/services/add-case.service.js
+++ b/ang/civicase/case/services/add-case.service.js
@@ -1,0 +1,87 @@
+(function (_, angular, checkPerm, loadForm, getCrmUrl) {
+  var module = angular.module('civicase');
+
+  module.service('AddCase', AddCaseService);
+
+  /**
+   * Add Case Service
+   *
+   * @param {object} ts ts
+   * @param {object} $location the location service.
+   * @param {object} $window the window service.
+   * @param {string} CaseCategoryWebformSettings service to fetch case category webform settings
+   */
+  function AddCaseService (ts, $location, $window, CaseCategoryWebformSettings) {
+    this.clickHandler = clickHandler;
+    this.isVisible = isVisible;
+
+    /**
+     * Displays a form to add a new case. If a custom "Add Case" webform url has been configured,
+     * it will redirect to it. Otherwise it will open a CRM form popup to add a new case.
+     *
+     * @param {string} caseTypeCategory case type category
+     * @param {string} contactId contact id
+     * @param {Function} callback callback function
+     */
+    function clickHandler (caseTypeCategory, contactId, callback) {
+      var webformSettings = CaseCategoryWebformSettings.getSettingsFor(caseTypeCategory);
+      var hasCustomNewCaseWebformUrl = !!webformSettings.newCaseWebformUrl;
+
+      hasCustomNewCaseWebformUrl
+        ? redirectToCustomNewCaseWebformUrl(webformSettings, contactId)
+        : openNewCaseForm(caseTypeCategory, contactId, callback);
+    }
+
+    /**
+     * Will display the button if the user can add cases.
+     *
+     * @returns {boolean} returns true when the user can add cases.
+     */
+    function isVisible () {
+      var canAddCases = checkPerm('add cases');
+
+      return canAddCases;
+    }
+
+    /**
+     * Opens a new CRM form popup to add new cases. If a case type category was defined we
+     * use it to limit the type of cases that can be created by this category.
+     *
+     * @param {string} caseTypeCategory case type category
+     * @param {string} contactId contact id
+     * @param {Function} callback callback function
+     */
+    function openNewCaseForm (caseTypeCategory, contactId, callback) {
+      var formParams = {
+        action: 'add',
+        case_type_category: caseTypeCategory,
+        context: 'standalone',
+        reset: 1
+      };
+
+      if (contactId) {
+        formParams.civicase_cid = contactId;
+      }
+
+      var formUrl = getCrmUrl('civicrm/case/add', formParams);
+
+      loadForm(formUrl)
+        .on('crmFormSuccess crmPopupFormSuccess', callback);
+    }
+
+    /**
+     * Redirects the user to the custom webform URL as defined in the configuration.
+     *
+     * @param {string} webformSettings web form settings
+     * @param {string} contactId contact id
+     */
+    function redirectToCustomNewCaseWebformUrl (webformSettings, contactId) {
+      var url = webformSettings.newCaseWebformUrl;
+
+      if (contactId) {
+        url += '?' + webformSettings.newCaseWebformClient + '=' + contactId;
+      }
+      $window.location.href = url;
+    }
+  }
+})(CRM._, angular, CRM.checkPerm, CRM.loadForm, CRM.url);

--- a/ang/civicase/case/services/add-case.service.js
+++ b/ang/civicase/case/services/add-case.service.js
@@ -17,17 +17,15 @@
      * Displays a form to add a new case. If a custom "Add Case" webform url has been configured,
      * it will redirect to it. Otherwise it will open a CRM form popup to add a new case.
      *
-     * @param {string} caseTypeCategory case type category
-     * @param {string} contactId contact id
-     * @param {Function} callback callback function
+     * @param {addCaseConfig} params parameters
      */
-    function clickHandler (caseTypeCategory, contactId, callback) {
-      var webformSettings = CaseCategoryWebformSettings.getSettingsFor(caseTypeCategory);
+    function clickHandler (params) {
+      var webformSettings = CaseCategoryWebformSettings.getSettingsFor(params.caseTypeCategoryName);
       var hasCustomNewCaseWebformUrl = !!webformSettings.newCaseWebformUrl;
 
       hasCustomNewCaseWebformUrl
-        ? redirectToCustomNewCaseWebformUrl(webformSettings, contactId)
-        : openNewCaseForm(caseTypeCategory, contactId, callback);
+        ? redirectToCustomNewCaseWebformUrl(webformSettings, params.contactId)
+        : openNewCaseForm(params);
     }
 
     /**
@@ -45,26 +43,24 @@
      * Opens a new CRM form popup to add new cases. If a case type category was defined we
      * use it to limit the type of cases that can be created by this category.
      *
-     * @param {string} caseTypeCategory case type category
-     * @param {string} contactId contact id
-     * @param {Function} callback callback function
+     * @param {addCaseConfig} params parameters
      */
-    function openNewCaseForm (caseTypeCategory, contactId, callback) {
+    function openNewCaseForm (params) {
       var formParams = {
         action: 'add',
-        case_type_category: caseTypeCategory,
+        case_type_category: params.caseTypeCategoryName,
         context: 'standalone',
         reset: 1
       };
 
-      if (contactId) {
-        formParams.civicase_cid = contactId;
+      if (params.contactId) {
+        formParams.civicase_cid = params.contactId;
       }
 
       var formUrl = getCrmUrl('civicrm/case/add', formParams);
 
       loadForm(formUrl)
-        .on('crmFormSuccess crmPopupFormSuccess', callback);
+        .on('crmFormSuccess crmPopupFormSuccess', params.callbackFn);
     }
 
     /**
@@ -79,7 +75,15 @@
       if (contactId) {
         url += '?' + webformSettings.newCaseWebformClient + '=' + contactId;
       }
+
       $window.location.href = url;
     }
+
+    /**
+     * @typedef {object} addCaseConfig
+     * @property {string} caseTypeCategoryName the case category name
+     * @property {number} contactId contact id
+     * @property {number} callbackFn callback function
+     */
   }
 })(CRM._, angular, CRM.checkPerm, CRM.loadForm, CRM.url);

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
@@ -6,16 +6,9 @@
   <!-- Added for SEO purpose (This will be hidden through css) -->
   <h1 crm-page-title class="element-invisible"> {{ ts('Related cases to the user') }} </h1>
   <div class="civicase__contact-cases-tab clearfix">
-    <a ng-if="checkPerm('add cases') && !webformSettings.newCaseWebformUrl"
+    <a ng-if="isVisible()"
       class="btn-primary btn civicase__contact-cases-tab-add"
-      ng-href="{{ 'civicrm/case/add' | civicaseCrmUrl:{civicase_cid: contactId, reset: 1, action: 'add', context: 'standalone', case_type_category: caseTypeCategoryName } }}"
-      crm-popup-form-success="refresh()">
-      <i class="material-icons">add_circle</i>
-      {{ ts('Add case') }}
-    </a>
-    <a ng-if="checkPerm('add cases') && webformSettings.newCaseWebformUrl"
-      class="btn-primary btn"
-      ng-href="{{ webformSettings.newCaseWebformUrl | civicaseCrmUrl:{[webformSettings.newCaseWebformClient]: contactId} }}">
+      ng-click="clickHandler(caseTypeCategoryName, contactId, refresh)">
       <i class="material-icons">add_circle</i>
       {{ ts('Add case') }}
     </a>
@@ -127,10 +120,10 @@
     <div class="civicase__activity-no-result-icon civicase__activity-no-result-icon--case"></div>
     <div class="civicase__activity-card--big--empty-title"> {{ ts('This contact has no cases') }} </div>
     <div class="civicase__activity-card--big--empty-description"> {{ ts('Click the button below to create a new case for this contact') }} </div>
-    <a ng-if="checkPerm('add cases')"
+    <a
+      ng-if="isVisible()"
       class="civicase__activity-card--big--empty-button btn"
-      ng-href="{{ 'civicrm/case/add' | civicaseCrmUrl:{civicase_cid: contactId, reset: 1, action: 'add', context: 'standalone', case_type_category: caseTypeCategoryName } }}"
-      crm-popup-form-success="refresh()">
+      ng-click="clickHandler(caseTypeCategoryName, contactId, refresh)">
       {{ ts('Add new case') }}
     </a>
   </div>

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
@@ -8,7 +8,11 @@
   <div class="civicase__contact-cases-tab clearfix">
     <a ng-if="isAddCaseVisible()"
       class="btn-primary btn civicase__contact-cases-tab-add"
-      ng-click="addCase(caseTypeCategoryName, contactId, refresh)">
+      ng-click="addCase({
+        caseTypeCategoryName: caseTypeCategoryName,
+        contactId: contactId,
+        callbackFn: refresh,
+      })">
       <i class="material-icons">add_circle</i>
       {{ ts('Add case') }}
     </a>
@@ -123,7 +127,11 @@
     <a
       ng-if="isAddCaseVisible()"
       class="civicase__activity-card--big--empty-button btn"
-      ng-click="addCase(caseTypeCategoryName, contactId, refresh)">
+      ng-click="addCase({
+        caseTypeCategoryName: caseTypeCategoryName,
+        contactId: contactId,
+        callbackFn: refresh,
+      })">
       {{ ts('Add new case') }}
     </a>
   </div>

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
@@ -6,9 +6,9 @@
   <!-- Added for SEO purpose (This will be hidden through css) -->
   <h1 crm-page-title class="element-invisible"> {{ ts('Related cases to the user') }} </h1>
   <div class="civicase__contact-cases-tab clearfix">
-    <a ng-if="isVisible()"
+    <a ng-if="isAddCaseVisible()"
       class="btn-primary btn civicase__contact-cases-tab-add"
-      ng-click="clickHandler(caseTypeCategoryName, contactId, refresh)">
+      ng-click="addCase(caseTypeCategoryName, contactId, refresh)">
       <i class="material-icons">add_circle</i>
       {{ ts('Add case') }}
     </a>
@@ -121,9 +121,9 @@
     <div class="civicase__activity-card--big--empty-title"> {{ ts('This contact has no cases') }} </div>
     <div class="civicase__activity-card--big--empty-description"> {{ ts('Click the button below to create a new case for this contact') }} </div>
     <a
-      ng-if="isVisible()"
+      ng-if="isAddCaseVisible()"
       class="civicase__activity-card--big--empty-button btn"
-      ng-click="clickHandler(caseTypeCategoryName, contactId, refresh)">
+      ng-click="addCase(caseTypeCategoryName, contactId, refresh)">
       {{ ts('Add new case') }}
     </a>
   </div>

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
@@ -74,8 +74,8 @@
       }
     ];
 
-    $scope.clickHandler = AddCase.clickHandler;
-    $scope.isVisible = AddCase.isVisible;
+    $scope.addCase = AddCase.clickHandler;
+    $scope.isAddCaseVisible = AddCase.isVisible;
     $scope.checkPerm = CRM.checkPerm;
     $scope.handleContactTabChange = handleContactTabChange;
     $scope.ts = ts;

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
@@ -23,11 +23,11 @@
    * @param {Function} formatCase the format case service
    * @param {object} Contact the contact service
    * @param {object} ContactsCache the contacts cache service
-   * @param {string} CaseCategoryWebformSettings service to fetch case category webform settings
+   * @param {string} AddCase service to open add case popup
    */
   function CivicaseContactCaseTabController ($scope, ts, CaseTypeCategory,
     CaseTypeCategoryTranslationService, crmApi, formatCase, Contact,
-    ContactsCache, CaseCategoryWebformSettings) {
+    ContactsCache, AddCase) {
     var commonConfigs = {
       isLoaded: false,
       showSpinner: false,
@@ -41,7 +41,6 @@
     $scope.caseDetailsLoaded = false;
     $scope.caseTypeCategoryName = CaseTypeCategory.getAll()[$scope.caseTypeCategory].name;
     $scope.contactId = Contact.getCurrentContactID();
-    $scope.webformSettings = CaseCategoryWebformSettings.getSettingsFor($scope.caseTypeCategoryName);
     $scope.casesListConfig = [
       {
         name: 'opened',
@@ -75,6 +74,8 @@
       }
     ];
 
+    $scope.clickHandler = AddCase.clickHandler;
+    $scope.isVisible = AddCase.isVisible;
     $scope.checkPerm = CRM.checkPerm;
     $scope.handleContactTabChange = handleContactTabChange;
     $scope.ts = ts;

--- a/ang/civicase/dashboard/directives/add-case-dashboard-action-button.controller.js
+++ b/ang/civicase/dashboard/directives/add-case-dashboard-action-button.controller.js
@@ -21,7 +21,9 @@
      * Click handler for the Add Case Dashboard button.
      */
     function clickHandler () {
-      AddCase.clickHandler(getCaseTypeCategory());
+      AddCase.clickHandler({
+        caseTypeCategoryName: getCaseTypeCategory()
+      });
     }
 
     /**

--- a/ang/civicase/dashboard/directives/add-case-dashboard-action-button.controller.js
+++ b/ang/civicase/dashboard/directives/add-case-dashboard-action-button.controller.js
@@ -8,30 +8,20 @@
    *
    * @param {object} $scope scope object
    * @param {object} ts ts
-   * @param {object} $location the location service.
-   * @param {object} $window the window service.
-   * @param {string} currentCaseCategory the current case type category configuration value.
-   * @param {string} CaseCategoryWebformSettings service to fetch case category webform settings
+   * @param {object} $location the location service
+   * @param {object} AddCase Add Case Service
    */
-  function AddCaseDashboardActionButtonController ($scope, ts, $location, $window,
-    currentCaseCategory, CaseCategoryWebformSettings) {
-    var webformSettings = CaseCategoryWebformSettings.getSettingsFor(currentCaseCategory);
-
+  function AddCaseDashboardActionButtonController ($scope, ts, $location, AddCase) {
     $scope.ts = ts;
 
     $scope.clickHandler = clickHandler;
-    $scope.isVisible = isVisible;
+    $scope.isVisible = AddCase.isVisible;
 
     /**
-     * Displays a form to add a new case. If a custom "Add Case" webform url has been configured,
-     * it will redirect to it. Otherwise it will open a CRM form popup to add a new case.
+     * Click handler for the Add Case Dashboard button.
      */
     function clickHandler () {
-      var hasCustomNewCaseWebformUrl = !!webformSettings.newCaseWebformUrl;
-
-      hasCustomNewCaseWebformUrl
-        ? redirectToCustomNewCaseWebformUrl()
-        : openNewCaseForm();
+      AddCase.clickHandler(getCaseTypeCategory());
     }
 
     /**
@@ -43,41 +33,6 @@
       var currentUrlParams = $location.search();
 
       return currentUrlParams.case_type_category;
-    }
-
-    /**
-     * Will display the button if the user can add cases.
-     *
-     * @returns {boolean} returns true when the user can add cases.
-     */
-    function isVisible () {
-      var canAddCases = checkPerm('add cases');
-
-      return canAddCases;
-    }
-
-    /**
-     * Opens a new CRM form popup to add new cases. If a case type category was defined we
-     * use it to limit the type of cases that can be created by this category.
-     */
-    function openNewCaseForm () {
-      var caseTypeCategory = getCaseTypeCategory();
-
-      var formUrl = getCrmUrl('civicrm/case/add', {
-        action: 'add',
-        case_type_category: caseTypeCategory || currentCaseCategory,
-        context: 'standalone',
-        reset: 1
-      });
-
-      loadForm(formUrl);
-    }
-
-    /**
-     * Redirects the user to the custom webform URL as defined in the configuration.
-     */
-    function redirectToCustomNewCaseWebformUrl () {
-      $window.location.href = webformSettings.newCaseWebformUrl;
     }
   }
 })(CRM._, angular, CRM.checkPerm, CRM.loadForm, CRM.url);

--- a/ang/test/civicase/case/services/add-case.service.spec.js
+++ b/ang/test/civicase/case/services/add-case.service.spec.js
@@ -1,0 +1,133 @@
+/* eslint-env jasmine */
+
+(($, loadForm, getCrmUrl) => {
+  describe('AddCaseService', () => {
+    let $window, AddCase, mockedFormPopUp, CaseCategoryWebformSettings;
+
+    beforeEach(() => {
+      $window = { location: { href: '' } };
+    });
+
+    describe('Button Visibility', () => {
+      let isButtonVisible;
+
+      beforeEach(module('civicase-base', 'civicase'));
+      beforeEach(() => {
+        injectDependencies();
+      });
+
+      describe('when the user can add new cases', () => {
+        beforeEach(() => {
+          CRM.checkPerm.and.returnValue(true);
+
+          isButtonVisible = AddCase.isVisible();
+        });
+
+        it('displays the button', () => {
+          expect(isButtonVisible).toBe(true);
+        });
+      });
+
+      describe('when the user cannot add new cases', () => {
+        beforeEach(() => {
+          CRM.checkPerm.and.returnValue(false);
+
+          isButtonVisible = AddCase.isVisible();
+        });
+
+        it('does not display the button', () => {
+          expect(isButtonVisible).toBe(false);
+        });
+      });
+    });
+
+    describe('click handler', () => {
+      beforeEach(module('civicase', ($provide) => {
+        CaseCategoryWebformSettings = jasmine.createSpyObj('CaseCategoryWebformSettings', ['getSettingsFor']);
+        $provide.value('CaseCategoryWebformSettings', CaseCategoryWebformSettings);
+      }));
+
+      describe('when the new case web form url configuration value is defined', () => {
+        beforeEach(module('civicase', ($provide) => {
+          $provide.value('$window', $window);
+          CaseCategoryWebformSettings.getSettingsFor.and.returnValue({
+            newCaseWebformUrl: '/someurl',
+            newCaseWebformClient: 'cid'
+          });
+        }));
+
+        beforeEach(() => {
+          injectDependencies();
+          AddCase.clickHandler('case', '5');
+        });
+
+        it('redirects the user to the configured web form url value', () => {
+          expect($window.location.href).toBe('/someurl?cid=5');
+        });
+      });
+
+      describe('when the new case web form url configuration value is not defined', () => {
+        beforeEach(module('civicase-base', 'civicase', ($provide) => {
+          CaseCategoryWebformSettings.getSettingsFor.and.returnValue({ newCaseWebformUrl: null });
+          $provide.value('$window', $window);
+        }));
+
+        beforeEach(() => {
+          injectDependencies();
+          mockFormPopUpDom();
+          AddCase.clickHandler();
+        });
+
+        it('does not redirect the user', () => {
+          expect($window.location.href).toBe('');
+        });
+      });
+
+      describe('opening a new case form popup', () => {
+        let expectedFormUrl;
+
+        beforeEach(module('civicase', 'civicase.data', ($provide) => {
+          CaseCategoryWebformSettings.getSettingsFor.and.returnValue({ newCaseWebformUrl: null });
+        }));
+
+        beforeEach(() => {
+          injectDependencies();
+          mockFormPopUpDom();
+
+          expectedFormUrl = getCrmUrl('civicrm/case/add', {
+            action: 'add',
+            case_type_category: 'case',
+            civicase_cid: '5',
+            context: 'standalone',
+            reset: 1
+          });
+
+          AddCase.clickHandler('case', '5');
+        });
+
+        it('opens the new case form', () => {
+          expect(loadForm).toHaveBeenCalledWith(expectedFormUrl);
+        });
+      });
+    });
+
+    /**
+     * Injects and hoists the dependencies used by this spec file.
+     */
+    function injectDependencies () {
+      inject((_$window_, _AddCase_) => {
+        $window = _$window_;
+        AddCase = _AddCase_;
+      });
+    }
+
+    /**
+     * Creates a mocked popup element that will be returned by the load form function.
+     */
+    function mockFormPopUpDom () {
+      mockedFormPopUp = $('<div></div>');
+
+      loadForm.and.returnValue(mockedFormPopUp);
+    }
+  });
+})(CRM.$, CRM.loadForm, CRM.url);

--- a/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
+++ b/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
@@ -3,7 +3,7 @@
 ((_) => {
   describe('Contact Case Tab', () => {
     var $controller, $rootScope, $scope, CaseTypeCategoryTranslationService,
-      crmApi, mockContactId, mockContactService;
+      crmApi, mockContactId, mockContactService, AddCase;
 
     beforeEach(module('civicase.data', 'civicase', ($provide) => {
       mockContactService = jasmine.createSpyObj('Contact', ['getCurrentContactID']);
@@ -12,10 +12,11 @@
     }));
 
     beforeEach(inject((_$controller_, _$rootScope_, _CaseTypeCategoryTranslationService_,
-      _crmApi_) => {
+      _crmApi_, _AddCase_) => {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       CaseTypeCategoryTranslationService = _CaseTypeCategoryTranslationService_;
+      AddCase = _AddCase_;
       crmApi = _crmApi_;
 
       spyOn(CaseTypeCategoryTranslationService, 'restoreTranslation');
@@ -109,6 +110,35 @@
         it('does not restore the case type category translation', () => {
           expect(CaseTypeCategoryTranslationService.restoreTranslation)
             .not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('Add Case Button', () => {
+      beforeEach(() => {
+        spyOn(AddCase, 'clickHandler');
+        spyOn(AddCase, 'isVisible');
+      });
+
+      describe('visibility of Add Case Button', () => {
+        beforeEach(() => {
+          initController();
+          $scope.isAddCaseVisible();
+        });
+
+        it('displays the Add Case button only when adequate permission is available', () => {
+          expect(AddCase.isVisible).toHaveBeenCalled();
+        });
+      });
+
+      describe('when clicking on Add Case Button', () => {
+        beforeEach(() => {
+          initController();
+          $scope.addCase('cases', '5', jasmine.any(Function));
+        });
+
+        it('creates a new case', () => {
+          expect(AddCase.clickHandler).toHaveBeenCalledWith('cases', '5', jasmine.any(Function));
         });
       });
     });

--- a/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
+++ b/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
@@ -134,11 +134,19 @@
       describe('when clicking on Add Case Button', () => {
         beforeEach(() => {
           initController();
-          $scope.addCase('cases', '5', jasmine.any(Function));
+          $scope.addCase({
+            caseTypeCategoryName: 'cases',
+            contactId: '5',
+            callbackFn: jasmine.any(Function)
+          });
         });
 
         it('creates a new case', () => {
-          expect(AddCase.clickHandler).toHaveBeenCalledWith('cases', '5', jasmine.any(Function));
+          expect(AddCase.clickHandler).toHaveBeenCalledWith({
+            caseTypeCategoryName: 'cases',
+            contactId: '5',
+            callbackFn: jasmine.any(Function)
+          });
         });
       });
     });

--- a/ang/test/civicase/dashboard/directives/add-case-dashboard-action-button.controller.spec.js
+++ b/ang/test/civicase/dashboard/directives/add-case-dashboard-action-button.controller.spec.js
@@ -1,138 +1,39 @@
 /* eslint-env jasmine */
 
-(($, loadForm, getCrmUrl) => {
+(($) => {
   describe('AddCaseDashboardActionButtonController', () => {
-    let $location, $window, $rootScope, $scope, $controller, currentCaseCategory,
-      mockedFormPopUp, CaseCategoryWebformSettings;
+    let $location, $rootScope, $scope, $controller, AddCase;
 
-    beforeEach(() => {
-      $window = { location: { href: '' } };
-    });
+    beforeEach(module('civicase-base', 'civicase'));
 
     describe('Button Visibility', () => {
-      let isButtonVisible;
-
-      beforeEach(module('civicase-base', 'civicase'));
       beforeEach(() => {
         injectDependencies();
+        spyOn(AddCase, 'isVisible');
+        initController();
+
+        $scope.isVisible();
       });
 
-      describe('when the user can add new cases', () => {
-        beforeEach(() => {
-          CRM.checkPerm.and.returnValue(true);
-
-          isButtonVisible = $scope.isVisible();
-        });
-
-        it('displays the button', () => {
-          expect(isButtonVisible).toBe(true);
-        });
-      });
-
-      describe('when the user cannot add new cases', () => {
-        beforeEach(() => {
-          CRM.checkPerm.and.returnValue(false);
-
-          isButtonVisible = $scope.isVisible();
-        });
-
-        it('does not display the button', () => {
-          expect(isButtonVisible).toBe(false);
-        });
+      it('displays the Add Case button only when adequate permission is available', () => {
+        expect(AddCase.isVisible).toHaveBeenCalled();
       });
     });
 
-    describe('click handler', () => {
-      beforeEach(module('civicase', ($provide) => {
-        CaseCategoryWebformSettings = jasmine.createSpyObj('CaseCategoryWebformSettings', ['getSettingsFor']);
-        $provide.value('CaseCategoryWebformSettings', CaseCategoryWebformSettings);
-      }));
-
-      describe('when the new case web form url configuration value is defined', () => {
-        beforeEach(module('civicase', ($provide) => {
-          $provide.value('$window', $window);
-          CaseCategoryWebformSettings.getSettingsFor.and.returnValue({ newCaseWebformUrl: '/someurl' });
-        }));
-
-        beforeEach(() => {
-          injectDependencies();
-          $scope.clickHandler();
+    describe('Click Event', () => {
+      beforeEach(() => {
+        injectDependencies();
+        spyOn(AddCase, 'clickHandler');
+        spyOn($location, 'search').and.returnValue({
+          case_type_category: 'cases'
         });
+        initController();
 
-        it('redirects the user to the configured web form url value', () => {
-          expect($window.location.href).toBe('/someurl');
-        });
+        $scope.clickHandler();
       });
 
-      describe('when the new case web form url configuration value is not defined', () => {
-        beforeEach(module('civicase-base', 'civicase', ($provide) => {
-          CaseCategoryWebformSettings.getSettingsFor.and.returnValue({ newCaseWebformUrl: null });
-          $provide.value('$window', $window);
-        }));
-
-        beforeEach(() => {
-          injectDependencies();
-          mockFormPopUpDom();
-          $scope.clickHandler();
-        });
-
-        it('does not redirect the user', () => {
-          expect($window.location.href).toBe('');
-        });
-      });
-
-      describe('opening a new case form popup', () => {
-        let expectedFormUrl;
-
-        beforeEach(module('civicase', 'civicase.data', ($provide) => {
-          CaseCategoryWebformSettings.getSettingsFor.and.returnValue({ newCaseWebformUrl: null });
-        }));
-
-        beforeEach(() => {
-          injectDependencies();
-          mockFormPopUpDom();
-
-          spyOn($location, 'search').and.returnValue({});
-        });
-
-        describe('when creating a new case from the default cases dashboard', () => {
-          beforeEach(() => {
-            expectedFormUrl = getCrmUrl('civicrm/case/add', {
-              action: 'add',
-              case_type_category: currentCaseCategory,
-              context: 'standalone',
-              reset: 1
-            });
-
-            $scope.clickHandler();
-          });
-
-          it('opens the new case form for the default case type category', () => {
-            expect(loadForm).toHaveBeenCalledWith(expectedFormUrl);
-          });
-        });
-
-        describe('when creating a new case from the dashboard of a custom case type category', () => {
-          const caseTypeCategory = 'traveling';
-
-          beforeEach(() => {
-            expectedFormUrl = getCrmUrl('civicrm/case/add', {
-              action: 'add',
-              case_type_category: caseTypeCategory,
-              context: 'standalone',
-              reset: 1
-            });
-
-            $location.search.and.returnValue({
-              case_type_category: caseTypeCategory
-            });
-            $scope.clickHandler();
-          });
-
-          it('opens the new case form for the custom case type category', () => {
-            expect(loadForm).toHaveBeenCalledWith(expectedFormUrl);
-          });
-        });
+      it('creates a new case', () => {
+        expect(AddCase.clickHandler).toHaveBeenCalledWith('cases');
       });
     });
 
@@ -149,25 +50,12 @@
      * Injects and hoists the dependencies used by this spec file.
      */
     function injectDependencies () {
-      inject((_$location_, _$rootScope_, _$window_, _$controller_,
-        _currentCaseCategory_) => {
+      inject((_$location_, _$rootScope_, _$controller_, _AddCase_) => {
         $location = _$location_;
-        $window = _$window_;
         $controller = _$controller_;
         $rootScope = _$rootScope_;
-        currentCaseCategory = _currentCaseCategory_;
-
-        initController();
+        AddCase = _AddCase_;
       });
     }
-
-    /**
-     * Creates a mocked popup element that will be returned by the load form function.
-     */
-    function mockFormPopUpDom () {
-      mockedFormPopUp = $('<div></div>');
-
-      loadForm.and.returnValue(mockedFormPopUp);
-    }
   });
-})(CRM.$, CRM.loadForm, CRM.url);
+})(CRM.$);

--- a/ang/test/civicase/dashboard/directives/add-case-dashboard-action-button.controller.spec.js
+++ b/ang/test/civicase/dashboard/directives/add-case-dashboard-action-button.controller.spec.js
@@ -33,7 +33,9 @@
       });
 
       it('creates a new case', () => {
-        expect(AddCase.clickHandler).toHaveBeenCalledWith('cases');
+        expect(AddCase.clickHandler).toHaveBeenCalledWith({
+          caseTypeCategoryName: 'cases'
+        });
       });
     });
 


### PR DESCRIPTION
## Overview
The Add Case button in Contact Tab((when there are no existing cases) did not redirect to Webforms even when webforms are configured for the case type category. This PR fixes this bug.

## Before
![before](https://user-images.githubusercontent.com/5058867/78640767-ea22cf00-78cd-11ea-92f0-571a17179445.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/78640712-d37c7800-78cd-11ea-9e56-c3729d7f7d6f.gif)

## Technical Details
**`AddCase` - A new Service**
A new service `AddCase` has been created, to reuse the common logic of creating a new case.
It has 2 functions,
1. `clickHandler` - It accepts 3 parameters and it abstracts the logic to either redirect to webform or open the new case popup.
    * caseTypeCategory - Case Category Name
    * contactId - contact ID (optional)
    * callback - call back function to be called after a case is created (optional)
2. `isVisible` - Checks the permission and returns true if the logged in user has permission to Add New Case.