### PR TITLE
CATL-1356: Backstop tests for Other Cases block and Tab

### DIFF
--- a/tests/backstop_data/engine_scripts/puppet/on-before.js
+++ b/tests/backstop_data/engine_scripts/puppet/on-before.js
@@ -1,10 +1,18 @@
 'use strict';
 
+const cv = require('civicrm-cv')({ mode: 'sync' });
 const loadCookies = require('./load-cookies');
 
 module.exports = async (page, scenario, vp) => {
   console.log('--------------------------------------------');
   console.log('Running Scenario "' + scenario.label + '" ' + scenario.count);
+
+  // Execute api calls defined in the scenario
+  if (scenario.apiCalls) {
+    scenario.apiCalls.forEach((apiCall) => {
+      cv('api ' + apiCall);
+    });
+  }
 
   await loadCookies(page, scenario);
 };

--- a/tests/backstop_data/gulp-tasks/backstopjs.js
+++ b/tests/backstop_data/gulp-tasks/backstopjs.js
@@ -433,6 +433,8 @@ function setupData () {
     data_type: 'String',
     html_type: 'Text'
   });
+
+  return Promise.resolve();
 }
 
 /**

--- a/tests/backstop_data/gulp-tasks/backstopjs.js
+++ b/tests/backstop_data/gulp-tasks/backstopjs.js
@@ -381,6 +381,8 @@ function runBackstopJS (command) {
 
 /**
  * Setups the data needed for some of the backstop tests.
+ *
+ * @returns {Promise} An empty promise that is resolved when the task is done.
  */
 function setupData () {
   var activeCaseId = getActiveCaseId();

--- a/tests/backstop_data/scenarios/manage-cases.json
+++ b/tests/backstop_data/scenarios/manage-cases.json
@@ -87,6 +87,25 @@
       "onReadyScript": "manage-cases/files-tab-upload-file.js"
     },
     {
+      "label": "Manage Cases - Case Overview - Linked Cases Panel",
+      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}&tab=Summary",
+      "waitForLoadingComplete": ".civicase__summary-tab",
+      "selectors": [
+        ".civicase__summary-tab__other-cases"
+      ],
+      "apiCalls": [
+        "setting.create civicaseAllowLinkedCasesTab=0"
+      ]
+    },
+    {
+      "label": "Manage Cases - Case Overview - Linked Cases Tab",
+      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}&tab=LinkedCases",
+      "waitForLoadingComplete": "#crm-main-content-wrapper",
+      "apiCalls": [
+        "setting.create civicaseAllowLinkedCasesTab=1"
+      ]
+    }
+    {
       "label": "Manage Cases - List - Bulk action with checkbox selected and dropdown opened",
       "url": "{url}/civicrm/case/a/#/case/list",
       "onReadyScript": "manage-cases/bulk-actions.js"

--- a/tests/backstop_data/scenarios/manage-cases.json
+++ b/tests/backstop_data/scenarios/manage-cases.json
@@ -18,7 +18,18 @@
     },
     {
       "label": "Manage Cases - Case Overview",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}"
+      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}",
+      "waitForLoadingComplete": ".civicase__summary-tab",
+      "apiCalls": [
+        "setting.create civicaseAllowLinkedCasesTab=0"
+      ],
+      "viewports": [
+        {
+          "label": "Full Vertical Screen",
+          "width": 1680,
+          "height": 3000
+        }
+      ]
     },
     {
       "label": "Manage Cases - Case Overview - Loading",
@@ -87,24 +98,13 @@
       "onReadyScript": "manage-cases/files-tab-upload-file.js"
     },
     {
-      "label": "Manage Cases - Case Overview - Linked Cases Panel",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}&tab=Summary",
-      "waitForLoadingComplete": ".civicase__summary-tab",
-      "selectors": [
-        ".civicase__summary-tab__other-cases"
-      ],
-      "apiCalls": [
-        "setting.create civicaseAllowLinkedCasesTab=0"
-      ]
-    },
-    {
       "label": "Manage Cases - Case Overview - Linked Cases Tab",
       "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}&tab=LinkedCases",
       "waitForLoadingComplete": "#crm-main-content-wrapper",
       "apiCalls": [
         "setting.create civicaseAllowLinkedCasesTab=1"
       ]
-    }
+    },
     {
       "label": "Manage Cases - List - Bulk action with checkbox selected and dropdown opened",
       "url": "{url}/civicrm/case/a/#/case/list",


### PR DESCRIPTION
## Overview
This PR Adds Backstop tests for the linked cases tab and the "Other Cases" block on the case summary tab.

## How it looks

### Case Overview scenario, including linked cases block
![Civicase51_Manage_Cases_-_Case_Overview_-_Linked_Cases_Panel_0_document_0_Full_Vertical_Screen (2)](https://user-images.githubusercontent.com/1642119/83254582-067c1300-a17d-11ea-9c1e-736ff9552c68.png)

### Case Linked Cases Tab
![Civicase51_Manage_Cases_-_Case_Overview_-_Linked_Cases_Tab_0_document_0_desktop](https://user-images.githubusercontent.com/1642119/83083702-d2a5ce00-a054-11ea-8829-6dd9368321d6.png)


## Technical Details

We introduced a new property for scenarios: `apiCalls`. It should contain an array of strings which have api calls in the format accepted by [CiviCRM CV](https://github.com/civicrm/cv). Example:

```json
{
  "label": "My Scenario",
  "url": "some-url",
  "apiCalls": [
    "contact.create first_name=Jon last_name=Snow contact_type=individual",
    "settings.create mySetting=1"
  ]
}
```

These calls will be made before the scenario is executed. Important: even though we can create any type of record, this is better used for changing settings only. If we need to setup data, we need to change the [backstop data setup task](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/tests/backstop_data/gulp-tasks/backstopjs.js#L385) instead.

We used this new feature to change the settings for displaying the linked cases in a new tab, or in the summary tab.

We included the Linked Cases block test in the existing "Manage Cases - Case Overview" scenario, but due to an issue where the whole summary page was not visible due to its content being hidden inside scrolls we decided to add a viewport definition with enough vertical space to display the full page. We have also added a `waitForLoadingComplete` for this scenario since there were instances where it would take a screenshot of the loading state instead of the intended screen.

Finally, the backstop setup data task was failing because gulp expects some signal to mark the task as completed. We added a `Promise.resolve()` which is understood by gulp as the end of the setup task.