### PR TITLE
CPS-248: Release v1.2.0

### DIFF
--- a/ang/civicase/activity/card/directives/activity-card-big.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-big.directive.html
@@ -37,7 +37,13 @@
           </a>
           <!-- End - Rating -->
           <!-- Contact icons -->
-          <span ng-if="activity.assignee_contact_name" civicase-contact-card avatar="true" contacts="activity.assignee_contact_name"></span>
+          <span
+            ng-if="activity.assignee_contact_name"
+            civicase-contact-card
+            avatar="true"
+            case-id="activity.case_id"
+            contacts="activity.assignee_contact_name"
+          ></span>
           <!-- End contact icons -->
           <!-- 3 dot menu -->
           <div ng-include="'~/civicase/activity/card/directives/activity-card-menu.html'"></div>
@@ -80,7 +86,12 @@
         <!-- With -->
         <div class="civicase__activity-card-row">
           <span class="civicase__activity-with">With:&nbsp;</span>
-          <span class="civicase__contact-card" civicase-contact-card contacts="activity.target_contact_name"></span>
+          <span
+            class="civicase__contact-card"
+            civicase-contact-card
+            case-id="activity.case_id"
+            contacts="activity.target_contact_name"
+          ></span>
         </div>
         <!-- End - With -->
       </div>

--- a/ang/civicase/activity/card/directives/activity-card-long.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-long.directive.html
@@ -96,7 +96,13 @@
           <!-- End - Activity Date -->
 
           <!-- Avatar -->
-          <span ng-if="activity.assignee_contact_name" civicase-contact-card avatar="true" contacts="activity.assignee_contact_name"></span>
+          <span
+            ng-if="activity.assignee_contact_name"
+            civicase-contact-card
+            avatar="true"
+            case-id="activity.case_id"
+            contacts="activity.assignee_contact_name"
+          ></span>
           <!-- End - Avatar -->
           <div ng-include="'~/civicase/activity/card/directives/activity-card-menu-feed.html'" ng-if="bulkAllowed"></div>
         </span>
@@ -112,11 +118,21 @@
       >
         <div>
           <span>To:&nbsp;</span>
-          <span ng-if="activity.target_contact_name" civicase-contact-card contacts="activity.target_contact_name"></span>
+          <span
+            ng-if="activity.target_contact_name"
+            civicase-contact-card
+            contacts="activity.target_contact_name"
+            case-id="activity.case_id"
+          ></span>
         </div>
         <div class="civicase__activity__right-container">
           <span>From:&nbsp;</span>
-          <span ng-if="activity.source_contact_id" civicase-contact-card contacts="activity.source_contact_id"></span>
+          <span
+            ng-if="activity.source_contact_id"
+            civicase-contact-card
+            case-id="activity.case_id"
+            contacts="activity.source_contact_id"
+          ></span>
         </div>
       </div>
       <div class="civicase__activity-card-row" ng-if="activity.category.indexOf('alert') > -1">
@@ -152,7 +168,11 @@
           <span class="civicase__activity-card__case-type">{{ activity.case.type.title }}</span>
           <div class="civicase__activity__right-container">
             <div>
-              <span civicase-contact-card contacts="activity.case.client"></span>
+              <span
+                civicase-contact-card
+                case-id="activity.case_id"
+                contacts="activity.case.client"
+              ></span>
             </div>
             <span class="crm_notification-badge" style="background-color: {{ activity.case.status.color }};">{{ activity.case.status.label }}</span>
           </div>

--- a/ang/civicase/activity/card/directives/activity-card-short.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-short.directive.html
@@ -59,7 +59,13 @@
           <!-- End - Rating -->
 
           <!-- Avatar -->
-          <span ng-if="activity.assignee_contact_name" civicase-contact-card avatar="true" contacts="activity.assignee_contact_name"></span>
+          <span
+            ng-if="activity.assignee_contact_name"
+            civicase-contact-card
+            avatar="true"
+            case-id="activity.case_id"
+            contacts="activity.assignee_contact_name"
+          ></span>
           <!-- End - Avatar -->
         </span>
       </div>
