### PR TITLE
CPS-134: Fix caseid parameter for saving draft and sending emails

### DIFF
--- a/ang/civicase/activity/activity-forms/services/draft-email-activity-form.service.js
+++ b/ang/civicase/activity/activity-forms/services/draft-email-activity-form.service.js
@@ -34,7 +34,7 @@
       return getCrmUrl('civicrm/activity/email/' + options.action, {
         action: options.action,
         atype: activity.activity_type_id,
-        caseId: activity.case_id,
+        caseid: activity.case_id,
         cid: assigneeContactId,
         draft_id: activity.id,
         id: activity.id,

--- a/ang/civicase/activity/activity-forms/services/draft-email-activity-form.service.js
+++ b/ang/civicase/activity/activity-forms/services/draft-email-activity-form.service.js
@@ -30,16 +30,23 @@
     function getActivityFormUrl (activity, optionsWithoutDefaults) {
       var options = _.defaults({}, optionsWithoutDefaults, { action: 'add' });
       var assigneeContactId = _.first(activity.assignee_contact_id);
-
-      return getCrmUrl('civicrm/activity/email/' + options.action, {
+      var draftFormParameters = {
         action: options.action,
         atype: activity.activity_type_id,
-        caseid: activity.case_id,
         cid: assigneeContactId,
         draft_id: activity.id,
         id: activity.id,
         reset: '1'
-      });
+      };
+
+      if (activity.case_id) {
+        draftFormParameters.caseid = activity.case_id;
+      }
+
+      return getCrmUrl(
+        'civicrm/activity/email/' + options.action,
+        draftFormParameters
+      );
     }
   }
 })(CRM._, angular, CRM.url);

--- a/ang/test/civicase/activity/activity-forms/services/draft-email-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/draft-email-activity-form.service.spec.js
@@ -52,7 +52,7 @@
         expectedActivityFormUrlParams = {
           action: 'add',
           atype: activity.activity_type_id,
-          caseId: activity.case_id,
+          caseid: activity.case_id,
           cid: activity.assignee_contact_id[0],
           draft_id: activity.id,
           id: activity.id,

--- a/ang/test/civicase/activity/activity-forms/services/draft-email-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/draft-email-activity-form.service.spec.js
@@ -60,9 +60,26 @@
         };
       });
 
-      describe('when getting the form URL', () => {
+      describe('when getting the form URL for a case activity', () => {
         beforeEach(() => {
           expectedActivityFormUrlParams.action = 'add';
+          activityFormUrl = DraftEmailActivityForm.getActivityFormUrl(activity);
+          expectedActivityFormUrl = getCrmUrl('civicrm/activity/email/add',
+            expectedActivityFormUrlParams);
+        });
+
+        it('returns the popup form URL for the draft activity in create mode by default', () => {
+          expect(activityFormUrl).toEqual(expectedActivityFormUrl);
+        });
+      });
+
+      describe('when getting the form URL for a standalone activity', () => {
+        beforeEach(() => {
+          expectedActivityFormUrlParams.action = 'add';
+
+          delete expectedActivityFormUrlParams.caseid;
+          delete activity.case_id;
+
           activityFormUrl = DraftEmailActivityForm.getActivityFormUrl(activity);
           expectedActivityFormUrl = getCrmUrl('civicrm/activity/email/add',
             expectedActivityFormUrlParams);


### PR DESCRIPTION
## Overview
This PR fixes an issue where saving a draft email and then sending the actual email does not save an email activity for the case.

## Before
![gif](https://user-images.githubusercontent.com/1642119/80002265-694b0200-848d-11ea-9bb7-69ea7180535d.gif)

## After
![gif](https://user-images.githubusercontent.com/1642119/80002513-bdee7d00-848d-11ea-822e-410ecf252893.gif)

## Technical Details

First, we depended on [this core PR](https://github.com/civicrm/civicrm-core/pull/16105) to be merged because it fixes an issue where the email activity didn't support cases.

After that we identified that we have been passing the case ID parameter as `caseId` instead of `caseid` which is how both [the form used for draft emails](https://github.com/civicrm/civicrm-core/blob/master/CRM/Contact/Form/Task/Email.php#L35) and the [email form](https://github.com/civicrm/civicrm-core/blob/master/CRM/Case/Form/Activity.php#L56) expect the parameter to be written.

The remaining question is: how come creating and updating the draft worked if we were sending `caseId`?

First, when creating the draft activity we are using the right parameter:
https://github.com/compucorp/uk.co.compucorp.civicase/commit/e8b51543ba2e61820c69ece6180f775b08bdc1a0#diff-cd434780828d9e80934d1cb61c3b3183R62

But when updating the draft or sending the email we are sending the wrong one. It works because when we try to update the draft activity [here](https://github.com/compucorp/uk.co.compucorp.civicase/commit/c0149a9afe9b3fec805ef09ec99dec56c8e08319#diff-a5eafd62c28609d17cf23526e51f2ea4R67) we are actually sending `NULL` and CiviCRM api ignores the `case_id` field instead of replacing the previous value with `NULL`.

# CPS-189: Fix Standalone Email Draft Activities

When we introduced this fix we broke the forms for standalone email draft activities. Previously we were sending `caseId=` (case Id equal empty) to this form, and this was fine since the form didn't understand the `caseId` parameter. When we fixed the parameter name to `caseid` we were sending `caseid=` (case id equal empty) and this was breaking the form. To fix this issue we only pass the `caseid` parameter conditionally.

## Before
![gif](https://user-images.githubusercontent.com/1642119/80231048-d2af4a00-8620-11ea-8813-2d588acebe95.gif)

## After

![gif](https://user-images.githubusercontent.com/1642119/80230913-954abc80-8620-11ea-8cf8-259fa2ec214a.gif)
