### PR TITLE
CPS-168: Display case list when searching

### DIFF
--- a/ang/civicase/case/search/directives/search.directive.html
+++ b/ang/civicase/case/search/directives/search.directive.html
@@ -5,9 +5,26 @@
       {{ pageTitle }}
     </h3>
     <form class="form-inline civicase__case-filters-container">
-      <input class="form-control civicase__case-filter__input" ng-list crm-ui-select="{allowClear: true, multiple: true, placeholder: ts('Case Type: Any'), data: caseTypeOptions}" ng-model="filters.case_type_id" />
-      <input class="form-control civicase__case-filter__input" ng-list crm-ui-select="{allowClear: true, multiple: true, placeholder: ts('Status: All open cases'), data: caseStatusOptions}" ng-model="filters.status_id" />
-      <input class="form-control civicase__case-filter__input" ng-list crm-ui-select="{allowClear: false, multiple: false, placeholder: ts('Relationship Type: All'), data: caseRelationshipOptions}" ng-model="relationshipType" />
+      <input
+        class="form-control civicase__case-filter__input"
+        ng-list
+        crm-ui-select="{allowClear: true, multiple: true, placeholder: ts('Case Type: Any'), data: caseTypeOptions}"
+        ng-model="filters.case_type_id"
+        ng-change="doSearchIfNotExpanded()"
+      />
+      <input
+        class="form-control civicase__case-filter__input"
+        ng-list crm-ui-select="{allowClear: true, multiple: true, placeholder: ts('Status: All open cases'), data: caseStatusOptions}"
+        ng-model="filters.status_id"
+        ng-change="doSearchIfNotExpanded()"
+      />
+      <input
+        class="form-control civicase__case-filter__input"
+        ng-list
+        crm-ui-select="{allowClear: false, multiple: false, placeholder: ts('Relationship Type: All'), data: caseRelationshipOptions}"
+        ng-model="relationshipType"
+        ng-change="doSearchIfNotExpanded()"
+      />
       <button class="btn btn-primary btn-sm pull-right civicase__case-filter-panel__button" ng-click="expanded = true" ng-show="!expanded">
         <i class="fa fa-gear"></i> {{ filterDescription.length ? ts('Edit Search') : ts('Other Criteria') }}
       </button>

--- a/ang/civicase/case/search/directives/search.directive.html
+++ b/ang/civicase/case/search/directives/search.directive.html
@@ -11,7 +11,7 @@
       <button class="btn btn-primary btn-sm pull-right civicase__case-filter-panel__button" ng-click="expanded = true" ng-show="!expanded">
         <i class="fa fa-gear"></i> {{ filterDescription.length ? ts('Edit Search') : ts('Other Criteria') }}
       </button>
-      <button class="btn btn-primary btn-sm pull-right civicase__case-filter-panel__button" ng-click="doSearch()" ng-show="expanded">
+      <button class="btn btn-primary btn-sm pull-right civicase__case-filter-panel__button" ng-click="handleSearchSubmit()" ng-show="expanded">
         <i class="fa fa-search"></i> {{ ts('Search') }}
       </button>
     </form>

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -180,7 +180,8 @@
      * @returns {boolean} if the current logged in user is a case manager
      */
     function caseManagerIsMe () {
-      return $scope.filters.case_manager && $scope.filters.case_manager.length === 1 && parseInt($scope.filters.case_manager[0], 10) === CRM.config.user_contact_id;
+      return !!$scope.filters.case_manager && $scope.filters.case_manager.length === 1 &&
+        parseInt($scope.filters.case_manager[0], 10) === CRM.config.user_contact_id;
     }
 
     /**

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -109,7 +109,6 @@
      */
     $scope.doSearch = function () {
       $scope.filterDescription = buildDescription();
-      $scope.expanded = false;
       $rootScope.$broadcast('civicase::case-search::filters-updated', {
         selectedFilters: formatSearchFilters($scope.filters)
       });
@@ -125,6 +124,14 @@
       };
       $scope.filters = {};
       $scope.doSearch();
