### PR TITLE
CATL-1345: Display style field when extending case entity

### DIFF
--- a/CRM/Civicase/Helper/CaseCategory.php
+++ b/CRM/Civicase/Helper/CaseCategory.php
@@ -8,23 +8,7 @@ use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
  */
 class CRM_Civicase_Helper_CaseCategory {
 
-  const CASE_TYPE_CATEGORY_GROUP_NAME = 'case_type_categories';
   const CASE_TYPE_CATEGORY_NAME = 'Cases';
-
-  /**
-   * Returns the full list of case type categories.
-   *
-   * @return array
-   *   a list of case categories as returned by the option value API.
-   */
-  public static function getCaseCategories() {
-    $result = civicrm_api3('OptionValue', 'get', [
-      'sequential' => 1,
-      'option_group_id' => self::CASE_TYPE_CATEGORY_GROUP_NAME,
-    ]);
-
-    return $result['values'];
-  }
 
   /**
    * Returns the case category name for the case Id.

--- a/CRM/Civicase/Helper/CaseCategory.php
+++ b/CRM/Civicase/Helper/CaseCategory.php
@@ -8,7 +8,23 @@ use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
  */
 class CRM_Civicase_Helper_CaseCategory {
 
+  const CASE_TYPE_CATEGORY_GROUP_NAME = 'case_type_categories';
   const CASE_TYPE_CATEGORY_NAME = 'Cases';
+
+  /**
+   * Returns the full list of case type categories.
+   *
+   * @return array
+   *   a list of case categories as returned by the option value API.
+   */
+  public static function getCaseCategories() {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'option_group_id' => self::CASE_TYPE_CATEGORY_GROUP_NAME,
+    ]);
+
+    return $result['values'];
+  }
 
   /**
    * Returns the case category name for the case Id.

--- a/CRM/Civicase/Hook/BuildForm/AddStyleFieldToCaseCustomGroups.php
+++ b/CRM/Civicase/Hook/BuildForm/AddStyleFieldToCaseCustomGroups.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Allows selecting the display style for custom fields targeting cases.
+ *
+ * Normally these field is only available for contact related entities.
+ */
+class CRM_Civicase_Hook_BuildForm_AddStyleFieldToCaseCustomGroups {
+
+  /**
+   * Includes "Case" in the list of entities that suppport the "style" field.
+   *
+   * For core these entities are exclusively related to contacts, hence we need
+   * to override the `contactTypes` template var.
+   *
+   * We also include a JS file so we can hide an extra display option
+   * (tab table) that is not by the Case entity, but added manually by Core.
+   *
+   * @param object $form
+   *   The current form's reference.
+   * @param string $formName
+   *   The name of the current form.
+   */
+  public function run($form, $formName) {
+    if (!$this->shouldRun($form)) {
+      return;
+    }
+
+    $contactTypes = json_decode($form->get_template_vars('contactTypes'));
+    $contactTypes[] = 'Case';
+
+    $form->assign('contactTypes', json_encode($contactTypes));
+
+    CRM_Core_Resources::singleton()
+      ->addScriptFile('uk.co.compucorp.civicase', 'js/custom-group-form.js');
+  }
+
+  /**
+   * Runs only when using the custom group form.
+   *
+   * @return bool
+   *   true when using the custom group form.
+   */
+  private function shouldRun($form) {
+    return get_class($form) === CRM_Custom_Form_Group::class;
+  }
+
+}

