### PR TITLE
CATL-1348: related case tab setting

### DIFF
--- a/CRM/Civicase/Hook/PreProcess/AddCaseAdminSettings.php
+++ b/CRM/Civicase/Hook/PreProcess/AddCaseAdminSettings.php
@@ -21,10 +21,42 @@ class CRM_Civicase_Hook_PreProcess_AddCaseAdminSettings {
     }
 
     $settings = $form->getVar('_settings');
-    $settings['civicaseAllowCaseLocks'] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;
-    $this->setCaseCategoryWebformSettings($form, $settings);
 
+    $this->setCaseCategoryWebformSettings($form, $settings);
+    $this->addCivicaseSettingsToForm($settings);
     $form->setVar('_settings', $settings);
+  }
+
+  /**
+   * Takes civicase setting names and adds them to the admin form.
+   *
+   * The settings are taken from the civicase settings file. This function is
+   * needed to properly display these settings on the form.
+   *
+   * @param array $settings
+   *   Settings array.
+   */
+  private function addCivicaseSettingsToForm(array &$settings) {
+    $civicaseSettings = $this->getCiviCaseSettings();
+    $settingKeys = array_keys($civicaseSettings);
+
+    foreach ($settingKeys as $settingKey) {
+      $settings[$settingKey] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;
+    }
+  }
+
+  /**
+   * Returns the list of settings defined in the civicase settings file.
+   *
+   * @return array
+   *   The civicase settings.
+   */
+  private function getCiviCaseSettings() {
+    $civicasePath = (new CRM_Extension_System())
+      ->getFullContainer()
+      ->getPath('uk.co.compucorp.civicase');
+
+    return require $civicasePath . '/settings/CiviCase.setting.php';
   }
 
   /**
@@ -38,11 +70,6 @@ class CRM_Civicase_Hook_PreProcess_AddCaseAdminSettings {
   private function setCaseCategoryWebformSettings(CRM_Core_Form &$form, array &$settings) {
     $caseSetting = new CaseCategorySetting();
     $caseCategoryWebFormSetting = $caseSetting->getForWebform();
-    $settingKeys = array_keys($caseCategoryWebFormSetting);
-
-    foreach ($settingKeys as $settingKey) {
-      $settings[$settingKey] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;
-    }
 
     $form->assign('caseCategoryWebFormSetting', $caseCategoryWebFormSetting);
   }

--- a/CRM/Civicase/Hook/alterContent/CivicaseSettingsForm.php
+++ b/CRM/Civicase/Hook/alterContent/CivicaseSettingsForm.php
@@ -1,0 +1,25 @@
+<?php
+
+class CRM_Civicase_Hook_alterContent_CivicaseSettingsForm {
+
+  public function run(&$content, $context, $templateName, $form) {
+    if (!$this->shouldRun($form)) {
+      return;
+    }
+
+    $settingsTemplate = &CRM_Core_Smarty::singleton();
+    $settingsTemplateHtml = $settingsTemplate->fetchWith('CRM/Civicase/Admin/Form/Settings.tpl', []);
+
+    $doc = phpQuery::newDocumentHTML($content);
+    $doc->find('table.form-layout tr:last')->append($settingsTemplateHtml);
+
+    $content = $doc->getDocument();
+  }
+
+  private function shouldRun($form) {
+    $isViewingTheCaseAdminForm = get_class($form) === CRM_Admin_Form_Setting_Case::class;
+
+    return false;
+  }
+
+}

--- a/ang/civicase-base.ang.php
+++ b/ang/civicase-base.ang.php
@@ -51,6 +51,7 @@ expose_settings($options, [
 function expose_settings(array &$options, array $defaults) {
   $options['allowMultipleCaseClients'] = (bool) Civi::settings()->get('civicaseAllowMultipleClients');
   $options['allowCaseLocks'] = (bool) Civi::settings()->get('civicaseAllowCaseLocks');
+  $options['allowLinkedCasesPage'] = (bool) Civi::settings()->get('civicaseAllowLinkedCasesPage');
   $options['caseTypeCategoriesWhereUserCanAccessActivities'] =
     CRM_Civicase_Helper_CaseCategory::getWhereUserCanAccessActivities();
   $options['currentCaseCategory'] = $defaults['caseCategoryName']

--- a/settings/CiviCase.setting.php
+++ b/settings/CiviCase.setting.php
@@ -21,6 +21,21 @@ $setting = [
     'description' => 'This will allow cases to be locked for certain contacts.',
     'help_text' => '',
   ],
+  'civicaseAllowLinkedCasesPage' => [
+    'group_name' => 'CiviCRM Preferences',
+    'group' => 'core',
+    'name' => 'civicaseAllowLinkedCasesPage',
+    'type' => 'Boolean',
+    'quick_form_type' => 'YesNo',
+    'default' => FALSE,
+    'html_type' => 'radio',
+    'add' => '4.7',
+    'title' => 'Allow linked cases page',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => '',
+    'help_text' => '',
+  ],
 ];
 
 $caseSetting = new CRM_Civicase_Service_CaseCategorySetting();


### PR DESCRIPTION
## Overview
This PR adds the "Allow linked cases page" setting to the Civicase admin form.

## Before
![Settings_CiviCase_case8004 (1)](https://user-images.githubusercontent.com/1642119/81627432-2a450800-93cc-11ea-944d-ef0a558ef9f7.png)


## After
![Settings_CiviCase_case8004](https://user-images.githubusercontent.com/1642119/81627280-cfabac00-93cb-11ea-821c-f51daa84348c.png)

### Technical details

* We updated the `settings/CiviCase.setting.php` file to add the new settings configuration.
* We refactored the the `AddCaseAdminSettings.php` hook class so it automatically adds all the settings that have been configured to `settings/CiviCase.setting.php`.
* We exposed the `civicaseAllowLinkedCasesPage` value on the `ang/civicase-base.ang.php` file so it's available to the FE.


