### PR TITLE
CPS-194: Remove URL parameters added by individual tabs when changing case

### DIFF
--- a/ang/civicase/case/list/directives/case-list-table.directive.js
+++ b/ang/civicase/case/list/directives/case-list-table.directive.js
@@ -51,9 +51,9 @@
   });
 
   module.controller('CivicaseCaseListTableController', function ($rootScope,
-    $scope, $window, BulkActions, crmApi, crmStatus, crmUiHelp,
+    $route, $scope, $window, BulkActions, crmApi, crmStatus, crmUiHelp,
     crmThrottle, currentCaseCategory, $timeout, formatCase, ContactsCache, CasesUtils, ts,
-    ActivityCategory, ActivityType, CaseStatus, $routeParams, $route, $location) {
+    ActivityCategory, ActivityType, CaseStatus) {
     var firstLoad = true;
     var allCases;
 

--- a/ang/civicase/case/list/directives/case-list-table.directive.js
+++ b/ang/civicase/case/list/directives/case-list-table.directive.js
@@ -188,6 +188,7 @@
 
       if (!$event || !$($event.target).is('a, a *, input, button')) {
         $scope.unfocusCase();
+        removeExtraRouteParams();
         if ($scope.viewingCase === id) {
           $scope.viewingCase = null;
           $scope.viewingCaseDetails = null;
@@ -199,6 +200,17 @@
       }
       setPageTitle();
       $($window).scrollTop(0); // Scrolls the window to top once new data loads
+    }
+
+    /**
+     * Remove route params added by individual tabs
+     */
+    function removeExtraRouteParams () {
+      var allowedRouteParams = ['caseId', 'cf'];
+
+      $route.current.params = _.pick($route.current.params, function (value, key) {
+        return allowedRouteParams.indexOf(key) !== -1;
+      });
     }
 
     /**

--- a/ang/civicase/case/list/directives/case-list-table.directive.js
+++ b/ang/civicase/case/list/directives/case-list-table.directive.js
@@ -53,7 +53,7 @@
   module.controller('CivicaseCaseListTableController', function ($rootScope,
     $scope, $window, BulkActions, crmApi, crmStatus, crmUiHelp,
     crmThrottle, currentCaseCategory, $timeout, formatCase, ContactsCache, CasesUtils, ts,
-    ActivityCategory, ActivityType, CaseStatus) {
+    ActivityCategory, ActivityType, CaseStatus, $routeParams, $route, $location) {
     var firstLoad = true;
     var allCases;
 
@@ -79,18 +79,31 @@
       initSubscribers();
     }());
 
-    $scope.applyAdvSearch = function (newFilters) {
+    $scope.applyAdvSearch = applyAdvSearch;
+    $scope.changeSortDir = changeSortDir;
+    $scope.isSelection = isSelection;
+    $scope.selectAll = selectAll;
+    $scope.refresh = refresh;
+    $scope.unfocusCase = unfocusCase;
+    $scope.viewCase = viewCase;
+
+    /**
+     * Apply advanced search
+     *
+     * @param {object} newFilters new filters object
+     */
+    function applyAdvSearch (newFilters) {
       $scope.filters = newFilters;
       getAllCasesforSelectAll();
       getCases();
-    };
+    }
 
     /**
      * Change Sort Direction
      */
-    $scope.changeSortDir = function () {
+    function changeSortDir () {
       $scope.sort.dir = ($scope.sort.dir === 'ASC' ? 'DESC' : 'ASC');
-    };
+    }
 
     /**
      * Checks if selection is active on based of
@@ -99,7 +112,7 @@
      * @param {string} condition condition
      * @returns {boolean} if selection is active
      */
-    $scope.isSelection = function (condition) {
+    function isSelection (condition) {
       if (!$scope.cases) {
         return false;
       }
@@ -113,7 +126,7 @@
       }
 
       return count === condition;
-    };
+    }
 
     /**
      * Refresh the Case List View
@@ -122,7 +135,7 @@
      * @param {boolean} backgroundLoading - if loading animation should not be
      *   shown
      */
-    $scope.refresh = function (apiCalls, backgroundLoading) {
+    function refresh (apiCalls, backgroundLoading) {
       backgroundLoading = backgroundLoading || false;
       $scope.isLoading = true && !backgroundLoading;
       apiCalls = apiCalls || [];
@@ -135,10 +148,15 @@
           $scope.isLoading = false;
           deselectAllCases();
         });