--- a/CRM/Civicase/Hook/BuildForm/AddStyleFieldToCaseCustomGroups.php
+++ b/CRM/Civicase/Hook/BuildForm/AddStyleFieldToCaseCustomGroups.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_Case_BAO_CaseType as CaseType;
+
 /**
  * Allows selecting the display style for custom fields targeting cases.
  *
@@ -27,8 +29,7 @@ class CRM_Civicase_Hook_BuildForm_AddStyleFieldToCaseCustomGroups {
     }
 
     $contactTypes = json_decode($form->get_template_vars('contactTypes'));
-    $caseCategories = CRM_Civicase_Helper_CaseCategory::getCaseCategories();
-    $caseEntityNames = array_column($caseCategories, 'name');
+    $caseEntityNames = CaseType::buildOptions('case_type_category', 'validate');
 
     // This is the generic entity for all cases.
     $caseEntityNames[] = 'Case';

--- a/CRM/Civicase/Hook/BuildForm/AddStyleFieldToCaseCustomGroups.php
+++ b/CRM/Civicase/Hook/BuildForm/AddStyleFieldToCaseCustomGroups.php
@@ -8,7 +8,7 @@
 class CRM_Civicase_Hook_BuildForm_AddStyleFieldToCaseCustomGroups {
 
   /**
-   * Includes "Case" in the list of entities that suppport the "style" field.
+   * Includes Case entities to the list of that suppport the "style" field.
    *
    * For core these entities are exclusively related to contacts, hence we need
    * to override the `contactTypes` template var.
@@ -27,10 +27,15 @@ class CRM_Civicase_Hook_BuildForm_AddStyleFieldToCaseCustomGroups {
     }
 
     $contactTypes = json_decode($form->get_template_vars('contactTypes'));
-    $contactTypes[] = 'Case';
+    $caseCategories = CRM_Civicase_Helper_CaseCategory::getCaseCategories();
+    $caseEntityNames = array_column($caseCategories, 'name');
+    $caseEntityNames[] = 'Case';
+    $contactTypes = array_merge($contactTypes, $caseEntityNames);
 
     $form->assign('contactTypes', json_encode($contactTypes));
-
+    CRM_Core_Resources::singleton()->addSetting([
+      'caseEntityNames' => $caseEntityNames,
+    ]);
     CRM_Core_Resources::singleton()
       ->addScriptFile('uk.co.compucorp.civicase', 'js/custom-group-form.js');
   }

--- a/CRM/Civicase/Hook/BuildForm/AddStyleFieldToCaseCustomGroups.php
+++ b/CRM/Civicase/Hook/BuildForm/AddStyleFieldToCaseCustomGroups.php
@@ -29,7 +29,10 @@ class CRM_Civicase_Hook_BuildForm_AddStyleFieldToCaseCustomGroups {
     $contactTypes = json_decode($form->get_template_vars('contactTypes'));
     $caseCategories = CRM_Civicase_Helper_CaseCategory::getCaseCategories();
     $caseEntityNames = array_column($caseCategories, 'name');
+
+    // This is the generic entity for all cases.
     $caseEntityNames[] = 'Case';
+
     $contactTypes = array_merge($contactTypes, $caseEntityNames);
 
     $form->assign('contactTypes', json_encode($contactTypes));

--- a/CRM/Civicase/Hook/BuildForm/CaseCategoryCustomGroupDisplay.php
+++ b/CRM/Civicase/Hook/BuildForm/CaseCategoryCustomGroupDisplay.php
@@ -35,20 +35,20 @@ class CRM_Civicase_Hook_BuildForm_CaseCategoryCustomGroupDisplay {
    */
   private function setDefaultFormValueForCaseCategory(CRM_Core_Form &$form) {
     $defaults = $form->getVar('_defaults');
-    $extends = $defaults['extends'][0];
     $extendsId = $defaults['extends_entity_column_id'];
     $caseTypeCategories = (CRM_Case_BAO_CaseType::buildOptions('case_type_category', 'validate'));
-    if ($extends === 'Case' && !empty($extendsId)) {
-      $defaults['extends'][0] = $caseTypeCategories[$extendsId];
-      $hierSelect = $form->getElement('extends');
-      $hierSelectElements = $hierSelect->getElements();
-      $hierSelectElements[1]->_options = [];
-      $hierSelect->setValue([$caseTypeCategories[$extendsId]]);
-    }
+    $defaults['extends'][0] = $caseTypeCategories[$extendsId];
+    $hierSelect = $form->getElement('extends');
+    $hierSelectElements = $hierSelect->getElements();
+    $hierSelectElements[1]->_options = [];
+
+    $hierSelect->setValue([$caseTypeCategories[$extendsId]]);
   }
 
   /**
    * Determines if the hook will run.
+   *
+   * Runs when extending case entities.
    *
    * @param string $formName
    *   Form name.
@@ -59,7 +59,13 @@ class CRM_Civicase_Hook_BuildForm_CaseCategoryCustomGroupDisplay {
    *   returns a boolean to determine if hook will run or not.
    */
   private function shouldRun($formName, CRM_Core_Form $form) {
-    return $formName == CRM_Custom_Form_Group::class && $form->getVar('_action') != CRM_Core_Action::ADD;
+    $defaults = $form->getVar('_defaults');
+    $extends = $defaults['extends'][0];
+
+    return $formName == CRM_Custom_Form_Group::class &&
+      $form->getVar('_action') != CRM_Core_Action::ADD &&
+      $extends === 'Case' &&
+      !empty($defaults['extends_entity_column_id']);
   }
 
 }

--- a/CRM/Civicase/Hook/PageRun/CaseCategoryCustomGroupListing.php
+++ b/CRM/Civicase/Hook/PageRun/CaseCategoryCustomGroupListing.php
@@ -56,6 +56,10 @@ class CRM_Civicase_Hook_PageRun_CaseCategoryCustomGroupListing {
   /**
    * Determines if the hook will run.
    *
+   * Runs when listing the custom field groups. Since the create and update
+   * form use the same page we check that the action URL parameter is not
+   * defined so we avoid running the hook for those forms.
+   *
    * @param object $page
    *   Page Object.
    *
@@ -63,7 +67,9 @@ class CRM_Civicase_Hook_PageRun_CaseCategoryCustomGroupListing {
    *   returns a boolean to determine if hook will run or not.
    */
   private function shouldRun($page) {
-    return $page instanceof CRM_Custom_Page_Group;
+    $hasNoAction = empty(CRM_Utils_Request::retrieve('action', 'String'));
+
+    return $page instanceof CRM_Custom_Page_Group && $hasNoAction;
   }
 
 }

