### PR TITLE
CATL-1437: Fix 'Cases I am involved in' filter text

### DIFF
--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -35,7 +35,7 @@
     var caseRelationshipConfig = [
       { text: ts('All Cases'), id: 'all' },
       { text: ts('My Cases'), id: 'is_case_manager' },
-      { text: ts('Cases I am involved'), id: 'is_involved' }
+      { text: ts('Cases I am involved in'), id: 'is_involved' }
     ];
     var DEFAULT_CASE_FILTERS = {
       case_type_category: currentCaseCategory

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -98,7 +98,7 @@
           expect($scope.caseRelationshipOptions).toEqual([
             { text: ts('All Cases'), id: 'all' },
             { text: ts('My Cases'), id: 'is_case_manager' },
-            { text: ts('Cases I am involved'), id: 'is_involved' }
+            { text: ts('Cases I am involved in'), id: 'is_involved' }
           ]);
         });
       });


### PR DESCRIPTION
## Overview
Fix the 'Cases I am involved' filter text in Case Search to 'Cases I am involved in'.

## Before
![2020-06-16 at 2 11 PM](https://user-images.githubusercontent.com/5058867/84752360-45aebe80-afdb-11ea-820f-48b304a00a06.jpg)

## After
![2020-06-16 at 2 10 PM](https://user-images.githubusercontent.com/5058867/84752305-362f7580-afdb-11ea-9aed-e13fd3c4c55e.jpg)