### PR TITLE
CPS-127: Replace 'case' with respective category in email subject

### DIFF
--- a/CRM/Civicase/Hook/alterMailParams/SubjectCaseTypeCategoryProcessor.php
+++ b/CRM/Civicase/Hook/alterMailParams/SubjectCaseTypeCategoryProcessor.php
@@ -1,0 +1,67 @@
+<?php
+
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+
+/**
+ * Class CRM_Civicase_Hook_alterMailParams_CaseTypeCategorySubjectProcessor.
+ */
+class CRM_Civicase_Hook_alterMailParams_SubjectCaseTypeCategoryProcessor {
+
+  /**
+   * A substring of email subject that should be replaced.
+   *
+   * @var string
+   *   This substring will be replaced with respective case type category name.
+   */
+  private $toReplace = '[case ';
+
+  /**
+   * Email subject processor.
+   *
+   * Replaces word 'case' with related case type category in email subject.
+   *
+   * @param array $params
+   *   Mail parameters.
+   * @param string $context
+   *   Mail context.
+   */
+  public function run(array &$params, $context) {
+    $caseId = CRM_Utils_Request::retrieve('caseid', 'Integer');
+    if (!$this->shouldRun($params, $context, $caseId)) {
+      return;
+    }
+
+    // Get case category name for the case.
+    $caseTypeCategory = CaseCategoryHelper::getCategoryName($caseId);
+    if (empty($caseTypeCategory)) {
+      return;
+    }
+
+    // Get replacement words and replace the word 'case' in subject.
+    $wordReplacements = CaseCategoryHelper::getWordReplacements($caseTypeCategory);
+    if (!empty($wordReplacements['case'])) {
+      // Make sure we make just 1 replacement.
+      $subject = explode($this->toReplace, $params['subject'], 2);
+      $params['subject'] = '[' . $wordReplacements['case'] . ' ' . $subject[1];
+    }
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * @param array $params
+   *   Mail parameters.
+   * @param string $context
+   *   Mail context.
+   * @param int $caseId
+   *   Case id.
+   *
+   * @return bool
+   *   returns TRUE if hook should run, FALSE otherwise.
+   */
+  private function shouldRun(array $params, $context, $caseId) {
+    // If case id is set and email subject starts with '[case '.
+    return $caseId && strpos($params['subject'], $this->toReplace) === 0;
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -588,3 +588,16 @@ function _civicase_add_case_category_case_type_entity(array &$entityTypes) {
     ];
   };
 }
+
+/**
+ * Implements hook_civicrm_alterMailParams().
+ */
+function civicase_civicrm_alterMailParams(&$params, $context) {
+  $hooks = [
+    new CRM_Civicase_Hook_alterMailParams_SubjectCaseTypeCategoryProcessor(),
+  ];
+
+  foreach ($hooks as &$hook) {
+    $hook->run($params, $context);
+  }
+}


### PR DESCRIPTION
## Overview
There was an issue with emails being sent via a case from cases of some case type category: subject contains the word 'case' instead of case type category name.
Now it's fixed.

## Before
![image](https://user-images.githubusercontent.com/39520000/78754673-8c02f400-7980-11ea-9403-7193db52d228.png)

## After
![image](https://user-images.githubusercontent.com/39520000/78754661-886f6d00-7980-11ea-95d7-045b54f4fb84.png)

## Technical Details
Automatic word replacement was not working for subject in emails (because civicrm does not run translation function for that). So to workaround it we added `civicase_civicrm_alterMailParams()` hook to alter email subject manually, all the job is done by new `CRM_Civicase_Hook_alterMailParams_SubjectCaseTypeCategoryProcessor()` class.
To fetch the case type category name we need case id which is not present in `$params` of the hook function, luckily `$_GET['caseid']` is available, so we used it instead.