### PR TITLE
CATL-1314: Update Move/Copy activity endpoints

### DIFF
--- a/ang/civicase/activity/actions/services/move-copy-activity-action.service.js
+++ b/ang/civicase/activity/actions/services/move-copy-activity-action.service.js
@@ -96,57 +96,25 @@
      * @returns {Array} api call configuration
      */
     function prepareApiCalls (activitiesObject, operation, model) {
-      if (activitiesObject.selectedActivities.length === 1) {
-        return prepareAPICallsForSingleActivity(activitiesObject, operation, model);
-      } else {
-        return prepareAPICallsForMultipleActivities(activitiesObject, operation, model);
-      }
-    }
-
-    /**
-     * Prepare the API calls for the move/copy operation
-     *
-     * @param {object} activitiesObject object containing configuration of activities
-     * @param {string} operation move or copy operation
-     * @param {object} model model object for dialog box
-     * @returns {Array} api call configuration
-     */
-    function prepareAPICallsForSingleActivity (activitiesObject, operation, model) {
-      var activity = activitiesObject.selectedActivities[0];
-
-      if (operation === 'copy') {
-        delete activity.id;
-      }
-
-      activity.subject = model.subject;
-      activity.case_id = model.case_id;
-
-      return [['Activity', 'create', activity]];
-    }
-
-    /**
-     * Prepare the API calls for the move/copy operation
-     *
-     * @param {object} activitiesObject object containing configuration of activities
-     * @param {string} operation move or copy operation
-     * @param {object} model model object for dialog box
-     * @returns {Array} api call configuration
-     */
-    function prepareAPICallsForMultipleActivities (activitiesObject, operation, model) {
       var action = operation === 'copy' ? 'copybyquery' : 'movebyquery';
+      var selectedActivitiesIds = _.map(activitiesObject.selectedActivities, 'id');
+      var isSingleActivity = selectedActivitiesIds.length === 1;
 
       if (activitiesObject.isSelectAll) {
         return [['Activity', action, {
           params: activitiesObject.searchParams,
           case_id: model.case_id
         }]];
+      } else if (isSingleActivity) {
+        return [['Activity', action, {
+          case_id: model.case_id,
+          id: selectedActivitiesIds,
+          subject: model.subject
+        }]];
       } else {
         return [['Activity', action, {
           case_id: model.case_id,
-          id: activitiesObject.selectedActivities.map(function (activity) {
-            return activity.id;
-          }),
-          subject: model.subject
+          id: selectedActivitiesIds
         }]];
       }
     }

--- a/ang/civicase/activity/actions/services/move-copy-activity-action.service.js
+++ b/ang/civicase/activity/actions/services/move-copy-activity-action.service.js
@@ -99,24 +99,19 @@
       var action = operation === 'copy' ? 'copybyquery' : 'movebyquery';
       var selectedActivitiesIds = _.map(activitiesObject.selectedActivities, 'id');
       var isSingleActivity = selectedActivitiesIds.length === 1;
+      var apiCallParams = { case_id: model.case_id };
 
       if (activitiesObject.isSelectAll) {
-        return [['Activity', action, {
-          params: activitiesObject.searchParams,
-          case_id: model.case_id
-        }]];
-      } else if (isSingleActivity) {
-        return [['Activity', action, {
-          case_id: model.case_id,
-          id: selectedActivitiesIds,
-          subject: model.subject
-        }]];
+        apiCallParams.params = activitiesObject.searchParams;
       } else {
-        return [['Activity', action, {
-          case_id: model.case_id,
-          id: selectedActivitiesIds
-        }]];
+        if (isSingleActivity) {
+          apiCallParams.subject = model.subject;
+        }
+
+        apiCallParams.id = selectedActivitiesIds;
       }
+
+      return [['Activity', action, apiCallParams]];
     }
   }
 })(angular, CRM.$, CRM._);

