### PR TITLE
RSE-1056: Redirect to case details after creating a case

### DIFF
--- a/CRM/Civicase/Helper/CaseUrl.php
+++ b/CRM/Civicase/Helper/CaseUrl.php
@@ -1,0 +1,45 @@
+<?php
+
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+
+/**
+ * Case URL Helper.
+ *
+ * Returns URLs for case pages.
+ */
+class CRM_Civicase_Helper_CaseUrl {
+
+  /**
+   * Returns the URL for the case details page.
+   *
+   * @param int $caseId
+   *   The ID of the case we want the details URL for.
+   *
+   * @return string
+   *   The case details URL.
+   */
+  public static function getDetailsPage($caseId) {
+    $case = civicrm_api3('Case', 'getsingle', [
+      'id' => $caseId,
+      'return' => [
+        'case_type_id.name',
+        'case_type_id.case_type_category',
+        'status_id',
+      ],
+    ]);
+    $caseCategoryName = CaseCategoryHelper::getCaseCategoryNameFromOptionValue(
+      $case['case_type_id.case_type_category']
+    );
+    $caseFilters = [
+      'case_type_id' => [$case['case_type_id.name']],
+      'status_id' => [$case['status_id']],
+    ];
+    $caseDetailsUrlPath = 'civicrm/case/a/?case_type_category=' . $caseCategoryName
+      . '#/case/list?caseId=' . $caseId
+      . '&sf=id&sd=DESC&cf='
+      . urlencode(json_encode($caseFilters));
+
+    return CRM_Utils_System::url($caseDetailsUrlPath, NULL, TRUE);
+  }
+
+}

--- a/CRM/Civicase/Hook/PageRun/ViewCasePageRedirect.php
+++ b/CRM/Civicase/Hook/PageRun/ViewCasePageRedirect.php
@@ -1,7 +1,5 @@
 <?php
 
-use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
-
 /**
  * Class CRM_Civicase_Hook_PageRun_ViewCasePageRedirect.
  */
