### PR TITLE
RSE-647: Case Category Type Custom Fields

### DIFF
--- a/CRM/Civicase/Form/CaseCategoryTypeCustomField.php
+++ b/CRM/Civicase/Form/CaseCategoryTypeCustomField.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * This class generates form components for custom data for a case category.
+ */
+abstract class CRM_Civicase_Form_CaseCategoryTypeCustomField extends CRM_Core_Form {
+
+  /**
+   * The entity id, used when editing/creating custom data.
+   *
+   * @var int
+   */
+  protected $entityId;
+
+  /**
+   * Entity sub type of the table id.
+   *
+   * @var int
+   */
+  protected $subTypeId;
+
+  /**
+   * Custom group Id.
+   *
+   * @var int
+   */
+  protected $groupId;
+
+  /**
+   * Entity Table.
+   *
+   * @var string
+   */
+  protected $entityTable = 'civicrm_case_type';
+
+  /**
+   * Returns entity type for the case category.
+   *
+   * @return string
+   *   Entity type.
+   */
+  abstract protected function getEntityType();
+
+  /**
+   * Sets the appropriate variables needed by the custom data templates.
+   */
+  public function preProcess() {
+    $this->groupId = CRM_Utils_Request::retrieve('groupId', 'Positive', $this, FALSE, NULL);
+    $this->entityId = CRM_Utils_Request::retrieve('entityId', 'Positive', $this, TRUE);
+
+    $groupTree = CRM_Core_BAO_CustomGroup::getTree(
+      $this->getEntityType(),
+      NULL,
+      $this->entityId,
+      $this->groupId ? $this->groupId : NULL,
+      $this->entityId
+    );
+
+    // Simplified formatted groupTree.
+    $groupTree = CRM_Core_BAO_CustomGroup::formatGroupTree(
+      $groupTree,
+      1,
+      $this
+    );
+
+    foreach ($groupTree as $groupValues) {
+      $pageTitle = count($groupTree) > 1 ? 'Custom Group Fields' : $groupValues['title'];
+      break;
+    }
+
+    CRM_Utils_System::setTitle(ts('Administer %1', [1 => $pageTitle]));
+
+    $this->_defaults = [];
+    CRM_Core_BAO_CustomGroup::setDefaults($groupTree, $this->_defaults);
+    $this->setDefaults($this->_defaults);
+
+    CRM_Core_BAO_CustomGroup::buildQuickForm($this, $groupTree);
+
+    // Need to assign custom data type and subtype to the template.
+    $this->assign('entityID', $this->entityId);
+    $this->assign('groupID', $this->groupId);
+    $this->assign('subType', $this->subTypeId);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function buildQuickForm() {
+    $this->addButtons(
+      [
+        [
+          'type' => 'upload',
+          'name' => ts('Save'),
+          'isDefault' => TRUE,
+        ],
+        [
+          'type' => 'cancel',
+          'name' => ts('Cancel'),
+        ],
+      ]
+    );
+  }
+
+  /**
+   * Process the user submitted custom data values.
+   */
+  public function postProcess() {
+    $params = $this->controller->exportValues($this->_name);
+    CRM_Core_BAO_CustomValueTable::postProcess(
+      $params,
+      $this->entityTable,
+      $this->entityId,
+      $this->getEntityType()
+    );
+  }
+
+}

--- a/CRM/Civicase/Helper/CaseCategory.php
+++ b/CRM/Civicase/Helper/CaseCategory.php
@@ -32,7 +32,8 @@ class CRM_Civicase_Helper_CaseCategory {
 
         return $caseTypeCategories[$caseCategoryId];
       }
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
       return NULL;
     }
 
