### PR TITLE
CPS-33: Set Activity Contact With For Print/Merge Document On Contact actions

### DIFF
--- a/CRM/Civicase/Hook/ValidateForm/SaveActivityDraft.php
+++ b/CRM/Civicase/Hook/ValidateForm/SaveActivityDraft.php
@@ -122,28 +122,10 @@ class CRM_Civicase_Hook_ValidateForm_SaveActivityDraft {
     }
 
     if (strpos($referer, 'civicrm/contact/view') !== FALSE) {
-      $cid = $this->getParameterFromUrl($referer, 'cid');
+      $cid = $form->getVar('_contactIds')[0];
 
       return CRM_Utils_System::url('civicrm/contact/view', "&show=1&action=browse&cid={$cid}&selectedChild=activity");
     }
-  }
-
-  /**
-   * Get parameter from a URL string.
-   *
-   * @param string $url
-   *   URL.
-   * @param string $parameterName
-   *   Parameter Name.
-   *
-   * @return string
-   *   Parameter value from URL.
-   */
-  private function getParameterFromUrl($url, $parameterName) {
-    $urlParams = parse_url(htmlspecialchars_decode($url), PHP_URL_QUERY);
-    parse_str($urlParams, $urlParams);
-
-    return !empty($urlParams[$parameterName]) ? $urlParams[$parameterName] : '';
   }
 
   /**

--- a/CRM/Civicase/Hook/ValidateForm/SaveActivityDraft.php
+++ b/CRM/Civicase/Hook/ValidateForm/SaveActivityDraft.php
@@ -67,8 +67,7 @@ class CRM_Civicase_Hook_ValidateForm_SaveActivityDraft {
       'id' => $form->getVar('_activityId'),
     ];
 
-    $isContactViewAction = $this->isFromContactViewPage() && !$caseId;
-    if ($isContactViewAction) {
+    if (!$caseId) {
       $params['target_contact_id'] = $form->getVar('_contactIds');
     }
     else {
@@ -122,7 +121,7 @@ class CRM_Civicase_Hook_ValidateForm_SaveActivityDraft {
       return CRM_Utils_System::url('civicrm/contact/view/case', "reset=1&action=view&cid={$form->getVar('_contactIds')[0]}&id={$caseId}&show=1&tab=Activities");
     }
 
-    if ($this->isFromContactViewPage()) {
+    if (strpos($referer, 'civicrm/contact/view') !== FALSE) {
       $cid = $this->getParameterFromUrl($referer, 'cid');
 
       return CRM_Utils_System::url('civicrm/contact/view', "&show=1&action=browse&cid={$cid}&selectedChild=activity");
@@ -145,16 +144,6 @@ class CRM_Civicase_Hook_ValidateForm_SaveActivityDraft {
     parse_str($urlParams, $urlParams);
 
     return !empty($urlParams[$parameterName]) ? $urlParams[$parameterName] : '';
-  }
-
-  /**
-   * Checks whether the referrer is the contact view page.
-   *
-   * @return bool
-   *   whether the referrer is the contact view page.
-   */
-  protected  function isFromContactViewPage() {
-    return strpos($_SERVER['HTTP_REFERER'], 'civicrm/contact/view') !== FALSE;
   }
 
   /**


### PR DESCRIPTION
## Overview
When the Print/Merge document form is clicked from the contact actions menu and saved as draft, we need to set the activity created to be with the contact that is being viewed and make the activity to be unassigned. This behaviour is different from when the form is used on Manage cases for instance where the activity is attached to the case and the activity is not with any contact.

<img width="960" alt="alawode alawode  CiviAwards 2020-04-22 12-45-50" src="https://user-images.githubusercontent.com/6951813/79978202-6fde7700-8497-11ea-8e4b-74eb3a8e7136.png">


## Before
The scenario describes in overview exists.

## After
When the print merge form on the contact actions menu is used and saved as draft, the activity created is set to be with the viewed contact and the assigned to set as blank.
The current behaviour of the form on manage cases and elsewhere when used within a case context is maintained. The changes only affect when these form is used via the contact actions outside a case context.

<img width="1280" alt="alawode alawode  CiviAwards 2020-04-22 12-51-23" src="https://user-images.githubusercontent.com/6951813/79978784-5e499f00-8498-11ea-8cd8-18a54956342d.png">

## Comments
When creating the activity for the Forms, `assignee_id` was passed rather than `assignee_contact_id` . This was fixed. Even though the previous code was working as expected but the expected parameter is supposed to be `assignee_contact_id` as seen from the API explorer and activity API file.