--- a/civicase.php
+++ b/civicase.php
@@ -186,6 +186,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_EnableCaseCategoryIconField(),
     new CRM_Civicase_Hook_BuildForm_CaseCategoryCustomGroupDisplay(),
     new CRM_Civicase_Hook_BuildForm_ModifyCaseTypesForAdvancedSearch(),
+    new CRM_Civicase_Hook_BuildForm_AddStyleFieldToCaseCustomGroups(),
   ];
 
   foreach ($hooks as $hook) {

--- a/js/custom-group-form.js
+++ b/js/custom-group-form.js
@@ -1,0 +1,36 @@
+(function ($) {
+  $(document).on('crmLoad', function () {
+    var $multipleRecordsCheckboxRow = $('#is_multiple_row');
+    var $styleSelectTabWithTableOption = $('select[name="style"] option[value="Tab with table"]');
+    var $extendSelect = $('#extends_0');
+
+    (function init () {
+      hideShowElementsNotRelevantWhenExtendingCases();
+      $extendSelect.on('change', hideShowElementsNotRelevantWhenExtendingCases);
+    })();
+
+    /**
+     * This function will hide or show elements that are not relevant when extending
+     * the Case entity. The elements we hide or show are:
+     *
+     * - Multiple Records Checkbox.
+     * - Style Select's "Tab with table" option.
+     *
+     * We use a timeout to wait for the original core script to do its own changes
+     * and to alter these after core is done.
+     *
+     * If the checkbox row was hidden we don't need to restore it since core does
+     * this automatically, unlike the style option which we need to manually restore.
+     */
+    function hideShowElementsNotRelevantWhenExtendingCases () {
+      setTimeout(function () {
+        if ($extendSelect.val() === 'Case') {
+          $multipleRecordsCheckboxRow.css('display', 'none');
+          $styleSelectTabWithTableOption.hide();
+        } else {
+          $styleSelectTabWithTableOption.show();
+        }
+      }, 0);
+    }
+  });
+})(CRM.$);

--- a/js/custom-group-form.js
+++ b/js/custom-group-form.js
@@ -1,4 +1,4 @@
-(function ($) {
+(function ($, _, caseEntityNames) {
   $(document).on('crmLoad', function () {
     var $multipleRecordsCheckboxRow = $('#is_multiple_row');
     var $styleSelectTabWithTableOption = $('select[name="style"] option[value="Tab with table"]');
@@ -11,7 +11,7 @@
 
     /**
      * This function will hide or show elements that are not relevant when extending
-     * the Case entity. The elements we hide or show are:
+     * the Case entities. The elements we hide or show are:
      *
      * - Multiple Records Checkbox.
      * - Style Select's "Tab with table" option.
@@ -24,7 +24,7 @@
      */
     function hideShowElementsNotRelevantWhenExtendingCases () {
       setTimeout(function () {
-        if ($extendSelect.val() === 'Case') {
+        if (_.includes(caseEntityNames, $extendSelect.val())) {
           $multipleRecordsCheckboxRow.css('display', 'none');
           $styleSelectTabWithTableOption.hide();
         } else {
@@ -33,4 +33,4 @@
       }, 0);
     }
   });
-})(CRM.$);
+})(CRM.$, CRM._, CRM.caseEntityNames);


### PR DESCRIPTION
## Overview

This PR helps us show the "Display Style" field when creating custom fields for cases. This field is exclusive for contact related entities, but we have made it so it's available for cases as well.

## Before
![Screen Shot 2020-05-31 at 7 08 39 PM](https://user-images.githubusercontent.com/1642119/83364843-2a547a00-a372-11ea-82bd-c184632a8f42.png)
The "Display Style" field is not visible

## After
![gif](https://user-images.githubusercontent.com/1642119/83364827-0c871500-a372-11ea-9e7b-7449c12f4e84.gif)

## Technical Details

The "Display Style" field is normally only visible to contact related entities, as defined by Core. We changed this behaviour by creating a `AddStyleFieldToCaseCustomGroups` hook that appends `Case` to the list of entities that support the "Display Style" field.

We also included a JS file to accomplish the following things:

* Hiding the "Support Multiple Records" checkbox, which only makes sense for contact entities.
* Hiding an extra option that shows up in the "Display Style" select after it's saved. This option is called "Tab Table". It's not clear why this option is not visible when creating the custom group, only when editing. Regardless, we do not support this display style so we hid it only when extending cases.