@@ -85,22 +86,6 @@ class CRM_Civicase_Helper_CaseCategory {
   }
 
   /**
-   * Returns the case types for the cases category.
-   *
-   * @return array
-   *   Array of Case Types indexed by Id.
-   */
-  public static function getCaseTypesForCase() {
-    $result = civicrm_api3('CaseType', 'get', [
-      'sequential' => 1,
-      'return' => ['title', 'id'],
-      'case_type_category' => self::CASE_TYPE_CATEGORY_NAME,
-    ]);
-
-    return array_column($result['values'], 'title', 'id');
-  }
-
-  /**
    * Returns the case type category word replacements.
    *
    * @param string $caseTypeCategoryName
@@ -117,7 +102,8 @@ class CRM_Civicase_Helper_CaseCategory {
         'name' => $optionName,
       ]);
 
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
       if (!$caseTypeCategoryName || strtolower($caseTypeCategoryName) == 'cases') {
         return [];
       }

--- a/CRM/Civicase/Service/CaseCategoryCaseTypeCustomFieldExtends.php
+++ b/CRM/Civicase/Service/CaseCategoryCaseTypeCustomFieldExtends.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Class CRM_Civicase_Service_CaseCategoryCaseTypeCustomFieldExtends.
+ */
+class CRM_Civicase_Service_CaseCategoryCaseTypeCustomFieldExtends extends CRM_Civicase_Service_CaseCategoryCustomFieldExtends {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $entityTable = 'civicrm_case_type';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getCustomEntityValue($caseCategoryName) {
+    return "{$caseCategoryName}Type";
+  }
+
+}

--- a/CRM/Civicase/Service/CaseCategoryCustomFieldExtends.php
+++ b/CRM/Civicase/Service/CaseCategoryCustomFieldExtends.php
@@ -6,14 +6,23 @@
 class CRM_Civicase_Service_CaseCategoryCustomFieldExtends {
 
   /**
+   * Entity table value.
+   *
+   * @var string
+   */
+  protected $entityTable = 'civicrm_case';
+
+  /**
    * Creates the Custom field extend option group for case category.
    *
    * @param string $caseCategoryName
    *   Case Category Name.
    * @param string $label
    *   Label.
+   * @param string $entityTypeFunction
+   *   Function to fetch entity types for the entity.
    */
-  public function create($caseCategoryName, $label) {
+  public function create($caseCategoryName, $label, $entityTypeFunction = NULL) {
     $result = $this->getCgExtendOptionValue($caseCategoryName);
 
     if ($result['count'] > 0) {
@@ -22,10 +31,10 @@ class CRM_Civicase_Service_CaseCategoryCustomFieldExtends {
 
     civicrm_api3('OptionValue', 'create', [
       'option_group_id' => 'cg_extend_objects',
-      'name' => 'civicrm_case',
+      'name' => $this->entityTable,
       'label' => $label,
-      'value' => $caseCategoryName,
-      'description' => NULL,
+      'value' => $this->getCustomEntityValue($caseCategoryName),
+      'description' => $entityTypeFunction,
       'is_active' => TRUE,
       'is_reserved' => TRUE,
     ]);
@@ -56,14 +65,28 @@ class CRM_Civicase_Service_CaseCategoryCustomFieldExtends {
    * @return array
    *   Cg Extend option value.
    */
-  private function getCgExtendOptionValue($caseCategoryName) {
+  protected function getCgExtendOptionValue($caseCategoryName) {
     $result = civicrm_api3('OptionValue', 'get', [
       'sequential' => 1,
-      'value' => $caseCategoryName,
+      'value' => $this->getCustomEntityValue($caseCategoryName),
       'option_group_id' => 'cg_extend_objects',
+      'name' => $this->entityTable,
     ]);
 
     return $result;
+  }
+
+  /**
+   * Returns the custom entity value.
+   *
+   * @param string $caseCategoryName
+   *   Case category name.
+   *
+   * @return string
+   *   Custom entity value.
+   */
+  protected function getCustomEntityValue($caseCategoryName) {
+    return $caseCategoryName;
   }
 
 }


### PR DESCRIPTION
## Overview
Currently Custom fields for Case Types are not supported in Civicrm core but we need this support for Award case types and possibly for any other case types in the future.
This PR adds the functionality and required classes to make this functionality available for custom field support for case types of case categories.

## Before
- This functionality is not available.

## After
- A `CRM_Civicase_Form_CaseCategoryTypeCustomField` class is added that can be extended by other case categories and allows values for custom fields for case type categories to be created/edited. This form can be extended by Awards category or any other category that intends to have a form for processing values for custom fields for case types.

- A new class `CRM_Civicase_Service_CaseCategoryCaseTypeCustomFieldExtends` was added that extends the `CRM_Civicase_Service_CaseCategoryCustomFieldExtend` class and helps to add the case category case type entity that can be extended by custo field sets. This class can be used to process custom field support for case types by other case category that needs this functionality.


