### PR TITLE
CPS-156: People Tab Bugs

### DIFF
--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
@@ -301,9 +301,7 @@
       };
 
       return _.map(item.client, function (client) {
-        params.contact_id_a = client.contact_id;
-
-        return ['Relationship', 'create', params];
+        return ['Relationship', 'create', _.extend({ contact_id_a: client.contact_id }, params)];
       });
     }
 

--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
@@ -409,7 +409,6 @@
     function getReplaceClientApiCalls (contactPromptResult) {
       var activitySubject = getActivitySubjectForReplaceCaseContact(contactPromptResult);
       var apiCalls = [
-        unassignRoleCall(contactPromptResult.role),
         getCreateRoleActivityApiCall({
           activity_type_id: 'Reassigned Case',
           subject: activitySubject,
@@ -418,9 +417,13 @@
             contactPromptResult.role.contact_id
           ]
         }),
-        ['CaseContact', 'create', {
+        ['CaseContact', 'get', {
           case_id: item.id,
-          contact_id: contactPromptResult.contact.id
+          contact_id: contactPromptResult.role.contact_id,
+          'api.CaseContact.create': {
+            case_id: item.id,
+            contact_id: parseInt(contactPromptResult.contact.id)
+          }
         }]
       ];
 

--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
@@ -241,6 +241,7 @@
       }).on('crmConfirm:yes', function () {
         var apiCalls = [unassignRoleCall(role)];
 
+        // when client
         if (!role.relationship_type_id) {
           apiCalls.push(['Relationship', 'get', {
             case_id: item.id,
@@ -257,6 +258,7 @@
           activity_type_id: role.relationship_type_id ? 'Remove Case Role' : 'Remove Client From Case',
           subject: ts('%1 removed as %2', { 1: role.display_name, 2: role.role })
         }]);
+
         $scope.refresh(apiCalls);
       });
     };

--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
@@ -387,6 +387,7 @@
     function getApiParamsToDuplicateExistingRelationshipsToNewClient (contactPromptResult, apiCalls) {
       apiCalls.push(['Relationship', 'get', {
         case_id: item.id,
+        contact_id_a: item.client[0].contact_id,
         is_active: 1,
         'api.Relationship.create': {
           id: false,

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
@@ -67,7 +67,7 @@
         title: ts('Other cases for this contact'),
         filterParams: {
           'case_type_id.case_type_category': $scope.caseTypeCategory,
-          contact_id: { '!=': $scope.contactId },
+          exclude_for_client_id: $scope.contactId,
           contact_involved: $scope.contactId,
           is_deleted: 0
         },

--- a/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
@@ -263,6 +263,7 @@ describe('Case Details People Tab', () => {
         expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
           ['Relationship', 'get', {
             case_id: $scope.item.id,
+            contact_id_a: $scope.item.client[0].contact_id,
             is_active: 1,
             'api.Relationship.create': {
               id: false,

--- a/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
@@ -25,7 +25,9 @@ describe('Case Details People Tab', () => {
     crmConfirmYesEvent.preventDefault = jasmine.createSpy('preventDefault');
     CRM.confirm = function (options) {
       crmConfirmDialog.append(options.message);
-      options.open();
+      if (options.open) {
+        options.open();
+      }
 
       return crmConfirmDialog;
     };
@@ -257,6 +259,24 @@ describe('Case Details People Tab', () => {
         ]));
       });
 
+      it('duplicates all existing relations for current case for the new client', () => {
+        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
+          ['Relationship', 'get', {
+            case_id: $scope.item.id,
+            is_active: 1,
+            'api.Relationship.create': {
+              id: false,
+              contact_id_a: contact.contact_id,
+              start_date: 'now',
+              contact_id_b: '$value.contact_id_b',
+              relationship_type_id: '$value.relationship_type_id',
+              description: '$value.description',
+              case_id: '$value.case_id'
+            }
+          }]
+        ]));
+      });
+
       it('closes the contact selection dialog', () => {
         expect(crmConfirmYesEvent.preventDefault).not.toHaveBeenCalled();
       });
@@ -295,6 +315,17 @@ describe('Case Details People Tab', () => {
         ]));
       });
 
+      it('updates all existing relationships for the old contact with the new client', () => {
+        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
+          ['Relationship', 'get', {
+            case_id: $scope.item.id,
+            is_active: true,
+            contact_id_a: previousContact.contact_id,
+            'api.Relationship.update': { contact_id_a: contact.contact_id }
+          }]
+        ]));
+      });
+
       it('creates a new completed activity to record the case being reassigned to another client', () => {
         expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
           ['Activity', 'create', {
@@ -312,6 +343,50 @@ describe('Case Details People Tab', () => {
 
       it('closes the contact selection dialog', () => {
         expect(crmConfirmYesEvent.preventDefault).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when unassigning a client', () => {
+      let sampleContact;
+
+      beforeEach(() => {
+        sampleContact = CRM._.sample(ContactsData.values);
+
+        $scope.unassignRole({
+          contact_id: sampleContact.contact_id,
+          display_name: sampleContact.display_name,
+          role: 'Client'
+        });
+
+        crmConfirmDialog.trigger(crmConfirmYesEvent);
+        $rootScope.$digest();
+      });
+
+      it('deletes the client', () => {
+        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([['CaseContact', 'get', {
+          case_id: $scope.item.id,
+          contact_id: sampleContact.contact_id,
+          'api.CaseContact.delete': {}
+        }]]));
+      });
+
+      it('makes the exisiting relationships with the client as inactive', () => {
+        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([['Relationship', 'get', {
+          case_id: $scope.item.id,
+          is_active: 1,
+          contact_id_a: sampleContact.contact_id,
+          'api.Relationship.create': { is_active: 0, end_date: 'now' }
+        }]]));
+      });
+
+      it('creates an activity about removing the client', () => {
+        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([['Activity', 'create', {
+          case_id: $scope.item.id,
+          target_contact_id: sampleContact.contact_id,
+          status_id: 'Completed',
+          activity_type_id: 'Remove Client From Case',
+          subject: sampleContact.display_name + ' removed as Client'
+        }]]));
       });
     });
   });

--- a/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
@@ -296,21 +296,15 @@ describe('Case Details People Tab', () => {
         $rootScope.$digest();
       });
 
-      it('removes the existing client from the case', () => {
+      it('replaces the old client with the new selected contact', () => {
         expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
           ['CaseContact', 'get', {
             case_id: $scope.item.id,
             contact_id: previousContact.contact_id,
-            'api.CaseContact.delete': {}
-          }]
-        ]));
-      });
-
-      it('creates a new client using the selected contact', () => {
-        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
-          ['CaseContact', 'create', {
-            case_id: $scope.item.id,
-            contact_id: contact.contact_id
+            'api.CaseContact.create': {
+              case_id: $scope.item.id,
+              contact_id: parseInt(contact.contact_id)
+            }
           }]
         ]));
       });

