### PR TITLE
IN-336: Add linters and unit tests workflows

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,36 @@
+name: Linters
+
+on: pull_request
+     
+env:
+  GITHUB_BASE_REF: ${{ github.base_ref }}
+
+jobs:
+  run-linters:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Run npm install
+      run: npm i
+
+    - name: Fetch target branch
+      run: git fetch -n origin ${GITHUB_BASE_REF}
+            
+    - name: Run phpcs linter 
+      run: git diff origin/${GITHUB_BASE_REF} --name-only -- '*.php' | xargs -r ./bin/phpcs.phar --standard=phpcs-ruleset.xml
+
+    - name: Run stylelint linter
+      #This step will always run regardless of previous step's status
+      #without if: ${{ always() }}, if the previous step is failure,
+      #the remaining step will not be executed. 
+      if: ${{ always() }} 
+      run: git diff origin/${GITHUB_BASE_REF} --name-only -- '*.scss' | xargs -r  npx stylelint --config .stylelintrc 
+        
+
+    - name: Run eslint linter
+      if: ${{ always() }}
+      run: git diff origin/${GITHUB_BASE_REF} --name-only -- '*.js' | xargs -r  npx eslint --max-warnings=0 -c .eslintrc.json 
+        

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,46 @@
+name: Tests
+
+on: pull_request
+
+jobs:   
+  run-unit-tests:
+
+    runs-on: ubuntu-latest
+    container: compucorp/civicrm-buildkit:1.0.0
+    
+    env:
+      CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
+    
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+        - 3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
+      
+      - name: Config mysql database as per CiviCRM requirement 
+        run: echo "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));" | mysql -u root --password=root --host=mysql
+
+      - name: Config amp
+        run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
+      
+      - name: Build Drupal site 
+        run: civibuild create drupal-clean --civi-ver 5.24.6 --web-root $GITHUB_WORKSPACE/site
+
+      - uses: actions/checkout@v2
+        with:
+            path: ${{ env.CIVICRM_EXTENSIONS_DIR }}/civicase
+ 
+      - name: Installing CiviCase and its dependencies
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
+        run: |
+          git clone --depth 1 https://github.com/civicrm/org.civicrm.shoreditch.git
+          cv en shoreditch civicase
+
+      - name: Run phpunit tests
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/civicase
+        run: phpunit5 


### PR DESCRIPTION
## Overview
This PR is to add two Github Action workflows which are:

- Linters workflow that contains Eslint, Stylelint, PHPCS
- Unit Tests workflow that contains PHPUnitTest

Currently, the workflow does not run JS tests (Karma tests) as we are having inconstancy issue when tests are failing randomly with Compuclient and always fails with Drupal vanilla. 

## Before
Linters and tests were not executed automatically for Pull Requests

## After
Linters workflow will be triggered and run on when every PR is created and/or updated.

- PHPCS will only run if *.php is updated.
- Stylelint will only run if .*scss is updated.
- Eslint will only run if .*js is updated

Unit Tests workflow will be triggered and run when every PR is created and/or updated. 
- On the event that PR is created, the workflow will run all phpunit tests.

## Technical Details

* Workflows: Currently, workflows are implemented as two separate workflows, Linters and Unitests, the reason for this implementation is for maintainability as we are separating Unit Tests and Linters tasks s they are not depending on each other.  Linters and Unit Tests workflow is running on the different container, Unit tests workflow is running on a custom docker image which has CivCRM Buildkit pre-installed where LInter require to run on Github Action based container. 
*  Drupal clean vs Compuclient: The Unit Tests workflow was originally tested on Docker image that has Drupal with Compuclient profile pre-installed and later the workflow was migrated to use Drupal clean installation for a few reasons:
   * Compuclient is currently being maintained privately and GitHub Action currently does not support private Docker image thus we could not be able to have a public docker image pre-install Compuclient. 
   * CiviCase should NOT be depending on Compuclient and it should be working with any CiviCRM installation.



