### PR TITLE
RSE-978: Fix Duplicate Case Role Field in Activity Report

### DIFF
--- a/CRM/Civicase/XMLProcessor/Report.php
+++ b/CRM/Civicase/XMLProcessor/Report.php
@@ -183,8 +183,8 @@ AND    ac.case_id = %1
    */
   private static function processCaseRelationshipFields(CRM_Civicase_XMLProcessor_Report &$report, array &$caseRoles, array &$caseRelationships, $isRedact) {
     foreach ($caseRelationships as $key => & $value) {
-      if (!empty($caseRoles[$value['relation_type']])) {
-        unset($caseRoles[$value['relation_type']]);
+      if (!empty($caseRoles[$value['relation_type'] . '_' . $value['relationship_direction']])) {
+        unset($caseRoles[$value['relation_type'] . '_' . $value['relationship_direction']]);
       }
 
       if (!$isRedact) {


### PR DESCRIPTION
## Overview
When viewing the activity report, each case role that has a user assigned is shown in duplicates. An empty case role field is shown in addition to the case role field.
This PR fixes the issue.

## Before
<img width="1276" alt="case-award localcivicrmcasecustomreportprintall1redact0cid2asnstandard_timelinecaseID15sact3922C382 2020-04-09 17-37-59" src="https://user-images.githubusercontent.com/6951813/78918952-16367f80-7a89-11ea-86e6-74f1dad5cb11.png">

## After
<img width="1280" alt="case-award localcivicrmcasecustomreportprintall1redact0cid2asnstandard_timelinecaseID15sact3922C382 2020-04-09 17-38-50" src="https://user-images.githubusercontent.com/6951813/78918968-1f275100-7a89-11ea-8209-48d0cf82a440.png">


## Technical Details
The `CRM_Civicase_XMLProcessor_Report` is based off the core `CRM_Case_XMLProcessor_Report` class. This issue existed in the core class but was fixed [here](https://github.com/civicrm/civicrm-core/commit/5655a8d4acd2af4d6452148c781a55a5836df5ed). The fix is to apply this core fix to the clase in civicase.
At some point we might need to sync all the changes in the base class to this class or probably find a way to use the core class without copying the code. This is out of scope for this task however.


