### PR TITLE
RSE-999: Fix file activity search

### DIFF
--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -307,7 +307,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
       'option_group_id' => 'activity_type',
       'label' => ts('File Upload'),
       'name' => 'File Upload',
-      // 'grouping' => '',
+      'grouping' => 'file',
       'is_reserved' => 0,
       'description' => ts('Add files to a case'),
       'component_id' => 'CiviCase',

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -558,7 +558,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
    *
    * @param CRM_Queue_TaskContext $context
    *   Context.
-   * @param \object $step
+   * @param object $step
    *   Step.
    *
    * @return true

--- a/CRM/Civicase/Upgrader/Steps/Step0011.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0011.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * CRM_Civicase_Upgrader_Steps_Step0011 class.
+ */
+class CRM_Civicase_Upgrader_Steps_Step0011 {
+
+  /**
+   * Performs Upgrade.
+   */
+  public function apply() {
+    $this->updateFileUploadCategoryGrouping();
+
+    return TRUE;
+  }
+
+  /**
+   * Update file upload category grouping.
+   */
+  private function updateFileUploadCategoryGrouping() {
+    try {
+      // Find category.
+      $category = civicrm_api3('OptionValue', 'getsingle', [
+        'name' => 'File Upload',
+        'component_id' => 'CiviCase',
+        'option_group_id' => 'activity_type',
+        'grouping' => ['IS NULL' => 1],
+      ]);
+
+      // Set it's grouping to 'file'.
+      if (!empty($category['id'])) {
+        $category['grouping'] = 'file';
+        civicrm_api3('OptionValue', 'create', $category);
+      }
+    }
+    catch (Exception $e) {
+    }
+  }
+
+}


### PR DESCRIPTION
## Overview
The search for file activity of the case was not working - results where always empty.

How to reproduce:
1. Create a case
2. Upload a file
3. Go to activities tab
4. Select “File“ from “All activity categories“ filter.
5. Results are empty, but file upload activity is expected.

Now it's fixed.

## Before
![image](https://user-images.githubusercontent.com/39520000/78788647-c5555700-79b4-11ea-9714-1af689a25048.png)

## After
![image](https://user-images.githubusercontent.com/39520000/78788676-cb4b3800-79b4-11ea-9ffa-4468007fec1c.png)

## Technical Details
The `File Upload` activity type was used here which was missing grouping property. In this PR we set this property to `file` in order to make the search work.
Respective upgrader is added - `CRM_Civicase_Upgrader_Steps_Step0011`.
Also as part of this PR some comments where fixed to pass phpcs checks.