-    };
+    }
 
-    $scope.selectAll = function (e) {
-      var checked = e.target.checked;
+    /**
+     * Select all cases for bulk action
+     *
+     * @param {object} event event object
+     */
+    function selectAll (event) {
+      var checked = event.target.checked;
 
       _.each($scope.cases, function (item) {
         // Case is marked as selected only if it's not locked for the current user.
@@ -146,13 +164,22 @@
           item.selected = checked;
         }
       });
-    };
+    }
 
-    $scope.unfocusCase = function () {
+    /**
+     * Unfocus a case. It hides the details section
+     */
+    function unfocusCase () {
       $scope.caseIsFocused = false;
-    };
+    }
 
-    $scope.viewCase = function (id, $event) {
+    /**
+     * View sent case
+     *
+     * @param {number/string} id id of the case
+     * @param {object} $event event object
+     */
+    function viewCase (id, $event) {
       var currentCase = _.findWhere($scope.cases, { id: id });
 
       if (!$scope.bulkAllowed || currentCase.lock) {
@@ -172,7 +199,7 @@
       }
       setPageTitle();
       $($window).scrollTop(0); // Scrolls the window to top once new data loads
-    };
+    }
 
     /**
      * Binds all route parameters to scope

--- a/ang/test/civicase/case/list/directives/case-list-table.directive.spec.js
+++ b/ang/test/civicase/case/list/directives/case-list-table.directive.spec.js
@@ -105,15 +105,27 @@
     }
   });
 
-  describe('CivicaseCaseListTableController', function () {
-    var $controller, $q, $scope, CasesData, crmApi;
+  fdescribe('CivicaseCaseListTableController', function () {
+    var $controller, $q, $scope, $route, CasesData, crmApi;
 
-    beforeEach(module('civicase', 'civicase.data', 'crmUtil'));
+    beforeEach(module('civicase', 'civicase.data', 'crmUtil', function ($provide) {
+      $provide.value('$route', {
+        current: {
+          params: {
+            cf: 1,
+            caseId: 2,
+            otherParam: 3,
+            otherParam2: 4
+          }
+        }
+      });
+    }));
 
-    beforeEach(inject(function (_$controller_, _$q_, $rootScope, _CasesData_, _crmApi_,
-      _formatCase_) {
+    beforeEach(inject(function (_$controller_, _$q_, _$route_, $rootScope,
+      _CasesData_, _crmApi_, _formatCase_) {
       $controller = _$controller_;
       $q = _$q_;
+      $route = _$route_;
       $scope = $rootScope.$new();
       CasesData = _CasesData_.get();
       crmApi = _crmApi_;
@@ -199,6 +211,23 @@
       function removeAdditionalMarkup () {
         $('.civicase__case-list-panel').remove();
       }
+    });
+
+    describe('when switching to displaying a new case details', () => {
+      var expectedParams;
+
+      beforeEach(function () {
+        initController();
+        $scope.cases = _.cloneDeep(CasesData.values);
+
+        $scope.viewCase(CasesData.values[0].id);
+
+        expectedParams = { cf: 1, caseId: 2 };
+      });
+
+      it('removes all url parameters added by individual tabs', function () {
+        expect($route.current.params).toEqual(expectedParams);
+      });
     });
 
     /**


### PR DESCRIPTION
## Overview
When changing a Case from Manage Case List, the existing tab filters(activity tab, people tab) were applied to the new case also. This PR fixes that issue, and removes any extra filters.

## Before
![before](https://user-images.githubusercontent.com/5058867/85126217-a859c180-b24a-11ea-9b07-57e06af868a6.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/85126174-8d874d00-b24a-11ea-9e3b-548a96863e49.gif)

## Technical Details
Added a new function `removeExtraRouteParams`, which removes all parameters added by the individual tabs, when switching to a new case.

```javascript
function removeExtraRouteParams () {
  var allowedRouteParams = ['caseId', 'cf'];

  $route.current.params = _.pick($route.current.params, function (value, key) {
    return allowedRouteParams.indexOf(key) !== -1;
  });
}
```