@@ -26,30 +24,22 @@ class CRM_Civicase_Hook_PageRun_ViewCasePageRedirect {
   /**
    * Redirects the core view case page to an angular page provided by civicase.
    *
+   * OLD: http://localhost/civicrm/contact/view/case?reset=1&action=view&cid=129&id=51
+   * NEW: http://localhost/civicrm/case/a/?case_type_category=case_category_name#/case/list?
+   * sf=contact_id.sort_name&sd=ASC&focus=0&cf=%7B%7D&caseId=51&tab=summary&sx=0
+   *
+   * We also inherit the *tab* parameter from the current URL and pass it to the
+   * case details URL.
+   *
    * @param int $caseId
    *   Case Id.
    */
   private function redirectViewCasePage($caseId) {
-    // OLD: http://localhost/civicrm/contact/view/case?reset=1&action=view&cid=129&id=51
-    // NEW: http://localhost/civicrm/case/a/?case_type_category=case_category_name#/case/list?
-    // sf=contact_id.sort_name&sd=ASC&focus=0&cf=%7B%7D&caseId=51&tab=summary&sx=0
-    $case = civicrm_api3('Case', 'getsingle', [
-      'id' => $caseId,
-      'return' => [
-        'case_type_id.name',
-        'status_id',
-        'case_type_id.case_type_category',
-      ],
-    ]);
-
-    // Add selected parameters passed to this page to the redirect URL.
     $relevantUrlParams = [['name' => 'tab', 'type' => 'String']];
-    $caseCategoryName = CaseCategoryHelper::getCaseCategoryNameFromOptionValue($case['case_type_id.case_type_category']);
-    $fragment = "/case/list?sf=id&sd=DESC&caseId={$caseId}&cf=%7B%22case_type_category%22:%22" . strtolower($caseCategoryName) . "%22,%22status_id%22:%5B%22{$case['status_id']}%22%5D,%22case_type_id%22:%5B%22{$case['case_type_id.name']}%22%5D%7D";
-    $this->addRelevantUrlParamsToFragment($fragment, $relevantUrlParams);
-    $url = CRM_Utils_System::url('civicrm/case/a/', ['case_type_category' => strtolower($caseCategoryName)], TRUE, $fragment, FALSE);
+    $caseDetailsUrl = CRM_Civicase_Helper_CaseUrl::getDetailsPage($caseId);
+    $this->addRelevantUrlParamsToFragment($caseDetailsUrl, $relevantUrlParams);
 
-    CRM_Utils_System::redirect($url);
+    CRM_Utils_System::redirect($caseDetailsUrl);
   }
 
   /**

--- a/CRM/Civicase/Hook/PostProcess/RedirectToCaseDetails.php
+++ b/CRM/Civicase/Hook/PostProcess/RedirectToCaseDetails.php
@@ -1,0 +1,51 @@
+<?php
+
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+
+/**
+ * Redirect to case details post process hook.
+ */
+class CRM_Civicase_Hook_PostProcess_RedirectToCaseDetails {
+
+  /**
+   * Redirects the user to the case details after creating the case.
+   *
+   * @param string $formName
+   *   The class name of the submitted form.
+   * @param object $form
+   *   The submitted form instance.
+   */
+  public function run($formName, $form) {
+    if (!$this->shouldRun($form)) {
+      return;
+    }
+
+    $caseId = $form->getVar('_caseId');
+    $caseCategoryName = CaseCategoryHelper::getCategoryName($caseId);
+    $caseDetailsUrl = 'civicrm/case/a/?case_type_category=' . $caseCategoryName
+      . '#/case/list?caseId=' . $caseId;
+
+    CRM_Core_Session::singleton()
+      ->pushUserContext(CRM_Utils_System::url($caseDetailsUrl, NULL, TRUE));
+  }
+
+  /**
+   * Determines if the hook should run.
+   *
+   * Runs when:
+   * - Using the cases form.
+   * - Is creating a new case.
+   * - The user is not adding more cases after this one.
+   *
+   * @return bool
+   *   True when the hook can be run.
+   */
+  private function shouldRun($form) {
+    $submittedValues = $form->getVar('_submitValues');
+    $isCaseForm = get_class($form) === 'CRM_Case_Form_Case';
+    $isAddAction = $form->getVar('_action') === CRM_Core_Action::ADD;
+    $isNotAddingMoreCases = isset($submittedValues['_qf_Case_upload']);
+
+    return $isCaseForm && $isAddAction && $isNotAddingMoreCases;
+  }
+}

--- a/CRM/Civicase/Hook/PostProcess/RedirectToCaseDetails.php
+++ b/CRM/Civicase/Hook/PostProcess/RedirectToCaseDetails.php
@@ -48,4 +48,5 @@ class CRM_Civicase_Hook_PostProcess_RedirectToCaseDetails {
 
     return $isCaseForm && $isAddAction && $isNotAddingMoreCases;
   }
+
 }

--- a/CRM/Civicase/Hook/PostProcess/RedirectToCaseDetails.php
+++ b/CRM/Civicase/Hook/PostProcess/RedirectToCaseDetails.php
@@ -1,7 +1,5 @@
 <?php
 
-use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
-
 /**
  * Redirect to case details post process hook.
  */
@@ -21,12 +19,10 @@ class CRM_Civicase_Hook_PostProcess_RedirectToCaseDetails {
     }
 
     $caseId = $form->getVar('_caseId');
-    $caseCategoryName = CaseCategoryHelper::getCategoryName($caseId);
-    $caseDetailsUrl = 'civicrm/case/a/?case_type_category=' . $caseCategoryName
-      . '#/case/list?caseId=' . $caseId;
+    $caseDetailsUrl = CRM_Civicase_Helper_CaseUrl::getDetailsPage($caseId);
 
     CRM_Core_Session::singleton()