--- a/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
+++ b/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
@@ -77,7 +77,7 @@
         expect(crmApi.calls.allArgs()).toContain(jasmine.arrayContaining([
           jasmine.objectContaining({
             cases: ['Case', 'getcaselist', jasmine.objectContaining({
-              contact_id: { '!=': $scope.contactId },
+              exclude_for_client_id: $scope.contactId,
               contact_involved: $scope.contactId,
               'case_type_id.case_type_category': 2,
               is_deleted: 0

--- a/api/v3/Case/Getdetails.php
+++ b/api/v3/Case/Getdetails.php
@@ -95,7 +95,9 @@ function civicrm_api3_case_getdetails(array $params) {
   }
 
   if (!empty($params['exclude_for_client_id'])) {
-    $sql->where("a.id NOT IN (SELECT case_id FROM civicrm_case_contact WHERE contact_id = {$params['exclude_for_client_id']})");
+    $sql->where('a.id NOT IN (SELECT case_id FROM civicrm_case_contact WHERE contact_id = #contact_id', [
+      '#contact_id' => $params['exclude_for_client_id'],
+    ]);
   }
 
   // Filter deleted contacts from results.

--- a/api/v3/Case/Getdetails.php
+++ b/api/v3/Case/Getdetails.php
@@ -24,6 +24,12 @@ function _civicrm_api3_case_getdetails_spec(array &$spec) {
     'type' => CRM_Utils_Type::T_INT,
   ];
 
+  $spec['exclude_for_client_id'] = [
+    'title' => 'Exclude For Client ID',
+    'description' => "Contact id of the Client to be excluded",
+    'type' => CRM_Utils_Type::T_INT,
+  ];
+
   $spec['contact_involved'] = [
     'title' => 'Contact Involved',
     'description' => 'Id of the contact involved as case roles',
@@ -86,6 +92,10 @@ function civicrm_api3_case_getdetails(array $params) {
   // Add clause to search by non manager role and non client.
   if (!empty($params['contact_involved'])) {
     CRM_Civicase_APIHelpers_CasesByContactInvolved::filter($sql, $params['contact_involved']);
+  }
+
+  if (!empty($params['exclude_for_client_id'])) {
+    $sql->where("a.id NOT IN (SELECT case_id FROM civicrm_case_contact WHERE contact_id = {$params['exclude_for_client_id']})");
   }
 
   // Filter deleted contacts from results.

--- a/api/v3/Case/Getdetails.php
+++ b/api/v3/Case/Getdetails.php
@@ -95,7 +95,7 @@ function civicrm_api3_case_getdetails(array $params) {
   }
 
   if (!empty($params['exclude_for_client_id'])) {
-    $sql->where('a.id NOT IN (SELECT case_id FROM civicrm_case_contact WHERE contact_id = #contact_id', [
+    $sql->where('a.id NOT IN (SELECT case_id FROM civicrm_case_contact WHERE contact_id = #contact_id)', [
       '#contact_id' => $params['exclude_for_client_id'],
     ]);
   }


### PR DESCRIPTION
## Overview
This PR fixes few bugs, related to People's tab.

## Bug 1
When a Client is removed, all existing relationships for that client should be set to inactive.
This is not a regression.

**Technical Details**
This is fixed in `$scope.unassignRole` function, with the following code
```javascript
// when client
if (!role.relationship_type_id) {
  apiCalls.push(['Relationship', 'get', {
    case_id: item.id,
    is_active: 1,
    contact_id_a: role.contact_id,
    'api.Relationship.create': { is_active: 0, end_date: 'now' }
  }]);
}
```

## Bug 2
When replacing a client, all existing relationships for that client, should be reassigned to the new client.

This is not a regression.

**Technical Details**
This is fixed in `getReplaceClientApiCalls` function, with the following code
```javascript
['Relationship', 'get', {
  case_id: item.id,
  is_active: true,
  contact_id_a: contactPromptResult.role.contact_id,
  'api.Relationship.update': { contact_id_a: contactPromptResult.contact.id }
}]
```

## Bug 3
When a new Client is added, all existing relationships in case, should be duplicated with the new Client set as Contact A.

This is not a regression.

**Technical Details**
This is fixed in `handleAssignClient` function, with the following code
```javascript
['Relationship', 'get', {
  case_id: item.id,
  is_active: 1,
  'api.Relationship.create': {
    id: false,
    contact_id_a: contactPromptResult.contact.id,
    start_date: 'now',
    contact_id_b: '$value.contact_id_b',
    relationship_type_id: '$value.relationship_type_id',
    description: '$value.description',
    case_id: '$value.case_id'
  }
}]
```

## Bug 4
When a role is added to a Case having multiple clients, the Role was being assigned to only one of the clients.

This is same as CPS-212 and not a regression.

**Technical Details**
In `getCreateCaseRoleApiCalls`, previously the role was being assigned to the last client.

```javascript
return _.map(item.client, function (client) {
  // because of pass by reference, the last client id was being sent for all requests
  params.contact_id_a = client.contact_id;

  return ['Relationship', 'create', params];	
});
```

so this is replaced by 
```javascript
return _.map(item.client, function (client) {
  return ['Relationship', 'create', _.extend({ contact_id_a: client.contact_id }, params)];
});
```

## Bug 5
There was a bug in the Contacts Case tab. It’s showing “load more“ button when there’s only one case to be shown under this section. “Load more“ button should be shown only if there are more than 3 cases that meet this criteria.

**Technical Details**
In `contact-case-tab.directive.js`, previously `contact_id: { '!=': $scope.contactId }` was sent to find the cases where user is not a client, but any other roles, but this logic did not work if case has more than one client. To fix this, a new parameter `exclude_for_client_id` has been added which returns the Cases where sent parameter is not a client.

This is regression caused by, https://github.com/compucorp/uk.co.compucorp.civicase/pull/304

```php
if (!empty($params['exclude_for_client_id'])) {
  $sql->where("a.id NOT IN (SELECT case_id FROM civicrm_case_contact WHERE contact_id = {$params['exclude_for_client_id']})");
}
```

## Bug 6
In Peoples Tab, when "Reassign Client" was clicked, there was an Error thrown by the Backend, if "Delete <Case Type Category>" permission is not present.

**Technical Details**
Previously when reassigning a client, we were removing the old record and then creating a new one. But this resulted in backend error if permissions are not available. To fix this, the Delete Case Contact Api call has been removed, instead now we are updating the existing client record.
```javascript
['CaseContact', 'get', {
  case_id: item.id,
  contact_id: contactPromptResult.role.contact_id,
  'api.CaseContact.create': {
    case_id: item.id,
    contact_id: parseInt(contactPromptResult.contact.id)
  }
}]
```


## Reopened Fixes
1. In https://github.com/compucorp/uk.co.compucorp.civicase/pull/466/commits/5efa6c5cc3d04aea2ac39f91edbe222abed74229#diff-7e1cebc15b8f3470c5fde4d0ba8acc87L98, there was syntax error in the SQL Query. So it has been fixed.

2. When new client is added in people tab, we were duplicating, all existing relationships for the new client, but this logic was wrong. We should duplicate all relationships for a single client. Otherwise if the case has n(>1) clients, then all those relationships were getting duplicated, which is wrong.
So in `getApiParamsToDuplicateExistingRelationshipsToNewClient`, now only relationships for a single client is fetched and then duplicated.
```
['Relationship', 'get', {
	case_id: item.id,
	contact_id_a: item.client[0].contact_id,
	is_active: 1,
	'api.Relationship.create': { ... }
}]
```