### PR TITLE
CPS-239: Fix PHP lint error

### DIFF
--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -10,5 +10,8 @@
     <!--Drupal expects function names like civicase_civicrm_pre_process but civi can have-->
     <!--civicase_civicrm_preProcess which is valid for civi.-->
     <exclude name="Drupal.NamingConventions.ValidFunctionName.InvalidName"/>
+
+    <!-- this was was added in drupal, but in civicrm we ignore this rule -->
+    <exclude name="Drupal.Classes.UseGlobalClass.RedundantUseStatement"/>
   </rule>
 </ruleset>


### PR DESCRIPTION
## Overview
The PHP Linter is producing error in local/github action. This PR fixes the same.

## Before
![2020-06-09 at 11 50 AM](https://user-images.githubusercontent.com/5058867/84113017-6dd07780-aa47-11ea-9392-7e58f3161035.jpg)

## After
Error is not present anymore.

## Technical Details
Few days back, the “Drupal Coder” php rule set was updated with a new rule, which is in result breaking our PRs.
https://git.drupalcode.org/project/coder/-/commit/7385c9df4a7c93aef8690c1cf22f6f6a52e152ed

`Drupal.Classes.UseGlobalClass.RedundantUseStatement` rule has been excluded to fix this.