### PR TITLE
RSE-1013: Fix 'Disable' link of case type category

### DIFF
--- a/CRM/Civicase/Event/Listener/ActivityFilter.php
+++ b/CRM/Civicase/Event/Listener/ActivityFilter.php
@@ -1,7 +1,9 @@
 <?php
 
+use Civi\API\Event\PrepareEvent;
+
 /**
- * Class CRM_Civicase_ActivityFilter
+ * Class CRM_Civicase_Event_Listener_ActivityFilter
  *
  * Enhance the `Activity.get` API by allowing the option `case_filter`.
  * This accepts any argument supported by `Case.getdetails`.
@@ -14,7 +16,7 @@
  * ));
  * @endCode
  */
-class CRM_Civicase_ActivityFilter {
+class CRM_Civicase_Event_Listener_ActivityFilter {
 
   /**
    * Whenever there's a call for `Activity.get case_filter=...`, translate
@@ -23,7 +25,7 @@ class CRM_Civicase_ActivityFilter {
    * @param \Civi\API\Event\PrepareEvent $e
    * @throws \API_Exception
    */
-  public static function onPrepare(\Civi\API\Event\PrepareEvent $e) {
+  public static function onPrepare(PrepareEvent $e) {
     $apiRequest = $e->getApiRequest();
 
     // Only apply to `Activity.get case_filter=...`
@@ -37,7 +39,7 @@ class CRM_Civicase_ActivityFilter {
       throw new API_Exception("case_filter and case_id are mutually exclusive");
     }
 
-    CRM_Civicase_ActivityFilter::updateParams($apiRequest['params']);
+    self::updateParams($apiRequest['params']);
 
     $e->setApiRequest($apiRequest);
   }

--- a/CRM/Civicase/Event/Listener/CaseTypeCategoryIsActiveToggler.php
+++ b/CRM/Civicase/Event/Listener/CaseTypeCategoryIsActiveToggler.php
@@ -1,0 +1,85 @@
+<?php
+
+use CRM_Civicase_Factory_CaseTypeCategoryEventHandler as CaseTypeCategoryEventHandlerFactory;
+use Civi\API\Event\RespondEvent;
+
+/**
+ * Class CRM_Civicase_Event_Listener_CaseTypeCategoryIsActiveToggler.
+ *
+ * Contains extra processing for case type category when it is
+ * enabled / disabled, e.g. show / hide related menu item.
+ */
+class CRM_Civicase_Event_Listener_CaseTypeCategoryIsActiveToggler {
+
+  /**
+   * Update case type category related objects on category update.
+   *
+   * @param \Civi\API\Event\RespondEvent $e
+   *   Event data.
+   */
+  public static function onRespond(RespondEvent $e) {
+    $apiRequest = $e->getApiRequest();
+    if ($apiRequest['entity'] != 'OptionValue' || $apiRequest['action'] != 'create') {
+      return;
+    }
+    if (!self::checkReferrer() || !self::checkOptionGroup($apiRequest['params']['option_group_id'])) {
+      return;
+    }
+
+    $handler = CaseTypeCategoryEventHandlerFactory::create();
+    $handler->onUpdate(
+      $apiRequest['params']['id'],
+      isset($apiRequest['params']['is_active']) ? $apiRequest['params']['is_active'] : NULL,
+      isset($apiRequest['params']['icon']) ? $apiRequest['params']['icon'] : NULL
+    );
+  }
+
+  /**
+   * Checks the referer page for this request.
+   *
+   * This check may be used for the sake of performance. As we have to listen
+   * for events of all OptionValues to catch ones related to case type
+   * categories, we may check first if request was sent by user from civicrm
+   * admin page and not is triggered by some code, e.g. civicrm_api3().
+   *
+   * @return bool
+   *   TRUE if request is sent from civicrm Option Groups page, FALSE otherwise.
+   */
+  protected static function checkReferrer() {
+    return strpos($_SERVER['HTTP_REFERER'], '/civicrm/admin/options') != FALSE;
+  }
+
+  /**
+   * Checks if OptionValue belongs to Case Type Categories option group.
+   *
+   * @param int $optionGroupId
+   *   Case type category option group id or name. If is id then name would be
+   *   fetched from DB.
+   *
+   * @return bool
+   *   TRUE if option value belongs to Case Type Categories option group,
+   *   FALSE otherwise.
+   */
+  protected static function checkOptionGroup($optionGroupId) {
+    $res = FALSE;
+    if (!$optionGroupId) {
+      return $res;
+    }
+
+    try {
+      // Load option group.
+      $optionGroup = civicrm_api3('OptionGroup', 'getsingle', [
+        'id' => $optionGroupId,
+      ]);
+
+      // We're only interested in Case Type Categories option group.
+      if (!empty($optionGroup['name']) && $optionGroup['name'] == 'case_type_categories') {
+        $res = TRUE;
+      }
+    }
+    catch (Exception $e) {
+    }
+
+    return $res;
+  }
+}

--- a/CRM/Civicase/Event/Listener/CaseTypeCategoryIsActiveToggler.php
+++ b/CRM/Civicase/Event/Listener/CaseTypeCategoryIsActiveToggler.php
@@ -18,7 +18,7 @@ class CRM_Civicase_Event_Listener_CaseTypeCategoryIsActiveToggler {
    *   Event data.
    */
   public static function onRespond(RespondEvent $e) {
-    $apiRequest = $e->getApiRequest();
+    $apiRequest = (array) $e->getApiRequest();
     if (!self::shouldRun($apiRequest)) {
       return;
     }

--- a/CRM/Civicase/Factory/CaseTypeCategoryEventHandler.php
+++ b/CRM/Civicase/Factory/CaseTypeCategoryEventHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 use CRM_Civicase_Service_CaseTypeCategoryEventHandler as CaseTypeCategoryEventHandler;
-use CRM_Civicase_Service_CaseCategoryMenu as CaseCategoryMenuService;
+use CRM_Civicase_Service_CaseCategoryMenu as CaseCategoryMenu;
 use CRM_Civicase_Service_CaseCategoryCustomDataType as CaseCategoryCustomDataType;
 use CRM_Civicase_Service_CaseCategoryCustomFieldExtends as CaseCategoryCustomFieldExtends;
 
@@ -18,7 +18,7 @@ class CRM_Civicase_Factory_CaseTypeCategoryEventHandler {
    */
   public static function create() {
     return new CaseTypeCategoryEventHandler(
-      new CaseCategoryMenuService(),
+      new CaseCategoryMenu(),
       new CaseCategoryCustomDataType(),
       new CaseCategoryCustomFieldExtends()
     );

--- a/CRM/Civicase/Factory/CaseTypeCategoryEventHandler.php
+++ b/CRM/Civicase/Factory/CaseTypeCategoryEventHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+use CRM_Civicase_Service_CaseTypeCategoryEventHandler as CaseTypeCategoryEventHandler;
+use CRM_Civicase_Service_CaseCategoryMenu as CaseCategoryMenuService;
+use CRM_Civicase_Service_CaseCategoryCustomDataType as CaseCategoryCustomDataType;
+use CRM_Civicase_Service_CaseCategoryCustomFieldExtends as CaseCategoryCustomFieldExtends;
+
+/**
+ * Class CRM_Civicase_Factory_CaseTypeCategoryEventHandler.
+ */
+class CRM_Civicase_Factory_CaseTypeCategoryEventHandler {
+
+  /**
+   * Creates instance of CaseTypeCategoryEventHandler.
+   *
+   * @return \CRM_Civicase_Service_CaseTypeCategoryEventHandler
+   *   CaseTypeCategoryEventHandler instance.
+   */
+  public static function create() {
+    return new CaseTypeCategoryEventHandler(
+      new CaseCategoryMenuService(),
+      new CaseCategoryCustomDataType(),
+      new CaseCategoryCustomFieldExtends()
+    );
+  }
+
+}

--- a/CRM/Civicase/Hook/PostProcess/CaseCategoryPostProcessor.php
+++ b/CRM/Civicase/Hook/PostProcess/CaseCategoryPostProcessor.php
@@ -26,24 +26,22 @@ class CRM_Civicase_Hook_PostProcess_CaseCategoryPostProcessor {
     // Get object data from submitted from.
     $formValues = $form->_submitValues;
     $caseCategoryValues = $form->getVar('_values');
-    $category = [
-      'id' => $form->getVar('_id'),
-      'name' => !empty($caseCategoryValues['name']) ? $caseCategoryValues['name'] : $formValues['label'],
-      'is_active' => $formValues['is_active'],
-      'icon' => $formValues['icon'],
-    ];
+    $categoryId = $form->getVar('_id');
+    $categoryName = !empty($caseCategoryValues['name']) ? $caseCategoryValues['name'] : $formValues['label'];
+    $categoryStatus = $formValues['is_active'];
+    $categoryIcon = $formValues['icon'];
 
-    $op = $form->getVar('_action');
+    $formAction = $form->getVar('_action');
     $handler = CaseTypeCategoryEventHandlerFactory::create();
 
-    if ($op == CRM_Core_Action::UPDATE) {
-      $handler->onUpdate($category['id'], $category['is_active'], $category['icon']);
+    if ($formAction == CRM_Core_Action::UPDATE) {
+      $handler->onUpdate($categoryId, $categoryStatus, $categoryIcon);
     }
-    elseif ($op == CRM_Core_Action::ADD) {
-      $handler->onCreate($category['name']);
+    elseif ($formAction == CRM_Core_Action::ADD) {
+      $handler->onCreate($categoryName);
     }
-    elseif ($op == CRM_Core_Action::DELETE) {
-      $handler->onDelete($category['name']);
+    elseif ($formAction == CRM_Core_Action::DELETE) {
+      $handler->onDelete($categoryName);
     }
   }
 

--- a/CRM/Civicase/Hook/PostProcess/CaseCategoryPostProcessor.php
+++ b/CRM/Civicase/Hook/PostProcess/CaseCategoryPostProcessor.php
@@ -1,8 +1,6 @@
 <?php
 
-use CRM_Civicase_Service_CaseCategoryMenu as CaseCategoryMenuService;
-use CRM_Civicase_Service_CaseCategoryCustomDataType as CaseCategoryCustomDataType;
-use CRM_Civicase_Service_CaseCategoryCustomFieldExtends as CaseCategoryCustomFieldExtends;
+use CRM_Civicase_Factory_CaseTypeCategoryEventHandler as CaseTypeCategoryEventHandlerFactory;
 
 /**
  * Class CRM_Civicase_Hook_PostProcess_CaseCategoryPostProcessor.
@@ -25,53 +23,28 @@ class CRM_Civicase_Hook_PostProcess_CaseCategoryPostProcessor {
       return;
     }
 
-    $caseCategoryMenu = new CaseCategoryMenuService();
-    $caseCategoryCustomData = new CaseCategoryCustomDataType();
-    $caseCategoryCustomFieldExtends = new CaseCategoryCustomFieldExtends();
-
+    // Get object data from submitted from.
     $formValues = $form->_submitValues;
-    $formAction = $form->getVar('_action');
+    $caseCategoryValues = $form->getVar('_values');
+    $category = [
+      'id' => $form->getVar('_id'),
+      'name' => !empty($caseCategoryValues['name']) ? $caseCategoryValues['name'] : $formValues['label'],
+      'is_active' => $formValues['is_active'],
+      'icon' => $formValues['icon'],
+    ];
 
-    if ($formAction == CRM_Core_Action::DELETE) {
-      $caseCategoryValues = $form->getVar('_values');
-      $caseCategoryMenu->deleteItems($caseCategoryValues['name']);
-      $caseCategoryCustomFieldExtends->delete($caseCategoryValues['name']);
-      $caseCategoryCustomData->delete($caseCategoryValues['name']);
+    $op = $form->getVar('_action');
+    $handler = CaseTypeCategoryEventHandlerFactory::create();
+
+    if ($op == CRM_Core_Action::UPDATE) {
+      $handler->onUpdate($category['id'], $category['is_active'], $category['icon']);
     }
-
-    if ($formAction == CRM_Core_Action::ADD) {
-      $caseCategoryMenu->createItems($formValues['label']);
-      $caseCategoryCustomFieldExtends->create($formValues['label'], "Case ({$formValues['label']})");
-      $caseCategoryCustomData->create($formValues['label']);
+    elseif ($op == CRM_Core_Action::ADD) {
+      $handler->onCreate($category['name']);
     }
-
-    if ($formAction == CRM_Core_Action::UPDATE) {
-      $updateParams = [
-        'is_active' => !empty($formValues['is_active']) ? 1 : 0,
-        'icon' => 'crm-i ' . $formValues['icon'],
-      ];
-
-      $caseCategoryMenu->updateItems($form->getVar('_id'), $updateParams);
+    elseif ($op == CRM_Core_Action::DELETE) {
+      $handler->onDelete($category['name']);
     }
-  }
-
-  /**
-   * Returns the option value name given it's id.
-   *
-   * @param int $id
-   *   Option value id.
-   *
-   * @return string
-   *   Option value name.
-   */
-  private function getOptionValueName($id) {
-    $result = civicrm_api3('OptionValue', 'get', [
-      'option_group_id' => 'case_type_categories',
-      'id' => $id,
-      'return' => ['name'],
-    ]);
-
-    return $result['values'][$id]['name'];
   }
 
   /**

--- a/CRM/Civicase/Service/CaseTypeCategoryEventHandler.php
+++ b/CRM/Civicase/Service/CaseTypeCategoryEventHandler.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * Class CRM_Civicase_Service_CaseTypeCategoryEventHandler.
+ */
+class CRM_Civicase_Service_CaseTypeCategoryEventHandler {
+
+  /**
+   * Menu handler.
+   *
+   * @var \CRM_Civicase_Service_CaseCategoryMenu
+   */
+  protected $menu;
+
+  /**
+   * Custom data handler.
+   *
+   * @var \CRM_Civicase_Service_CaseCategoryCustomDataType
+   */
+  protected $customData;
+
+  /**
+   * Custom field handler.
+   *
+   * @var \CRM_Civicase_Service_CaseCategoryCustomFieldExtends
+   */
+  protected $customFieldExtends;
+
+  /**
+   * CRM_Civicase_Service_CaseTypeCategoryEventHandler constructor.
+   *
+   * @param \CRM_Civicase_Service_CaseCategoryMenu $menu
+   *   Menu handler.
+   * @param \CRM_Civicase_Service_CaseCategoryCustomDataType $customData
+   *   Custom data handler.
+   * @param \CRM_Civicase_Service_CaseCategoryCustomFieldExtends $customFieldExtends
+   *   Custom field handler.
+   */
+  public function __construct($menu, $customData, $customFieldExtends) {
+    $this->menu = $menu;
+    $this->customData = $customData;
+    $this->customFieldExtends = $customFieldExtends;
+  }
+
+  /**
+   * Perform actions on case type category create.
+   *
+   * @param string $caseCategoryName
+   *   Case type category name.
+   */
+  public function onCreate($caseCategoryName) {
+    if (!$caseCategoryName) {
+      return;
+    }
+
+    $this->menu->createItems($caseCategoryName);
+    $this->customFieldExtends->create($caseCategoryName, "Case ({$caseCategoryName})");
+    $this->customData->create($caseCategoryName);
+  }
+
+  /**
+   * Perform actions on case type category create.
+   *
+   * @param int $caseCategoryId
+   *   Case type category id.
+   * @param bool $caseCategoryStatus
+   *   (Optional) Case type category status (enabled / disabled).
+   * @param string $caseCategoryIcon
+   *   (Optional) Case type category icon.
+   */
+  public function OnUpdate($caseCategoryId, $caseCategoryStatus = NULL, $caseCategoryIcon = NULL){
+    if (!$caseCategoryId) {
+      return;
+    }
+
+    $updateParams = [];
+    if (isset($caseCategoryStatus)) {
+      $updateParams['is_active'] = !empty($caseCategoryStatus) ? 1 : 0;
+    }
+    if (isset($caseCategoryIcon)) {
+      $updateParams['icon'] = 'crm-i ' . $caseCategoryIcon;
+    }
+
+    if (!empty($updateParams)) {
+      $this->menu->updateItems($caseCategoryId, $updateParams);
+    }
+  }
+
+  /**
+   * Removes case type category menu item from the civicrm navigation bar.
+   *
+   * @param string $caseCategoryName
+   *   Case type category name.
+   */
+  public function onDelete($caseCategoryName) {
+    if (!$caseCategoryName) {
+      return;
+    }
+
+    $this->menu->deleteItems($caseCategoryName);
+    $this->customFieldExtends->delete($caseCategoryName);
+    $this->customData->delete($caseCategoryName);
+  }
+
+}

--- a/CRM/Civicase/Service/CaseTypeCategoryEventHandler.php
+++ b/CRM/Civicase/Service/CaseTypeCategoryEventHandler.php
@@ -1,5 +1,9 @@
 <?php
 
+use CRM_Civicase_Service_CaseCategoryMenu as CaseCategoryMenu;
+use CRM_Civicase_Service_CaseCategoryCustomDataType as CaseCategoryCustomDataType;
+use CRM_Civicase_Service_CaseCategoryCustomFieldExtends as CaseCategoryCustomFieldExtends;
+
 /**
  * Class CRM_Civicase_Service_CaseTypeCategoryEventHandler.
  */
@@ -36,7 +40,7 @@ class CRM_Civicase_Service_CaseTypeCategoryEventHandler {
    * @param \CRM_Civicase_Service_CaseCategoryCustomFieldExtends $customFieldExtends
    *   Custom field handler.
    */
-  public function __construct($menu, $customData, $customFieldExtends) {
+  public function __construct(CaseCategoryMenu $menu, CaseCategoryCustomDataType $customData, CaseCategoryCustomFieldExtends $customFieldExtends) {
     $this->menu = $menu;
     $this->customData = $customData;
     $this->customFieldExtends = $customFieldExtends;
@@ -59,7 +63,7 @@ class CRM_Civicase_Service_CaseTypeCategoryEventHandler {
   }
 
   /**
-   * Perform actions on case type category create.
+   * Perform actions on case type category update.
    *
    * @param int $caseCategoryId
    *   Case type category id.
@@ -68,7 +72,7 @@ class CRM_Civicase_Service_CaseTypeCategoryEventHandler {
    * @param string $caseCategoryIcon
    *   (Optional) Case type category icon.
    */
-  public function OnUpdate($caseCategoryId, $caseCategoryStatus = NULL, $caseCategoryIcon = NULL){
+  public function onUpdate($caseCategoryId, $caseCategoryStatus = NULL, $caseCategoryIcon = NULL) {
     if (!$caseCategoryId) {
       return;
     }
@@ -81,9 +85,11 @@ class CRM_Civicase_Service_CaseTypeCategoryEventHandler {
       $updateParams['icon'] = 'crm-i ' . $caseCategoryIcon;
     }
 
-    if (!empty($updateParams)) {
-      $this->menu->updateItems($caseCategoryId, $updateParams);
+    if (empty($updateParams)) {
+      return;
     }
+
+    $this->menu->updateItems($caseCategoryId, $updateParams);
   }
 
   /**

--- a/api/v3/Activity/Getmonthswithactivities.php
+++ b/api/v3/Activity/Getmonthswithactivities.php
@@ -1,5 +1,6 @@
 <?php
-use CRM_Civicase_ExtensionUtil as E;
+
+use CRM_Civicase_Event_Listener_ActivityFilter as CivicaseActivityFilter;
 
 /**
  * Activity.Getmonthswithactivities API specification
@@ -91,7 +92,7 @@ function get_records_from_activity_get_api($params) {
   $sql = CRM_Utils_SQL_Select::fragment();
 
   if (isset($params['case_filter'])) {
-    CRM_Civicase_ActivityFilter::updateParams($params);
+    CivicaseActivityFilter::updateParams($params);
   }
 
   _civicrm_api3_activity_get_extraFilters($params, $sql);

--- a/civicase.php
+++ b/civicase.php
@@ -47,7 +47,7 @@ function civicase_civicrm_config(&$config) {
   }
   Civi::$statics[__FUNCTION__] = 1;
 
-  Civi::dispatcher()->addListener('civi.api.prepare', ['CRM_Civicase_ActivityFilter', 'onPrepare'], 10);
+  Civi::dispatcher()->addListener('civi.api.prepare', ['CRM_Civicase_Event_Listener_ActivityFilter', 'onPrepare'], 10);
   Civi::dispatcher()->addListener('civi.api.respond', ['CRM_Civicase_Event_Listener_CaseTypeCategoryIsActiveToggler', 'onRespond'], 10);
 }
 

--- a/civicase.php
+++ b/civicase.php
@@ -48,6 +48,7 @@ function civicase_civicrm_config(&$config) {
   Civi::$statics[__FUNCTION__] = 1;
 
   Civi::dispatcher()->addListener('civi.api.prepare', ['CRM_Civicase_ActivityFilter', 'onPrepare'], 10);
+  Civi::dispatcher()->addListener('civi.api.respond', ['CRM_Civicase_Event_Listener_CaseTypeCategoryIsActiveToggler', 'onRespond'], 10);
 }
 
 /**


### PR DESCRIPTION
## Overview
We had a bug with case type categories - disabling a case type category doesn’t hide respective item from main menu. Actually it's working fine when user clicks _Edit_ and unticks _Enabled_ checkbox, but not working when user clicks _Disable_ link in the categories list:
![image](https://user-images.githubusercontent.com/39520000/79314773-d0efd300-7f0a-11ea-8cb6-05068af64e8b.png)

Now it's fixed.

## Technical Details
Enable / Disable was working fine when user submits a form, because we have a post processor for this form. But when user clicks the link normal api request is called, which has no processing.
So to fix it:
1. The `CRM_Civicase_Event_Listener_CaseTypeCategoryIsActiveToggler` listener was added to listen for api call responses.
1. To avoid duplication the `CRM_Civicase_Service_CaseTypeCategoryEventHandler` class was created which handles create/update/delete processing for case type category option values.
So listener uses this class to run necessary actions.
1. Also `CRM_Civicase_Factory_CaseTypeCategoryEventHandler` factory was created for new class.
1. The `CRM_Civicase_Hook_PostProcess_CaseCategoryPostProcessor` post process hook was refactored to reuse new class.
1. As we created `Event/Listener` folder for new listener we also moved one existing listener `CRM_Civicase_Event_Listener_ActivityFilter` to the same folder. All calls of this class where updated respectively.