### PR TITLE
CPS-180: Fix broken People Tab when certain relationships are present

### DIFF
--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
@@ -37,7 +37,7 @@
    *    }
    *  },
    *  description: string,
-   *  event: document#event
+   *  event: document#event,
    *  role: Role,
    *  showContactSelectionError: (message: string) => void
    * }} ContactPromptResult
@@ -61,9 +61,8 @@
     var clients = _.indexBy($scope.item.client, 'contact_id');
     var item = $scope.item;
     var relTypes = RelationshipType.getAll();
-    var relTypesByName = _.indexBy(relTypes, 'name_b_a');
-    $scope.ts = ts;
 
+    $scope.ts = ts;
     $scope.allowMultipleCaseClients = allowMultipleCaseClients;
     $scope.roles = [];
     $scope.rolesFilter = '';
@@ -583,7 +582,9 @@ included in the confirmation dialog.
      * @param {object} role role
      */
     function formatRole (role) {
-      var relType = relTypesByName[role.name];
+      var relType = _.find(relTypes, function (relation) {
+        return relation.name_a_b === role.name || relation.name_b_a === role.name;
+      });
       role.role = relType.label_b_a;
       role.contact_type = relType.contact_type_b;
       role.contact_sub_type = relType.contact_sub_type_b;

--- a/ang/test/civicase-base/services/case-actions.service.spec.js
+++ b/ang/test/civicase-base/services/case-actions.service.spec.js
@@ -8,7 +8,7 @@
 
     beforeEach(inject((_CaseActions_, _CaseActionsData_) => {
       CaseActions = _CaseActions_;
-      CaseActionsData = _CaseActionsData_.values;
+      CaseActionsData = _CaseActionsData_.get();
     }));
 
     describe('when getting all case actions', () => {

--- a/ang/test/civicase/case/actions/services/webforms-case-action.service.spec.js
+++ b/ang/test/civicase/case/actions/services/webforms-case-action.service.spec.js
@@ -18,7 +18,7 @@
       beforeEach(function () {
         attributes = {};
         cases = [CasesData[0]];
-        webformAction = _.find(CaseActionsData.values, function (action) {
+        webformAction = _.find(CaseActionsData.get(), function (action) {
           return action.action === 'Webforms';
         });
       });

--- a/ang/test/civicase/dashboard/directives/dashboard.directive.spec.js
+++ b/ang/test/civicase/dashboard/directives/dashboard.directive.spec.js
@@ -34,7 +34,7 @@
 
         it('shows the `All Cases` filter option', function () {
           expect($scope.caseRelationshipOptions).toEqual([
-            { text: 'My cases', id: 'is_case_manager' },
+            { text: 'My Cases', id: 'is_case_manager' },
             { text: 'Cases I am involved in', id: 'is_involved' },
             { text: 'All Cases', id: 'all' }
           ]);
@@ -49,7 +49,7 @@
 
         it('does not show the `All Cases` filter option', function () {
           expect($scope.caseRelationshipOptions).toEqual([
-            { text: 'My cases', id: 'is_case_manager' },
+            { text: 'My Cases', id: 'is_case_manager' },
             { text: 'Cases I am involved in', id: 'is_involved' }
           ]);
         });

--- a/ang/test/mocks/data/case-actions.data.js
+++ b/ang/test/mocks/data/case-actions.data.js
@@ -1,4 +1,4 @@
-(function () {
+(function (angular, _) {
   const module = angular.module('civicase.data');
 
   CRM.civicase.caseActions = [{
@@ -35,7 +35,9 @@
     }]
   }];
 
-  module.constant('CaseActionsData', {
-    values: CRM.civicase.caseActions
+  module.service('CaseActionsData', function () {
+    this.get = function () {
+      return _.clone(CRM.civicase.caseActions);
+    };
   });
-}());
+}(angular, CRM._));


### PR DESCRIPTION
## Overview
When a "Relationship A to B" is added inside a Case Type, the Case Details People Tab did not work, it is fixed now.

## Before
![2020-04-27 at 3 50 PM](https://user-images.githubusercontent.com/5058867/80361578-cdf7c980-889e-11ea-9e15-ddcd02d0d735.jpg)

## After
![2020-04-27 at 3 50 PM](https://user-images.githubusercontent.com/5058867/80361591-d7813180-889e-11ea-8bd6-0f84fa41fee5.jpg)

## Technical Details
Previously only the `name_b_a` was used to fetch the relationship in `case-details-people-tab.directive.js `. But if "Relationship A to B" was used, then this logic failed and produced error. So changed the logic
```javascript
var relType = _.find(relTypes, function (relation) {
  return relation.name_a_b === role.name || relation.name_b_a === role.name;
});
```