-      ->pushUserContext(CRM_Utils_System::url($caseDetailsUrl, NULL, TRUE));
+      ->pushUserContext($caseDetailsUrl);
   }
 
   /**

--- a/ang/civicase/dashboard/directives/add-case-dashboard-action-button.controller.js
+++ b/ang/civicase/dashboard/directives/add-case-dashboard-action-button.controller.js
@@ -1,4 +1,4 @@
-(function (_, angular, checkPerm, loadForm, getCrmUrl) {
+(function (angular) {
   var module = angular.module('civicase');
 
   module.controller('AddCaseDashboardActionButtonController', AddCaseDashboardActionButtonController);
@@ -44,4 +44,4 @@
       $window.location.href = response.userContext;
     }
   }
-})(CRM._, angular, CRM.checkPerm, CRM.loadForm, CRM.url);
+})(angular);

--- a/ang/civicase/dashboard/directives/add-case-dashboard-action-button.controller.js
+++ b/ang/civicase/dashboard/directives/add-case-dashboard-action-button.controller.js
@@ -37,7 +37,10 @@
      * @param {object} response add case form response.
      */
     function redirectToUserContext (event, response) {
-      if (!response.userContext) {
+      var hasNoUserContext = !response.userContext;
+      var isCreatingMoreCases = response.buttonName === 'upload_new';
+
+      if (hasNoUserContext || isCreatingMoreCases) {
         return;
       }
 

--- a/ang/civicase/dashboard/directives/add-case-dashboard-action-button.controller.js
+++ b/ang/civicase/dashboard/directives/add-case-dashboard-action-button.controller.js
@@ -7,11 +7,12 @@
    * Add Case Dashboard Action Button Controller
    *
    * @param {object} $scope scope object
+   * @param {object} $window window object
    * @param {object} ts ts
    * @param {object} AddCase Add Case Service
    * @param {string} currentCaseCategory the current case category name
    */
-  function AddCaseDashboardActionButtonController ($scope, ts, AddCase,
+  function AddCaseDashboardActionButtonController ($scope, $window, ts, AddCase,
     currentCaseCategory) {
     $scope.ts = ts;
 
@@ -23,8 +24,24 @@
      */
     function clickHandler () {
       AddCase.clickHandler({
+        callbackFn: redirectToUserContext,
         caseTypeCategoryName: currentCaseCategory
       });
+    }
+
+    /**
+     * Redirects the user to the user context as provided by the case form
+     * response.
+     *
+     * @param {object} event add case form event reference.
+     * @param {object} response add case form response.
+     */
+    function redirectToUserContext (event, response) {
+      if (!response.userContext) {
+        return;
+      }
+
+      $window.location.href = response.userContext;
     }
   }
 })(CRM._, angular, CRM.checkPerm, CRM.loadForm, CRM.url);

--- a/ang/civicase/dashboard/directives/add-case-dashboard-action-button.controller.js
+++ b/ang/civicase/dashboard/directives/add-case-dashboard-action-button.controller.js
@@ -8,10 +8,11 @@
    *
    * @param {object} $scope scope object
    * @param {object} ts ts
-   * @param {object} $location the location service
    * @param {object} AddCase Add Case Service
+   * @param {string} currentCaseCategory the current case category name
    */
-  function AddCaseDashboardActionButtonController ($scope, ts, $location, AddCase) {
+  function AddCaseDashboardActionButtonController ($scope, ts, AddCase,
+    currentCaseCategory) {
     $scope.ts = ts;
 
     $scope.clickHandler = clickHandler;
@@ -22,19 +23,8 @@
      */
     function clickHandler () {
       AddCase.clickHandler({
-        caseTypeCategoryName: getCaseTypeCategory()
+        caseTypeCategoryName: currentCaseCategory
       });
-    }
-
-    /**
-     * Returns the case type category as defined in the URL parameters.
-     *
-     * @returns {string} the case type category
-     */
-    function getCaseTypeCategory () {
-      var currentUrlParams = $location.search();
-
-      return currentUrlParams.case_type_category;
     }
   }
 })(CRM._, angular, CRM.checkPerm, CRM.loadForm, CRM.url);

--- a/ang/test/civicase/activity/card/directives/activity-card.directive.spec.js
+++ b/ang/test/civicase/activity/card/directives/activity-card.directive.spec.js
@@ -28,7 +28,9 @@
       viewInPopup = _viewInPopup_;
 
       $scope = $rootScope.$new();
-      $scope.activity = {};
+      $scope.activity = {
+        type: 'Meeting'
+      };
 
       $('<div id="bootstrap-theme"></div>').appendTo('body');
       initDirective();
@@ -65,6 +67,7 @@
           });
           $scope.activity = _.sample(activitiesMockData.get());
           $scope.activity.case_id = _.uniqueId();
