### PR TITLE
BASW-634: Civicase Release v1.1.0

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">http://FIXME</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2020-04-28</releaseDate>
-  <version>1.0.0</version>
+  <releaseDate>2020-05-28</releaseDate>
+  <version>1.1.0</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>4.7</ver>


### PR DESCRIPTION
## Release Update - 28th May, 2020

**Improvements**
- Case category word replacements improvements

**Bug Fixes**
- Fixed an issue where Lower section of the UI not showing cases when user clicks on "Find cases" link from main menu.
- Fixed being unable to search for cases by case client under activities tab for Case categories when moving an activity to another case.
- Fixed numerous issues with the People's tabs on a case including:  
-- Error when adding a case role using Add another Case Role Name menu on the contact row, 
-- Being unable to filter roles on manage cases
-- When removing the first client from a case with multiple clients, the client gets incorrectly assigned to the case manager role.
-- Error shown when adding Benefits Specialist after adding a case client.
- Fix issue with Settings/Webforms URL field being visible when "No" is selected on civicase settings for case categories