@@ -88,8 +94,12 @@
       <div class="civicase__activity-card-row" ng-if="activity.target_contact_name">
         <!-- With -->
         <span class="civicase__activity-with">With:&nbsp;</span>
-        <div class="civicase__contact-card" civicase-contact-card contacts="activity.target_contact_name">
-        </div>
+        <div
+          class="civicase__contact-card"
+          civicase-contact-card
+          case-id="activity.case_id"
+          contacts="activity.target_contact_name"
+        ></div>
         <!-- End - With -->
       </div>
     </div>

--- a/ang/civicase/activity/feed/directives/activity-feed.directive.html
+++ b/ang/civicase/activity/feed/directives/activity-feed.directive.html
@@ -65,9 +65,12 @@
                 ng-class="{'civicase__activity-feed__list__vertical_bar': $index< activityGroup.activities.length - 1 && activity.source_contact_id}"
                 class="civicase__activity-feed__list-item">
                 <span
-                  ng-if="activity.source_contact_id" civicase-contact-card avatar="true"
-                  contacts="activity.source_contact_id">
-                </span>
+                  ng-if="activity.source_contact_id"
+                  civicase-contact-card
+                  avatar="true"
+                  case-id="activity.case_id"
+                  contacts="activity.source_contact_id"
+                ></span>
                 <div class="civicase__activity-feed__activity-container">
                   <div
                     case-activity-card="activity"

--- a/ang/civicase/activity/panel/directives/activity-panel.directive.html
+++ b/ang/civicase/activity/panel/directives/activity-panel.directive.html
@@ -103,9 +103,11 @@
           <!-- Avatar -->
           <span
             ng-if="activity.assignee_contact_name"
-            civicase-contact-card avatar="true"
-            contacts="activity.assignee_contact_name">
-          </span>
+            civicase-contact-card
+            avatar="true"
+            case-id="activity.case_id"
+            contacts="activity.assignee_contact_name"
+          ></span>
           <!-- End - Avatar -->
         </div>
       </h3>

--- a/ang/civicase/case/card/directives/case-card-case-list.directive.html
+++ b/ang/civicase/case/card/directives/case-card-case-list.directive.html
@@ -16,7 +16,12 @@
       ng-click="toggleSelected(); $event.stopPropagation();">
       <i ng-if="data.selected" class="civicase__checkbox--checked material-icons">check_box</i>
     </span>
-    <div civicase-contact-card class="civicase__case-card__contact" contacts="data.client"></div>
+    <div
+      civicase-contact-card
+      class="civicase__case-card__contact"
+      case-id="data.id"
+      contacts="data.client"
+    ></div>
     <div class="civicase__case-card__additional-information">
       <span class="civicase__case-card__case-id">
         {{ ts("Case ID:") }} {{ data.id }}

--- a/ang/civicase/case/card/directives/case-card-dashboard.directive.html
+++ b/ang/civicase/case/card/directives/case-card-dashboard.directive.html
@@ -5,7 +5,11 @@
   <div class="panel-body">
     <div class="civicase__case-card__row civicase__case-card__row--secondary clearfix">
       <div class="pull-left">
-        <div civicase-contact-card contacts="data.client"></div>
+        <div
+          civicase-contact-card
+          case-id="data.id"
+          contacts="data.client"
+        ></div>
       </div>
       <div class="pull-right">
         <span class="crm_notification-badge" style="background-color: {{data.color}};">{{data.status}}</span>

--- a/ang/civicase/case/card/directives/case-card-other-cases.directive.html
+++ b/ang/civicase/case/card/directives/case-card-other-cases.directive.html
@@ -15,7 +15,12 @@
       <i ng-if="!data.is_linked" class="civicase__case-card__link-type material-icons" title="{{ ts('Case is for the same client(s)') }}">person</i>
     </div>
 
-    <div civicase-contact-card class="civicase__case-card__contact" contacts="data.client"></div>
+    <div
+      civicase-contact-card
+      class="civicase__case-card__contact"
+      case-id="data.id"
+      contacts="data.client"
+    ></div>
 
     <div class="civicase__case-card__type">{{ data.case_type }}</div>
 

