### PR TITLE
BASW-621: Fix for Cases with disabled Case Status

### DIFF
--- a/ang/civicase/case/factories/format-case.factory.js
+++ b/ang/civicase/case/factories/format-case.factory.js
@@ -3,7 +3,7 @@
 
   module.factory('formatCase', function (formatActivity, ContactsCache, CaseStatus, CaseType) {
     var caseTypes = CaseType.getAll();
-    var caseStatuses = CaseStatus.getAll();
+    var caseStatuses = CaseStatus.getAll(true);
 
     return function (item) {
       item.client = [];


### PR DESCRIPTION
## Overview
If a case status is disabled, then there is an error in Manage Cases page, if a case with disabled case status is present.

## Before
![2020-05-29 at 2 25 PM](https://user-images.githubusercontent.com/5058867/83241355-53c9a600-a1b8-11ea-88ea-50056d0f6301.jpg)

## After
![2020-05-29 at 2 26 PM](https://user-images.githubusercontent.com/5058867/83241405-680da300-a1b8-11ea-93c9-f9e9f911bde7.jpg)

## Technical Details
In `format-case.factory.js`, only active cases statuses were loaded to fetch the Label of the Case Status for a Case. But if the status is disabled, error was thrown. To fix this, All Case Statuses are loaded.