+    };
+
+    /**
+     * Executes the search and hides the search form.
+     */
+    $scope.handleSearchSubmit = function () {
+      $scope.doSearch();
+      $scope.expanded = false;
     };
 
     /**
@@ -291,9 +298,7 @@
     function filtersWatcher () {
       setCaseTypesBasedOnCategory();
 
-      if (!$scope.expanded) {
-        $scope.doSearch();
-      }
+      $scope.doSearch();
     }
 
     /**

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -61,6 +61,7 @@
 
     $scope.caseManagerIsMe = caseManagerIsMe;
     $scope.clearSearch = clearSearch;
+    $scope.doSearchIfNotExpanded = doSearchIfNotExpanded;
     $scope.handleSearchSubmit = handleSearchSubmit;
     $scope.isEnabled = isEnabled;
     $scope.toggleIsDeleted = toggleIsDeleted;
@@ -242,6 +243,17 @@
       $rootScope.$broadcast('civicase::case-search::filters-updated', {
         selectedFilters: formatSearchFilters($scope.filters)
       });
+    }
+
+    /**
+     * Executes the search as long as the component is not expanded.
+     */
+    function doSearchIfNotExpanded () {
+      if ($scope.expanded) {
+        return;
+      }
+
+      doSearch();
     }
 
     /**

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -58,6 +58,13 @@
       { id: 'client', text: ts('Client') }
     ];
 
+    $scope.caseManagerIsMe = caseManagerIsMe;
+    $scope.clearSearch = clearSearch;
+    $scope.doSearch = doSearch;
+    $scope.handleSearchSubmit = handleSearchSubmit;
+    $scope.isEnabled = isEnabled;
+    $scope.toggleIsDeleted = toggleIsDeleted;
+
     (function init () {
       bindRouteParamsToScope();
       applyDefaultFilters();
@@ -68,71 +75,6 @@
       requestCaseRoles().then(addCaseRolesToContactRoles);
       setRelationshipTypeByFilterValues();
     }());
-
-    /**
-     * Check/Uncheck `Show deleted` filters
-     *
-     * @param {object} $event - event object of Event API
-     */
-    $scope.toggleIsDeleted = function ($event) {
-      var pressedSpaceOrEnter = $event.type === 'keydown' && ($event.keyCode === 32 || $event.keyCode === 13);
-
-      if ($event.type === 'click' || pressedSpaceOrEnter) {
-        $scope.filters.is_deleted = !$scope.filters.is_deleted;
-        $event.preventDefault();
-      }
-    };
-
-    /**
-     * Show filter only when not hidden
-     * This is configured from the backend
-     *
-     * @param {string} field - key of the field to be checked for
-     * @returns {boolean} - boolean value if the filter is enabled
-     */
-    $scope.isEnabled = function (field) {
-      return !$scope.hiddenFilters || !$scope.hiddenFilters[field];
-    };
-
-    /**
-     * Checks if the current logged in user is a case manager
-     *
-     * @returns {boolean} if the current logged in user is a case manager
-     */
-    $scope.caseManagerIsMe = function () {
-      return $scope.filters.case_manager && $scope.filters.case_manager.length === 1 && parseInt($scope.filters.case_manager[0], 10) === CRM.config.user_contact_id;
-    };
-
-    /**
-     * Setup filter params and call search API
-     * to feed results for cases
-     */
-    $scope.doSearch = function () {
-      $scope.filterDescription = buildDescription();
-      $rootScope.$broadcast('civicase::case-search::filters-updated', {
-        selectedFilters: formatSearchFilters($scope.filters)
-      });
-    };
-
-    /**
-     * Resets filter options and reload search items
-     */
-    $scope.clearSearch = function () {
-      $scope.contactRoleFilter = {
-        selectedContacts: null,
-        selectedContactRoles: ['all-case-roles']
-      };
-      $scope.filters = {};
-      $scope.doSearch();
-    };
-
-    /**
-     * Executes the search and hides the search form.
-     */
-    $scope.handleSearchSubmit = function () {
-      $scope.doSearch();
-      $scope.expanded = false;
-    };
 
     /**
      * Adds the given case roles to the list of contact roles.
@@ -226,6 +168,15 @@
     }
 
     /**
+     * Checks if the current logged in user is a case manager
+     *
+     * @returns {boolean} if the current logged in user is a case manager
+     */
+    function caseManagerIsMe () {
+      return $scope.filters.case_manager && $scope.filters.case_manager.length === 1 && parseInt($scope.filters.case_manager[0], 10) === CRM.config.user_contact_id;
+    }
+
+    /**
      * Watches changes to the case role filters, prepares the params to be sent
      * to the API and appends them to the filters object.
      */