+          $scope.activity.type = 'Meeting';
           $scope.activity.case = {
             case_id: $scope.activity.case_id,
             case_type_id: caseTypeId
@@ -101,6 +104,7 @@
     describe('"From" and "To" fields visibility', () => {
       beforeEach(() => {
         $scope.activity = activitiesMockData.get()[0];
+        $scope.activity.type = 'Meeting';
       });
 
       describe('when the activity is a communication of the "Print/Merge Document" type', () => {
@@ -148,6 +152,7 @@
 
       beforeEach(() => {
         activity = activitiesMockData.get()[0];
+        activity.type = 'Meeting';
 
         activityCard.isolateScope().viewInPopup(null, activity);
       });

--- a/ang/test/civicase/dashboard/directives/add-case-dashboard-action-button.controller.spec.js
+++ b/ang/test/civicase/dashboard/directives/add-case-dashboard-action-button.controller.spec.js
@@ -50,11 +50,12 @@
         $scope.clickHandler();
       });
 
-      describe('when the case response contains a user context URL', () => {
+      describe('when the case response contains a user context URL and the user clicked on "Save"', () => {
         let expectedUrl;
 
         beforeEach(() => {
           addCaseCallback(mockEvent, {
+            buttonName: 'upload',
             userContext: '/expected-url'
           });
 
@@ -69,6 +70,19 @@
       describe('when the case response does not contain a user context URL', () => {
         beforeEach(() => {
           addCaseCallback(mockEvent, {});
+        });
+
+        it('does not redirect the user', () => {
+          expect($window.location.href).toBe('');
+        });
+      });
+
+      describe('when the case response contains a user context URL, but the "Save and New" was clicked', () => {
+        beforeEach(() => {
+          addCaseCallback(mockEvent, {
+            buttonName: 'upload_new',
+            userContext: '/some-url'
+          });
         });
 
         it('does not redirect the user', () => {

--- a/ang/test/civicase/dashboard/directives/add-case-dashboard-action-button.controller.spec.js
+++ b/ang/test/civicase/dashboard/directives/add-case-dashboard-action-button.controller.spec.js
@@ -2,7 +2,7 @@
 
 (($) => {
   describe('AddCaseDashboardActionButtonController', () => {
-    let $location, $rootScope, $scope, $controller, AddCase;
+    let $rootScope, $scope, $controller, AddCase, currentCaseCategory;
 
     beforeEach(module('civicase-base', 'civicase'));
 
@@ -24,9 +24,6 @@
       beforeEach(() => {
         injectDependencies();
         spyOn(AddCase, 'clickHandler');
-        spyOn($location, 'search').and.returnValue({
-          case_type_category: 'cases'
-        });
         initController();
 
         $scope.clickHandler();
@@ -34,7 +31,7 @@
 
       it('creates a new case', () => {
         expect(AddCase.clickHandler).toHaveBeenCalledWith({
-          caseTypeCategoryName: 'cases'
+          caseTypeCategoryName: currentCaseCategory
         });
       });
     });
@@ -52,11 +49,12 @@
      * Injects and hoists the dependencies used by this spec file.
      */
     function injectDependencies () {
-      inject((_$location_, _$rootScope_, _$controller_, _AddCase_) => {
-        $location = _$location_;
+      inject((_$location_, _$rootScope_, _$controller_, _AddCase_,
+        _currentCaseCategory_) => {
         $controller = _$controller_;
         $rootScope = _$rootScope_;
         AddCase = _AddCase_;
+        currentCaseCategory = _currentCaseCategory_;
       });
     }
   });

--- a/ang/test/civicase/dashboard/directives/add-case-dashboard-action-button.controller.spec.js
+++ b/ang/test/civicase/dashboard/directives/add-case-dashboard-action-button.controller.spec.js
@@ -62,7 +62,7 @@
           expectedUrl = '/expected-url';
         });
 
-        it('redirects the user the user context URL provided by the response', () => {
+        it('redirects the user context URL provided by the response', () => {
           expect($window.location.href).toBe(expectedUrl);
         });
       });

--- a/ang/test/mocks/data/activities.data.js
+++ b/ang/test/mocks/data/activities.data.js
@@ -4,118 +4,118 @@
   module.service('activitiesMockData', ['datesMockData', function (dates) {
     var activitiesMockData = [
       {
-        'id': '1717',
-        'activity_type_id': '13',
-        'activity_date_time': dates.yesterday,
-        'status_id': '2',
-        'is_star': '0',
-        'case_id': [
+        id: '1717',
+        activity_type_id: '13',
+        activity_date_time: dates.yesterday,
+        status_id: '2',
+        is_star: '0',
+        case_id: [
           '136'
         ],
-        'is_overdue': '0',
-        'source_contact_id': '202',
-        'target_contact_id': [
+        is_overdue: '0',
+        source_contact_id: '202',
+        target_contact_id: [
           '197'
         ],
-        'assignee_contact_id': []
+        assignee_contact_id: []
       },
       {
-        'id': '1718',
-        'activity_type_id': '56',
-        'activity_date_time': dates.today,
-        'status_id': '2',
-        'is_star': '0',
-        'case_id': [
+        id: '1718',
+        activity_type_id: '56',
+        activity_date_time: dates.today,
+        status_id: '2',
+        is_star: '0',
+        case_id: [
           '136'
         ],
-        'is_overdue': '0',
-        'source_contact_id': '202',
-        'target_contact_id': [
+        is_overdue: '0',
+        source_contact_id: '202',
+        target_contact_id: [
           '197'
         ],
-        'assignee_contact_id': []
+        assignee_contact_id: []
       },
       {
-        'id': '1719',
-        'activity_type_id': '58',
-        'activity_date_time': dates.today,
-        'status_id': '1',
-        'is_star': '0',
-        'case_id': [
+        id: '1719',
+        activity_type_id: '58',
+        activity_date_time: dates.today,
+        status_id: '1',
+        is_star: '0',
+        case_id: [
           '136'
         ],
-        'is_overdue': '1',
-        'source_contact_id': '202',
-        'target_contact_id': [
+        is_overdue: '1',
+        source_contact_id: '202',
+        target_contact_id: [
           '197'
         ],
-        'assignee_contact_id': []
+        assignee_contact_id: []
       },
       {
-        'id': '1720',
-        'activity_type_id': '66',
-        'activity_date_time': dates.today,
-        'status_id': '1',
-        'is_star': '0',
-        'case_id': [
+        id: '1720',
+        activity_type_id: '66',
+        activity_date_time: dates.today,
+        status_id: '1',
+        is_star: '0',
+        case_id: [
           '136'
         ],
-        'is_overdue': '1',
-        'source_contact_id': '202',
-        'target_contact_id': [
+        is_overdue: '1',
+        source_contact_id: '202',
+        target_contact_id: [
           '197'
         ],
-        'assignee_contact_id': []
+        assignee_contact_id: []
       },
       {
-        'id': '1721',
-        'activity_type_id': '14',
-        'activity_date_time': dates.tomorrow,
-        'status_id': '1',
-        'is_star': '0',
-        'case_id': [
+        id: '1721',
+        activity_type_id: '14',
+        activity_date_time: dates.tomorrow,
+        status_id: '1',
+        is_star: '0',
+        case_id: [
           '136'
         ],
-        'is_overdue': '1',
-        'source_contact_id': '202',
-        'target_contact_id': [
+        is_overdue: '1',
+        source_contact_id: '202',
+        target_contact_id: [
           '197'
         ],
-        'assignee_contact_id': []
+        assignee_contact_id: []
       },
       {
-        'id': '1722',
-        'activity_type_id': '14',
-        'activity_date_time': dates.tomorrow,
-        'status_id': '2',
-        'is_star': '0',
-        'case_id': [
+        id: '1722',
+        activity_type_id: '14',
+        activity_date_time: dates.tomorrow,
+        status_id: '2',
+        is_star: '0',
+        case_id: [
           '136'
         ],
-        'is_overdue': '0',
-        'source_contact_id': '202',
-        'target_contact_id': [
+        is_overdue: '0',
+        source_contact_id: '202',
+        target_contact_id: [
           '197'
         ],
-        'assignee_contact_id': [
+        assignee_contact_id: [
           '147'
         ]
       },
       {
-        'id': '1723',
-        'activity_type_id': '14',
-        'activity_date_time': dates.theDayAfterTomorrow,
-        'status_id': '1',
-        'is_star': '0',
-        'case_id': [
+        id: '1723',
+        activity_type_id: '14',
+        activity_date_time: dates.theDayAfterTomorrow,
+        status_id: '1',
+        is_star: '0',
+        case_id: [
           '136'
         ],
-        'is_overdue': '0',
-        'source_contact_id': '202',
-        'target_contact_id': [
+        is_overdue: '0',
+        source_contact_id: '202',
+        target_contact_id: [
           '197'
         ],
-        'assignee_contact_id': []
+        assignee_contact_id: []
       }
     ];
 
@@ -123,7 +123,7 @@
       /**
        * Returns a list of mocked activities
        *
-       * @return {Array} each array contains an object with the activity data.
+       * @returns {object[]} each array contains an object with the activity data.
        */
       get: function () {
         return _.clone(activitiesMockData);
@@ -132,7 +132,8 @@
       /**
        * Returns sent number of mocked activities
        *
-       * @return {Array} each array contains an object with the activity data.
+       * @param {number} number the number of activities to return.
+       * @returns {object[]} each array contains an object with the activity data.
        */
       getSentNoOfActivities: function (number) {
         var activities = [];

--- a/ang/test/mocks/data/case-actions.data.js
+++ b/ang/test/mocks/data/case-actions.data.js
@@ -37,7 +37,7 @@
 
   module.service('CaseActionsData', function () {
     this.get = function () {
-      return _.clone(CRM.civicase.caseActions);
+      return _.cloneDeep(CRM.civicase.caseActions);
     };
   });
 }(angular, CRM._));

--- a/civicase.php
+++ b/civicase.php
@@ -407,6 +407,7 @@ function civicase_civicrm_postProcess($formName, &$form) {
     new CRM_Civicase_Hook_PostProcess_SetUserContextForSaveAndNewCase(),
     new CRM_Civicase_Hook_PostProcess_CaseCategoryPostProcessor(),
     new CRM_Civicase_Hook_PostProcess_ActivityFormStatusWordReplacement(),
+    new CRM_Civicase_Hook_PostProcess_RedirectToCaseDetails(),
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview
This PR redirects the user to the case details after creating a new case from the dashboard.

## Before
![gif](https://user-images.githubusercontent.com/1642119/80925847-347a5d00-8d61-11ea-960e-eea646540e02.gif)

## After
![gif](https://user-images.githubusercontent.com/1642119/80926065-c2a31300-8d62-11ea-8acc-037c88e85cad.gif)

## Technical Details

* We added a new post process hook to add the expected case details URL to the user context. The reason for this is that the FE does not know the ID of the newly created case and this must be returned by the BE.
* We also updated the `add-case-dashboard-action-button.controller.js` file so it redirects the user when: the user context variable is defined, and the user has not clicked on the "Save and New" button. The reason for this last check is that the BE will send a user context URL when clicking on this button, and this URL is used by `CRM.loadForm` to reload the case form. Since we don't need to handle this scenario we ignore it.

## Notes

* Removed the `getCaseTypeCategory` function that was reading the case type category from the URL in favour of using `currentCaseCategory` which already contains the case category we should be passing to the BE. We should use this parameter as much as possible and avoid reading it from the URL.
* Did not pass the `case_type_category` parameter to the FE part of the URL since it's already being passed to the BE part and the FE gets this value through the previously mentioned `currentCaseCategory` variable.

## Tests fixes

The following tests were breaking on `master` and needed to be fixed:

* `webforms-case-action.service.spec.js`: [This test](https://github.com/compucorp/uk.co.compucorp.civicase/pull/433/files#diff-91fbd01df734a06b34449027e1efcb11R33) would randomly fail because [a different test](https://github.com/compucorp/uk.co.compucorp.civicase/pull/433/files#diff-91fbd01df734a06b34449027e1efcb11R39) was cleaning up the list of action items. Tests are executed in random order, hence the reason for the test to fail randomly. To fix this issue we deep clone this object when requesting the mock data for it.
* `activity-card.directive.spec.js`: https://github.com/compucorp/uk.co.compucorp.civicase/pull/443 introduced a regression for this test file. When we updated the templates for the activity card we didn't mock up the `type` property for this activity. This property does not come from the mock data since it's not returned by the API, but by the activity's card container. To avoid breaking this test we have added a mock type for the activity under test.

## Update

This PR was about to introduce a regression where after creating the case and being redirected to its details we would not automatically filter the list of cases by the same type and status as the one we recently created, on top of showing the created case.

### How it looks after the fix

![gif](https://user-images.githubusercontent.com/1642119/81758608-55912b00-9490-11ea-9392-58b4590763a6.gif)

### Technical details

The code to redirect the case and maintain the filters was already implemented for the "view case redirect", but not for the new "redirect after creating a case". Since this code was used for both hooks we moved it to a common helper function. 