### PR TITLE
RSE-1082: Fix case details placeholder translation

### DIFF
--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
@@ -75,7 +75,7 @@
             crm-editable="item"
             data-field="details"
             data-type="textarea"
-            data-placeholder="This case doesn't currently have a description. Click here to add now">
+            data-placeholder="{{ ts('This case doesn\'t currently have a description. Click here to add now.') }}">
           </p>
         </div>
         <span class="civicase__case-header__case-type">

--- a/ang/civicase/case/details/summary-tab/case-details-summary-tab.html
+++ b/ang/civicase/case/details/summary-tab/case-details-summary-tab.html
@@ -7,7 +7,12 @@
           <p crm-editable="item" data-field="subject" data-type="text" data-placeholder="Click to add subject" crm-form-success="onChangeSubject($data)"></p>
         </div>
         <div class="civicase__summary-tab__description">
-          <p crm-editable="item" data-field="details" data-type="textarea" data-placeholder="This case doesn't currently have a description. Click here to add now"></p>
+          <p
+            crm-editable="item"
+            data-field="details"
+            data-type="textarea"
+            data-placeholder="{{ ts('This case doesn\'t currently have a description. Click here to add now.') }}">
+          </p>
         </div>
         <div class="civicase__summary-tab__last-updated">
           <span class="civicase__summary-tab__last-updated__label">{{ts("Case last updated: ")}}</span>


### PR DESCRIPTION
## Overview
This PR fixes the translation for the case details field's placeholder.

## Before & After

<table>
  <tr>
    <th></th>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <th>Contact's Page</th>
    <td><img src="https://user-images.githubusercontent.com/1642119/80918738-7fca4680-8d34-11ea-89af-4e9f5478c948.png" /></td>
    <td><img src="https://user-images.githubusercontent.com/1642119/80918733-7d67ec80-8d34-11ea-8ce0-8a0369f8223f.png" /></td>
  </tr>
  <tr>
    <th>Case Details</th>
    <td><img src="https://user-images.githubusercontent.com/1642119/80918739-8062dd00-8d34-11ea-8f22-dda39697735f.png" /></td>
    <td><img src="https://user-images.githubusercontent.com/1642119/80918735-7e991980-8d34-11ea-8d47-90375b3545c9.png" /></td>
  </tr>
</table>

## Technical Details

When we first introduced the editable case details field [here](https://github.com/compucorp/uk.co.compucorp.civicase/pull/422) we forgot to wrap the placeholder in a `ts` function. This has been corrected.