@@ -263,6 +214,29 @@
         }
       }
     }
+
+    /**
+     * Resets filter options and reload search items
+     */
+    function clearSearch () {
+      $scope.contactRoleFilter = {
+        selectedContacts: null,
+        selectedContactRoles: ['all-case-roles']
+      };
+      $scope.filters = {};
+      $scope.doSearch();
+    };
+
+    /**
+     * Setup filter params and call search API
+     * to feed results for cases
+     */
+    function doSearch () {
+      $scope.filterDescription = buildDescription();
+      $rootScope.$broadcast('civicase::case-search::filters-updated', {
+        selectedFilters: formatSearchFilters($scope.filters)
+      });
+    };
 
     /**
      * Watcher for expanded state and update tableHeader top offset likewise
@@ -322,6 +296,14 @@
     }
 
     /**
+     * Executes the search and hides the search form.
+     */
+    function handleSearchSubmit () {
+      $scope.doSearch();
+      $scope.expanded = false;
+    };
+
+    /**
      * All subscribers are initiated here
      */
     function initSubscribers () {
@@ -337,6 +319,17 @@
       $scope.$watch('caseTypeCategory', setCaseTypesBasedOnCategory);
       $scope.$watchCollection('filters', filtersWatcher);
       $scope.$watchCollection('contactRoleFilter', caseRoleWatcher);
+    }
+
+    /**
+     * Show filter only when not hidden
+     * This is configured from the backend
+     *
+     * @param {string} field - key of the field to be checked for
+     * @returns {boolean} - boolean value if the filter is enabled
+     */
+    function isEnabled (field) {
+      return !$scope.hiddenFilters || !$scope.hiddenFilters[field];
     }
 
     /**
@@ -464,6 +457,20 @@
         $scope.relationshipType = ['is_case_manager'];
       } else if (isFilterEqualToLoggedInUser('contact_involved')) {
         $scope.relationshipType = ['is_involved'];
+      }
+    }
+
+    /**
+     * Check/Uncheck `Show deleted` filters
+     *
+     * @param {object} $event - event object of Event API
+     */
+    function toggleIsDeleted ($event) {
+      var pressedSpaceOrEnter = $event.type === 'keydown' && ($event.keyCode === 32 || $event.keyCode === 13);
+
+      if ($event.type === 'click' || pressedSpaceOrEnter) {
+        $scope.filters.is_deleted = !$scope.filters.is_deleted;
+        $event.preventDefault();
       }
     }
   });

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -60,7 +60,6 @@
 
     $scope.caseManagerIsMe = caseManagerIsMe;
     $scope.clearSearch = clearSearch;
-    $scope.doSearch = doSearch;
     $scope.handleSearchSubmit = handleSearchSubmit;
     $scope.isEnabled = isEnabled;
     $scope.toggleIsDeleted = toggleIsDeleted;
@@ -224,8 +223,8 @@
         selectedContactRoles: ['all-case-roles']
       };
       $scope.filters = {};
