### PR TITLE
CATL-1321: Fix dashboard tab affix when Admin Menu is visible

### DIFF
--- a/ang/civicase/crm-dashboard/directives/crm-dashboard-tabset-affix.directive.js
+++ b/ang/civicase/crm-dashboard/directives/crm-dashboard-tabset-affix.directive.js
@@ -34,14 +34,38 @@
             offset: {
               top: $tabContainer.offset().top - (toolbarDrawerHeight + $civicrmMenu.height())
             }
-          }).on('affixed.bs.affix', function () {
-            $tabNavigation.css('top', $civicrmMenu.height() + toolbarDrawerHeight);
-            $parentContainer.css('padding-top', parentOriginalTopPadding + $tabNavigation.height());
-          }).on('affixed-top.bs.affix', function () {
-            $parentContainer.css('padding-top', parentOriginalTopPadding);
-            $tabNavigation.css('top', 'auto');
-          });
+          })
+            .on('affixed.bs.affix', handleTabNavigationAffix)
+            .on('affixed-top.bs.affix', handleTabNavigationRestore);
         });
+      }
+
+      /**
+       * Handles the changes that happen when the tab navigation is affixed.
+       * It adds top spacing to both the navigation menu and the dashboard to
+       * properly display the affixed elements.
+       */
+      function handleTabNavigationAffix () {
+        var $adminMenu = $('#admin-menu');
+        var adminMenuHeight = $adminMenu.is(':visible')
+          ? $adminMenu.height()
+          : 0;
+        var tabNavigationTopPosition = $civicrmMenu.height() + toolbarDrawerHeight +
+          adminMenuHeight;
+        var parentContainerPaddingTop = $tabNavigation.height() +
+          parentOriginalTopPadding + adminMenuHeight;
+
+        $tabNavigation.css('top', tabNavigationTopPosition);
+        $parentContainer.css('padding-top', parentContainerPaddingTop);
+      }
+
+      /**
+       * It restore the navigation tabs and the dashboard container to their
+       * original states.
+       */
+      function handleTabNavigationRestore () {
+        $parentContainer.css('padding-top', parentOriginalTopPadding);
+        $tabNavigation.css('top', 'auto');
       }
 
       /**


### PR DESCRIPTION
## Overview
This PR fixes the dashboard tab navigation elements when they need to be affixed and the Admin Menu element is visible. Previously the affixing was not taking into consideration this element.

## Before
![gif](https://user-images.githubusercontent.com/1642119/79346202-1529a600-7f00-11ea-95e3-da03f17cd498.gif)

## After
![gif](https://user-images.githubusercontent.com/1642119/79346090-ed3a4280-7eff-11ea-9aa7-8577102c28a9.gif)

## Technical Details

We updated the code so it includes the Admin Menu height to the position `top` of the CRM Menu and to the `padding-top` of the dashboard container. This extra spacing is only applied when the Admin Menu is visible.