--- a/ang/test/civicase/activity/actions/services/move-copy-activity-action.service.spec.js
+++ b/ang/test/civicase/activity/actions/services/move-copy-activity-action.service.spec.js
@@ -3,7 +3,7 @@
 (function (_, $) {
   describe('MoveCopyActivityAction', function () {
     var $q, $rootScope, MoveCopyActivityAction, activitiesMockData,
-      crmApiMock, dialogServiceMock;
+      crmApiMock, dialogServiceMock, originalDialogFunction;
 
     beforeEach(module('civicase', 'civicase.data', function ($provide) {
       crmApiMock = jasmine.createSpy('crmApi');
@@ -19,7 +19,14 @@
       $rootScope = _$rootScope_;
       activitiesMockData = _activitiesMockData_;
       MoveCopyActivityAction = _MoveCopyActivityAction_;
+      originalDialogFunction = $.fn.dialog;
+
+      spyOn($.fn, 'dialog');
     }));
+
+    afterEach(function () {
+      $.fn.dialog = originalDialogFunction;
+    });
 
     describe('Copy Activities bulk action', function () {
       var activities, modalOpenCall, model;
@@ -78,16 +85,13 @@
           beforeEach(function () {
             var saveMethod = modalOpenCall[3].buttons[0].click;
             model.case_id = _.uniqueId();
-            model.subject = 'subject';
             expectedActivitySavingCalls = [['Activity', 'copybyquery', {
               case_id: model.case_id,
-              subject: model.subject,
               id: $scope.selectedActivities.map(function (activity) {
                 return activity.id;
               })
             }]];
 
-            spyOn($.fn, 'dialog');
             spyOn($rootScope, '$broadcast');
             crmApiMock.and.returnValue($q.resolve([{ values: $scope.selectedActivities }]));
             saveMethod();
@@ -112,7 +116,6 @@
             var saveMethod = modalOpenCall[3].buttons[0].click;
             model.case_id = $scope.selectedActivities[0].case_id;
 
-            spyOn($.fn, 'dialog');
             spyOn($rootScope, '$broadcast');
             crmApiMock.and.returnValue($q.resolve([{ values: $scope.selectedActivities }]));
             saveMethod();
@@ -159,6 +162,31 @@
 
           it('defines an empty subject', function () {
             expect(model.subject).toBe($scope.selectedActivities[0].subject);
+          });
+        });
+
+        describe('when saving the copy action modal', function () {
+          var expectedActivitySavingCalls;
+
+          beforeEach(function () {
+            var saveMethod = modalOpenCall[3].buttons[0].click;
+            model.case_id = _.uniqueId();
+            model.subject = 'a sample subject';
+            expectedActivitySavingCalls = [['Activity', 'copybyquery', {
+              case_id: model.case_id,
+              subject: model.subject,
+              id: $scope.selectedActivities.map(function (activity) {
+                return activity.id;
+              })
+            }]];
+
+            crmApiMock.and.returnValue($q.resolve([{ values: $scope.selectedActivities }]));
+            saveMethod();
+            $rootScope.$digest();
+          });
+
+          it('saves a new copy of each of the activity and assigns it to the selected case using the new activity subject', function () {
+            expect(crmApiMock.calls.mostRecent().args[0]).toEqual(expectedActivitySavingCalls);
           });
         });
       });
@@ -221,16 +249,13 @@
           beforeEach(function () {
             var saveMethod = modalOpenCall[3].buttons[0].click;
             model.case_id = _.uniqueId();
-            model.subject = 'subject';
             expectedActivitySavingCalls = [['Activity', 'movebyquery', {
               case_id: model.case_id,
-              subject: model.subject,
               id: $scope.selectedActivities.map(function (activity) {
                 return activity.id;
               })
             }]];
 
-            spyOn($.fn, 'dialog');
             spyOn($rootScope, '$broadcast');
             crmApiMock.and.returnValue($q.resolve([{ values: $scope.selectedActivities }]));
             saveMethod();
@@ -255,7 +280,6 @@
             var saveMethod = modalOpenCall[3].buttons[0].click;
             model.case_id = $scope.selectedActivities[0].case_id;
 
-            spyOn($.fn, 'dialog');
             spyOn($rootScope, '$broadcast');
             crmApiMock.and.returnValue($q.resolve([{ values: $scope.selectedActivities }]));
             saveMethod();
@@ -302,6 +326,31 @@
 
           it('defines an empty subject', function () {
             expect(model.subject).toBe($scope.selectedActivities[0].subject);
+          });
+        });
+
+        describe('when saving the move action modal', function () {
+          var expectedActivitySavingCalls;
+
+          beforeEach(function () {
+            var saveMethod = modalOpenCall[3].buttons[0].click;
+            model.case_id = _.uniqueId();
+            model.subject = 'a sample subject';
+            expectedActivitySavingCalls = [['Activity', 'movebyquery', {
+              case_id: model.case_id,
+              subject: model.subject,
+              id: $scope.selectedActivities.map(function (activity) {
+                return activity.id;
+              })
+            }]];
+
+            crmApiMock.and.returnValue($q.resolve([{ values: $scope.selectedActivities }]));
+            saveMethod();
+            $rootScope.$digest();
+          });
+
+          it('moves the activity and assigns it to the selected case using the new activity subject', function () {
+            expect(crmApiMock.calls.mostRecent().args[0]).toEqual(expectedActivitySavingCalls);
           });
         });
       });

--- a/ang/test/civicase/activity/actions/services/move-copy-activity-action.service.spec.js
+++ b/ang/test/civicase/activity/actions/services/move-copy-activity-action.service.spec.js
@@ -138,7 +138,11 @@
 
       describe('when selecting a single activity and copying it to a new case', function () {
         beforeEach(function () {
-          $scope.selectedActivities = _.sample(activities, 1);
+          $scope.selectedActivities = _.chain(activities)
+            .sample(1)
+            .cloneDeep()
+            .value();
+          $scope.selectedActivities[0].type = 'Meeting';
 
           MoveCopyActivityAction.doAction($scope, { operation: 'copy' });
 
@@ -146,9 +150,8 @@
           model = modalOpenCall[2];
         });
 
-        it('displays the modal title as "Copy Type Activity"', function () {
-          // @FIX: the activity at this point only has the id, source_contact_id properties. The type field is not defined:
-          expect(modalOpenCall[3].title).toBe('Copy Activity');
+        it('displays the modal title as "Copy Meeting Activity"', function () {
+          expect(modalOpenCall[3].title).toBe('Copy Meeting Activity');
         });
 
         describe('the model', function () {
@@ -302,7 +305,11 @@
 
       describe('when selecting a single activity and moving it to a new case', function () {
         beforeEach(function () {
-          $scope.selectedActivities = _.sample(activities, 1);
+          $scope.selectedActivities = _.chain(activities)
+            .sample(1)
+            .cloneDeep()
+            .value();
+          $scope.selectedActivities[0].type = 'Meeting';
 
           MoveCopyActivityAction.doAction($scope, { operation: 'move' });
 
@@ -310,9 +317,8 @@
           model = modalOpenCall[2];
         });
 
-        it('displays the modal title as "Move Type Activity"', function () {
-          // @FIX: the activity at this point only has the id, source_contact_id properties. The type field is not defined:
-          expect(modalOpenCall[3].title).toBe('Move Activity');
+        it('displays the modal title as "Move Meeting Activity"', function () {
+          expect(modalOpenCall[3].title).toBe('Move Meeting Activity');
         });
 
         describe('the model', function () {

--- a/ang/test/civicase/activity/actions/services/move-copy-activity-action.service.spec.js
+++ b/ang/test/civicase/activity/actions/services/move-copy-activity-action.service.spec.js
@@ -1,11 +1,11 @@
 /* eslint-env jasmine */
 
-(function (_, $) {
-  describe('MoveCopyActivityAction', function () {
-    var $q, $rootScope, MoveCopyActivityAction, activitiesMockData,
+((_, $) => {
+  describe('MoveCopyActivityAction', () => {
+    let $q, $rootScope, MoveCopyActivityAction, activitiesMockData,
       crmApiMock, dialogServiceMock, originalDialogFunction;
 
-    beforeEach(module('civicase', 'civicase.data', function ($provide) {
+    beforeEach(module('civicase', 'civicase.data', ($provide) => {
       crmApiMock = jasmine.createSpy('crmApi');
       dialogServiceMock = jasmine.createSpyObj('dialogService', ['open']);
 
@@ -24,35 +24,35 @@
       spyOn($.fn, 'dialog');
     }));
 
-    afterEach(function () {
+    afterEach(() => {
       $.fn.dialog = originalDialogFunction;
     });
 
-    describe('Copy Activities bulk action', function () {
-      var activities, modalOpenCall, model;
-      var $scope = {};
+    describe('Copy Activities bulk action', () => {
+      let activities, modalOpenCall, model;
+      const $scope = {};
 
-      beforeEach(function () {
-        var caseId = _.uniqueId();
+      beforeEach(() => {
+        const caseId = _.uniqueId();
 
         activities = activitiesMockData.get();
 
-        activities.forEach(function (activity) {
+        activities.forEach((activity) => {
           activity.case_id = caseId;
         });
 
         $scope.selectedActivities = _.sample(activities, 2);
       });
 
-      describe('when selecting some activities and then copy them to a new case', function () {
-        beforeEach(function () {
+      describe('when selecting some activities and then copy them to a new case', () => {
+        beforeEach(() => {
           MoveCopyActivityAction.doAction($scope, { operation: 'copy' });
 
           modalOpenCall = dialogServiceMock.open.calls.mostRecent().args;
           model = modalOpenCall[2];
         });
 
-        it('opens a case selection modal', function () {
+        it('opens a case selection modal', () => {
           expect(dialogServiceMock.open).toHaveBeenCalledWith(
             'MoveCopyActCard',
             '~/civicase/activity/actions/services/move-copy-activity-action.html',
@@ -61,33 +61,33 @@
           );
         });
 
-        it('displays the title as "Copy 2 Activities"', function () {
+        it('displays the title as "Copy 2 Activities"', () => {
           expect(modalOpenCall[3].title).toBe('Copy 2 Activities');
         });
 
-        describe('the model', function () {
-          it('defines an empty case id', function () {
+        describe('the model', () => {
+          it('defines an empty case id', () => {
             expect(model.case_id).toBe('');
           });
 
-          it('does not display the subject', function () {
+          it('does not display the subject', () => {
             expect(model.isSubjectVisible).toBe(false);
           });
 
-          it('defines an empty subject', function () {
+          it('defines an empty subject', () => {
             expect(model.subject).toBe('');
           });
         });
 
-        describe('when saving the copy action modal', function () {
-          var expectedActivitySavingCalls;
+        describe('when saving the copy action modal', () => {
+          let expectedActivitySavingCalls;
 
-          beforeEach(function () {
-            var saveMethod = modalOpenCall[3].buttons[0].click;
+          beforeEach(() => {
+            const saveMethod = modalOpenCall[3].buttons[0].click;
             model.case_id = _.uniqueId();
             expectedActivitySavingCalls = [['Activity', 'copybyquery', {
               case_id: model.case_id,
-              id: $scope.selectedActivities.map(function (activity) {
+              id: $scope.selectedActivities.map((activity) => {
                 return activity.id;
               })
             }]];
@@ -98,22 +98,22 @@
             $rootScope.$digest();
           });
 
-          it('saves a new copy of each of the activities and assign them to the selected case', function () {
+          it('saves a new copy of each of the activities and assign them to the selected case', () => {
             expect(crmApiMock.calls.mostRecent().args[0]).toEqual(expectedActivitySavingCalls);
           });
 
-          it('emits a civicase activity updated event', function () {
+          it('emits a civicase activity updated event', () => {
             expect($rootScope.$broadcast).toHaveBeenCalledWith('civicase::activity::updated');
           });
 
-          it('closes the dialog', function () {
+          it('closes the dialog', () => {
             expect($.fn.dialog).toHaveBeenCalled();
           });
         });
 
-        describe('when the selected case is the same as the current case', function () {
-          beforeEach(function () {
-            var saveMethod = modalOpenCall[3].buttons[0].click;
+        describe('when the selected case is the same as the current case', () => {
+          beforeEach(() => {
+            const saveMethod = modalOpenCall[3].buttons[0].click;
             model.case_id = $scope.selectedActivities[0].case_id;
 
             spyOn($rootScope, '$broadcast');
@@ -122,22 +122,22 @@
             $rootScope.$digest();
           });
 
-          it('does not request the activities data', function () {
+          it('does not request the activities data', () => {
             expect(crmApiMock).not.toHaveBeenCalled();
           });
 
-          it('does not emit the civicase activity updated event', function () {
+          it('does not emit the civicase activity updated event', () => {
             expect($rootScope.$broadcast).not.toHaveBeenCalledWith('civicase::activity::updated');
           });
 
-          it('closes the dialog', function () {
+          it('closes the dialog', () => {
             expect($.fn.dialog).toHaveBeenCalled();
           });
         });
       });
 
-      describe('when selecting a single activity and copying it to a new case', function () {
-        beforeEach(function () {
+      describe('when selecting a single activity and copying it to a new case', () => {
+        beforeEach(() => {
           $scope.selectedActivities = _.chain(activities)
             .sample(1)
             .cloneDeep()
@@ -150,35 +150,35 @@
           model = modalOpenCall[2];
         });
 
-        it('displays the modal title as "Copy Meeting Activity"', function () {
+        it('displays the modal title as "Copy Meeting Activity"', () => {
           expect(modalOpenCall[3].title).toBe('Copy Meeting Activity');
         });
 
-        describe('the model', function () {
-          it('defines the case id the same as the selected activity', function () {
+        describe('the model', () => {
+          it('defines the case id the same as the selected activity', () => {
             expect(model.case_id).toBe($scope.selectedActivities[0].case_id);
           });
 
-          it('displays the subject', function () {
+          it('displays the subject', () => {
             expect(model.isSubjectVisible).toBe(true);
           });
 
-          it('defines an empty subject', function () {
+          it('defines an empty subject', () => {
             expect(model.subject).toBe($scope.selectedActivities[0].subject);
           });
         });
 
-        describe('when saving the copy action modal', function () {
-          var expectedActivitySavingCalls;
+        describe('when saving the copy action modal', () => {
+          let expectedActivitySavingCalls;
 
-          beforeEach(function () {
-            var saveMethod = modalOpenCall[3].buttons[0].click;
+          beforeEach(() => {
+            const saveMethod = modalOpenCall[3].buttons[0].click;
             model.case_id = _.uniqueId();
             model.subject = 'a sample subject';
             expectedActivitySavingCalls = [['Activity', 'copybyquery', {
               case_id: model.case_id,
               subject: model.subject,
-              id: $scope.selectedActivities.map(function (activity) {
+              id: $scope.selectedActivities.map((activity) => {
                 return activity.id;
               })
             }]];
@@ -188,38 +188,38 @@
             $rootScope.$digest();
           });
 
-          it('saves a new copy of each of the activity and assigns it to the selected case using the new activity subject', function () {
+          it('saves a new copy of each of the activity and assigns it to the selected case using the new activity subject', () => {
             expect(crmApiMock.calls.mostRecent().args[0]).toEqual(expectedActivitySavingCalls);
           });
         });
       });
     });
 
-    describe('Move Activities bulk action', function () {
-      var activities, modalOpenCall, model;
-      var $scope = {};
+    describe('Move Activities bulk action', () => {
+      let activities, modalOpenCall, model;
+      const $scope = {};
 
-      beforeEach(function () {
-        var caseId = _.uniqueId();
+      beforeEach(() => {
+        const caseId = _.uniqueId();
 
         activities = activitiesMockData.get();
 
-        activities.forEach(function (activity) {
+        activities.forEach((activity) => {
           activity.case_id = caseId;
         });
 
         $scope.selectedActivities = _.sample(activities, 2);
       });
 
-      describe('when selecting some activities and then move them to a new case', function () {
-        beforeEach(function () {
+      describe('when selecting some activities and then move them to a new case', () => {
+        beforeEach(() => {
           MoveCopyActivityAction.doAction($scope, { operation: 'move' });
 
           modalOpenCall = dialogServiceMock.open.calls.mostRecent().args;
           model = modalOpenCall[2];
         });
 
-        it('opens a case selection modal', function () {
+        it('opens a case selection modal', () => {
           expect(dialogServiceMock.open).toHaveBeenCalledWith(
             'MoveCopyActCard',
             '~/civicase/activity/actions/services/move-copy-activity-action.html',
@@ -228,33 +228,33 @@
           );
         });
 
-        it('displays the title as "Move 2 Activities"', function () {
+        it('displays the title as "Move 2 Activities"', () => {
           expect(modalOpenCall[3].title).toBe('Move 2 Activities');
         });
 
-        describe('the model', function () {
-          it('defines an empty case id', function () {
+        describe('the model', () => {
+          it('defines an empty case id', () => {
             expect(model.case_id).toBe('');
           });
 
-          it('does not display the subject', function () {
+          it('does not display the subject', () => {
             expect(model.isSubjectVisible).toBe(false);
           });
 
-          it('defines an empty subject', function () {
+          it('defines an empty subject', () => {
             expect(model.subject).toBe('');
           });
         });
 
-        describe('when saving the move action modal', function () {
-          var expectedActivitySavingCalls;
+        describe('when saving the move action modal', () => {
+          let expectedActivitySavingCalls;
 
-          beforeEach(function () {
-            var saveMethod = modalOpenCall[3].buttons[0].click;
+          beforeEach(() => {
+            const saveMethod = modalOpenCall[3].buttons[0].click;
             model.case_id = _.uniqueId();
             expectedActivitySavingCalls = [['Activity', 'movebyquery', {
               case_id: model.case_id,
-              id: $scope.selectedActivities.map(function (activity) {
+              id: $scope.selectedActivities.map((activity) => {
                 return activity.id;
               })
             }]];
@@ -265,22 +265,22 @@
             $rootScope.$digest();
           });
 
-          it('moves each of the activities and assign them to the selected case', function () {
+          it('moves each of the activities and assign them to the selected case', () => {
             expect(crmApiMock.calls.mostRecent().args[0]).toEqual(expectedActivitySavingCalls);
           });
 
-          it('emits a civicase activity updated event', function () {
+          it('emits a civicase activity updated event', () => {
             expect($rootScope.$broadcast).toHaveBeenCalledWith('civicase::activity::updated');
           });
 
-          it('closes the dialog', function () {
+          it('closes the dialog', () => {
             expect($.fn.dialog).toHaveBeenCalled();
           });
         });
 
-        describe('when the selected case is the same as the current case', function () {
-          beforeEach(function () {
-            var saveMethod = modalOpenCall[3].buttons[0].click;
+        describe('when the selected case is the same as the current case', () => {
+          beforeEach(() => {
+            const saveMethod = modalOpenCall[3].buttons[0].click;
             model.case_id = $scope.selectedActivities[0].case_id;
 
             spyOn($rootScope, '$broadcast');
@@ -289,22 +289,22 @@
             $rootScope.$digest();
           });
 
-          it('does not request the activities data', function () {
+          it('does not request the activities data', () => {
             expect(crmApiMock).not.toHaveBeenCalled();
           });
 
-          it('does not emit the civicase activity updated event', function () {
+          it('does not emit the civicase activity updated event', () => {
             expect($rootScope.$broadcast).not.toHaveBeenCalledWith('civicase::activity::updated');
           });
 
-          it('closes the dialog', function () {
+          it('closes the dialog', () => {
             expect($.fn.dialog).toHaveBeenCalled();
           });
         });
       });
 
-      describe('when selecting a single activity and moving it to a new case', function () {
-        beforeEach(function () {
+      describe('when selecting a single activity and moving it to a new case', () => {
+        beforeEach(() => {
           $scope.selectedActivities = _.chain(activities)
             .sample(1)
             .cloneDeep()
@@ -317,35 +317,35 @@
           model = modalOpenCall[2];
         });
 
-        it('displays the modal title as "Move Meeting Activity"', function () {
+        it('displays the modal title as "Move Meeting Activity"', () => {
           expect(modalOpenCall[3].title).toBe('Move Meeting Activity');
         });
 
-        describe('the model', function () {
-          it('defines the case id the same as the selected activity', function () {
+        describe('the model', () => {
+          it('defines the case id the same as the selected activity', () => {
             expect(model.case_id).toBe($scope.selectedActivities[0].case_id);
           });
 
-          it('displays the subject', function () {
+          it('displays the subject', () => {
             expect(model.isSubjectVisible).toBe(true);
           });
 
-          it('defines an empty subject', function () {
+          it('defines an empty subject', () => {
             expect(model.subject).toBe($scope.selectedActivities[0].subject);
           });
         });
 
-        describe('when saving the move action modal', function () {
-          var expectedActivitySavingCalls;
+        describe('when saving the move action modal', () => {
+          let expectedActivitySavingCalls;
 
-          beforeEach(function () {
-            var saveMethod = modalOpenCall[3].buttons[0].click;
+          beforeEach(() => {
+            const saveMethod = modalOpenCall[3].buttons[0].click;
             model.case_id = _.uniqueId();
             model.subject = 'a sample subject';
             expectedActivitySavingCalls = [['Activity', 'movebyquery', {
               case_id: model.case_id,
               subject: model.subject,
-              id: $scope.selectedActivities.map(function (activity) {
+              id: $scope.selectedActivities.map((activity) => {
                 return activity.id;
               })
             }]];
@@ -355,7 +355,7 @@
             $rootScope.$digest();
           });
 
-          it('moves the activity and assigns it to the selected case using the new activity subject', function () {
+          it('moves the activity and assigns it to the selected case using the new activity subject', () => {
             expect(crmApiMock.calls.mostRecent().args[0]).toEqual(expectedActivitySavingCalls);
           });
         });


### PR DESCRIPTION
## Overview
This PR updates the endpoints we use for Move and Copy activity. Previously we were creating new activities, but now we use the new `movebyquery` and `copybyquery` endpoints.

For more information about why this change is required please refer to: https://github.com/compucorp/uk.co.compucorp.civicase/pull/437

## Before
![gif](https://user-images.githubusercontent.com/1642119/79703807-05052400-827c-11ea-8ab4-887903b4cfdf.gif)
Moving activities does not work

## After
![gif](https://user-images.githubusercontent.com/1642119/79703641-f8340080-827a-11ea-9c37-f11c9a74aa15.gif)


## Technical Details

We updated the `move-copy-activity-action.service.js` activity action service. We removed the `prepareAPICallsForSingleActivity` function since the new endpoints support a single or multiple activities so long as they are sent through the `id` parameter.

We also updated the previous `prepareAPICallsForMultipleActivities` so it only sends the subject parameter for multiple activities.

Also fixed some tests related to displaying the activity type title on the move/copy modal and updated the spec file so it uses ES6+ syntax.