--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
@@ -60,7 +60,12 @@
     </div>
     <div class="civicase__contact-cases-tab__panel-row civicase__contact-cases-tab__panel-row--dark clearfix">
       <div>
-        <div class="civicase__contact-card--client" civicase-contact-card contacts="item.client"></div>
+        <div
+          class="civicase__contact-card--client"
+          civicase-contact-card
+          case-id="item.id"
+          contacts="item.client"
+        ></div>
         <div class="civicase__summary-tab__subject crm-entity" data-entity="Case" data-id="{{ item.id }}">
           <p
             crm-editable="item"
@@ -122,8 +127,10 @@
         <span>
           <span
             class="civicase__contact-card civicase__contact-card--manager"
-            civicase-contact-card contacts="[item.manager]">
-          </span>
+            civicase-contact-card
+            case-id="item.id"
+            contacts="[item.manager]"
+          ></span>
         </span>
       </span>
     </div>

--- a/ang/civicase/case/details/directives/case-details-header.directive.html
+++ b/ang/civicase/case/details/directives/case-details-header.directive.html
@@ -11,7 +11,13 @@
           class="civicase__case-header__content__trash text-danger material-icons"
           title="{{ ts('Case is in Trash') }}">delete_outline
         </i>
-        <div class="civicase__contact-card--client" civicase-contact-card contacts="item.client" no-icon="item.is_deleted"></div>
+        <div
+          class="civicase__contact-card--client"
+          civicase-contact-card
+          case-id="item.id"
+          contacts="item.client"
+          no-icon="item.is_deleted"
+        ></div>
       </div>
       <div class="civicase__case-header__dates">
         <span>{{ CRM.utils.formatDate(item.start_date) || '. . .' }}</span> -
@@ -46,7 +52,14 @@
 
         <span class="pull-right">
           <span>{{ ts("Case Manager:") }}</span>
-          <span><span class="civicase__contact-card civicase__contact-card--manager" civicase-contact-card contacts="[item.manager]"></span></span>
+          <span>
+            <span
+              class="civicase__contact-card civicase__contact-card--manager"
+              civicase-contact-card
+              case-id="item.id"
+              contacts="[item.manager]"
+            ></span>
+          </span>
         </span>
       </div>
     </div>

--- a/ang/civicase/contact/directives/contact-card.directive.html
+++ b/ang/civicase/contact/directives/contact-card.directive.html
@@ -2,7 +2,10 @@
   <span ng-if="!isAvatar" class="civicase__contact-name-container">
     <!-- Contact Icons -->
     <span ng-if="!noIcon">
-      <civicase-contact-icon contact-id="contacts[0].contact_id"></civicase-contact-icon>
+      <civicase-contact-icon
+        case-id="caseId"
+        contact-id="contacts[0].contact_id"
+      ></civicase-contact-icon>
     </span>
     <!-- End - Contact Icons -->
     <!-- Contact Name -->
@@ -51,8 +54,9 @@
           href="{{ url('civicrm/contact/view', {cid: contact.contact_id}) }}">
           <civicase-contact-icon
             auto-close-other-popovers="false"
-            contact-id="contact.contact_id">
-          </civicase-contact-icon>
+            case-id="caseId"
+            contact-id="contact.contact_id"
+          ></civicase-contact-icon>
           <span class="civicase__contact-name-additional">{{ contact.display_name }}</span>
         </a>
       </li>

--- a/ang/civicase/contact/directives/contact-card.directive.js
+++ b/ang/civicase/contact/directives/contact-card.directive.js
@@ -8,14 +8,19 @@
       controller: civicaseContactCardController,
       templateUrl: '~/civicase/contact/directives/contact-card.directive.html',
       scope: {
+        caseId: '<?',
         data: '=contacts',
         isAvatar: '=avatar',
-        noIcon: '=noIcon'
+        noIcon: '='
       }
     };
 
