### PR TITLE
CPS-107: Only display case statuses belonging to loaded case types

### DIFF
--- a/ang/civicase-base/providers/case-type-category.provider.js
+++ b/ang/civicase-base/providers/case-type-category.provider.js
@@ -30,7 +30,7 @@
       return {
         getAll: getAll,
         findByName: findByName,
-        getCategoriesWithAccessToActivity: getCategoriesWithAccessToActivity,
+        getCategoriesWithAccessToActivity: getCategoriesWithAccessToActivity
       };
     }
 
@@ -66,7 +66,7 @@
      */
     function findByName (caseTypeCategoryName) {
       return _.find(allCaseTypeCategories, function (category) {
-        return category.name === caseTypeCategoryName;
+        return category.name.toLowerCase() === caseTypeCategoryName.toLowerCase();
       });
     }
   }

--- a/ang/civicase-base/services/case-type-filterer/case-type-filterer.service.js
+++ b/ang/civicase-base/services/case-type-filterer/case-type-filterer.service.js
@@ -1,0 +1,45 @@
+(function (_, angular) {
+  var module = angular.module('civicase-base');
+
+  module.service('CaseTypeFilterer', CaseTypeFilterer);
+
+  /**
+   * CaseTypeFilterer
+   *
+   * @param {object} BelongsToCategoryCaseTypeFilter case type filter reference.
+   * @param {object} CaseType case type service reference.
+   * @param {object} HasIdCaseTypeFilter case type filter reference.
+   * @param {object} IsIncludedInListOfIdsCaseTypeFilter case type filter reference.
+   */
+  function CaseTypeFilterer (BelongsToCategoryCaseTypeFilter, CaseType,
+    HasIdCaseTypeFilter, IsIncludedInListOfIdsCaseTypeFilter) {
+    var listOfFilters = [
+      BelongsToCategoryCaseTypeFilter,
+      IsIncludedInListOfIdsCaseTypeFilter,
+      HasIdCaseTypeFilter
+    ];
+
+    this.filter = filter;
+
+    /**
+     * Returns a filtered list of case types. The case types are matched against
+     * a list of filters. These filters are selected depending on the parameters
+     * sent through `caseTypeFilters`.
+     *
+     * @param {object} caseTypeFilters parameters to use for filtering the case types.
+     * @returns {object[]} a list of case types.
+     */
+    function filter (caseTypeFilters) {
+      var caseTypes = _.values(CaseType.getAll());
+      var listOfFiltersToRun = _.filter(listOfFilters, function (filter) {
+        return filter.shouldRun(caseTypeFilters);
+      });
+
+      return _.filter(caseTypes, function (caseType) {
+        return _.every(listOfFiltersToRun, function (filter) {
+          return filter.run(caseType, caseTypeFilters);
+        });
+      });
+    }
+  }
+})(CRM._, angular);

--- a/ang/civicase-base/services/case-type-filterer/filters/belongs-to-category.service.js
+++ b/ang/civicase-base/services/case-type-filterer/filters/belongs-to-category.service.js
@@ -1,0 +1,35 @@
+(function (_, angular) {
+  var module = angular.module('civicase-base');
+
+  module.service('BelongsToCategoryCaseTypeFilter', BelongsToCategoryCaseTypeFilter);
+
+  /**
+   * BelongsToCategory Case Type Filter service.
+   *
+   * @param {object} CaseTypeCategory case type category service reference.
+   */
+  function BelongsToCategoryCaseTypeFilter (CaseTypeCategory) {
+    this.run = run;
+    this.shouldRun = shouldRun;
+
+    /**
+     * @param {object} caseType case type to match.
+     * @param {object} caseTypeFilters list of parameters to use for matching.
+     * @returns {boolean} true when the case type belongs to the given category.
+     */
+    function run (caseType, caseTypeFilters) {
+      var caseCategory = CaseTypeCategory
+        .findByName(caseTypeFilters.case_type_category);
+
+      return caseCategory && caseType.case_type_category === caseCategory.value;
+    }
+
+    /**
+     * @param {object} caseTypeFilters list of parameters to use for matching.
+     * @returns {boolean} true when filters include a case type category parameter.
+     */
+    function shouldRun (caseTypeFilters) {
+      return !!caseTypeFilters.case_type_category;
+    }
+  }
+})(CRM._, angular);

--- a/ang/civicase-base/services/case-type-filterer/filters/has-id.service.js
+++ b/ang/civicase-base/services/case-type-filterer/filters/has-id.service.js
@@ -1,0 +1,30 @@
+(function (_, angular) {
+  var module = angular.module('civicase-base');
+
+  module.service('HasIdCaseTypeFilter', HasIdCaseTypeFilter);
+
+  /**
+   * HasId Case Type Filter service.
+   */
+  function HasIdCaseTypeFilter () {
+    this.run = run;
+    this.shouldRun = shouldRun;
+
+    /**
+     * @param {object} caseType case type to match.
+     * @param {object} caseTypeFilters list of parameters to use for matching.
+     * @returns {boolean} true when the case type is equal to the given ID.
+     */
+    function run (caseType, caseTypeFilters) {
+      return caseType.id === caseTypeFilters.id;
+    }
+
+    /**
+     * @param {object} caseTypeFilters list of parameters to use for matching.
+     * @returns {boolean} true when filters include a single ID used for matching.
+     */
+    function shouldRun (caseTypeFilters) {
+      return caseTypeFilters.id && !caseTypeFilters.id.IN;
+    }
+  }
+})(CRM._, angular);

