### PR TITLE
CPS-129: Add Relationship Description to Other Relationships tab

### DIFF
--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.html
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.html
@@ -219,6 +219,7 @@
         <tr>
           <th class="civicase__people-tab__table-column">{{ ts('Name') }}</th>
           <th class="civicase__people-tab__table-column">{{ ts('Relationship') }}</th>
+          <th class="civicase__people-tab__table-column">{{ ts('Description') }}</th>
           <th class="civicase__people-tab__table-column">{{ ts('Client') }}</th>
           <th class="civicase__people-tab__table-column">{{ ts('Phone') }}</th>
           <th class="civicase__people-tab__table-column">{{ ts('Email') }}</th>
@@ -238,6 +239,7 @@
             </label>
           </td>
           <td class="civicase__people-tab__table-column">{{ contact.relation }}</td>
+          <td class="civicase__people-tab__table-column">{{ contact.relationship_description }}</td>
           <td class="civicase__people-tab__table-column">{{ contact.client }}</td>
           <td class="civicase__people-tab__table-column">{{ contact.phone }}</td>
           <td class="civicase__people-tab__table-column">{{ contact.email }}</td>

--- a/api/v3/Case/Getrelations.php
+++ b/api/v3/Case/Getrelations.php
@@ -1,16 +1,20 @@
 <?php
 
+/**
+ * @file
+ * Case.getrelations file.
+ */
+
 require_once 'api/v3/Contact.php';
 
 /**
- * Case.Getrelations API specification (optional)
- * This is used for documentation and validation.
+ * Case.Getrelations API specification.
  *
- * @param array $spec description of fields supported by this API call
- * @return void
+ * @param array $spec
+ *   description of fields supported by this API call.
  * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
  */
-function _civicrm_api3_case_getrelations_spec(&$spec) {
+function _civicrm_api3_case_getrelations_spec(array &$spec) {
   _civicrm_api3_contact_get_spec($spec);
   $spec['case_id'] = array(
     'title' => 'Case ID',
@@ -20,15 +24,19 @@ function _civicrm_api3_case_getrelations_spec(&$spec) {
 }
 
 /**
- * Case.Getrelations API
+ * Case.Getrelations API.
  *
  * Perform a search for contacts related to clients of a case.
  *
  * @param array $params
- * @return array API result
+ *   Parameters.
+ *
+ * @return array
+ *   API result.
+ *
  * @throws API_Exception
  */
-function civicrm_api3_case_getrelations($params) {
+function civicrm_api3_case_getrelations(array $params) {
   $relations = array();
   $params += array('options' => array());
   $caseContacts = civicrm_api3('CaseContact', 'get', array(
@@ -45,9 +53,15 @@ function civicrm_api3_case_getrelations($params) {
     "contact_id_a" => array('IN' => $clientIds),
     "contact_id_b" => array('IN' => $clientIds),
     'options' => array('or' => array(array("contact_id_a", "contact_id_b"))) + $params['options'],
-    'return' => array('relationship_type_id', 'contact_id_a', 'contact_id_b'),
+    'return' => array(
+      'relationship_type_id',
+      'contact_id_a',
+      'contact_id_b',
+      'description',
+    ),
   );
   $result = civicrm_api3('Relationship', 'get', $relationshipParams);
+
   foreach ($result['values'] as $relation) {
     $a = in_array($relation['contact_id_a'], $clientIds) ? 'b' : 'a';
     $b = in_array($relation['contact_id_a'], $clientIds) ? 'a' : 'b';
@@ -57,14 +71,18 @@ function civicrm_api3_case_getrelations($params) {
       'client_contact_id' => $relation["contact_id_$b"],
       'relationship_id' => $relation['id'],
       'relationship_type_id' => $relation['relationship_type_id'],
+      'relationship_description' => $relation['description'],
       'relationship_direction' => "{$a}_{$b}",
     );
   }
+
   if (!$relations) {
     return $result;
   }
+
   unset($params['case_id'], $params['options']);
   $contacts = civicrm_api3('Contact', 'get', array('sequential' => 0, 'id' => array('IN' => $contactIds)) + $params);
+
   foreach ($relations as &$relation) {
     if (isset($contacts['values'][$relation['id']])) {
       $relation += $contacts['values'][$relation['id']];
@@ -74,7 +92,9 @@ function civicrm_api3_case_getrelations($params) {
       --$result['count'];
     }
   }
+
   $out = civicrm_api3_create_success(array_filter($relations), $params, 'Case', 'getrelations');
   $out['count'] = $result['count'];
+
   return $out;
 }


### PR DESCRIPTION
## Overview
The "Description" column has been added to the Other Relationships tabs in Case Details section.

## Before
![2020-04-13 at 12 11 PM](https://user-images.githubusercontent.com/5058867/79098583-edabcf80-7d7f-11ea-8f66-f1724f1ef370.jpg)

## After
![2020-04-13 at 12 07 PM](https://user-images.githubusercontent.com/5058867/79098354-6a8a7980-7d7f-11ea-88b1-1f2723ec6ff6.jpg)

## Technical Details
1. `Case.getrelations` has been modified to also return the `description` field.
2. Markup to show `Description` field is added to `case-details-people-tab.directive.html`.