### PR TITLE
CPS-72: Fix Activity Feed link

### DIFF
--- a/ang/civicase/activity/factories/get-activity-feed-url.factory.js
+++ b/ang/civicase/activity/factories/get-activity-feed-url.factory.js
@@ -46,7 +46,7 @@
         // If we're not already viewing a case, force the case id filter
         finalUrlParams.cf = JSON.stringify({ id: urlParams.caseId });
       } else {
-        finalUrlParams.tab = 'activities';
+        finalUrlParams.tab = 'Activities';
       }
 
       if (urlParams.caseId) {

--- a/ang/test/civicase/activity/factories/get-activity-feed-url.factory.spec.js
+++ b/ang/test/civicase/activity/factories/get-activity-feed-url.factory.spec.js
@@ -43,7 +43,7 @@
 
       it('returns a url pointing to the case activity feed', function () {
         expect(activityFeedUrlObject.baseUrl).toBe('#/case/list');
-        expect(activityFeedUrlObject.params.tab).toBe('activities');
+        expect(activityFeedUrlObject.params.tab).toBe('Activities');
       });
     });
 


### PR DESCRIPTION
## Overview
Clicking on Case tasks from Case Details does not open up filtered tasks. This PR fixes the problem.

## Before
![before](https://user-images.githubusercontent.com/5058867/78875153-13c52d00-7a6b-11ea-927d-96a6be9b45da.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/78875049-eed0ba00-7a6a-11ea-9972-aa3c388ab98c.gif)

## Technical Details
This is a regression issue, 
In https://github.com/compucorp/uk.co.compucorp.civicase/pull/281/files#diff-c0737ba8aafd36cf7a4e7a001d7f13d7R12, we implemented a new solution to show tabs. So the URL to show the Activity tabs needs to be changed to `Activities`.