--- a/ang/civicase-base/services/case-type-filterer/filters/is-included-in-list-of-ids.service.js
+++ b/ang/civicase-base/services/case-type-filterer/filters/is-included-in-list-of-ids.service.js
@@ -1,0 +1,31 @@
+(function (_, angular) {
+  var module = angular.module('civicase-base');
+
+  module.service('IsIncludedInListOfIdsCaseTypeFilter', IsIncludedInListOfIdsCaseTypeFilter);
+
+  /**
+   * IsIncludedInListOfIds Case Type Filter service.
+   */
+  function IsIncludedInListOfIdsCaseTypeFilter () {
+    this.run = run;
+    this.shouldRun = shouldRun;
+
+    /**
+     * @param {object} caseType case type to match.
+     * @param {object} caseTypeFilters list of parameters to use for matching.
+     * @returns {boolean} true when the case type is included in the list of
+     *   IDs defined in the filters.
+     */
+    function run (caseType, caseTypeFilters) {
+      return _.includes(caseTypeFilters.id.IN, caseType.id);
+    }
+
+    /**
+     * @param {object} caseTypeFilters list of parameters to use for matching.
+     * @returns {boolean} true when filters include a list of IDs.
+     */
+    function shouldRun (caseTypeFilters) {
+      return caseTypeFilters.id && caseTypeFilters.id.IN;
+    }
+  }
+})(CRM._, angular);

--- a/ang/civicase/case/directives/case-overview.directive.html
+++ b/ang/civicase/case/directives/case-overview.directive.html
@@ -30,7 +30,7 @@
           <i
             class="material-icons civicase__case-overview__flow-status__icon"
             ng-click="toggleBrekdownVisibility()"
-            ng-if="caseTypesLength > 0">
+            ng-if="caseTypes.length > 0">
             {{showBreakdown ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}}
           </i>
         </div>

--- a/ang/civicase/case/directives/case-overview.directive.html
+++ b/ang/civicase/case/directives/case-overview.directive.html
@@ -29,7 +29,7 @@
           Overview
           <i
             class="material-icons civicase__case-overview__flow-status__icon"
-            ng-click="toggleBrekdownVisibility()"
+            ng-click="toggleBreakdownVisibility()"
             ng-if="caseTypes.length > 0">
             {{showBreakdown ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}}
           </i>

--- a/ang/civicase/case/directives/case-overview.directive.html
+++ b/ang/civicase/case/directives/case-overview.directive.html
@@ -14,9 +14,9 @@
               <ul class="dropdown-menu" role="menu">
                 <li ng-repeat="status in caseStatuses">
                   <a class="civicase__checkbox-container"
-                    href ng-click="toggleStatusVisibility($event, $index)">
+                    href ng-click="toggleStatusVisibility($event, status.value)">
                     <span class="civicase__checkbox">
-                      <i ng-if="!status.isHidden" class="civicase__checkbox--checked material-icons">check_box</i>
+                      <i ng-if="!hiddenCaseStatuses[status.value]" class="civicase__checkbox--checked material-icons">check_box</i>
                     </span>
                     <span>
                       {{ status.label }}
@@ -36,7 +36,7 @@
         </div>
         <div
           class="civicase__case-overview__flow-status civicase__case-overview__flow-status--hoverable"
-          ng-if="!status.isHidden"
+          ng-if="!hiddenCaseStatuses[status.value]"
           ng-repeat="status in caseStatuses"
           uib-popover="{{ status.label }}"
           popover-trigger="'mouseenter'"
@@ -82,7 +82,7 @@
         </div>
         <div
           class="civicase__case-overview__breakdown-field"
-          ng-if="!status.isHidden"
+          ng-if="!hiddenCaseStatuses[status.value]"
           ng-repeat="status in caseStatuses">
           <a ng-href="{{ linkToManageCase(caseType.name, status.value) }}">
             {{ summaryData[caseType.id][status.value] || '0' }}

--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -58,12 +58,6 @@
       .value();
 
     (function init () {
-      getCaseTypes();
-      // We hide the breakdown when there's only one case type
-      if ($scope.caseTypesLength < 2) {
-        $scope.showBreakdown = false;
-      }
-
       $scope.$watch('caseFilter', caseFilterWatcher, true);
       loadHiddenCaseStatuses();
     }());