+    /**
+     * Contact Card directive's controller
+     *
+     * @param {object} $scope scope object reference.
+     */
     function civicaseContactCardController ($scope) {
-      $scope.ts = CRM.ts('civicase');
       $scope.url = CRM.url;
       $scope.mainContact = null;
 
@@ -35,14 +40,20 @@
             if ($scope.isAvatar) {
               prepareAvatarData(name, contactID);
             } else {
-              $scope.contacts.push({display_name: name, contact_id: contactID});
+              $scope.contacts.push({ display_name: name, contact_id: contactID });
             }
           });
         } else if (typeof $scope.data === 'string') {
           if ($scope.isAvatar) {
-            prepareAvatarData(ContactsCache.getCachedContact($scope.data).display_name, $scope.data);
+            prepareAvatarData(
+              ContactsCache.getCachedContact($scope.data).display_name,
+              $scope.data
+            );
           } else {
-            $scope.contacts.push({display_name: ContactsCache.getCachedContact($scope.data).display_name, contact_id: $scope.data});
+            $scope.contacts.push({
+              contact_id: $scope.data,
+              display_name: ContactsCache.getCachedContact($scope.data).display_name
+            });
           }
         } else {
           $scope.contacts = _.cloneDeep($scope.data);
@@ -53,11 +64,12 @@
        * Get initials from the sent parameter
        * Example: JD should be returned for John Doe
        *
-       * @param {String} string
-       * @return {String}
+       * @param {string} contactFullName the contact's full name.
+       *
+       * @returns {string} the contact's initials.
        */
-      function getInitials (string) {
-        var names = string.split(' ');
+      function getInitials (contactFullName) {
+        var names = contactFullName.split(' ');
         var initials = names[0].substring(0, 1).toUpperCase();
 
         if (names.length > 1) {
@@ -70,8 +82,8 @@
       /**
        * Prepares data when the directive is avatar
        *
-       * @param {String} name
-       * @param {String} contactID
+       * @param {string} name the contact's full name.
+       * @param {string} contactID the contact's id.
        */
       function prepareAvatarData (name, contactID) {
         var avatarText;
@@ -93,8 +105,9 @@
       /**
        * Checks whether the sent parameter is a valid email address
        *
-       * @param {String} email
-       * @return {Boolean}
+       * @param {string} email the contact's email.
+       *
+       * @returns {boolean} true when the email is valid.
        */
       function validateEmail (email) {
         var re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()\\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;

--- a/ang/civicase/contact/directives/contact-icon.directive.html
+++ b/ang/civicase/contact/directives/contact-icon.directive.html
@@ -13,6 +13,9 @@
     </span>
   </civicase-popover-toggle-button>
   <civicase-popover-content>
-    <civicase-contact-popover-content contact-id="contactId"></civicase-contact-popover-content>
+    <civicase-contact-popover-content
+      case-id="caseId"
+      contact-id="contactId"
+    ></civicase-contact-popover-content>
   </civicase-popover-content>
 </civicase-popover>

--- a/ang/civicase/contact/directives/contact-icon.directive.js
+++ b/ang/civicase/contact/directives/contact-icon.directive.js
@@ -7,6 +7,7 @@
       templateUrl: '~/civicase/contact/directives/contact-icon.directive.html',
       scope: {
         autoCloseOtherPopovers: '<?',
+        caseId: '<?',
         contactId: '<'
       }
     };

--- a/ang/civicase/contact/directives/contact-popover-content.directive.html
+++ b/ang/civicase/contact/directives/contact-popover-content.directive.html
@@ -28,7 +28,11 @@
   <div class="civicase__contact-popover__column">
     <div class="civicase__contact-popover__detail-group">
       <div class="civicase__contact-popover__detail-header"><strong>Primary Email</strong></div>
-      <div class="civicase__contact-popover__detail-value">{{contact.email}}</div>
+      <div class="civicase__contact-popover__detail-value">
+        <a class="crm-popup" ng-href="{{ getEmailUrl() }}">
+          {{contact.email}}
+        </a>
+      </div>
     </div>
     <div class="civicase__contact-popover__detail-group">
       <div class="civicase__contact-popover__detail-header"><strong>Groups</strong></div>

--- a/ang/civicase/contact/directives/contact-popover-content.directive.js
+++ b/ang/civicase/contact/directives/contact-popover-content.directive.js
@@ -1,4 +1,4 @@
-(function (angular) {
+(function (angular, getCrmUrl) {
   var module = angular.module('civicase');
 
   module.directive('civicaseContactPopoverContent', function () {
@@ -6,12 +6,39 @@
       controller: 'civicaseContactPopoverContentController',
       templateUrl: '~/civicase/contact/directives/contact-popover-content.directive.html',
       scope: {
+        caseId: '<?',
         contactId: '<'
       }
     };
   });
 
-  module.controller('civicaseContactPopoverContentController', function ($scope, ContactsCache) {
+  module.controller('civicaseContactPopoverContentController', civicaseContactPopoverContentController);
+
+  /**
+   * Contact Popover Content directive's controller.
+   *
+   * @param {object} $scope Scope object.
+   * @param {object} ContactsCache Contacts Cache service reference.
+   */
+  function civicaseContactPopoverContentController ($scope, ContactsCache) {
     $scope.contact = ContactsCache.getCachedContact($scope.contactId);
-  });
-})(angular);
+    $scope.getEmailUrl = getEmailUrl;
+
+    /**
+     * @returns {string} The URL for composing an email for the current contact.
+     */
+    function getEmailUrl () {
+      var emailUrlParameters = {
+        action: 'add',
+        cid: $scope.contactId,
+        reset: 1
+      };
+
+      if ($scope.caseId) {
+        emailUrlParameters.caseid = $scope.caseId;
+      }
+
+      return getCrmUrl('civicrm/activity/email/add', emailUrlParameters);
+    }
+  }
+})(angular, CRM.url);

--- a/info.xml
+++ b/info.xml
@@ -9,9 +9,9 @@
     <email>info@compucorp.co.uk</email>
   </maintainer>
   <urls>
-    <url desc="Main Extension Page">http://FIXME</url>
-    <url desc="Documentation">http://FIXME</url>
-    <url desc="Support">http://FIXME</url>
+    <url desc="Main Extension Page">https://github.com/compucorp/uk.co.compucorp.civicase</url>
+    <url desc="Documentation">https://github.com/compucorp/uk.co.compucorp.civicase</url>
+    <url desc="Support">https://github.com/compucorp/uk.co.compucorp.civicase/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2020-06-18</releaseDate>

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">http://FIXME</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2020-06-04</releaseDate>
-  <version>1.1.1</version>
+  <releaseDate>2020-06-18</releaseDate>
+  <version>1.2.0</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>4.7</ver>


### PR DESCRIPTION
## Release Update - 18th June, 2020

### New Features

* ‘coming soon’ block in case summary configurable (setting added so can remove ‘coming soon’) https://github.com/compucorp/uk.co.compucorp.civicase/pull/463
* Added a related cases tab (configurable) https://github.com/compucorp/uk.co.compucorp.civicase/pull/473  
* Case overview card on contact record redesigned
  * included last activity on case panel and reordered so ‘next activity’ then ‘last activity’ https://github.com/compucorp/uk.co.compucorp.civicase/pull/486 
  * summary moved to the top https://github.com/compucorp/uk.co.compucorp.civicase/pull/484
  * removed ‘upcoming’ and ‘status’ https://github.com/compucorp/uk.co.compucorp.civicase/pull/484
* Show tags when uploading files https://github.com/compucorp/uk.co.compucorp.civicase/pull/476
* Email addresses are a ‘URL’ to open email module across cases https://github.com/compucorp/uk.co.compucorp.civicase/pull/489
* Limit the case statuses on the overview section to only the ones that belong to the displayed case types under relevant case type category https://github.com/compucorp/uk.co.compucorp.civicase/pull/427 

### Bug Fixes

* Cases filter dropdown changed from ‘cases I’m involved' → ‘Cases I’m involved in' https://github.com/compucorp/uk.co.compucorp.civicase/pull/497

### Updates for Developers

* Fixed PHP lint errors displayed on Pull Requests by Github Actions https://github.com/compucorp/uk.co.compucorp.civicase/pull/483 