### PR TITLE
CPS-248: Release v1.2.0

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -9,9 +9,9 @@
     <email>info@compucorp.co.uk</email>
   </maintainer>
   <urls>
-    <url desc="Main Extension Page">http://FIXME</url>
-    <url desc="Documentation">http://FIXME</url>
-    <url desc="Support">http://FIXME</url>
+    <url desc="Main Extension Page">https://github.com/compucorp/uk.co.compucorp.civicase</url>
+    <url desc="Documentation">https://github.com/compucorp/uk.co.compucorp.civicase</url>
+    <url desc="Support">https://github.com/compucorp/uk.co.compucorp.civicase/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-06-18</releaseDate>

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">http://FIXME</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2020-06-04</releaseDate>
-  <version>1.1.1</version>
+  <releaseDate>2020-06-18</releaseDate>
+  <version>1.2.0</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>4.7</ver>


### PR DESCRIPTION
## Release Update - 18th June, 2020

### New Features

* ‘coming soon’ block in case summary configurable (setting added so can remove ‘coming soon’) https://github.com/compucorp/uk.co.compucorp.civicase/pull/463
* Added a related cases tab (configurable) https://github.com/compucorp/uk.co.compucorp.civicase/pull/473  🔍  (already shipped in v1.1.1 but it was not announced) 
* Case overview card on contact record redesigned
  * included last activity on case panel and reordered so ‘next activity’ then ‘last activity’ https://github.com/compucorp/uk.co.compucorp.civicase/pull/486 
  * summary moved to the top https://github.com/compucorp/uk.co.compucorp.civicase/pull/484 ⚠️  (has not been merged, needed rebasing)
  * 'Go to Case' button at top of card 🛑  (No PR or Ticket for this task)
  * removed ‘upcoming’ and ‘status’ https://github.com/compucorp/uk.co.compucorp.civicase/pull/484 ⚠️  (has not been merged, needed rebasing)
* Show tags when uploading files https://github.com/compucorp/uk.co.compucorp.civicase/pull/476
* Email addresses are a ‘URL’ to open email module across cases https://github.com/compucorp/uk.co.compucorp.civicase/pull/489 ⚠️  (PR Not merged or tested. Waiting for Core Patch https://github.com/compucorp/civicrm-core/pull/35)
* Limit the case statuses on the overview section to only the ones that belong to the displayed case types https://github.com/compucorp/uk.co.compucorp.civicase/pull/427 🔍   (this was not part of the release, but it has already been merged)

### Bug Fixes

* Cases filter dropdown changed from ‘cases I’m involved' → ‘Cases I’m involved in' https://github.com/compucorp/uk.co.compucorp.civicase/pull/497
* Fixed PHP lint errors displayed on Pull Requests by Github Actions https://github.com/compucorp/uk.co.compucorp.civicase/pull/483 🔍   (this was not part of the release, but it has already been merged)