### PR TITLE
CATL-1299: Add 'Last activity' to the Case Panel

### DIFF
--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
@@ -131,7 +131,7 @@
       <!-- Next Activity -->
       <div class="civicase__contact-cases-tab__panel-fields">
         <div class="civicase__contact-cases-tab__panel-field-title">
-          Next Activity
+          {{ ts('Next Activity') }}
         </div>
         <div
           case-activity-card="item.activity_summary.next[0]"
@@ -145,7 +145,7 @@
       <!-- Upcoming Tasks Counts -->
       <div class="civicase__contact-cases-tab__panel-fields">
         <div class="civicase__contact-cases-tab__panel-field-title">
-          Upcoming
+          {{ ts('Upcoming') }}
         </div>
         <div class="civicase__case-card__activity-info">
           <div class="civicase__case-card__activity-count-container">
@@ -238,7 +238,7 @@
       <!-- Contact Role -->
       <div class="civicase__contact-cases-tab__panel-fields" ng-if="item.contact_role">
         <div class="civicase__contact-cases-tab__panel-field-title">
-          Contact Role
+          {{ ts('Contact Role') }}
         </div>
         <div>
           {{ civicaseTs(item.contact_role) }}
@@ -248,7 +248,7 @@
       <!-- Last Modified -->
       <div class="civicase__contact-cases-tab__panel-fields">
         <div class="civicase__contact-cases-tab__panel-field-title">
-          Last Modified
+          {{ ts('Last Modified') }}
         </div>
         <span>{{ CRM.utils.formatDate(item.modified_date) }}</span>
       </div>

--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
@@ -128,6 +128,20 @@
       </span>
     </div>
     <div class="civicase__contact-cases-tab__panel-row clearfix">
+      <!-- Last Activity -->
+      <div class="civicase__contact-cases-tab__panel-fields">
+        <div class="civicase__contact-cases-tab__panel-field-title">
+          {{ ts('Last Activity') }}
+        </div>
+        <div
+          case-activity-card="item.activity_summary.last[0]"
+          refresh-callback="refresh"
+          case="item"
+          crm-popup-form-success="pushCaseData($data.civicase_reload[0])"
+        >
+        </div>
+      </div>
+      <!-- End Last Activity -->
       <!-- Next Activity -->
       <div class="civicase__contact-cases-tab__panel-fields">
         <div class="civicase__contact-cases-tab__panel-field-title">

--- a/api/v3/Case/Getdetails.php
+++ b/api/v3/Case/Getdetails.php
@@ -157,15 +157,19 @@ function civicrm_api3_case_getdetails(array $params) {
       }
 
       // Get last activity.
-      $lastActivity = _civicrm_api3_case_get_activities($ids, 1, [
+      $lastActivity = _civicrm_api3_case_get_activities($ids, [
         'check_permissions' => !empty($params['check_permissions']),
         'status_id.filter' => CRM_Activity_BAO_Activity::COMPLETED,
         'sequential' => 1,
+        'options' => [
+          'limit' => 1,
+          'sort' => 'activity_date_time DESC',
+        ],
       ]);
       $case['activity_summary']['last'] = $lastActivity['values'];
 
       // Get next activities.
-      $activities = _civicrm_api3_case_get_activities($ids, 0, [
+      $activities = _civicrm_api3_case_get_activities($ids, [
         'check_permissions' => !empty($params['check_permissions']),
         'status_id.filter' => CRM_Activity_BAO_Activity::INCOMPLETE,
       ]);
@@ -263,8 +267,6 @@ function civicrm_api3_case_getdetails(array $params) {
  *
  * @param array $case_ids
  *   Cases ids.
- * @param int $limit
- *   (Optional) Maximum number of items to fetch, defaults to no limit.
  * @param array $params
  *   (Optional) Additional api request parameters.
  *
@@ -274,7 +276,7 @@ function civicrm_api3_case_getdetails(array $params) {
  * @throws \CiviCRM_API3_Exception
  *   Civicrm exception.
  */
-function _civicrm_api3_case_get_activities(array $case_ids, $limit = 0, array $params = []) {
+function _civicrm_api3_case_get_activities(array $case_ids, array $params = []) {
   $default_params = [
     'return' => [
       'activity_type_id', 'subject', 'activity_date_time', 'status_id',
@@ -287,7 +289,7 @@ function _civicrm_api3_case_get_activities(array $case_ids, $limit = 0, array $p
     'is_test' => 0,
     'activity_type_id' => ['!=' => 'Bulk Email'],
     'options' => [
-      'limit' => $limit,
+      'limit' => 0,
       'sort' => 'activity_date_time',
     ],
   ];

--- a/api/v3/Case/Getdetails.php
+++ b/api/v3/Case/Getdetails.php
@@ -156,8 +156,16 @@ function civicrm_api3_case_getdetails(array $params) {
         }
       }
 
+      // Get last activity.
+      $lastActivity = _civicrm_api3_case_get_activities($ids, 1, [
+        'check_permissions' => !empty($params['check_permissions']),
+        'status_id.filter' => CRM_Activity_BAO_Activity::COMPLETED,
+        'sequential' => 1,
+      ]);
+      $case['activity_summary']['last'] = $lastActivity['values'];
+
       // Get next activities.
-      $activities = _civicrm_api3_case_get_activities($ids, [
+      $activities = _civicrm_api3_case_get_activities($ids, 0, [
         'check_permissions' => !empty($params['check_permissions']),
         'status_id.filter' => CRM_Activity_BAO_Activity::INCOMPLETE,
       ]);


### PR DESCRIPTION
## Overview
According to new requirements this PR adds *Last activity* field on Case Panel (on Cases tab of Contact page) above the *Next activity* field.

## Before
![image](https://user-images.githubusercontent.com/39520000/84297752-be82c600-ab56-11ea-9979-81e519b37000.png)

## After
![image](https://user-images.githubusercontent.com/39520000/84297788-cc384b80-ab56-11ea-985b-5a9c88db5ac0.png)

## Technical details
1. To fetch last activity we used respective code from next activity - the `_civicrm_api3_case_get_activities()` was added which is used to fetch both next and last activities now.
2. Also as part of this PR field labels in `contact-case-tab-case-details.directive.html ` were wrapped in `ts()` for consistency.