### PR TITLE
CATL-1313: Modify CopyByQuery and MoveByQuery Case Activity APIs

### DIFF
--- a/api/v3/Activity/Copybyquery.php
+++ b/api/v3/Activity/Copybyquery.php
@@ -72,10 +72,8 @@ function civicrm_api3_activity_copybyquery(array $params) {
     }
 
     $result = CRM_Activity_Page_AJAX::_convertToCaseActivity($caseActivityParams);
-    if (empty($result['error_msg'])) {
-      if (!empty($result['newId'])) {
-        $activityIds[] = $result['newId'];
-      }
+    if (empty($result['error_msg']) && !empty($result['newId'])) {
+      $activityIds[] = $result['newId'];
     }
   }
 

--- a/api/v3/Activity/Copybyquery.php
+++ b/api/v3/Activity/Copybyquery.php
@@ -27,6 +27,11 @@ function _civicrm_api3_activity_copybyquery_spec(array &$spec) {
     'description' => 'Array of parameters for Activity.Get API',
     'type' => CRM_Utils_Type::T_STRING,
   ];
+  $spec['subject'] = [
+    'title' => 'Activity Subject',
+    'description' => 'Activity Subject',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
 }
 
 /**
@@ -46,16 +51,32 @@ function _civicrm_api3_activity_copybyquery_spec(array &$spec) {
 function civicrm_api3_activity_copybyquery(array $params) {
   $activityQueryApiHelper = new CRM_Civicase_APIHelpers_ActivityQueryApi();
   $activityQueryApiHelper->validateParameters($params);
-  $activityApiParams = $activityQueryApiHelper->getActivityGetRequestApiParams($params);
   $genericApiHelper = new CRM_Civicase_APIHelpers_GenericApi();
-  $activities = $genericApiHelper->getEntityValues('Activity', $activityApiParams);
+
+  if (!empty($params['id'])) {
+    $activities = $genericApiHelper->getParameterValue($params, 'id');
+  }
+  else {
+    $activityApiParams = $activityQueryApiHelper->getActivityGetRequestApiParams($params);
+    $activities = array_column($genericApiHelper->getEntityValues('Activity', $activityApiParams, ['id']), 'id');
+  }
 
   $activityIds = [];
-  foreach ($activities as $activity) {
-    unset($activity['id']);
-    $activity['case_id'] = $params['case_id'];
-    $result = civicrm_api3('Activity', 'create', $activity);
-    $activityIds[] = $result['id'];
+  foreach ($activities as $activityId) {
+    $caseActivityParams = [
+      'activityID' => $activityId,
+      'caseID' => $params['case_id'],
+    ];
+    if (!empty($params['subject'])) {
+      $caseActivityParams['newSubject'] = $params['subject'];
+    }
+
+    $result = CRM_Activity_Page_AJAX::_convertToCaseActivity($caseActivityParams);
+    if (empty($result['error_msg'])) {
+      if (!empty($result['newId'])) {
+        $activityIds[] = $result['newId'];
+      }
+    }
   }
 
   return civicrm_api3_create_success($activityIds, $params, 'Activity', 'copybyquery');

--- a/api/v3/Activity/Movebyquery.php
+++ b/api/v3/Activity/Movebyquery.php
@@ -27,6 +27,11 @@ function _civicrm_api3_activity_Movebyquery_spec(array &$spec) {
     'description' => 'Array of parameters for Activity.Get API',
     'type' => CRM_Utils_Type::T_STRING,
   ];
+  $spec['subject'] = [
+    'title' => 'Activity Subject',
+    'description' => 'Activity Subject',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
 }
 
 /**
@@ -58,11 +63,22 @@ function civicrm_api3_activity_movebyquery(array $params) {
 
   $activityIds = [];
   foreach ($activities as $activityId) {
-    $activityIds[] = $activityId;
-    civicrm_api3('Activity', 'create', [
-      'id' => $activityId,
-      'case_id' => $params['case_id'],
-    ]);
+    $caseActivityParams = [
+      'activityID' => $activityId,
+      'caseID' => $params['case_id'],
+      'mode' => 'move',
+    ];
+
+    if (!empty($params['subject'])) {
+      $caseActivityParams['newSubject'] = $params['subject'];
+    }
+
+    $result = CRM_Activity_Page_AJAX::_convertToCaseActivity($caseActivityParams);
+    if (empty($result['error_msg'])) {
+      if (!empty($result['newId'])) {
+        $activityIds[] = $result['newId'];
+      }
+    }
   }
 
   return civicrm_api3_create_success($activityIds, $params, 'Activity', 'copybyquery');

--- a/api/v3/Activity/Movebyquery.php
+++ b/api/v3/Activity/Movebyquery.php
@@ -74,10 +74,8 @@ function civicrm_api3_activity_movebyquery(array $params) {
     }
 
     $result = CRM_Activity_Page_AJAX::_convertToCaseActivity($caseActivityParams);
-    if (empty($result['error_msg'])) {
-      if (!empty($result['newId'])) {
-        $activityIds[] = $result['newId'];
-      }
+    if (empty($result['error_msg']) && !empty($result['newId'])) {
+      $activityIds[] = $result['newId'];
     }
   }
 


### PR DESCRIPTION
## Overview
The Move To Case action for moving an activity to a case was not working. This PR fixes the issue.

## Before
- We were trying to move an activity to a case via the Activity.create API. However this does not work because of a couple of factors. One of such is that the API is explicitly hardcoded to copy to case and the mode parameter is not exposed as an option to be passed via the API, see [here](https://github.com/civicrm/civicrm-core/blob/master/api/v3/Activity.php#L120-L125).

## After
- When checking Core,  it turns out that the CRM_Activity_Page_AJAX::_convertToCaseActivity is used to move/copy activity to case. The same [function](https://github.com/civicrm/civicrm-core/blob/master/api/v3/Activity.php#L125) is used by the API but the API does not allow to set the mode. This function is now used in the already existing custom `Activity.movebyquery` and `Activity.copybyquery` API's to perform these needed operations.
- A new API parameter `subject` is also added to these two API's to allow the Activity subject to be modified when copying or moving to case. 

## Comments
A FE PR will be created in order to factor in changes made to these API's
