### PR TITLE
RSE-1020: Clear cache after Case type category create/update/delete

### DIFF
--- a/CRM/Civicase/Hook/PostProcess/CaseCategoryPostProcessor.php
+++ b/CRM/Civicase/Hook/PostProcess/CaseCategoryPostProcessor.php
@@ -43,6 +43,9 @@ class CRM_Civicase_Hook_PostProcess_CaseCategoryPostProcessor {
     elseif ($formAction == CRM_Core_Action::DELETE) {
       $handler->onDelete($categoryName);
     }
+
+    // Flush all caches using the API.
+    civicrm_api3('System', 'flush');
   }
 
   /**


### PR DESCRIPTION
## Overview
According to new requirements we need the menu item for new Case type category be visible right away, previously user had to clear cache to see it. Now cache is cleared automatically when Case type category is created / updated / deleted.

## Technical Details
There is a `CRM_Civicase_Hook_PostProcess_CaseCategoryPostProcessor` class which handles the Case type category create / update / delete, so we've just added flush cache command to it.