-      $scope.doSearch();
-    };
+      doSearch();
+    }
 
     /**
      * Setup filter params and call search API
@@ -236,7 +235,7 @@
       $rootScope.$broadcast('civicase::case-search::filters-updated', {
         selectedFilters: formatSearchFilters($scope.filters)
       });
-    };
+    }
 
     /**
      * Watcher for expanded state and update tableHeader top offset likewise
@@ -271,8 +270,7 @@
      */
     function filtersWatcher () {
       setCaseTypesBasedOnCategory();
-
-      $scope.doSearch();
+      doSearch();
     }
 
     /**
@@ -299,9 +297,9 @@
      * Executes the search and hides the search form.
      */
     function handleSearchSubmit () {
-      $scope.doSearch();
+      doSearch();
       $scope.expanded = false;
-    };
+    }
 
     /**
      * All subscribers are initiated here

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -43,6 +43,7 @@
 
     $scope.caseRelationshipOptions = caseRelationshipConfig;
     $scope.caseStatusOptions = _.map(caseStatuses, mapSelectOptions);
+    $scope.caseTypeOptions = [];
     $scope.checkPerm = CRM.checkPerm;
     $scope.customGroups = CustomSearchField.getAll();
     $scope.filterDescription = buildDescription();
@@ -73,6 +74,12 @@
       setCustomSearchFieldsAsSearchFilters();
       requestCaseRoles().then(addCaseRolesToContactRoles);
       setRelationshipTypeByFilterValues();
+
+      // We need to wait for sibling components to render before we
+      // trigger the initial search:
+      $timeout(function () {
+        doSearch();
+      });
     }());
 
     /**
@@ -265,15 +272,6 @@
     }
 
     /**
-     * Watcher for filter collection to update the search
-     * Only works when dropdown is unexpanded
-     */
-    function filtersWatcher () {
-      setCaseTypesBasedOnCategory();
-      doSearch();
-    }
-
-    /**
      * Returns case types filtered by given category
      *
      * @param {string} categoryName category name
@@ -314,8 +312,6 @@
     function initiateWatchers () {
       $scope.$watch('expanded', expandedWatcher);
       $scope.$watch('relationshipType', relationshipTypeWatcher);
-      $scope.$watch('caseTypeCategory', setCaseTypesBasedOnCategory);
-      $scope.$watchCollection('filters', filtersWatcher);
       $scope.$watchCollection('contactRoleFilter', caseRoleWatcher);
     }
 

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -156,8 +156,8 @@
             $scope.$digest();
           });
 
-          it('does not calls $scope.doSearch()', () => {
-            expect($scope.doSearch).not.toHaveBeenCalled();
+          it('calls $scope.doSearch()', () => {
+            expect($scope.doSearch).toHaveBeenCalled();
           });
         });
       });
@@ -239,7 +239,7 @@
       });
     });
 
-    describe('doSearch()', () => {
+    describe('handling search submit event', () => {
       beforeEach(() => {
         originalParentScope = $scope.$parent;
         $scope.$parent = {};
@@ -248,7 +248,7 @@
       beforeEach(() => {
         $scope.expanded = true;
         $scope.filters.case_manager = [203];
-        $scope.doSearch();
+        $scope.handleSearchSubmit();
       });
 
       afterEach(() => {

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -1,9 +1,9 @@
 /* eslint-env jasmine */
 (($, _) => {
   describe('civicaseSearch', () => {
-    let $controller, $rootScope, $scope, CaseFilters, CaseStatuses, CaseTypes, crmApi, currentCaseCategory,
-      affixOriginalFunction, offsetOriginalFunction, originalParentScope, affixReturnValue,
-      originalBindToRoute;
+    let $controller, $rootScope, $scope, $timeout, CaseFilters, CaseStatuses, CaseTypes,
+      crmApi, currentCaseCategory, affixOriginalFunction, offsetOriginalFunction,
+      originalParentScope, affixReturnValue, originalBindToRoute;
     const SEARCH_EVENT_NAME = 'civicase::case-search::filters-updated';
 
     beforeEach(module('civicase.templates', 'civicase', 'civicase.data', ($provide) => {
@@ -12,11 +12,12 @@
       $provide.value('crmApi', crmApi);
     }));
 
-    beforeEach(inject((_$controller_, $q, _$rootScope_, _CaseFilters_, _CaseStatuses_, _CaseTypesMockData_,
-      _currentCaseCategory_) => {
+    beforeEach(inject((_$controller_, $q, _$rootScope_, _$timeout_, _CaseFilters_,
+      _CaseStatuses_, _CaseTypesMockData_, _currentCaseCategory_) => {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       $scope = $rootScope.$new();
+      $timeout = _$timeout_;
       CaseFilters = _CaseFilters_;
       CaseStatuses = _CaseStatuses_.values;
       CaseTypes = _CaseTypesMockData_.get();
@@ -130,30 +131,26 @@
         });
       });
 
-      describe('$scope.filters', () => {
+      describe('on init', () => {
         beforeEach(() => {
           $scope.filters = CaseFilters.filter;
         });
 
-        describe('when $scope.expanded is false', () => {
-          beforeEach(() => {
-            $scope.expanded = false;
-            $scope.$digest();
-          });
-
-          it('executes the search', () => {
-            expect($rootScope.$broadcast).toHaveBeenCalledWith(SEARCH_EVENT_NAME, jasmine.any(Object));
+        describe('as soon as the component starts', () => {
+          it('does not execute the search', () => {
+            expect($rootScope.$broadcast).not
+              .toHaveBeenCalledWith(SEARCH_EVENT_NAME, jasmine.any(Object));
           });
         });
 
-        describe('when $scope.expanded is true', () => {
+        describe('after the component starts', () => {
           beforeEach(() => {
-            $scope.expanded = true;
-            $scope.$digest();
+            $timeout.flush();
           });
 
           it('executes the search', () => {
-            expect($rootScope.$broadcast).toHaveBeenCalledWith(SEARCH_EVENT_NAME, jasmine.any(Object));
+            expect($rootScope.$broadcast)
+              .toHaveBeenCalledWith(SEARCH_EVENT_NAME, jasmine.any(Object));
           });
         });
       });

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -201,35 +201,35 @@
       });
     });
 
-    describe('caseManagerIsMe()', () => {
-      describe('when case_manager is me', () => {
+    describe('checking when the case manager is the logged in user', () => {
+      describe('when case manager filter is the logged in user', () => {
         beforeEach(() => {
           $scope.filters.case_manager = [203];
         });
 
-        it('should return true', () => {
+        it('returns true', () => {
           expect($scope.caseManagerIsMe()).toBe(true);
         });
       });
 
-      describe('when case_manager is not me', () => {
-        describe('when case id is different', () => {
+      describe('when the case manager filter is not the logged in user', () => {
+        describe('when the case manager id is different', () => {
           beforeEach(() => {
             $scope.filters.case_manager = [201];
           });
 
-          it('should return false', () => {
+          it('returns false', () => {
             expect($scope.caseManagerIsMe()).toBe(false);
           });
         });
 
-        describe('when case id undefined', () => {
+        describe('when the case manager id is undefined', () => {
           beforeEach(() => {
             $scope.filters.case_manager = undefined;
           });
 
-          it('should return undefined', () => {
-            expect($scope.caseManagerIsMe()).toBeUndefined();
+          it('returns false', () => {
+            expect($scope.caseManagerIsMe()).toBe(false);
           });
         });
       });
@@ -321,16 +321,16 @@
         $scope.$parent = originalParentScope;
       });
 
-      it('should build filter description', () => {
+      it('builds the filter description', () => {
         expect($scope.filterDescription).toEqual([{ label: 'Case Manager', text: 'Me' }]);
       });
 
-      it('should close the dropdown', () => {
+      it('closes the dropdown', () => {
         expect($scope.expanded).toBe(false);
       });
     });
 
-    describe('clearSearch()', () => {
+    describe('when the search filters are cleared', () => {
       beforeEach(() => {
         $scope.filters = CaseFilters.filter;
         $scope.clearSearch();
@@ -342,12 +342,6 @@
 
       it('executes the search', () => {
         expect($rootScope.$broadcast).toHaveBeenCalledWith(SEARCH_EVENT_NAME, jasmine.any(Object));
-      });
-    });
-
-    describe('mapSelectOptions()', () => {
-      it('returns a mapped response', () => {
-        expect($scope.caseTypeOptions[0]).toEqual(jasmine.objectContaining({ id: jasmine.any(String), text: jasmine.any(String), color: jasmine.any(String), icon: jasmine.any(String) }));
       });
     });
 

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -2,8 +2,9 @@
 (($, _) => {
   describe('civicaseSearch', () => {
     let $controller, $rootScope, $scope, CaseFilters, CaseStatuses, CaseTypes, crmApi, currentCaseCategory,
-      affixOriginalFunction, offsetOriginalFunction, originalDoSearch, originalParentScope, affixReturnValue,
+      affixOriginalFunction, offsetOriginalFunction, originalParentScope, affixReturnValue,
       originalBindToRoute;
+    const SEARCH_EVENT_NAME = 'civicase::case-search::filters-updated';
 
     beforeEach(module('civicase.templates', 'civicase', 'civicase.data', ($provide) => {
       crmApi = jasmine.createSpy('crmApi');
@@ -36,6 +37,7 @@
       CRM.$.fn.affix.and.returnValue(affixReturnValue);
       originalBindToRoute = $scope.$bindToRoute;
       $scope.$bindToRoute = jasmine.createSpy('$bindToRoute');
+      spyOn($rootScope, '$broadcast');
 
       initController();
     });
@@ -130,13 +132,7 @@
 
       describe('$scope.filters', () => {
         beforeEach(() => {
-          originalDoSearch = $scope.doSearch;
-          $scope.doSearch = jasmine.createSpy('doSearch');
           $scope.filters = CaseFilters.filter;
-        });
-
-        afterEach(() => {
-          $scope.doSearch = originalDoSearch;
         });
 
         describe('when $scope.expanded is false', () => {
@@ -145,8 +141,8 @@
             $scope.$digest();
           });
 
-          it('calls $scope.doSearch()', () => {
-            expect($scope.doSearch).toHaveBeenCalled();
+          it('executes the search', () => {
+            expect($rootScope.$broadcast).toHaveBeenCalledWith(SEARCH_EVENT_NAME, jasmine.any(Object));
           });
         });
 
@@ -156,8 +152,8 @@
             $scope.$digest();
           });
 
-          it('calls $scope.doSearch()', () => {
-            expect($scope.doSearch).toHaveBeenCalled();
+          it('executes the search', () => {
+            expect($rootScope.$broadcast).toHaveBeenCalledWith(SEARCH_EVENT_NAME, jasmine.any(Object));
           });
         });
       });
@@ -266,22 +262,16 @@
 
     describe('clearSearch()', () => {
       beforeEach(() => {
-        originalDoSearch = $scope.doSearch;
-        $scope.doSearch = jasmine.createSpy('doSearch');
         $scope.filters = CaseFilters.filter;
         $scope.clearSearch();
-      });
-
-      afterEach(() => {
-        $scope.doSearch = originalDoSearch;
       });
 
       it('clears filters object', () => {
         expect($scope.filters).toEqual({});
       });
 
-      it('calls doSearch()', () => {
-        expect($scope.doSearch).toHaveBeenCalled();
+      it('executes the search', () => {
+        expect($rootScope.$broadcast).toHaveBeenCalledWith(SEARCH_EVENT_NAME, jasmine.any(Object));
       });
     });
 

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -190,6 +190,34 @@
       });
     });
 
+    describe('automatically searching when not expanding', () => {
+      describe('when the search is not expanded', () => {
+        beforeEach(() => {
+          $scope.expanded = false;
+
+          $scope.doSearchIfNotExpanded();
+        });
+
+        it('executes the search', () => {
+          expect($rootScope.$broadcast)
+            .toHaveBeenCalledWith(SEARCH_EVENT_NAME, jasmine.any(Object));
+        });
+      });
+
+      describe('when the search is expanded', () => {
+        beforeEach(() => {
+          $scope.expanded = true;
+
+          $scope.doSearchIfNotExpanded();
+        });
+
+        it('does not execute the search', () => {
+          expect($rootScope.$broadcast)
+            .not.toHaveBeenCalledWith(SEARCH_EVENT_NAME, jasmine.any(Object));
+        });
+      });
+    });
+
     describe('accepting URL values for the relationship type filter', () => {
       describe('when setting the case manager as the logged in user', () => {
         beforeEach(() => {


### PR DESCRIPTION
## Overview
This PR displays the list of cases when the manage case page loads with the expanded search.

## Before
![gif](https://user-images.githubusercontent.com/1642119/81121973-eea6cb80-8efd-11ea-80fb-31315273bc03.gif)

## After
![gif](https://user-images.githubusercontent.com/1642119/81121874-b69f8880-8efd-11ea-9594-f9bdb2bfd892.gif)

## Technical Details

### Background

First we need to understand that the search component is the one that triggers the event ([here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/ang/civicase/case/search/directives/search.directive.js#L291-L297)) that initiates the API call to fetch case types. The API call is executed in the case list table when the event that comes from the search component is triggered ([here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/ang/civicase/case/list/directives/case-list-table.directive.js#L397-L399)). Also note that these two components are siblings, not parent-child ([here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/ang/civicase/case/list/directives/case-list.html)). This is important to understand the solution that we have implemented.

### Fixing the search when the page loads

The problem is that we were triggering the search as soon as the component loads (through the watch), but only if the search component is not expanded. We couldn't simply remove this condition because this watch is used to automatically search when the search is not expanded, but to wait for the user to click on the "search" button when the component is expanded.

To fix this issue we have implemented the following changes:

- Removed the filters watch that triggered the event for the search
- Added a `doSearchIfNotExpanded` method that triggers the search event automatically when changing the inputs that are visible when the search is not expanded. This method is implemented using `ng-change` for the specific inputs instead of watching the whole filter object.
- We trigger the search event as soon as the search component starts.

As an important note related to the *background* section: we trigger the event at the start, but do it from a `$timeout` because the search component is not a child of the case list component. The search is initialised first, and the case list second. For this reason the case list won't be able to listen for this first search since it won't be ready.

### Removing the case type category watcher

The following watch was removed:

```js
$scope.$watch('caseTypeCategory', setCaseTypesBasedOnCategory);
```

There are multiple reasons for this:

- There has never been a `caseTypeCategory` property for the `$scope` object. Refer to the original PR https://github.com/compucorp/uk.co.compucorp.civicase/pull/220/files#diff-3ad0433e79c5217f12f2d4805f6fade0R302 if you check the `search.directive.js` file at that time you won't find any reference to this value.
- The `crm-ui-select` does not support changes to its list of options. Even if we had a reference the case type category and would update the list of case types depending on this value, this select component would not be updated:

![gif](https://user-images.githubusercontent.com/1642119/81125359-ee123300-8f05-11ea-8548-20eabf0e7564.gif)

The `setCaseTypesBasedOnCategory` function was already being called when the component started so there was no need to make any other changes.

## A case against `watch`

We should stop relying on using `watch` and try to remove them from existing components. Here are a few reasons for this proposal:

- `watch` is triggered as soon as the component starts, even if there was no change. In most cases this is not a desired behaviour.
- We only wanted to trigger an action when certain fields changed, not the whole filters object. This is the reason the watch function was not being executed when the `expand` variable was set to `false`.
- The `filters` object can be modified by the URL. Any other component can modify the URL. It would be confusing triggering a refresh after a random component updates the URL. The intended way to update the list of cases should be through the `civicase::case-search::filters-updated` which is explicit, not through a side effect.
- It's difficult to understand what triggered the change. It could have come from a parent component (when watching props), a change in the URL parameters, an event updated the value, or an input in the component changed.
- Trying to understand the flow of a component that has watchers is more difficult.

Everything can be achieved through `ng-change` and events.