### PR TITLE
CPS-152: Fix breadcrumbs

### DIFF
--- a/CRM/Civicase/Helper/CaseCategory.php
+++ b/CRM/Civicase/Helper/CaseCategory.php
@@ -32,7 +32,8 @@ class CRM_Civicase_Helper_CaseCategory {
 
         return $caseTypeCategories[$caseCategoryId];
       }
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
       return NULL;
     }
 
@@ -117,7 +118,8 @@ class CRM_Civicase_Helper_CaseCategory {
         'name' => $optionName,
       ]);
 
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
       if (!$caseTypeCategoryName || strtolower($caseTypeCategoryName) == 'cases') {
         return [];
       }
@@ -246,7 +248,7 @@ class CRM_Civicase_Helper_CaseCategory {
         'url' => CRM_Utils_System::url('civicrm', 'reset=1'),
       ],
       [
-        'title' => ts('Case Dashboard'),
+        'title' => ts('Manage Cases'),
         'url' => CRM_Utils_System::url('civicrm/case/a/', ['case_type_category' => $caseCategoryName], TRUE,
           "/case?case_type_category={$caseCategoryName}"),
       ],


### PR DESCRIPTION
## Overview
According to the new requirements we need to change the text in the breadcumbs:
Case Dashboard -> Manage Cases.

## Before / After
Cases before:
![image](https://user-images.githubusercontent.com/39520000/79754247-e6f0ff80-831f-11ea-9d38-aa209865da07.png)

Cases after:
![image](https://user-images.githubusercontent.com/39520000/79754322-0720be80-8320-11ea-9970-6f14b6ccf232.png)

Other case type category before:
![image](https://user-images.githubusercontent.com/39520000/79754235-e22c4b80-831f-11ea-85ee-4fcdaa43e3d5.png)

Other case type category after:
![image](https://user-images.githubusercontent.com/39520000/79754364-1869cb00-8320-11ea-834d-e70fc2946f36.png)

## Technical Details
Just updated the text which comes from `CRM_Civicase_Helper_CaseCategory::updateBreadcrumbs()`.
Also some small formatting issues were fixed to follow the standards.