--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -112,9 +112,7 @@
     function getCaseStatusNamesBelongingToCaseTypes (caseTypes) {
       return _.chain(caseTypes)
         .map(function (caseType) {
-          return caseType.definition.statuses
-            ? caseType.definition.statuses
-            : allCaseStatusNames;
+          return caseType.definition.statuses || allCaseStatusNames;
         })
         .flatten()
         .unique()

--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -56,7 +56,10 @@
     $scope.hiddenCaseStatuses = {};
     $scope.summaryData = [];
 
+    $scope.areAllStatusesHidden = areAllStatusesHidden;
     $scope.getItemsForCaseType = CaseType.getItemsForCaseType;
+    $scope.toggleBrekdownVisibility = toggleBrekdownVisibility;
+    $scope.toggleStatusVisibility = toggleStatusVisibility;
 
     (function init () {
       $scope.$watch('caseFilter', caseFilterWatcher, true);
@@ -68,11 +71,11 @@
      *
      * @returns {boolean} true when all statuses are hidden.
      */
-    $scope.areAllStatusesHidden = function () {
+    function areAllStatusesHidden () {
       return _.filter($scope.caseStatuses, function (status) {
         return !status.isHidden;
       }).length === 0;
-    };
+    }
 
     /**
      * Toggle status visibility.
@@ -80,19 +83,19 @@
      * @param {document#event:mousedown} $event the toggle DOM event.
      * @param {number} caseStatusId the id for the case status to hide or show.
      */
-    $scope.toggleStatusVisibility = function ($event, caseStatusId) {
+    function toggleStatusVisibility ($event, caseStatusId) {
       $scope.hiddenCaseStatuses[caseStatusId] = !$scope.hiddenCaseStatuses[caseStatusId];
 
       storeHiddenCaseStatuses();
       $event.stopPropagation();
-    };
+    }
 
     /**
      * Toggles the visibility of the breakdown dropdown
      */
-    $scope.toggleBrekdownVisibility = function () {
+    function toggleBrekdownVisibility () {
       $scope.showBreakdown = !$scope.showBreakdown;
-    };
+    }
 
     /**
      * Watcher function for caseFilter

--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -50,6 +50,7 @@
     var BROWSER_CACHE_IDENTIFIER = 'civicase.CaseOverview.hiddenCaseStatuses';
 
     $scope.getItemsForCaseType = CaseType.getItemsForCaseType;
+    $scope.hiddenCaseStatuses = {};
     $scope.summaryData = [];
     $scope.caseStatuses = _.chain(CaseStatus.getAll())
       .sortBy(function (status) { return status.weight; })
@@ -79,13 +80,14 @@
     };
 
     /**
-     * Toggle status view
+     * Toggle status visibility.
      *
      * @param {document#event:mousedown} $event the toggle DOM event.
-     * @param {number} index of the case status
+     * @param {number} caseStatusId the id for the case status to hide or show.
      */
-    $scope.toggleStatusVisibility = function ($event, index) {
-      $scope.caseStatuses[index + 1].isHidden = !$scope.caseStatuses[index + 1].isHidden;
+    $scope.toggleStatusVisibility = function ($event, caseStatusId) {
+      $scope.hiddenCaseStatuses[caseStatusId] = !$scope.hiddenCaseStatuses[caseStatusId];
+
       storeHiddenCaseStatuses();
       $event.stopPropagation();
     };
@@ -110,10 +112,11 @@
      * previously hidden and marks them as such.
      */
     function loadHiddenCaseStatuses () {
-      var hiddenCaseStatuses = BrowserCache.get(BROWSER_CACHE_IDENTIFIER, []);
+      var hiddenCaseStatusesIds = BrowserCache.get(BROWSER_CACHE_IDENTIFIER, []);
+      $scope.hiddenCaseStatuses = {};
 
-      hiddenCaseStatuses.forEach(function (caseStatusId) {
-        $scope.caseStatuses[caseStatusId].isHidden = true;
+      _.forEach(hiddenCaseStatusesIds, function (caseStatusId) {
+        $scope.hiddenCaseStatuses[caseStatusId] = true;
       });
     }
 
@@ -160,9 +163,9 @@
      * hidden.
      */
     function storeHiddenCaseStatuses () {
-      var hiddenCaseStatusesIds = _.chain($scope.caseStatuses)
-        .pick(function (caseStatus, key) {
-          return caseStatus.isHidden;
+      var hiddenCaseStatusesIds = _.chain($scope.hiddenCaseStatuses)
+        .pick(function (caseStatusIsHidden) {
+          return caseStatusIsHidden;
         })
         .keys()
         .value();

--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -45,14 +45,17 @@
    * @param {object} BrowserCache the browser cache service reference.
    * @param {object} CaseStatus the case status service reference.
    * @param {object} CaseType the case type service reference.
+   * @param {object} CaseTypeFilterer the case type filterer service reference.
    */
-  function civicaseCaseOverviewController ($scope, crmApi, BrowserCache, CaseStatus, CaseType) {
+  function civicaseCaseOverviewController ($scope, crmApi, BrowserCache, CaseStatus,
+    CaseType, CaseTypeFilterer) {
     var BROWSER_CACHE_IDENTIFIER = 'civicase.CaseOverview.hiddenCaseStatuses';
     var MAXIMUM_CASE_TYPES_TO_DISPLAY_BREAKDOWN = 1;
     var allCaseStatusNames = _.map(CaseStatus.getAll(), 'name');
     var caseStatusesIndexedByName = _.indexBy(CaseStatus.getAll(), 'name');
 
     $scope.caseStatuses = [];
+    $scope.caseTypes = [];
     $scope.hiddenCaseStatuses = {};
     $scope.summaryData = [];
 
@@ -83,17 +86,16 @@
      * @param {object} caseFilters parameters to use for filtering the stats data.
      */
     function caseFilterWatcher (caseFilters) {
+      var caseStatusNames;
+
+      $scope.caseTypes = getFilteredCaseTypes(caseFilters);
+      caseStatusNames = getCaseStatusNamesBelongingToCaseTypes($scope.caseTypes);
+      $scope.caseStatuses = getSortedCaseStatusesByName(caseStatusNames);
+      $scope.showBreakdown = $scope.caseTypes.length <=
+        MAXIMUM_CASE_TYPES_TO_DISPLAY_BREAKDOWN;
+
       loadStatsData(caseFilters);
-      loadCaseTypes(caseFilters)
-        .then(function () {
-          var caseStatusNames = getCaseStatusNamesBelongingToCaseTypes($scope.caseTypes);
-
-          $scope.showBreakdown = $scope.caseTypes.length <=
-            MAXIMUM_CASE_TYPES_TO_DISPLAY_BREAKDOWN;
-          $scope.caseStatuses = getSortedCaseStatusesByName(caseStatusNames);
-
-          $scope.$emit('civicase::custom-scrollbar::recalculate');
-        });
+      $scope.$emit('civicase::custom-scrollbar::recalculate');
     }
 
     /**
@@ -120,6 +122,17 @@
     }
 
     /**
+     * @param {object} caseFilters parameters to use for filtering case types.
+     * @returns {object[]} a list of filtered case types.
+     */
+    function getFilteredCaseTypes (caseFilters) {
+      return CaseTypeFilterer.filter({
+        case_type_category: caseFilters['case_type_id.case_type_category'],
+        id: caseFilters.case_type_id
+      });
+    }
+
+    /**
      * @param {string[]} caseStatusNames a list of case status names.
      * @returns {object[]} the full case status details belonging to the
      *   given case status names.
@@ -132,26 +145,6 @@
         .sortBy('weight')
         .indexBy('value')
         .value();
-    }
-
-    /**
-     * Get Case Types based on filters
-     *
-     * @param {object} caseFilters parameters to use for filtering case types.
-     * @returns {Promise} promise
-     */
-    function loadCaseTypes (caseFilters) {
-      var params = {
-        sequential: 1,
-        case_type_category: caseFilters['case_type_id.case_type_category'],
-        id: caseFilters.case_type_id,
-        is_active: 1
-      };
-
-      return crmApi('CaseType', 'get', params)
-        .then(function (data) {
-          $scope.caseTypes = data.values;
-        });
     }
 
     /**

--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -58,7 +58,7 @@
 
     $scope.areAllStatusesHidden = areAllStatusesHidden;
     $scope.getItemsForCaseType = CaseType.getItemsForCaseType;
-    $scope.toggleBrekdownVisibility = toggleBrekdownVisibility;
+    $scope.toggleBreakdownVisibility = toggleBreakdownVisibility;
     $scope.toggleStatusVisibility = toggleStatusVisibility;
 
     (function init () {
@@ -204,7 +204,7 @@
     /**
      * Toggles the visibility of the breakdown dropdown
      */
-    function toggleBrekdownVisibility () {
+    function toggleBreakdownVisibility () {
       $scope.showBreakdown = !$scope.showBreakdown;
     }
 

--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -78,26 +78,6 @@
     }
 
     /**
-     * Toggle status visibility.
-     *
-     * @param {document#event:mousedown} $event the toggle DOM event.
-     * @param {number} caseStatusId the id for the case status to hide or show.
-     */
-    function toggleStatusVisibility ($event, caseStatusId) {
-      $scope.hiddenCaseStatuses[caseStatusId] = !$scope.hiddenCaseStatuses[caseStatusId];
-
-      storeHiddenCaseStatuses();
-      $event.stopPropagation();
-    }
-
-    /**
-     * Toggles the visibility of the breakdown dropdown
-     */
-    function toggleBrekdownVisibility () {
-      $scope.showBreakdown = !$scope.showBreakdown;
-    }
-
-    /**
      * Watcher function for caseFilter
      *
      * @param {object} caseFilters parameters to use for filtering the stats data.
@@ -155,6 +135,26 @@
     }
 
     /**
+     * Get Case Types based on filters
+     *
+     * @param {object} caseFilters parameters to use for filtering case types.
+     * @returns {Promise} promise
+     */
+    function loadCaseTypes (caseFilters) {
+      var params = {
+        sequential: 1,
+        case_type_category: caseFilters['case_type_id.case_type_category'],
+        id: caseFilters.case_type_id,
+        is_active: 1
+      };
+
+      return crmApi('CaseType', 'get', params)
+        .then(function (data) {
+          $scope.caseTypes = data.values;
+        });
+    }
+
+    /**
      * Loads from the browser cache the ids of the case status that have been
      * previously hidden and marks them as such.
      */
@@ -187,26 +187,6 @@
     }
 
     /**
-     * Get Case Types based on filters
-     *
-     * @param {object} caseFilters parameters to use for filtering case types.
-     * @returns {Promise} promise
-     */
-    function loadCaseTypes (caseFilters) {
-      var params = {
-        sequential: 1,
-        case_type_category: caseFilters['case_type_id.case_type_category'],
-        id: caseFilters.case_type_id,
-        is_active: 1
-      };
-
-      return crmApi('CaseType', 'get', params)
-        .then(function (data) {
-          $scope.caseTypes = data.values;
-        });
-    }
-
-    /**
      * Stores in the browser cache the id values of the case statuses that have been
      * hidden.
      */
@@ -219,6 +199,26 @@
         .value();
 
       BrowserCache.set(BROWSER_CACHE_IDENTIFIER, hiddenCaseStatusesIds);
+    }
+
+    /**
+     * Toggles the visibility of the breakdown dropdown
+     */
+    function toggleBrekdownVisibility () {
+      $scope.showBreakdown = !$scope.showBreakdown;
+    }
+
+    /**
+     * Toggle status visibility.
+     *
+     * @param {document#event:mousedown} $event the toggle DOM event.
+     * @param {number} caseStatusId the id for the case status to hide or show.
+     */
+    function toggleStatusVisibility ($event, caseStatusId) {
+      $scope.hiddenCaseStatuses[caseStatusId] = !$scope.hiddenCaseStatuses[caseStatusId];
+
+      storeHiddenCaseStatuses();
+      $event.stopPropagation();
     }
   }
 })(angular, CRM.$, CRM._);

--- a/ang/test/civicase-base/providers/case-type-category.provider.spec.js
+++ b/ang/test/civicase-base/providers/case-type-category.provider.spec.js
@@ -31,6 +31,23 @@
       });
     });
 
+    describe('when a case type category is requested by lower case name, but it is stored in capital case', () => {
+      var expectedResult;
+
+      beforeEach(() => {
+        module('civicase-base');
+        injectDependencies();
+
+        expectedResult = _.find(CRM['civicase-base'].caseTypeCategories, function (caseTypeCategory) {
+          return caseTypeCategory.name === 'Cases';
+        });
+      });
+
+      it('returns the case type category which matches the name even if the category was stored in capital case', () => {
+        expect(CaseTypeCategory.findByName('cases')).toEqual(expectedResult);
+      });
+    });
+
     describe('when case type categories with access to activities are requested', () => {
       var expectedResults;
 

--- a/ang/test/civicase-base/services/case-type-filterer/case-type-filterer.service.spec.js
+++ b/ang/test/civicase-base/services/case-type-filterer/case-type-filterer.service.spec.js
@@ -1,0 +1,101 @@
+/* eslint-env jasmine */
+
+((_) => {
+  describe('CaseTypeFilterer service', () => {
+    let allCaseTypeCategories, allCaseTypes, CaseTypeFilterer, expectedCaseTypes,
+      returnedCaseTypes;
+
+    beforeEach(module('civicase-base'));
+
+    beforeEach(inject((_CaseType_, _CaseTypeCategory_, _CaseTypeFilterer_) => {
+      allCaseTypeCategories = _CaseTypeCategory_.getAll();
+      allCaseTypes = _CaseType_.getAll();
+      CaseTypeFilterer = _CaseTypeFilterer_;
+    }));
+
+    describe('when filtering by case type id', () => {
+      beforeEach(() => {
+        const sampleCaseType = _.sample(allCaseTypes);
+
+        expectedCaseTypes = [
+          sampleCaseType
+        ];
+
+        returnedCaseTypes = CaseTypeFilterer.filter({
+          id: sampleCaseType.id
+        });
+      });
+
+      it('returns a list of case types that only includes the requested case type', () => {
+        expect(returnedCaseTypes)
+          .toEqual(jasmine.arrayWithExactContents(expectedCaseTypes));
+      });
+    });
+
+    describe('when filtering by a list of case type ids', () => {
+      beforeEach(() => {
+        expectedCaseTypes = _.sample(allCaseTypes, 2);
+        const expectedCaseTypeIds = _.map(expectedCaseTypes, 'id');
+
+        returnedCaseTypes = CaseTypeFilterer.filter({
+          id: {
+            IN: expectedCaseTypeIds
+          }
+        });
+      });
+
+      it('returns a list of case types including all requested case types', () => {
+        expect(returnedCaseTypes)
+          .toEqual(jasmine.arrayWithExactContents(expectedCaseTypes));
+      });
+    });
+
+    describe('when filtering by a case type category', () => {
+      beforeEach(() => {
+        const prospectCategory = _.find(allCaseTypeCategories, {
+          name: 'Prospecting'
+        });
+
+        expectedCaseTypes = _.filter(allCaseTypes, {
+          case_type_category: prospectCategory.value
+        });
+
+        returnedCaseTypes = CaseTypeFilterer.filter({
+          case_type_category: prospectCategory.name
+        });
+      });
+
+      it('returns a list of case types belonging to the case type category', () => {
+        expect(returnedCaseTypes)
+          .toEqual(jasmine.arrayWithExactContents(expectedCaseTypes));
+      });
+    });
+
+    describe('multiple filters', () => {
+      describe('when filtering by multiple case type ids that belong to a particular category', () => {
+        beforeEach(() => {
+          const prospectCategory = _.find(allCaseTypeCategories, {
+            name: 'Prospecting'
+          });
+          const prospectCaseTypes = _.filter(allCaseTypes, {
+            case_type_category: prospectCategory.value
+          });
+
+          expectedCaseTypes = _.sample(prospectCaseTypes, 1);
+
+          returnedCaseTypes = CaseTypeFilterer.filter({
+            case_type_category: prospectCategory.name,
+            id: {
+              IN: _.map(expectedCaseTypes, 'id')
+            }
+          });
+        });
+
+        it('returns a list of case types filtered by multiple parameters', () => {
+          expect(returnedCaseTypes)
+            .toEqual(jasmine.arrayWithExactContents(expectedCaseTypes));
+        });
+      });
+    });
+  });
+})(CRM._);

--- a/ang/test/civicase/case/directives/case-overview.directive.spec.js
+++ b/ang/test/civicase/case/directives/case-overview.directive.spec.js
@@ -1,11 +1,11 @@
 /* eslint-env jasmine */
-(function ($, _) {
-  describe('CaseOverview', function () {
-    var $compile, $provide, $q, $rootScope, $scope, BrowserCache,
+(($, _) => {
+  describe('CaseOverview', () => {
+    let $compile, $provide, $q, $rootScope, $scope, BrowserCache,
       CasesOverviewStats, crmApi, element, targetElementScope,
       CaseStatus, CaseType, CaseTypeFilterer;
 
-    beforeEach(module('civicase.data', 'civicase', 'civicase.templates', function (_$provide_) {
+    beforeEach(module('civicase.data', 'civicase', 'civicase.templates', (_$provide_) => {
       $provide = _$provide_;
     }));
 
@@ -28,26 +28,26 @@
       spyOn(CaseTypeFilterer, 'filter').and.callThrough();
     }));
 
-    beforeEach(function () {
+    beforeEach(() => {
       $scope.caseStatuses = CaseStatus.getAll();
       $scope.summaryData = [];
     });
 
-    beforeEach(function () {
+    beforeEach(() => {
       listenForCaseOverviewRecalculate();
       compileDirective({});
     });
 
-    describe('compile directive', function () {
-      it('should have class civicase__case-overview-container', function () {
+    describe('compile directive', () => {
+      it('should have class civicase__case-overview-container', () => {
         expect(element.html()).toContain('civicase__case-overview-container');
       });
     });
 
-    describe('Case Types', function () {
+    describe('Case Types', () => {
       let expectedCaseTypes, expectedFilters;
 
-      beforeEach(function () {
+      beforeEach(() => {
         expectedFilters = {
           case_type_category: 'Cases',
           id: { IN: ['1', '2'] }
@@ -66,13 +66,13 @@
         expect(CaseTypeFilterer.filter).toHaveBeenCalledWith(expectedFilters);
       });
 
-      it('stores the filtered case types', function () {
+      it('stores the filtered case types', () => {
         expect(element.isolateScope().caseTypes).toEqual(expectedCaseTypes);
       });
     });
 
-    describe('Case Status Data', function () {
-      beforeEach(function () {
+    describe('Case Status Data', () => {
+      beforeEach(() => {
         crmApi.and.returnValue($q.resolve([CasesOverviewStats]));
         compileDirective({
           caseTypeCategory: 'Cases',
@@ -81,7 +81,7 @@
         });
       });
 
-      it('fetches the case statistics, but shows all case statuses', function () {
+      it('fetches the case statistics, but shows all case statuses', () => {
         expect(crmApi).toHaveBeenCalledWith([['Case', 'getstats', {
           'case_type_id.case_type_category': 'Cases',
           case_type_id: { IN: ['1', '2'] }
@@ -150,13 +150,13 @@
       });
     });
 
-    describe('Case Status visibility', function () {
-      describe('when the component loads', function () {
-        it('requests the case status that are hidden stored in the browser cache', function () {
+    describe('Case Status visibility', () => {
+      describe('when the component loads', () => {
+        it('requests the case status that are hidden stored in the browser cache', () => {
           expect(BrowserCache.get).toHaveBeenCalledWith('civicase.CaseOverview.hiddenCaseStatuses', []);
         });
 
-        it('hides the case statuses marked as hidden by the browser cache', function () {
+        it('hides the case statuses marked as hidden by the browser cache', () => {
           expect(element.isolateScope().hiddenCaseStatuses).toEqual({
             1: true,
             3: true
@@ -164,8 +164,8 @@
         });
       });
 
-      describe('when marking a status as hidden', function () {
-        beforeEach(function () {
+      describe('when marking a status as hidden', () => {
+        beforeEach(() => {
           element.isolateScope().hiddenCaseStatuses = {
             1: true,
             2: false,
@@ -175,13 +175,13 @@
           element.isolateScope().toggleStatusVisibility($.Event(), 2);
         });
 
-        it('stores the hidden case statuses including the new one', function () {
+        it('stores the hidden case statuses including the new one', () => {
           expect(BrowserCache.set).toHaveBeenCalledWith('civicase.CaseOverview.hiddenCaseStatuses', ['1', '2', '3']);
         });
       });
 
-      describe('when marking a status as enabled', function () {
-        beforeEach(function () {
+      describe('when marking a status as enabled', () => {
+        beforeEach(() => {
           element.isolateScope().hiddenCaseStatuses = {
             1: true,
             2: false,
@@ -191,46 +191,46 @@
           element.isolateScope().toggleStatusVisibility($.Event(), 1);
         });
 
-        it('stores the hidden case statuses including the new one', function () {
+        it('stores the hidden case statuses including the new one', () => {
           expect(BrowserCache.set).toHaveBeenCalledWith('civicase.CaseOverview.hiddenCaseStatuses', ['3']);
         });
       });
     });
 
-    describe('when showBreakdown is false', function () {
-      beforeEach(function () {
+    describe('when showBreakdown is false', () => {
+      beforeEach(() => {
         element.isolateScope().showBreakdown = false;
       });
 
-      describe('when toggleBreakdownVisibility is called', function () {
-        beforeEach(function () {
+      describe('when toggleBreakdownVisibility is called', () => {
+        beforeEach(() => {
           element.isolateScope().toggleBreakdownVisibility();
         });
 
-        it('resets showBreakdown to true', function () {
+        it('resets showBreakdown to true', () => {
           expect(element.isolateScope().showBreakdown).toBe(true);
         });
       });
     });
 
-    describe('when showBreakdown is true', function () {
-      beforeEach(function () {
+    describe('when showBreakdown is true', () => {
+      beforeEach(() => {
         element.isolateScope().showBreakdown = true;
       });
 
-      describe('when toggleBreakdownVisibility is called', function () {
-        beforeEach(function () {
+      describe('when toggleBreakdownVisibility is called', () => {
+        beforeEach(() => {
           element.isolateScope().toggleBreakdownVisibility();
         });
 
-        it('resets showBreakdown to false', function () {
+        it('resets showBreakdown to false', () => {
           expect(element.isolateScope().showBreakdown).toBe(false);
         });
       });
     });
 
-    describe('showBreakdown watcher', function () {
-      it('emit called and targetElementScope to be defined', function () {
+    describe('showBreakdown watcher', () => {
+      it('emit called and targetElementScope to be defined', () => {
         expect(targetElementScope).toEqual(element.isolateScope());
       });
     });
@@ -253,7 +253,7 @@
      * Listen for `civicase::custom-scrollbar::recalculate` event
      */
     function listenForCaseOverviewRecalculate () {
-      $rootScope.$on('civicase::custom-scrollbar::recalculate', function (event) {
+      $rootScope.$on('civicase::custom-scrollbar::recalculate', (event) => {
         targetElementScope = event.targetScope;
       });
     }

--- a/ang/test/civicase/case/directives/case-overview.directive.spec.js
+++ b/ang/test/civicase/case/directives/case-overview.directive.spec.js
@@ -189,9 +189,9 @@
         element.isolateScope().showBreakdown = false;
       });
 
-      describe('when toggleBrekdownVisibility is called', function () {
+      describe('when toggleBreakdownVisibility is called', function () {
         beforeEach(function () {
-          element.isolateScope().toggleBrekdownVisibility();
+          element.isolateScope().toggleBreakdownVisibility();
         });
 
         it('resets showBreakdown to true', function () {
@@ -205,9 +205,9 @@
         element.isolateScope().showBreakdown = true;
       });
 
-      describe('when toggleBrekdownVisibility is called', function () {
+      describe('when toggleBreakdownVisibility is called', function () {
         beforeEach(function () {
-          element.isolateScope().toggleBrekdownVisibility();
+          element.isolateScope().toggleBreakdownVisibility();
         });
 
         it('resets showBreakdown to false', function () {

--- a/ang/test/civicase/case/directives/case-overview.directive.spec.js
+++ b/ang/test/civicase/case/directives/case-overview.directive.spec.js
@@ -121,7 +121,7 @@
         });
       });
 
-      describe('when loading a case type that supports al statuses', () => {
+      describe('when loading a case type that supports all statuses', () => {
         beforeEach(() => {
           const allCaseStatuses = CaseStatus.getAll();
           const caseType = _.sample(CaseType.getAll());

--- a/ang/test/civicase/case/directives/case-overview.directive.spec.js
+++ b/ang/test/civicase/case/directives/case-overview.directive.spec.js
@@ -74,25 +74,29 @@
       });
     });
 
-    describe('Case Status', function () {
+    describe('Case Status visibility', function () {
       describe('when the component loads', function () {
         it('requests the case status that are hidden stored in the browser cache', function () {
           expect(BrowserCache.get).toHaveBeenCalledWith('civicase.CaseOverview.hiddenCaseStatuses', []);
         });
 
         it('hides the case statuses marked as hidden by the browser cache', function () {
-          expect($scope.caseStatuses[1].isHidden).toBe(true);
-          expect($scope.caseStatuses[3].isHidden).toBe(true);
+          expect(element.isolateScope().hiddenCaseStatuses).toEqual({
+            1: true,
+            3: true
+          });
         });
       });
 
       describe('when marking a status as hidden', function () {
         beforeEach(function () {
-          $scope.caseStatuses[1].isHidden = true;
-          $scope.caseStatuses[2].isHidden = false;
-          $scope.caseStatuses[3].isHidden = true;
+          element.isolateScope().hiddenCaseStatuses = {
+            1: true,
+            2: false,
+            3: true
+          };
 
-          element.isolateScope().toggleStatusVisibility($.Event(), 1); // disables the case status #2
+          element.isolateScope().toggleStatusVisibility($.Event(), 2);
         });
 
         it('stores the hidden case statuses including the new one', function () {
@@ -102,11 +106,13 @@
 
       describe('when marking a status as enabled', function () {
         beforeEach(function () {
-          $scope.caseStatuses[1].isHidden = true;
-          $scope.caseStatuses[2].isHidden = false;
-          $scope.caseStatuses[3].isHidden = true;
+          element.isolateScope().hiddenCaseStatuses = {
+            1: true,
+            2: false,
+            3: true
+          };
 
-          element.isolateScope().toggleStatusVisibility($.Event(), 0); // enables the case status #1
+          element.isolateScope().toggleStatusVisibility($.Event(), 1);
         });
 
         it('stores the hidden case statuses including the new one', function () {

--- a/ang/test/mocks/data/cases-types.data.js
+++ b/ang/test/mocks/data/cases-types.data.js
@@ -3,6 +3,7 @@
 
   var caseTypesMock = {
     1: {
+      id: '1',
       name: 'housing_support',
       title: 'Housing Support',
       description: 'Help homeless individuals obtain temporary and long-term housing',
@@ -198,6 +199,7 @@
       case_type_category: '1'
     },
     2: {
+      id: '2',
       name: 'adult_day_care_referral',
       title: 'Adult Day Care Referral',
       description: 'Arranging adult day care for senior individuals',


### PR DESCRIPTION
## Overview
This PR updates the case overview section of the dashboard so we only display the case statuses that have been enabled for the case types that are being displayed.

## Before & After

### Setup

* Permissive Award has Ongoing, Resolved, Won, and Lost statuses
* Award ON has Ongoing, Resolved, and Urgent statuses

Expected statuses: Ongoing, Resolved, Urgent, Won, and Lost.

### Before
![Screen Shot 2020-04-07 at 6 17 34 PM](https://user-images.githubusercontent.com/1642119/78724746-19503500-78fc-11ea-8236-e0ed9535ac68.png)

### After
![Screen Shot 2020-04-07 at 6 18 07 PM](https://user-images.githubusercontent.com/1642119/78724775-29681480-78fc-11ea-9f26-896344ccb984.png)

## Technical Details

Some refactoring was done in order to properly support this enhancement:

* Hidden case statuses are now stored in a separate variable. Since case statuses now depend on the loaded case types we don't need to reload the hidden case statuses from the browser cache each time we reload the case types and statuses.
* We removed the case type fetching and changed it for a local filtering service (more on this below).
* The logic to automatically display the breakdown when there's only a single case type has been moved from the init to the watch function, after loading the case types.
* We removed the `caseTypesLength` property in favour of using the `caseTypes.length` property directly.
* As noted in the code's comments, we have made it so that when the definition of a case type  does not include a `statuses` property, this means that we should support all case statuses. This is how core behaves.

### Case Type Filterer service

This service was introduced in order to be able to filter case types using a combination of complex filters. For example we could filter case types by category and ID, but the ID could come as a single value or as multiple values in the `{ IN: [...] }` format.

To avoid having complex conditions inside of a loop that would have been too hard to follow, we have opted to use a strategy pattern instead:

```js
function CaseTypeFilterer (/* ... */) {
  // all the filters we can potentially apply:
  var listOfFilters = [
    // ...
  ];

  function filter (caseTypeFilters) {
    // ...
    // we first determine the filters that can be used to filter the case types:
    var listOfFiltersToRun = _.filter(listOfFilters, function (filter) {
      return filter.shouldRun(caseTypeFilters);
    });

    return _.filter(caseTypes, function (caseType) {
      // we return case types that match all filters:
      return _.every(listOfFiltersToRun, function (filter) {
        return filter.run(caseType, caseTypeFilters);
      });
    });
  }
}
```

This means that we have a list of filters, but not every filter is applied. We only apply the filter if there is a parameter that wants to filter the returned list of case types. Each filter has a `shouldRun` and a `run` method, and should be structured as follows:

```js
function MyCaseTypeFilter() {
  this.run = run;
  this.shouldRun = shouldRun;

  function run(caseType, caseTypeFilters) {
    // should return true if the given case type matches the given filters
  }

  function shouldRun(caseTypeFilters) {
    // should return true if the given filter can be handled by this service
  }
}
```

Why do we need two functions? Why not just return `true`/`false` on the `run` function? Because the filter may only apply when filtering by `case_type_id`, as an example, and if this parameter is no passed we are returning a `true` or `false` value for something that is not handled by the service. So in short: `shouldRun` determines if the service can filter the case type using the given filter parameters, and `run` does the actual filtering.
