### PR TITLE
CPS-198: Replace `crmApi` with `civicaseCrmApi`

### DIFF
--- a/ang/civicase/activity/actions/services/delete-activity-action.service.js
+++ b/ang/civicase/activity/actions/services/delete-activity-action.service.js
@@ -7,10 +7,10 @@
    * Tags Activity Action Service
    *
    * @param {object} $rootScope rootscope object
-   * @param {object} crmApi service to use civicrm api
+   * @param {object} civicaseCrmApi service to use civicrm api
    * @param {object} dialogService service to open dialog box
    */
-  function DeleteActivityAction ($rootScope, crmApi, dialogService) {
+  function DeleteActivityAction ($rootScope, civicaseCrmApi, dialogService) {
     var ts = CRM.ts('civicase');
 
     /**
@@ -19,7 +19,12 @@
      * @param {object} $scope scope object
      */
     this.doAction = function ($scope) {
-      deleteActivity($scope.selectedActivities, $scope.isSelectAll, $scope.params, $scope.totalCount);
+      deleteActivity(
+        $scope.selectedActivities,
+        $scope.isSelectAll,
+        $scope.params,
+        $scope.totalCount
+      );
     };
 
     /**
@@ -39,7 +44,7 @@
       }).on('crmConfirm:yes', function () {
         var apiCalls = prepareApiCalls(activities, isSelectAll, params);
 
-        crmApi(apiCalls)
+        civicaseCrmApi(apiCalls)
           .then(function () {
             $rootScope.$broadcast('civicase::activity::updated');
           });

--- a/ang/civicase/activity/actions/services/move-copy-activity-action.service.js
+++ b/ang/civicase/activity/actions/services/move-copy-activity-action.service.js
@@ -7,12 +7,13 @@
    * Move Copy Activity Action Service
    *
    * @param {object} $rootScope rootscope object
-   * @param {object} crmApi service to call civicrm api
+   * @param {object} civicaseCrmApi service to call civicrm api
    * @param {object} dialogService service for opening dialog box
    * @param {Function} ts the translation service
    * @param {object} CaseTypeCategory the case type category service
    */
-  function MoveCopyActivityAction ($rootScope, crmApi, dialogService, ts, CaseTypeCategory) {
+  function MoveCopyActivityAction ($rootScope, civicaseCrmApi, dialogService,
+    ts, CaseTypeCategory) {
     /**
      * Perform the action
      *
@@ -46,23 +47,28 @@
         getCaseListApiParams: getCaseListApiParams
       };
 
-      dialogService.open('MoveCopyActCard', '~/civicase/activity/actions/services/move-copy-activity-action.html', model, {
-        autoOpen: false,
-        height: 'auto',
-        width: '40%',
-        title: title,
-        buttons: [{
-          text: ts('Save'),
-          icons: { primary: 'fa-check' },
-          click: function () {
-            moveCopyConfirmationHandler.call(this, operation, model, {
-              selectedActivities: activities,
-              isSelectAll: isSelectAll,
-              searchParams: params
-            });
-          }
-        }]
-      });
+      dialogService.open(
+        'MoveCopyActCard',
+        '~/civicase/activity/actions/services/move-copy-activity-action.html',
+        model,
+        {
+          autoOpen: false,
+          height: 'auto',
+          width: '40%',
+          title: title,
+          buttons: [{
+            text: ts('Save'),
+            icons: { primary: 'fa-check' },
+            click: function () {
+              moveCopyConfirmationHandler.call(this, operation, model, {
+                selectedActivities: activities,
+                isSelectAll: isSelectAll,
+                searchParams: params
+              });
+            }
+          }]
+        }
+      );
     }
 
     /**
@@ -87,7 +93,7 @@
       if (model.case_id && isCaseIdNew) {
         var apiCalls = prepareApiCalls(activitiesObject, operation, model);
 
-        crmApi(apiCalls)
+        civicaseCrmApi(apiCalls)
           .then(function () {
             $rootScope.$broadcast('civicase::activity::updated');
           });

--- a/ang/civicase/activity/actions/services/tags-activity-action.service.js
+++ b/ang/civicase/activity/actions/services/tags-activity-action.service.js
@@ -7,11 +7,12 @@
    * Tags Activity Action Service
    *
    * @param {object} $rootScope rootscope object
-   * @param {object} crmApi service to use civicrm api
+   * @param {object} civicaseCrmApi service to use civicrm api
    * @param {object} dialogService service to open dialog box
    * @param {Function} getSelect2Value service to get select 2 values
    */
-  function TagsActivityAction ($rootScope, crmApi, dialogService, getSelect2Value) {
+  function TagsActivityAction ($rootScope, civicaseCrmApi, dialogService,
+    getSelect2Value) {
     /**
      * Check if the Action is enabled
      *
@@ -29,7 +30,13 @@
      * @param {object} action action object
      */
     this.doAction = function ($scope, action) {
-      manageTags(action.operation, $scope.selectedActivities, $scope.isSelectAll, $scope.params, $scope.totalCount);
+      manageTags(
+        action.operation,
+        $scope.selectedActivities,
+        $scope.isSelectAll,
+        $scope.params,
+        $scope.totalCount
+      );
     };
 
     /**
@@ -114,7 +121,7 @@
     function addRemoveTagsConfirmationHandler (operation, activitiesObject, model) {
       var apiCalls = prepareApiCalls(operation, activitiesObject, model.selectedTags);
 
-      crmApi(apiCalls)
+      civicaseCrmApi(apiCalls)
         .then(function () {
           $rootScope.$broadcast('civicase::activity::updated');
         });
@@ -156,7 +163,7 @@
      * @returns {Promise} api call promise
      */
     function getTags () {
-      return crmApi('Tag', 'get', {
+      return civicaseCrmApi('Tag', 'get', {
         sequential: 1,
         used_for: { LIKE: '%civicrm_activity%' },
         options: { limit: 0 }

--- a/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
+++ b/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
@@ -154,16 +154,16 @@
   /**
    * Activities Calendar Controller
    *
-   * @param {*} $q $q service
-   * @param {*} $rootScope root scope object
-   * @param {*} $route route service
-   * @param {*} $sce sce service
-   * @param {*} $scope $scope scope object
-   * @param {*} ContactsCache contacts cache service
-   * @param {*} civicaseCrmApi crm api service
-   * @param {*} formatActivity format activity service
-   * @param {*} getActivityFeedUrl get activity feed url service
-   * @param {*} ActivityStatusType activity status type service
+   * @param {object} $q $q service
+   * @param {object} $rootScope root scope object
+   * @param {object} $route route service
+   * @param {object} $sce sce service
+   * @param {object} $scope $scope scope object
+   * @param {object} ContactsCache contacts cache service
+   * @param {Function} civicaseCrmApi crm api service
+   * @param {Function} formatActivity format activity service
+   * @param {Function} getActivityFeedUrl get activity feed url service
+   * @param {object} ActivityStatusType activity status type service
    */
   function civicaseActivitiesCalendarController ($q, $rootScope, $route, $sce,
     $scope, ContactsCache, civicaseCrmApi, formatActivity, getActivityFeedUrl, ActivityStatusType) {

--- a/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
+++ b/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
@@ -160,13 +160,13 @@
    * @param {*} $sce sce service
    * @param {*} $scope $scope scope object
    * @param {*} ContactsCache contacts cache service
-   * @param {*} crmApi crm api service
+   * @param {*} civicaseCrmApi crm api service
    * @param {*} formatActivity format activity service
    * @param {*} getActivityFeedUrl get activity feed url service
    * @param {*} ActivityStatusType activity status type service
    */
   function civicaseActivitiesCalendarController ($q, $rootScope, $route, $sce,
-    $scope, ContactsCache, crmApi, formatActivity, getActivityFeedUrl, ActivityStatusType) {
+    $scope, ContactsCache, civicaseCrmApi, formatActivity, getActivityFeedUrl, ActivityStatusType) {
     var ACTIVITIES_DISPLAY_LIMIT = 25;
     var DEBOUNCE_WAIT = 300;
 
@@ -440,7 +440,7 @@
         params.case_filter = $scope.caseParams;
       }
 
-      return crmApi('Activity', 'get', _.assign(params, {
+      return civicaseCrmApi('Activity', 'get', _.assign(params, {
         return: [
           'subject', 'details', 'activity_type_id', 'status_id',
           'source_contact_name', 'target_contact_name', 'assignee_contact_name',
@@ -536,7 +536,7 @@
         params.case_filter = $scope.caseParams;
       }
 
-      return crmApi('Activity', 'getdayswithactivities', params)
+      return civicaseCrmApi('Activity', 'getdayswithactivities', params)
         .then(function (result) {
           return result.values;
         })

--- a/ang/civicase/activity/card/directives/activity-card.directive.js
+++ b/ang/civicase/activity/card/directives/activity-card.directive.js
@@ -47,15 +47,16 @@
    * @param {object} CaseType a reference to the Case Type service
    * @param {object} CaseTypeCategory a reference to the Case Type Category service
    * @param {object} dialogService service to open the dialog box
-   * @param {Function} crmApi service to interact with the civicrm api
+   * @param {Function} civicaseCrmApi service to interact with the civicrm api
    * @param {object} crmBlocker crm blocker service
    * @param {object} crmStatus crm status service
    * @param {object} DateHelper date helper service
    * @param {object} ts ts service
    * @param {Function} viewInPopup factory to view an activity in a popup
    */
-  function caseActivityCardController ($filter, $scope, CaseType, CaseTypeCategory, dialogService, crmApi,
-    crmBlocker, crmStatus, DateHelper, ts, viewInPopup) {
+  function caseActivityCardController ($filter, $scope, CaseType,
+    CaseTypeCategory, dialogService, civicaseCrmApi, crmBlocker, crmStatus,
+    DateHelper, ts, viewInPopup) {
     var caseTypes = CaseType.getAll();
     var caseTypeCategories = CaseTypeCategory.getAll();
 
@@ -80,7 +81,10 @@
      * @returns {Promise} api call promise
      */
     $scope.markCompleted = function (activity) {
-      return crmApi([['Activity', 'create', { id: activity.id, status_id: activity.is_completed ? 'Scheduled' : 'Completed' }]])
+      return civicaseCrmApi([['Activity', 'create', {
+        id: activity.id,
+        status_id: activity.is_completed ? 'Scheduled' : 'Completed'
+      }]])
         .then(function (data) {
           if (!data[0].is_error) {
             activity.is_completed = !activity.is_completed;
@@ -163,7 +167,7 @@
        * @returns {Promise} promise
        */
       $scope.deleteFile = function (activity, file) {
-        var promise = crmApi('Attachment', 'delete', { id: file.id })
+        var promise = civicaseCrmApi('Attachment', 'delete', { id: file.id })
           .then(function () {
             $scope.refresh();
           });

--- a/ang/civicase/activity/feed/directives/activity-feed.directive.js
+++ b/ang/civicase/activity/feed/directives/activity-feed.directive.js
@@ -56,7 +56,7 @@
    * @param {object} $scope scope object
    * @param {object} $q $q service
    * @param {object} BulkActions bulk actions service
-   * @param {object} crmApi crm api service
+   * @param {object} civicaseCrmApi crm api service
    * @param {object} crmUiHelp crm ui help service
    * @param {object} crmThrottle crm throttle service
    * @param {object} formatActivity format activity service
@@ -67,7 +67,7 @@
    * @param {object} ActivityType activity type service
    * @param {object} CaseType case type service
    */
-  function civicaseActivityFeedController ($scope, $q, BulkActions, crmApi,
+  function civicaseActivityFeedController ($scope, $q, BulkActions, civicaseCrmApi,
     crmUiHelp, crmThrottle, formatActivity, $rootScope, dialogService,
     ContactsCache, ActivityStatus, ActivityType, CaseType) {
     // The ts() and hs() functions help load strings for this module.
@@ -88,9 +88,11 @@
     $scope.bulkAllowed = $scope.showBulkActions && BulkActions.isAllowed();
     $scope.selectedActivities = [];
     $scope.viewingActivity = {};
-    $scope.caseTimelines = $scope.caseTypeId ? _.sortBy(CaseType.getAll()[$scope.caseTypeId].definition.activitySets, 'label') : [];
     $scope.refreshAll = refreshAll;
     $scope.showSpinner = { up: false, down: false };
+    $scope.caseTimelines = $scope.caseTypeId
+      ? _.sortBy(CaseType.getAll()[$scope.caseTypeId].definition.activitySets, 'label')
+      : [];
 
     (function init () {
       applyFiltersFromBindings();
@@ -186,7 +188,11 @@
         // Mark email read
         if (act.status === 'Unread') {
           var statusId = _.findKey(ActivityStatus.getAll(), { name: 'Completed' });
-          crmApi('Activity', 'setvalue', { id: act.id, field: 'status_id', value: statusId }).then(function () {
+          civicaseCrmApi(
+            'Activity',
+            'setvalue',
+            { id: act.id, field: 'status_id', value: statusId }
+          ).then(function () {
             act.status_id = statusId;
             formatActivity(act);
           });
@@ -466,7 +472,7 @@
         }
       );
 
-      return crmApi({
+      return civicaseCrmApi({
         acts: ['Activity', apiAction, prepareActivityParams(returnParams, params)],
         all: ['Activity', apiActionAll, params]
       }).then(function (result) {
@@ -554,7 +560,7 @@
     /**
      * Refresh Activities
      * If: refreshCase callback is passed to the directive, calls the same
-     * Else: Calls crmApi directly
+     * Else: Calls civicaseCrmApi directly
      *
      * @param {Array} apiCalls apiCalls
      */
@@ -566,7 +572,7 @@
           apiCalls = [];
         }
 
-        crmApi(apiCalls, true).then(function (result) {
+        civicaseCrmApi(apiCalls, true).then(function (result) {
           getActivities({ direction: 'down' });
         });
       }

--- a/ang/civicase/activity/feed/directives/activity-month-nav.directive.js
+++ b/ang/civicase/activity/feed/directives/activity-month-nav.directive.js
@@ -15,11 +15,11 @@
     /**
      * Link function for civicaseActivityMonthNav
      *
-     * @param {Object} scope
-     * @param {Object} $el
-     * @param {Object} attr
+     * @param {object} scope scope object
+     * @param {object} $element directives html element
+     * @param {object} attr attributes of the directive
      */
-    function civicaseActivityMonthNavLink (scope, $el, attr) {
+    function civicaseActivityMonthNavLink (scope, $element, attr) {
       (function init () {
         scope.$watch('isLoading', checkIfLoadingCompleted);
       }());
@@ -46,7 +46,13 @@
 
   module.controller('civicaseActivityMonthNavController', civicaseActivityMonthNavController);
 
-  function civicaseActivityMonthNavController ($rootScope, $scope, crmApi) {
+  /**
+   *
+   * @param {object} $rootScope rootscope object
+   * @param {object} $scope scope object of the controller
+   * @param {Function} civicaseCrmApi service to access civicrm api
+   */
+  function civicaseActivityMonthNavController ($rootScope, $scope, civicaseCrmApi) {
     var previousApiCalls = null;
     var currentlyActiveMonth = null;
     $scope.navigateToMonth = navigateToMonth;
@@ -58,7 +64,8 @@
     /**
      * Checks if the first record of the month is already rendered
      *
-     * @param {Object} monthObj
+     * @param {object} monthObj month object
+     * @returns {boolean} if the first record of the month is already rendered
      */
     function checkIfMonthIsAlreadyLoaded (monthObj) {
       var selector = '[data-offset-number="' + monthObj.startingOffset + '"]';
@@ -69,8 +76,9 @@
     /**
      * Subscribe listener for civicaseActivityFeed.query
      *
-     * @param {Object} event
-     * @param {Object} feedQueryParams
+     * @param {object} event event object
+     * @param {object} feedQueryParams query parameters for activity feed
+     * @returns {Promise} promise
      */
     function feedQueryListener (event, feedQueryParams) {
       if (feedQueryParams.isMyActivitiesFilter) {
@@ -88,7 +96,7 @@
       }
       previousApiCalls = apiCalls;
 
-      return crmApi(apiCalls).then(function (result) {
+      return civicaseCrmApi(apiCalls).then(function (result) {
         initGroups();
 
         if (feedQueryParams.overdueFirst) {
@@ -109,9 +117,9 @@
     /**
      * Get API calls to load the months for the month nav
      *
-     * @param {Boolean} overdueFirst
-     * @param {Object} params
-     * @return {Array}
+     * @param {boolean} overdueFirst if overdues should be displayed first
+     * @param {object} params parameters of the api call
+     * @returns {Array} list of api calls
      */
     function getAPICalls (overdueFirst, params) {
       var apiCalls;
@@ -120,11 +128,11 @@
         apiCalls = {
           months_wo_overdue: [
             'Activity', 'getmonthswithactivities',
-            $.extend(true, {is_overdue: 0}, params)
+            $.extend(true, { is_overdue: 0 }, params)
           ],
           months_with_overdue: [
             'Activity', 'getmonthswithactivities',
-            $.extend(true, {is_overdue: 1}, params)
+            $.extend(true, { is_overdue: 1 }, params)
           ]
         };
       } else {
@@ -141,9 +149,9 @@
     /**
      * Group Dates into year and month for the given category
      *
-     * @param {Array} category
-     * @param {Object} dateObject
-     * @param {Boolean} isOverDueGroup
+     * @param {object} category category object
+     * @param {object} dateObject date object
+     * @param {boolean} isOverDueGroup if overdue group
      */
     function groupByYearFor (category, dateObject, isOverDueGroup) {
       var yearObject = _.find(category.records, function (yearObj) {
@@ -171,7 +179,7 @@
     /**
      * Group Months into year
      *
-     * @param {Array} monthsArray
+     * @param {Array} monthsArray list of months
      */
     function groupOthersByYear (monthsArray) {
       var current = {
@@ -203,7 +211,7 @@
     /**
      * Group Overdue Activity Months into year
      *
-     * @param {Array} monthsArray
+     * @param {Array} monthsArray list of months
      */
     function groupOverdueByYear (monthsArray) {
       var overdueGroup = _.find($scope.groups, function (group) {
@@ -240,7 +248,7 @@
      *  scrolls to the first record of the month
      * If Not, emits an event with the starting offset for that month
      *
-     * @param {Object} monthObj
+     * @param {object} monthObj month object
      */
     function navigateToMonth (monthObj) {
       if (currentlyActiveMonth) {
@@ -264,7 +272,7 @@
     /**
      * Scrolls and Highlights the first records of the month
      *
-     * @param {Object} monthObj
+     * @param {object} monthObj month object
      */
     function scrollAndHighlight (monthObj) {
       var selector = '[data-offset-number=' + monthObj.startingOffset + ']';

--- a/ang/civicase/activity/panel/directives/activity-panel.directive.js
+++ b/ang/civicase/activity/panel/directives/activity-panel.directive.js
@@ -117,7 +117,7 @@
    * @param {object} ActivityStatus activity status service
    * @param {object} ActivityType activity type service
    * @param {Function} checkIfDraftActivity check if activity function
-   * @param {object} crmApi crm api service
+   * @param {object} civicaseCrmApi crm api service
    * @param {object} crmBlocker crm blocker service
    * @param {object} crmStatus crm status service
    * @param {object} DateHelper date helper service
@@ -125,7 +125,7 @@
    * @param {object} Priority priority service
    */
   function civicaseActivityPanelController ($rootScope, $scope, ActivityStatus,
-    ActivityType, checkIfDraftActivity, crmApi, crmBlocker, crmStatus,
+    ActivityType, checkIfDraftActivity, civicaseCrmApi, crmBlocker, crmStatus,
     DateHelper, dialogService, Priority) {
     $scope.activityPriorties = Priority.getAll();
     $scope.allowedActivityStatuses = {};

--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-list.directive.js
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-list.directive.js
@@ -18,11 +18,12 @@
    * @param {object} $scope the controller scope
    * @param {Function} ts translation service
    * @param {Function} $rootScope the root scope
-   * @param {Function} crmApi the crm api service
+   * @param {Function} civicaseCrmApi the crm api service
    * @param {Function} formatCase the format case service
    * @param {Function} DateHelper the date helper service
    */
-  function CivicaseContactCaseTabCaseListController ($scope, ts, $rootScope, crmApi, formatCase, DateHelper) {
+  function CivicaseContactCaseTabCaseListController ($scope, ts, $rootScope,
+    civicaseCrmApi, formatCase, DateHelper) {
     var defaultPageSize = 2;
 
     $scope.loadingPlaceholders = _.range($scope.casesList.page.size || defaultPageSize);

--- a/ang/civicase/case/details/file-tab/directives/file-list.directive.js
+++ b/ang/civicase/case/details/file-tab/directives/file-list.directive.js
@@ -16,12 +16,10 @@
   /**
    * Controlle for File List
    *
-   * @param {Object} $scope
-   * @param {Object} crmApi
-   * @param {Object} crmBlocker
-   * @param {Object} crmStatus
+   * @param {object} $scope scope object
+   * @param {object} civicaseCrmApi service to access civicrm api
    */
-  function civicaseFileListController ($scope, crmApi) {
+  function civicaseFileListController ($scope, civicaseCrmApi) {
     $scope.ts = CRM.ts('civicase');
 
     (function init () {
@@ -31,12 +29,12 @@
     /**
      * Refreshes the UI state after updating the db from the api calls
      *
-     * @params {Array} apiCalls
+     * @param {Array} apiCalls lisy of api calls
      */
     $scope.refresh = function (apiCalls) {
       if (!_.isArray(apiCalls)) apiCalls = [];
 
-      crmApi(apiCalls, true).then(function (result) {
+      civicaseCrmApi(apiCalls, true).then(function (result) {
         $scope.fileLists.refresh();
       });
     };
@@ -44,7 +42,7 @@
     /**
      * Watcher function for fileLists.result collection
      *
-     * @params {Object} response
+     * @param {object} response response object
      */
     function fileListsWatcher (response) {
       // prettier html

--- a/ang/civicase/case/details/file-tab/directives/file-list.directive.js
+++ b/ang/civicase/case/details/file-tab/directives/file-list.directive.js
@@ -29,7 +29,7 @@
     /**
      * Refreshes the UI state after updating the db from the api calls
      *
-     * @param {Array} apiCalls lisy of api calls
+     * @param {Array} apiCalls list of api calls
      */
     $scope.refresh = function (apiCalls) {
       if (!_.isArray(apiCalls)) apiCalls = [];

--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
@@ -49,13 +49,13 @@
    * @param {object} $q $q
    * @param {object} $scope $scope
    * @param {object} allowMultipleCaseClients allow multiple clients configuration value
-   * @param {object} crmApi crmApi
+   * @param {object} civicaseCrmApi service to interact with civicrm api
    * @param {object} DateHelper DateHelper
    * @param {object} ts ts
    * @param {object} RelationshipType RelationshipType
    */
-  function civicaseViewPeopleController ($q, $scope, allowMultipleCaseClients, crmApi, DateHelper,
-    ts, RelationshipType) {
+  function civicaseViewPeopleController ($q, $scope, allowMultipleCaseClients,
+    civicaseCrmApi, DateHelper, ts, RelationshipType) {
     // The ts() and hs() functions help load strings for this module.
     var CONTACT_CANT_HAVE_ROLE_MESSAGE = ts('Case clients cannot be selected for a case role. Please select another contact.');
     var clients = _.indexBy($scope.item.client, 'contact_id');
@@ -311,9 +311,10 @@
     }
 
     /**
-     * Prompts the user to select a contact to assign them to the case. Relationships between
-     * the selected contact and the case clients are created using the provided role. This event is also
-     * recorded as an activity related to the case.
+     * Prompts the user to select a contact to assign them to the case.
+     * Relationships between the selected contact and the case clients are
+     * created using the provided role. This event is also recorded as an
+     * activity related to the case.
      *
      * @param {Role} role the role details.
      */
@@ -743,7 +744,7 @@ included in the confirmation dialog.
       if ($scope.relationsAlphaFilter) {
         params.display_name = $scope.relationsAlphaFilter;
       }
-      crmApi('Case', 'getrelations', params).then(function (contacts) {
+      civicaseCrmApi('Case', 'getrelations', params).then(function (contacts) {
         $scope.relations = _.each(contacts.values, function (rel) {
           var relType = relTypes[rel.relationship_type_id];
           rel.relation = relType['label_' + rel.relationship_direction];

--- a/ang/civicase/case/details/service/case-details-activity-tab.service.js
+++ b/ang/civicase/case/details/service/case-details-activity-tab.service.js
@@ -7,9 +7,8 @@
    * Activities Case Tab service.
    *
    * @param {object} $location the location service.
-   * @param {Function} crmApi the CRM API service.
    */
-  function ActivitiesCaseTab ($location, crmApi) {
+  function ActivitiesCaseTab ($location) {
     /**
      * @returns {string} Returns tab content HTMl template url.
      */

--- a/ang/civicase/case/details/service/case-details-files-tab.service.js
+++ b/ang/civicase/case/details/service/case-details-files-tab.service.js
@@ -7,9 +7,8 @@
    * Files Case Tab service.
    *
    * @param {object} $location the location service.
-   * @param {Function} crmApi the CRM API service.
    */
-  function FilesCaseTab ($location, crmApi) {
+  function FilesCaseTab ($location) {
     /**
      * @returns {string} Returns tab content HTMl template url.
      */

--- a/ang/civicase/case/details/service/case-details-people-tab.service.js
+++ b/ang/civicase/case/details/service/case-details-people-tab.service.js
@@ -7,9 +7,8 @@
    * People Case Tab service.
    *
    * @param {object} $location the location service.
-   * @param {Function} crmApi the CRM API service.
    */
-  function PeopleCaseTab ($location, crmApi) {
+  function PeopleCaseTab ($location) {
     /**
      * @returns {string} Returns tab content HTMl template url.
      */

--- a/ang/civicase/case/details/service/case-details-summary-tab.service.js
+++ b/ang/civicase/case/details/service/case-details-summary-tab.service.js
@@ -7,9 +7,8 @@
    * Summary Case Tab service.
    *
    * @param {object} $location the location service.
-   * @param {Function} crmApi the CRM API service.
    */
-  function SummaryCaseTab ($location, crmApi) {
+  function SummaryCaseTab ($location) {
     /**
      * @returns {string} Returns tab content HTMl template url.
      */

--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -41,14 +41,14 @@
    * Controller for civicaseCaseOverview.
    *
    * @param {object} $scope the controller's $scope object.
-   * @param {object} crmApi the crm api service reference.
+   * @param {object} civicaseCrmApi the crm api service reference.
    * @param {object} BrowserCache the browser cache service reference.
    * @param {object} CaseStatus the case status service reference.
    * @param {object} CaseType the case type service reference.
    * @param {object} CaseTypeFilterer the case type filterer service reference.
    */
-  function civicaseCaseOverviewController ($scope, crmApi, BrowserCache, CaseStatus,
-    CaseType, CaseTypeFilterer) {
+  function civicaseCaseOverviewController ($scope, civicaseCrmApi, BrowserCache,
+    CaseStatus, CaseType, CaseTypeFilterer) {
     var BROWSER_CACHE_IDENTIFIER = 'civicase.CaseOverview.hiddenCaseStatuses';
     var MAXIMUM_CASE_TYPES_TO_DISPLAY_BREAKDOWN = 1;
     var allCaseStatusNames = _.map(CaseStatus.getAll(true), 'name');
@@ -172,7 +172,7 @@
       delete params.status_id;
 
       apiCalls.push(['Case', 'getstats', params]);
-      crmApi(apiCalls).then(function (response) {
+      civicaseCrmApi(apiCalls).then(function (response) {
         $scope.summaryData = response[0].values;
       });
     }

--- a/ang/civicase/case/list/directives/case-list-table.directive.js
+++ b/ang/civicase/case/list/directives/case-list-table.directive.js
@@ -51,7 +51,7 @@
   });
 
   module.controller('CivicaseCaseListTableController', function ($rootScope,
-    $route, $scope, $window, BulkActions, crmApi, crmStatus, crmUiHelp,
+    $route, $scope, $window, BulkActions, civicaseCrmApi, crmStatus, crmUiHelp,
     crmThrottle, currentCaseCategory, $timeout, formatCase, ContactsCache, CasesUtils, ts,
     ActivityCategory, ActivityType, CaseStatus) {
     var firstLoad = true;
@@ -141,7 +141,7 @@
       apiCalls = apiCalls || [];
       apiCalls = apiCalls.concat(getCaseApiParams(angular.extend({}, $scope.filters, $scope.hiddenFilters), $scope.sort, $scope.page));
 
-      crmApi(apiCalls, true)
+      civicaseCrmApi(apiCalls, true)
         .then(function (result) {
           $scope.cases = _.each(result[apiCalls.length - 2].values, formatCase);
           $scope.totalCount = result[apiCalls.length - 1];
@@ -409,7 +409,7 @@
       params[0][2].return = ['case_type_id', 'status_id', 'is_deleted', 'contacts'];
       params[0][2].options.limit = 0;
 
-      crmApi(params).then(function (res) {
+      civicaseCrmApi(params).then(function (res) {
         allCases = res[0].values;
         $scope.isSelectAllAvailable = true;
       });
@@ -453,7 +453,7 @@
         params.push(['Case', 'getcaselistheaders']);
       }
 
-      return crmApi(params);
+      return civicaseCrmApi(params);
     }
 
     /**

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -18,8 +18,9 @@
   /**
    * Controller Function for civicase-search directive
    */
-  module.controller('civicaseSearchController', function ($scope, $rootScope, $timeout,
-    crmApi, getSelect2Value, ts, CaseStatus, CaseTypeCategory, CaseType, currentCaseCategory, CustomSearchField) {
+  module.controller('civicaseSearchController', function ($scope, $rootScope,
+    $timeout, civicaseCrmApi, getSelect2Value, ts, CaseStatus, CaseTypeCategory,
+    CaseType, currentCaseCategory, CustomSearchField) {
     var caseTypes = CaseType.getAll();
     var caseStatuses = CaseStatus.getAll();
     var caseTypeCategories = CaseTypeCategory.getAll();
@@ -277,7 +278,9 @@
     function formatSearchFilters (inp) {
       var search = {};
       _.each(inp, function (val, key) {
-        if (!_.isEmpty(val) || ((typeof val === 'number') && val) || ((typeof val === 'boolean') && val)) {
+        if (!_.isEmpty(val) ||
+          ((typeof val === 'number') && val) ||
+          ((typeof val === 'boolean') && val)) {
           search[key] = val;
         }
       });
@@ -380,8 +383,12 @@
      */
     function relationshipTypeWatcher () {
       if ($scope.relationshipType) {
-        $scope.relationshipType[0] === 'is_case_manager' ? $scope.filters.case_manager = [CRM.config.user_contact_id] : delete ($scope.filters.case_manager);
-        $scope.relationshipType[0] === 'is_involved' ? $scope.filters.contact_involved = [CRM.config.user_contact_id] : delete ($scope.filters.contact_involved);
+        $scope.relationshipType[0] === 'is_case_manager'
+          ? $scope.filters.case_manager = [CRM.config.user_contact_id]
+          : delete ($scope.filters.case_manager);
+        $scope.relationshipType[0] === 'is_involved'
+          ? $scope.filters.contact_involved = [CRM.config.user_contact_id]
+          : delete ($scope.filters.contact_involved);
       }
     }
 
@@ -392,7 +399,7 @@
      * @returns {Promise} resolves to a list of relationship types.
      */
     function requestCaseRoles () {
-      return crmApi('RelationshipType', 'getcaseroles', {
+      return civicaseCrmApi('RelationshipType', 'getcaseroles', {
         options: { limit: 0 }
       })
         .then(function (caseRolesResponse) {
@@ -477,7 +484,8 @@
      * @param {object} $event - event object of Event API
      */
     function toggleIsDeleted ($event) {
-      var pressedSpaceOrEnter = $event.type === 'keydown' && ($event.keyCode === 32 || $event.keyCode === 13);
+      var pressedSpaceOrEnter =
+        $event.type === 'keydown' && ($event.keyCode === 32 || $event.keyCode === 13);
 
       if ($event.type === 'click' || pressedSpaceOrEnter) {
         $scope.filters.is_deleted = !$scope.filters.is_deleted;

--- a/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+++ b/ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
@@ -19,14 +19,14 @@
    * @param {Function} ts translation service
    * @param {Function} CaseTypeCategory the case type category service
    * @param {Function} CaseTypeCategoryTranslationService the case type category translation service
-   * @param {Function} crmApi the crm api service
+   * @param {Function} civicaseCrmApi the crm api service
    * @param {Function} formatCase the format case service
    * @param {object} Contact the contact service
    * @param {object} ContactsCache the contacts cache service
    * @param {string} AddCase service to open add case popup
    */
   function CivicaseContactCaseTabController ($scope, ts, CaseTypeCategory,
-    CaseTypeCategoryTranslationService, crmApi, formatCase, Contact,
+    CaseTypeCategoryTranslationService, civicaseCrmApi, formatCase, Contact,
     ContactsCache, AddCase) {
     var commonConfigs = {
       isLoaded: false,
@@ -107,7 +107,10 @@
       var caseListIndex = _.findIndex($scope.casesListConfig, function (caseObj) {
         return caseObj.name === name;
       });
-      var params = getCaseApiParams($scope.casesListConfig[caseListIndex].filterParams, $scope.casesListConfig[caseListIndex].page);
+      var params = getCaseApiParams(
+        $scope.casesListConfig[caseListIndex].filterParams,
+        $scope.casesListConfig[caseListIndex].page
+      );
 
       $scope.casesListConfig[caseListIndex].showSpinner = true;
       updateCase(caseListIndex, params);
@@ -230,7 +233,7 @@
     function getTotalCasesCount (apiCall) {
       var count = 0;
 
-      crmApi(apiCall).then(function (response) {
+      civicaseCrmApi(apiCall).then(function (response) {
         _.each(response, function (ind) {
           count += ind;
         });
@@ -240,9 +243,10 @@
     }
 
     /**
-     * Triggers after the contact tab changes. When changing back to the tab belonging to this case
-     * type category, it restores the translations associated with it. This is done due to CiviCRM
-     * replacing the translation files when a new angular module is loaded. The solution is to manually
+     * Triggers after the contact tab changes. When changing back to the tab
+     * belonging to this case type category, it restores the translations
+     * associated with it. This is done due to CiviCRM replacing the translation
+     * files when a new angular module is loaded. The solution is to manually
      * restore the translations.
      *
      * @param {object} urlParams a map of the URL parameters belonging to the currently active tab.
@@ -264,7 +268,8 @@
     function initCasesConfig () {
       _.each($scope.casesListConfig, function (item, ind) {
         $scope.casesListConfig[ind].cases = [];
-        $scope.casesListConfig[ind] = $.extend(true, $scope.casesListConfig[ind], commonConfigs);
+        $scope.casesListConfig[ind] =
+          $.extend(true, $scope.casesListConfig[ind], commonConfigs);
       });
     }
 
@@ -321,7 +326,7 @@
      * @param {Array} params the parameters to use when updating the case list
      */
     function updateCase (caseListIndex, params) {
-      crmApi(params).then(function (response) {
+      civicaseCrmApi(params).then(function (response) {
         _.each(response.cases.values, function (item) {
           item.contact_role = getContactRole(item);
           $scope.casesListConfig[caseListIndex].cases.push(formatCase(item));
@@ -329,7 +334,8 @@
 
         $scope.casesListConfig[caseListIndex].isLoaded = true;
         $scope.casesListConfig[caseListIndex].showSpinner = false;
-        $scope.casesListConfig[caseListIndex].isLoadMoreAvailable = $scope.casesListConfig[caseListIndex].cases.length < response.count;
+        $scope.casesListConfig[caseListIndex].isLoadMoreAvailable =
+          $scope.casesListConfig[caseListIndex].cases.length < response.count;
 
         if ($scope.casesListConfig[caseListIndex].page.num === 1) {
           loadAdditionalDataWhenAllCasesLoaded();

--- a/ang/civicase/contact/services/contacts-cache.service.js
+++ b/ang/civicase/contact/services/contacts-cache.service.js
@@ -3,7 +3,14 @@
 
   module.service('ContactsCache', ContactsCache);
 
-  function ContactsCache (crmApi, $q, $rootScope) {
+  /**
+   * Contacts Cashe Service
+   *
+   * @param {Function} civicaseCrmApi service to access civicrm api
+   * @param {object} $q angular queue service
+   * @param {object} $rootScope root scope object
+   */
+  function ContactsCache (civicaseCrmApi, $q, $rootScope) {
     var defer;
     var savedContacts = [];
     var savedContactDetails = {};
@@ -24,8 +31,8 @@
     /**
      * Add data to the ContactsData service and fetches Profile Pic and Contact Type
      *
-     * @param {Array} contacts
-     * @return {Promise} resolves to undefined when the information for the given contacts
+     * @param {Array} contacts list of contacts to be added
+     * @returns {Promise} resolves to undefined when the information for the given contacts
      * has been fetched and stored.
      */
     this.add = function (contacts) {
@@ -40,25 +47,25 @@
 
       defer = $q.defer();
 
-      return crmApi('Contact', 'get', {
-        'sequential': 1,
-        'id': { 'IN': newContacts },
-        'return': requiredContactFields,
-        'options': { 'limit': 0 },
+      return civicaseCrmApi('Contact', 'get', {
+        sequential: 1,
+        id: { IN: newContacts },
+        return: requiredContactFields,
+        options: { limit: 0 },
         'api.Phone.get': {
-          'contact_id': '$value.id',
-          'phone_type_id.name': { 'IN': [ 'Mobile', 'Phone' ] },
-          'return': ['phone', 'phone_type_id.name', 'location_type_id'],
-          'api.LocationType.get': { 'id': '$value.location_type_id' }
+          contact_id: '$value.id',
+          'phone_type_id.name': { IN: ['Mobile', 'Phone'] },
+          return: ['phone', 'phone_type_id.name', 'location_type_id'],
+          'api.LocationType.get': { id: '$value.location_type_id' }
         },
         'api.GroupContact.get': {
-          'contact_id': '$value.id',
-          'return': [ 'title' ]
+          contact_id: '$value.id',
+          return: ['title']
         },
         'api.EntityTag.get': {
-          'entity_table': 'civicrm_contact',
-          'entity_id': '$value.id',
-          'return': [ 'tag_id.name', 'tag_id.description', 'tag_id.color' ]
+          entity_table: 'civicrm_contact',
+          entity_id: '$value.id',
+          return: ['tag_id.name', 'tag_id.description', 'tag_id.color']
         }
       }).then(function (data) {
         savedContactDetails = _.extend(savedContactDetails, _.indexBy(data.values, 'contact_id'));
@@ -70,8 +77,8 @@
     /**
      * Returns the cached information for the given contact.
      *
-     * @param {String} contactID
-     * @return {Object} contact object of the passed contact ID.
+     * @param {string} contactID contact id
+     * @returns {object} contact object of the passed contact ID.
      */
     this.getCachedContact = function (contactID) {
       var contact = _.clone(savedContactDetails[contactID]);
@@ -94,8 +101,8 @@
     /**
      * Returns the Profile Pic for the given contact id
      *
-     * @param {String} contactID
-     * @return {String}
+     * @param {string} contactID contact id
+     * @returns {string} image url of the sent contact
      */
     this.getImageUrlOf = function (contactID) {
       return savedContactDetails[contactID] ? savedContactDetails[contactID].image_URL : '';
@@ -104,8 +111,8 @@
     /**
      * Returns the Contact Type for the given contact id
      *
-     * @param {String} contactID
-     * @return {String}
+     * @param {string} contactID contact id
+     * @returns {string} icon of the sent contact
      */
     this.getContactIconOf = function (contactID) {
       return savedContactDetails[contactID] ? savedContactDetails[contactID].contact_type : '';
@@ -114,7 +121,7 @@
     /**
      * Formats the phone numbers in an array which can be used in the html
      *
-     * @param {Object} contact
+     * @param {object} contact contact object
      */
     function formatContactPhoneNumbers (contact) {
       var phoneNumbers = [];

--- a/ang/civicase/contact/services/contacts-cache.service.js
+++ b/ang/civicase/contact/services/contacts-cache.service.js
@@ -4,7 +4,7 @@
   module.service('ContactsCache', ContactsCache);
 
   /**
-   * Contacts Cashe Service
+   * Contacts Cache Service
    *
    * @param {Function} civicaseCrmApi service to access civicrm api
    * @param {object} $q angular queue service

--- a/ang/civicase/dashboard/directives/dashboard-tab.directive.js
+++ b/ang/civicase/dashboard/directives/dashboard-tab.directive.js
@@ -20,14 +20,14 @@
    * @param {object} $sce sce service
    * @param {object} $scope scope object
    * @param {object} ContactsCache contacts cache service
-   * @param {object} crmApi crm api service
+   * @param {object} civicaseCrmApi crm api service
    * @param {object} formatCase format case service
    * @param {object} formatActivity format activity service
    * @param {object} ts ts
    * @param {object} ActivityStatusType activity status type service
    */
   function dashboardTabController ($location, $rootScope, $route, $sce, $scope,
-    ContactsCache, crmApi, formatCase, formatActivity, ts, ActivityStatusType) {
+    ContactsCache, civicaseCrmApi, formatCase, formatActivity, ts, ActivityStatusType) {
     var ACTIVITIES_QUERY_PARAMS_DEFAULTS = {
       contact_id: 'user_contact_id',
       is_current_revision: 1,
@@ -38,10 +38,11 @@
       status_id: { IN: ActivityStatusType.getAll().incomplete },
       options: { sort: 'is_overdue DESC, activity_date_time ASC' },
       return: [
-        'subject', 'details', 'activity_type_id', 'status_id', 'source_contact_name',
-        'target_contact_name', 'assignee_contact_name', 'activity_date_time', 'is_star',
-        'original_id', 'tag_id.name', 'tag_id.description', 'tag_id.color', 'file_id',
-        'is_overdue', 'case_id', 'priority_id', 'case_id.case_type_id', 'case_id.status_id',
+        'subject', 'details', 'activity_type_id', 'status_id',
+        'source_contact_name', 'target_contact_name', 'assignee_contact_name',
+        'activity_date_time', 'is_star', 'original_id', 'tag_id.name',
+        'tag_id.description', 'tag_id.color', 'file_id', 'is_overdue', 'case_id',
+        'priority_id', 'case_id.case_type_id', 'case_id.status_id',
         'case_id.contacts'
       ]
     };
@@ -59,10 +60,11 @@
       status_id: { IN: ActivityStatusType.getAll().incomplete },
       options: { sort: 'is_overdue DESC, activity_date_time ASC' },
       return: [
-        'subject', 'details', 'activity_type_id', 'status_id', 'source_contact_name',
-        'target_contact_name', 'assignee_contact_name', 'activity_date_time', 'is_star',
-        'original_id', 'tag_id.name', 'tag_id.description', 'tag_id.color', 'file_id',
-        'is_overdue', 'case_id', 'priority_id', 'case_id.case_type_id', 'case_id.status_id',
+        'subject', 'details', 'activity_type_id', 'status_id',
+        'source_contact_name', 'target_contact_name', 'assignee_contact_name',
+        'activity_date_time', 'is_star', 'original_id', 'tag_id.name',
+        'tag_id.description', 'tag_id.color', 'file_id', 'is_overdue',
+        'case_id', 'priority_id', 'case_id.case_type_id', 'case_id.status_id',
         'case_id.contacts'
       ]
     };
@@ -120,7 +122,12 @@
         caseClick: casesCustomClick,
         viewCasesLink: viewCasesLink()
       },
-      query: { entity: 'Case', action: 'getcaselist', countAction: 'getdetailscount', params: getQueryParams('cases') },
+      query: {
+        entity: 'Case',
+        action: 'getcaselist',
+        countAction: 'getdetailscount',
+        params: getQueryParams('cases')
+      },
       handlers: {
         range: _.curry(rangeHandler)('start_date')('YYYY-MM-DD')(false),
         results: _.curry(resultsHandler)(formatCase)('contacts')
@@ -170,7 +177,7 @@
      * name(s)
      *
      * Unfortunately the activity card expects the callback to handle api calls
-     * for it, hence the `apiCalls` param and the usage of `crmApi`
+     * for it, hence the `apiCalls` param and the usage of `civicaseCrmApi`
      *
      * @see {@link https://github.com/compucorp/uk.co.compucorp.civicase/blob/develop/ang/civicase/ActivityCard.js#L97}
      *
@@ -182,7 +189,7 @@
         apiCalls = [];
       }
 
-      crmApi(apiCalls).then(function (result) {
+      civicaseCrmApi(apiCalls).then(function (result) {
         $rootScope.$emit('civicase::ActivitiesCalendar::reload');
         $rootScope.$emit('civicase::PanelQuery::reload', panelName);
       });

--- a/ang/civicase/dashboard/directives/dashboard.directive.js
+++ b/ang/civicase/dashboard/directives/dashboard.directive.js
@@ -15,15 +15,15 @@
    * Civicase Dashboard Controller.
    *
    * @param {object} $scope controller's scope.
-   * @param {Function} crmApi CRM API service reference.
+   * @param {Function} civicaseCrmApi CRM API service reference.
    * @param {string} currentCaseCategory current case type category setting value.
    * @param {object[]} DashboardActionItems Dashboard action items list.
    * @param {Function} formatActivity Format Activity service reference.
    * @param {Function} $timeout timeout service reference.
    * @param {Function} ts translate service reference.
    */
-  function civicaseDashboardController ($scope, crmApi, currentCaseCategory, DashboardActionItems,
-    formatActivity, $timeout, ts) {
+  function civicaseDashboardController ($scope, civicaseCrmApi,
+    currentCaseCategory, DashboardActionItems, formatActivity, $timeout, ts) {
     $scope.checkPerm = CRM.checkPerm;
     $scope.actionBarItems = DashboardActionItems;
     $scope.url = CRM.url;
@@ -74,8 +74,18 @@
      */
     function bindRouteParamsToScope () {
       $scope.$bindToRoute({ param: 'dtab', expr: 'activeTab', format: 'int', default: 0 });
-      $scope.$bindToRoute({ param: 'drel', expr: 'filters.caseRelationshipType', format: 'raw', default: 'is_involved' });
-      $scope.$bindToRoute({ param: 'case_type_category', expr: 'activityFilters.case_filter["case_type_id.case_type_category"]', format: 'raw', default: null });
+      $scope.$bindToRoute({
+        param: 'drel',
+        expr: 'filters.caseRelationshipType',
+        format: 'raw',
+        default: 'is_involved'
+      });
+      $scope.$bindToRoute({
+        param: 'case_type_category',
+        expr: 'activityFilters.case_filter["case_type_id.case_type_category"]',
+        format: 'raw',
+        default: null
+      });
     }
 
     /**

--- a/ang/civicase/shared/directives/api3-ctrl.directive.js
+++ b/ang/civicase/shared/directives/api3-ctrl.directive.js
@@ -9,7 +9,7 @@
         onRefresh: '@'
       },
       controllerAs: 'civicaseApi3Ctrl',
-      controller: function ($scope, $parse, crmThrottle, crmApi) {
+      controller: function ($scope, $parse, crmThrottle, civicaseCrmApi) {
         var ctrl = this;
 
         // CONSIDER: Trade-offs of upfront vs ongoing evaluation.
@@ -23,7 +23,7 @@
         ctrl.refresh = function refresh () {
           ctrl.loading = true;
           crmThrottle(function () {
-            return crmApi(ctrl.entity, ctrl.action, ctrl.params)
+            return civicaseCrmApi(ctrl.entity, ctrl.action, ctrl.params)
               .then(function (response) {
                 ctrl.result = response;
                 ctrl.loading = ctrl.firstLoad = false;

--- a/ang/civicase/shared/directives/file-uploader.directive.js
+++ b/ang/civicase/shared/directives/file-uploader.directive.js
@@ -16,14 +16,15 @@
   module.controller('civicaseFilesUploaderController', civicaseFilesUploaderController);
   /**
    * @param {object} $scope controllers scope object
-   * @param {object} crmApi service to access civicrm api
+   * @param {object} civicaseCrmApi service to access civicrm api
    * @param {object} crmBlocker crm blocker service
    * @param {object} crmStatus crm status service
    * @param {Function} FileUploader file uploader service
    * @param {object} $q angular queue service
    * @param {object} $timeout timeout service
    */
-  function civicaseFilesUploaderController ($scope, crmApi, crmBlocker, crmStatus, FileUploader, $q, $timeout) {
+  function civicaseFilesUploaderController ($scope, civicaseCrmApi, crmBlocker,
+    crmStatus, FileUploader, $q, $timeout) {
     $scope.block = crmBlocker();
     $scope.ts = CRM.ts('civicase');
     $scope.uploader = createUploader();
@@ -104,7 +105,7 @@
      * @returns {Promise} promise
      */
     function saveActivity () {
-      var promise = crmApi('Activity', 'create', $scope.activity)
+      var promise = civicaseCrmApi('Activity', 'create', $scope.activity)
         .then(function (activity) {
           saveTags(activity.id);
 
@@ -137,7 +138,7 @@
      * @returns {Promise} promise
      */
     function saveTags (activityID) {
-      return crmApi('EntityTag', 'create', {
+      return civicaseCrmApi('EntityTag', 'create', {
         entity_table: 'civicrm_activity',
         tag_id: $scope.tags.selected,
         entity_id: activityID
@@ -174,7 +175,7 @@
      * @returns {Promise} api call promise
      */
     function getTags () {
-      return crmApi('Tag', 'get', {
+      return civicaseCrmApi('Tag', 'get', {
         sequential: 1,
         used_for: { LIKE: '%civicrm_activity%' },
         options: { limit: 0 }

--- a/ang/civicase/shared/directives/panel-query.directive.js
+++ b/ang/civicase/shared/directives/panel-query.directive.js
@@ -48,10 +48,10 @@
    * @param {object} $q angular promise service
    * @param {object} $rootScope rootscope object
    * @param {object} $scope scope object
-   * @param {Function} crmApi crm api service
+   * @param {Function} civicaseCrmApi crm api service
    * @param {Function} ts translation service
    */
-  function civicasePanelQueryController ($q, $rootScope, $scope, crmApi, ts) {
+  function civicasePanelQueryController ($q, $rootScope, $scope, civicaseCrmApi, ts) {
     var PAGE_SIZE = 5;
     var cacheByPage = [];
 
@@ -142,7 +142,7 @@
 
       skipCount && (delete apiCalls.count);
 
-      return crmApi(apiCalls)
+      return civicaseCrmApi(apiCalls)
         .then(function (result) {
           !skipCount && ($scope.total = result.count);
 

--- a/ang/test/civicase/activity/actions/services/move-copy-activity-action.service.spec.js
+++ b/ang/test/civicase/activity/actions/services/move-copy-activity-action.service.spec.js
@@ -3,13 +3,13 @@
 ((_, $) => {
   describe('MoveCopyActivityAction', () => {
     let $q, $rootScope, MoveCopyActivityAction, activitiesMockData,
-      crmApiMock, dialogServiceMock, originalDialogFunction;
+      civicaseCrmApiMock, dialogServiceMock, originalDialogFunction;
 
     beforeEach(module('civicase', 'civicase.data', ($provide) => {
-      crmApiMock = jasmine.createSpy('crmApi');
+      civicaseCrmApiMock = jasmine.createSpy('civicaseCrmApi');
       dialogServiceMock = jasmine.createSpyObj('dialogService', ['open']);
 
-      $provide.value('crmApi', crmApiMock);
+      $provide.value('civicaseCrmApi', civicaseCrmApiMock);
       $provide.value('dialogService', dialogServiceMock);
     }));
 
@@ -105,13 +105,13 @@
             }]];
 
             spyOn($rootScope, '$broadcast');
-            crmApiMock.and.returnValue($q.resolve([{ values: $scope.selectedActivities }]));
+            civicaseCrmApiMock.and.returnValue($q.resolve([{ values: $scope.selectedActivities }]));
             saveMethod();
             $rootScope.$digest();
           });
 
           it('saves a new copy of each of the activities and assign them to the selected case', () => {
-            expect(crmApiMock.calls.mostRecent().args[0]).toEqual(expectedActivitySavingCalls);
+            expect(civicaseCrmApiMock.calls.mostRecent().args[0]).toEqual(expectedActivitySavingCalls);
           });
 
           it('emits a civicase activity updated event', () => {
@@ -129,13 +129,13 @@
             model.case_id = $scope.selectedActivities[0].case_id;
 
             spyOn($rootScope, '$broadcast');
-            crmApiMock.and.returnValue($q.resolve([{ values: $scope.selectedActivities }]));
+            civicaseCrmApiMock.and.returnValue($q.resolve([{ values: $scope.selectedActivities }]));
             saveMethod();
             $rootScope.$digest();
           });
 
           it('does not request the activities data', () => {
-            expect(crmApiMock).not.toHaveBeenCalled();
+            expect(civicaseCrmApiMock).not.toHaveBeenCalled();
           });
 
           it('does not emit the civicase activity updated event', () => {
@@ -195,13 +195,13 @@
               })
             }]];
 
-            crmApiMock.and.returnValue($q.resolve([{ values: $scope.selectedActivities }]));
+            civicaseCrmApiMock.and.returnValue($q.resolve([{ values: $scope.selectedActivities }]));
             saveMethod();
             $rootScope.$digest();
           });
 
           it('saves a new copy of each of the activity and assigns it to the selected case using the new activity subject', () => {
-            expect(crmApiMock.calls.mostRecent().args[0]).toEqual(expectedActivitySavingCalls);
+            expect(civicaseCrmApiMock.calls.mostRecent().args[0]).toEqual(expectedActivitySavingCalls);
           });
         });
       });
@@ -272,13 +272,13 @@
             }]];
 
             spyOn($rootScope, '$broadcast');
-            crmApiMock.and.returnValue($q.resolve([{ values: $scope.selectedActivities }]));
+            civicaseCrmApiMock.and.returnValue($q.resolve([{ values: $scope.selectedActivities }]));
             saveMethod();
             $rootScope.$digest();
           });
 
           it('moves each of the activities and assign them to the selected case', () => {
-            expect(crmApiMock.calls.mostRecent().args[0]).toEqual(expectedActivitySavingCalls);
+            expect(civicaseCrmApiMock.calls.mostRecent().args[0]).toEqual(expectedActivitySavingCalls);
           });
 
           it('emits a civicase activity updated event', () => {
@@ -296,13 +296,13 @@
             model.case_id = $scope.selectedActivities[0].case_id;
 
             spyOn($rootScope, '$broadcast');
-            crmApiMock.and.returnValue($q.resolve([{ values: $scope.selectedActivities }]));
+            civicaseCrmApiMock.and.returnValue($q.resolve([{ values: $scope.selectedActivities }]));
             saveMethod();
             $rootScope.$digest();
           });
 
           it('does not request the activities data', () => {
-            expect(crmApiMock).not.toHaveBeenCalled();
+            expect(civicaseCrmApiMock).not.toHaveBeenCalled();
           });
 
           it('does not emit the civicase activity updated event', () => {
@@ -374,13 +374,13 @@
               })
             }]];
 
-            crmApiMock.and.returnValue($q.resolve([{ values: $scope.selectedActivities }]));
+            civicaseCrmApiMock.and.returnValue($q.resolve([{ values: $scope.selectedActivities }]));
             saveMethod();
             $rootScope.$digest();
           });
 
           it('moves the activity and assigns it to the selected case using the new activity subject', () => {
-            expect(crmApiMock.calls.mostRecent().args[0]).toEqual(expectedActivitySavingCalls);
+            expect(civicaseCrmApiMock.calls.mostRecent().args[0]).toEqual(expectedActivitySavingCalls);
           });
         });
       });

--- a/ang/test/civicase/activity/actions/services/tags-activity-action.service.spec.js
+++ b/ang/test/civicase/activity/actions/services/tags-activity-action.service.spec.js
@@ -3,13 +3,13 @@
 (function (_, $) {
   describe('TagsActivityAction', function () {
     var $q, $rootScope, TagsActivityAction, activitiesMockData, TagsMockData,
-      crmApiMock, dialogServiceMock;
+      civicaseCrmApiMock, dialogServiceMock;
 
     beforeEach(module('civicase', 'civicase.data', function ($provide) {
-      crmApiMock = jasmine.createSpy('crmApi');
+      civicaseCrmApiMock = jasmine.createSpy('civicaseCrmApi');
       dialogServiceMock = jasmine.createSpyObj('dialogService', ['open']);
 
-      $provide.value('crmApi', crmApiMock);
+      $provide.value('civicaseCrmApi', civicaseCrmApiMock);
       $provide.value('dialogService', dialogServiceMock);
     }));
 
@@ -30,7 +30,7 @@
       var $scope = {};
 
       beforeEach(function () {
-        crmApiMock.and.returnValue($q.resolve({ values: TagsMockData.get() }));
+        civicaseCrmApiMock.and.returnValue($q.resolve({ values: TagsMockData.get() }));
         $scope.selectedActivities = activitiesMockData.get();
         TagsActivityAction.doAction($scope, { operation: 'add' });
         $rootScope.$digest();
@@ -38,7 +38,7 @@
       });
 
       it('fetches the tags from the api endpoint', function () {
-        expect(crmApiMock).toHaveBeenCalledWith('Tag', 'get', {
+        expect(civicaseCrmApiMock).toHaveBeenCalledWith('Tag', 'get', {
           sequential: 1,
           used_for: { LIKE: '%civicrm_activity%' },
           options: { limit: 0 }
@@ -90,7 +90,7 @@
           });
 
           it('saves the selected tags to the selected activities', function () {
-            expect(crmApiMock).toHaveBeenCalledWith(apiCalls);
+            expect(civicaseCrmApiMock).toHaveBeenCalledWith(apiCalls);
           });
         });
 
@@ -105,7 +105,7 @@
       var $scope = {};
 
       beforeEach(function () {
-        crmApiMock.and.returnValue($q.resolve({ values: TagsMockData.get() }));
+        civicaseCrmApiMock.and.returnValue($q.resolve({ values: TagsMockData.get() }));
         $scope.selectedActivities = activitiesMockData.get();
         TagsActivityAction.doAction($scope, { operation: 'remove' });
         $rootScope.$digest();
@@ -113,7 +113,7 @@
       });
 
       it('fetches the tags from the api endpoint', function () {
-        expect(crmApiMock).toHaveBeenCalledWith('Tag', 'get', {
+        expect(civicaseCrmApiMock).toHaveBeenCalledWith('Tag', 'get', {
           sequential: 1,
           used_for: { LIKE: '%civicrm_activity%' },
           options: { limit: 0 }
@@ -165,7 +165,7 @@
           });
 
           it('deletes the selected tags to the selected activities', function () {
-            expect(crmApiMock).toHaveBeenCalledWith(apiCalls);
+            expect(civicaseCrmApiMock).toHaveBeenCalledWith(apiCalls);
           });
         });
 

--- a/ang/test/civicase/activity/calendar/directives/activities-calendar.directive.spec.js
+++ b/ang/test/civicase/activity/calendar/directives/activities-calendar.directive.spec.js
@@ -2,7 +2,7 @@
 
 (function ($, _, moment) {
   describe('civicaseActivitiesCalendarController', function () {
-    var $controller, $q, $scope, $rootScope, $route, crmApi, formatActivity, dates,
+    var $controller, $q, $scope, $rootScope, $route, civicaseCrmApi, formatActivity, dates,
       mockedActivities, ActivityStatusType;
 
     beforeEach(function () {
@@ -21,19 +21,19 @@
       jasmine.clock().uninstall();
     });
 
-    beforeEach(inject(function (_$controller_, _$q_, _$rootScope_, _crmApi_,
+    beforeEach(inject(function (_$controller_, _$q_, _$rootScope_, _civicaseCrmApi_,
       _formatActivity_, datesMockData, _ActivityStatusType_) {
       $controller = _$controller_;
       $q = _$q_;
       $rootScope = _$rootScope_;
-      crmApi = _crmApi_;
+      civicaseCrmApi = _civicaseCrmApi_;
       formatActivity = _formatActivity_;
       ActivityStatusType = _ActivityStatusType_;
 
       $scope = $rootScope.$new();
       dates = datesMockData;
 
-      crmApi.and.returnValue($q.resolve({ values: [] }));
+      civicaseCrmApi.and.returnValue($q.resolve({ values: [] }));
     }));
 
     describe('when uib-datepicker signals that it is ready', function () {
@@ -50,7 +50,7 @@
       });
 
       it('loads the days with incomplete activities of the currently selected month', function () {
-        expect(crmApi).toHaveBeenCalledWith('Activity', 'getdayswithactivities', jasmine.objectContaining({
+        expect(civicaseCrmApi).toHaveBeenCalledWith('Activity', 'getdayswithactivities', jasmine.objectContaining({
           status_id: { IN: ActivityStatusType.getAll().incomplete },
           activity_date_time: {
             BETWEEN: [startOfMonth + ' 00:00:00', endOfMonth + ' 23:59:59']
@@ -59,17 +59,17 @@
       });
 
       it('does not load the days with complete activities right away', function () {
-        expect(crmApi.calls.count()).toBe(1);
+        expect(civicaseCrmApi.calls.count()).toBe(1);
       });
 
       describe('when loading is complete', function () {
         beforeEach(function () {
-          crmApi.calls.reset();
+          civicaseCrmApi.calls.reset();
           $scope.$digest();
         });
 
         it('loads the days with complete activities of the currently selected month', function () {
-          expect(crmApi).toHaveBeenCalledWith('Activity', 'getdayswithactivities', jasmine.objectContaining({
+          expect(civicaseCrmApi).toHaveBeenCalledWith('Activity', 'getdayswithactivities', jasmine.objectContaining({
             status_id: ActivityStatusType.getAll().completed[0],
             activity_date_time: {
               BETWEEN: [startOfMonth + ' 00:00:00', endOfMonth + ' 23:59:59']
@@ -92,8 +92,8 @@
         });
 
         it('loads the days with activities from that single cases', function () {
-          var apiParams1 = crmApi.calls.argsFor(0)[2];
-          var apiParams2 = crmApi.calls.argsFor(1)[2];
+          var apiParams1 = civicaseCrmApi.calls.argsFor(0)[2];
+          var apiParams2 = civicaseCrmApi.calls.argsFor(1)[2];
 
           expect(apiParams1.case_id).toEqual($scope.caseId);
           expect(apiParams2.case_id).toEqual($scope.caseId);
@@ -105,7 +105,7 @@
           });
 
           it('loads activities from that single cases when selecting a day', function () {
-            var apiParams = crmApi.calls.argsFor(0)[2];
+            var apiParams = civicaseCrmApi.calls.argsFor(0)[2];
 
             expect(apiParams.case_id).toEqual($scope.caseId);
           });
@@ -126,7 +126,7 @@
         });
 
         it('loads the days with activities from all the given cases', function () {
-          var apiParams1 = crmApi.calls.argsFor(0)[2];
+          var apiParams1 = civicaseCrmApi.calls.argsFor(0)[2];
 
           expect(apiParams1.case_filter).toEqual({ a: 'b' });
         });
@@ -137,7 +137,7 @@
           });
 
           it('loads activities from all the given cases when selecting a day', function () {
-            var apiParams = crmApi.calls.argsFor(0)[2];
+            var apiParams = civicaseCrmApi.calls.argsFor(0)[2];
 
             expect(apiParams.case_filter).toEqual({ a: 'b' });
           });
@@ -160,17 +160,17 @@
           newCaseId = 30;
 
           commonControllerSetup(oldCaseId);
-          crmApi.calls.reset();
+          civicaseCrmApi.calls.reset();
 
           $scope.caseId = newCaseId;
           $scope.$digest();
         });
 
         it('triggers a full reload', function () {
-          expect(crmApi.calls.count()).toBe(2);
+          expect(civicaseCrmApi.calls.count()).toBe(2);
 
           _.times(2, function (i) {
-            expect(crmApi.calls.argsFor(i)).toEqual([
+            expect(civicaseCrmApi.calls.argsFor(i)).toEqual([
               'Activity', 'getdayswithactivities', jasmine.objectContaining({
                 case_id: newCaseId
               })
@@ -197,8 +197,8 @@
        */
       function commonDateSelectSetup () {
         generateMockActivities();
-        crmApi.calls.reset();
-        crmApi.and.returnValue($q.resolve({
+        civicaseCrmApi.calls.reset();
+        civicaseCrmApi.and.returnValue($q.resolve({
           values: mockedActivities
         }));
 
@@ -408,14 +408,14 @@
         });
 
         it('makes an api request', function () {
-          expect(crmApi).toHaveBeenCalledWith('Activity', 'get', jasmine.any(Object));
+          expect(civicaseCrmApi).toHaveBeenCalledWith('Activity', 'get', jasmine.any(Object));
         });
 
         describe('api request params', function () {
           var params;
 
           beforeEach(function () {
-            params = crmApi.calls.argsFor(0)[2];
+            params = civicaseCrmApi.calls.argsFor(0)[2];
           });
 
           it('fetches the activities of the selected date', function () {
@@ -496,13 +496,13 @@
 
           $scope.onDateSelected();
           $scope.$digest();
-          crmApi.calls.reset();
+          civicaseCrmApi.calls.reset();
           $scope.onDateSelected();
           $scope.$digest();
         });
 
         it('uses the cache instead of making an api request', function () {
-          expect(crmApi).not.toHaveBeenCalled();
+          expect(civicaseCrmApi).not.toHaveBeenCalled();
           expect($scope.selectedActivites.length).not.toBe(0);
         });
       });
@@ -527,8 +527,8 @@
         $rootScope.$emit('civicase::uibDaypicker::compiled');
         $scope.$digest();
 
-        crmApi.calls.reset();
-        crmApi.and.returnValue((function () {
+        civicaseCrmApi.calls.reset();
+        civicaseCrmApi.and.returnValue((function () {
           return $q.resolve({
             values: returnDateFromApi ? mockedActivities : []
           });
@@ -539,13 +539,13 @@
     describe('refresh listener', function () {
       beforeEach(function () {
         initControllerAndEmitDatepickerReadyEvent();
-        crmApi.calls.reset();
+        civicaseCrmApi.calls.reset();
         $rootScope.$emit('civicase::ActivitiesCalendar::reload');
         $scope.$digest();
       });
 
       it('triggers a full reload', function () {
-        expect(crmApi.calls.count()).toBe(2);
+        expect(civicaseCrmApi.calls.count()).toBe(2);
       });
     });
 
@@ -564,11 +564,11 @@
         endOfMonth = nextMonth.endOf('month').format('YYYY-MM-DD');
 
         initControllerAndEmitDatepickerReadyEvent();
-        crmApi.calls.reset();
+        civicaseCrmApi.calls.reset();
         $rootScope.$emit('civicase::uibDaypicker::monthSelected', nextMonth.toDate());
         $scope.$digest();
 
-        allArgs = crmApi.calls.allArgs();
+        allArgs = civicaseCrmApi.calls.allArgs();
       });
 
       // @NOTE: the function that loads the data when a new month is selected
@@ -578,11 +578,11 @@
 
       it('invokes the load function after 300ms', function () {
         expect(_.debounce).toHaveBeenCalledWith(jasmine.any(Function), 300);
-        expect(crmApi).toHaveBeenCalled();
+        expect(civicaseCrmApi).toHaveBeenCalled();
       });
 
       it('loads the days with activities of the month of the selected date', function () {
-        expect(crmApi.calls.count()).toBe(2);
+        expect(civicaseCrmApi.calls.count()).toBe(2);
         allArgs.forEach(function (args) {
           expect(args[2].activity_date_time).toEqual({
             BETWEEN: [startOfMonth + ' 00:00:00', endOfMonth + ' 23:59:59']
@@ -663,7 +663,7 @@
      * @param {string} status any|completed|incomplete
      */
     function returnDateForStatus (date, status) {
-      crmApi.and.callFake(function (entity, action, params) {
+      civicaseCrmApi.and.callFake(function (entity, action, params) {
         var dates = [];
         var isCompleteActivitiesApiCall = params.status_id === ActivityStatusType.getAll().completed[0];
         var isIncompleteActivitiesApiCall = _.isEqual(params.status_id.IN, ActivityStatusType.getAll().incomplete);
@@ -703,7 +703,7 @@
 
   describe('Activities Calendar DOM Events', function () {
     var $compile, $q, $rootScope, $scope, $timeout, $uibPosition, activitiesCalendar,
-      crmApi, datepickerMock;
+      civicaseCrmApi, datepickerMock;
 
     beforeEach(module('civicase', 'civicase.data', 'civicase.templates', function ($compileProvider, $provide) {
       $uibPosition = jasmine.createSpyObj('$uibPosition', ['positionElements']);
@@ -722,14 +722,14 @@
       });
     }));
 
-    beforeEach(inject(function (_$compile_, _$q_, _$rootScope_, _$timeout_, _crmApi_) {
+    beforeEach(inject(function (_$compile_, _$q_, _$rootScope_, _$timeout_, _civicaseCrmApi_) {
       $compile = _$compile_;
       $q = _$q_;
       $rootScope = _$rootScope_;
       $timeout = _$timeout_;
-      crmApi = _crmApi_;
+      civicaseCrmApi = _civicaseCrmApi_;
 
-      crmApi.and.returnValue($q.resolve({ values: [] }));
+      civicaseCrmApi.and.returnValue($q.resolve({ values: [] }));
 
       $('<div id="bootstrap-theme"></div>').appendTo('body');
     }));

--- a/ang/test/civicase/activity/feed/directives/activity-feed.directive.spec.js
+++ b/ang/test/civicase/activity/feed/directives/activity-feed.directive.spec.js
@@ -3,14 +3,16 @@
 ((_) => {
   describe('civicaseActivityFeed', () => {
     describe('Activity Feed Controller', () => {
-      let $provide, $controller, $rootScope, $scope, $q, crmApi, CaseTypesMockData, activitiesMockData, ActivityType;
-      let activitiesInCurrentPage, totalNumberOfActivities;
+      let $provide, $controller, $rootScope, $scope, $q, civicaseCrmApi,
+        CaseTypesMockData, activitiesMockData, ActivityType,
+        activitiesInCurrentPage, totalNumberOfActivities;
 
       beforeEach(module('civicase', 'civicase.data', (_$provide_) => {
         $provide = _$provide_;
       }));
 
-      beforeEach(inject((_$controller_, _$rootScope_, _$q_, _CaseTypesMockData_, _crmApi_, _activitiesMockData_, _ActivityType_) => {
+      beforeEach(inject((_$controller_, _$rootScope_, _$q_, _CaseTypesMockData_,
+        _civicaseCrmApi_, _activitiesMockData_, _ActivityType_) => {
         $controller = _$controller_;
         $rootScope = _$rootScope_;
         $q = _$q_;
@@ -20,7 +22,7 @@
 
         $scope = $rootScope.$new();
         $scope.$bindToRoute = jasmine.createSpy('$bindToRoute');
-        crmApi = _crmApi_;
+        civicaseCrmApi = _civicaseCrmApi_;
       }));
 
       describe('loadActivities', () => {
@@ -51,14 +53,14 @@
           });
 
           it('requests the activities using the "get" api action', () => {
-            expect(crmApi).toHaveBeenCalledWith({
+            expect(civicaseCrmApi).toHaveBeenCalledWith({
               acts: ['Activity', 'get', jasmine.any(Object)],
               all: ['Activity', 'getcount', jasmine.any(Object)]
             });
           });
 
           it('filters by the activities of the selected activity set and the activity id', () => {
-            const args = crmApi.calls.mostRecent().args[0].acts[2].activity_type_id;
+            const args = civicaseCrmApi.calls.mostRecent().args[0].acts[2].activity_type_id;
 
             expect(args).toEqual({ IN: expectedActivityTypeIDs });
           });
@@ -72,7 +74,7 @@
           });
 
           it('requests the activities using the "get contact activities" api action', () => {
-            expect(crmApi).toHaveBeenCalledWith({
+            expect(civicaseCrmApi).toHaveBeenCalledWith({
               acts: ['Activity', 'getcontactactivities', jasmine.any(Object)],
               all: ['Activity', 'getcontactactivitiescount', jasmine.any(Object)]
             });
@@ -95,7 +97,7 @@
           });
 
           it('updates the activity feed', () => {
-            expect(crmApi).toHaveBeenCalledWith({
+            expect(civicaseCrmApi).toHaveBeenCalledWith({
               acts: ['Activity', 'get', jasmine.any(Object)],
               all: ['Activity', 'getcount', jasmine.any(Object)]
             });
@@ -274,7 +276,7 @@
         });
 
         it('shows records starting from the clicked month', () => {
-          expect(crmApi).toHaveBeenCalledWith(jasmine.objectContaining({
+          expect(civicaseCrmApi).toHaveBeenCalledWith(jasmine.objectContaining({
             acts: ['Activity', 'get', jasmine.objectContaining({
               options: jasmine.objectContaining({
                 offset: 10
@@ -349,7 +351,7 @@
        * Mocks Activities API calls
        */
       function mockActivitiesAPICall () {
-        crmApi.and.returnValue($q.resolve({
+        civicaseCrmApi.and.returnValue($q.resolve({
           acts: { values: activitiesInCurrentPage },
           all: totalNumberOfActivities
         }));

--- a/ang/test/civicase/activity/feed/directives/activity-month-nav.directive.spec.js
+++ b/ang/test/civicase/activity/feed/directives/activity-month-nav.directive.spec.js
@@ -81,18 +81,18 @@
     });
 
     describe('Activity Month Nav Controller', function () {
-      var $scope, $controller, $rootScope, crmApi, $q, monthNavMockData;
+      var $scope, $controller, $rootScope, civicaseCrmApi, $q, monthNavMockData;
 
       beforeEach(module('civicase', 'civicase.data'));
 
-      beforeEach(inject(function (_$controller_, _$rootScope_, _crmApi_, _$q_, _monthNavMockData_) {
+      beforeEach(inject(function (_$controller_, _$rootScope_, _civicaseCrmApi_, _$q_, _monthNavMockData_) {
         $controller = _$controller_;
         $rootScope = _$rootScope_;
         $q = _$q_;
         monthNavMockData = _monthNavMockData_;
 
         $scope = $rootScope.$new();
-        crmApi = _crmApi_;
+        civicaseCrmApi = _civicaseCrmApi_;
       }));
 
       describe('when activity feed has loaded all records', function () {
@@ -104,7 +104,7 @@
             var overdueFirst = false;
             monthData = monthNavMockData.get();
 
-            crmApi.and.returnValue($q.resolve({
+            civicaseCrmApi.and.returnValue($q.resolve({
               months: { values: monthData }
             }));
 
@@ -178,7 +178,7 @@
             var overdueFirst = true;
             monthData = monthNavMockData.get();
 
-            crmApi.and.returnValue($q.resolve({
+            civicaseCrmApi.and.returnValue($q.resolve({
               months_with_overdue: { values: monthData },
               months_wo_overdue: { values: [] }
             }));
@@ -232,7 +232,7 @@
            different params`, function () {
           beforeEach(function () {
             var monthData = monthNavMockData.get();
-            crmApi.and.returnValue($q.resolve({
+            civicaseCrmApi.and.returnValue($q.resolve({
               months: { values: monthData }
             }));
 
@@ -253,14 +253,14 @@
           });
 
           it('fetches the months data for changed parameters', function () {
-            expect(crmApi.calls.count()).toBe(2);
+            expect(civicaseCrmApi.calls.count()).toBe(2);
           });
         });
 
         describe(`when activity feed query event is fired with
            same params`, function () {
           beforeEach(function () {
-            crmApi.and.returnValue($q.resolve({
+            civicaseCrmApi.and.returnValue($q.resolve({
               months: { values: monthNavMockData.get() }
             }));
 
@@ -281,7 +281,7 @@
           });
 
           it('does not fetch the months data again', function () {
-            expect(crmApi.calls.count()).toBe(1);
+            expect(civicaseCrmApi.calls.count()).toBe(1);
           });
         });
       });
@@ -289,7 +289,7 @@
       describe('my activities filter', function () {
         beforeEach(function () {
           var monthData = monthNavMockData.get();
-          crmApi.and.returnValue($q.resolve({
+          civicaseCrmApi.and.returnValue($q.resolve({
             months: { values: monthData }
           }));
 
@@ -306,7 +306,7 @@
           });
 
           it('creates the month list based on the my activity filter', function () {
-            expect(crmApi).toHaveBeenCalledWith({
+            expect(civicaseCrmApi).toHaveBeenCalledWith({
               months: [
                 'Activity', 'getmonthswithactivities', {
                   isMyActivitiesFilter: true
@@ -325,7 +325,7 @@
           });
 
           it('creates the month list without the my activity filter', function () {
-            expect(crmApi).toHaveBeenCalledWith({
+            expect(civicaseCrmApi).toHaveBeenCalledWith({
               months: [
                 'Activity', 'getmonthswithactivities', {}
               ]

--- a/ang/test/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.spec.js
+++ b/ang/test/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.spec.js
@@ -6,7 +6,7 @@
 
     beforeEach(module('civicase', 'civicase.data'));
 
-    beforeEach(inject((_$controller_, _$rootScope_, _CasesData_, _CaseTypeCategory_, _crmApi_) => {
+    beforeEach(inject((_$controller_, _$rootScope_, _CasesData_, _CaseTypeCategory_) => {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       CaseTypeCategory = _CaseTypeCategory_;

--- a/ang/test/civicase/case/contact-case-tab/directives/contact-case-tab-case-list.directive.spec.js
+++ b/ang/test/civicase/case/contact-case-tab/directives/contact-case-tab-case-list.directive.spec.js
@@ -5,24 +5,24 @@
 
     beforeEach(module('civicase', 'civicase.templates', 'civicase.data'));
 
-    beforeEach(inject(function (_$q_, _$compile_, _$rootScope_, _crmApi_, _CasesData_) {
+    beforeEach(inject(function (_$q_, _$compile_, _$rootScope_, _CasesData_) {
       $compile = _$compile_;
       $rootScope = _$rootScope_;
       $scope = $rootScope.$new();
       CasesData = {
-        'name': 'opened',
-        'title': 'Open Cases',
-        'filterParams': {
+        name: 'opened',
+        title: 'Open Cases',
+        filterParams: {
           'status_id.grouping': 'Opened',
-          'contact_id': jasmine.any(Number)
+          contact_id: jasmine.any(Number)
         },
-        'isLoaded': false,
-        'showSpinner': false,
-        'cases': _CasesData_.get(),
-        'isLoadMoreAvailable': true,
-        'page': {
-          'size': 3,
-          'num': 1
+        isLoaded: false,
+        showSpinner: false,
+        cases: _CasesData_.get(),
+        isLoadMoreAvailable: true,
+        page: {
+          size: 3,
+          num: 1
         }
       };
     }));

--- a/ang/test/civicase/case/directives/case-overview.directive.spec.js
+++ b/ang/test/civicase/case/directives/case-overview.directive.spec.js
@@ -2,7 +2,7 @@
 (($, _) => {
   describe('CaseOverview', () => {
     let $compile, $provide, $q, $rootScope, $scope, BrowserCache,
-      CasesOverviewStats, crmApi, element, targetElementScope,
+      CasesOverviewStats, civicaseCrmApi, element, targetElementScope,
       CaseStatus, CaseType, CaseTypeFilterer;
 
     beforeEach(module('civicase.data', 'civicase', 'civicase.templates', (_$provide_) => {
@@ -10,12 +10,13 @@
     }));
 
     beforeEach(inject(function (_$compile_, _$q_, _$rootScope_, BrowserCacheMock,
-      _crmApi_, _CasesOverviewStatsData_, _CaseStatus_, _CaseType_, _CaseTypeFilterer_) {
+      _civicaseCrmApi_, _CasesOverviewStatsData_, _CaseStatus_, _CaseType_,
+      _CaseTypeFilterer_) {
       $compile = _$compile_;
       $q = _$q_;
       $rootScope = _$rootScope_;
       $scope = $rootScope.$new();
-      crmApi = _crmApi_;
+      civicaseCrmApi = _civicaseCrmApi_;
       CasesOverviewStats = _CasesOverviewStatsData_.get();
       BrowserCache = BrowserCacheMock;
       CaseStatus = _CaseStatus_;
@@ -24,7 +25,7 @@
 
       BrowserCache.get.and.returnValue([1, 3]);
       $provide.value('BrowserCache', BrowserCache);
-      crmApi.and.returnValue($q.resolve([CasesOverviewStats]));
+      civicaseCrmApi.and.returnValue($q.resolve([CasesOverviewStats]));
       spyOn(CaseTypeFilterer, 'filter').and.callThrough();
     }));
 
@@ -53,7 +54,7 @@
           id: { IN: ['1', '2'] }
         };
 
-        crmApi.and.returnValue($q.resolve([CasesOverviewStats]));
+        civicaseCrmApi.and.returnValue($q.resolve([CasesOverviewStats]));
         expectedCaseTypes = CaseTypeFilterer.filter(expectedFilters);
         CaseTypeFilterer.filter.calls.reset();
         compileDirective({
@@ -73,7 +74,7 @@
 
     describe('Case Status Data', () => {
       beforeEach(() => {
-        crmApi.and.returnValue($q.resolve([CasesOverviewStats]));
+        civicaseCrmApi.and.returnValue($q.resolve([CasesOverviewStats]));
         compileDirective({
           caseTypeCategory: 'Cases',
           caseTypeID: { IN: ['1', '2'] },
@@ -82,7 +83,7 @@
       });
 
       it('fetches the case statistics, but shows all case statuses', () => {
-        expect(crmApi).toHaveBeenCalledWith([['Case', 'getstats', {
+        expect(civicaseCrmApi).toHaveBeenCalledWith([['Case', 'getstats', {
           'case_type_id.case_type_category': 'Cases',
           case_type_id: { IN: ['1', '2'] }
         }]]);
@@ -105,7 +106,7 @@
             .indexBy('value')
             .value();
 
-          crmApi.and.callFake((entity) => {
+          civicaseCrmApi.and.callFake((entity) => {
             const response = entity === 'CaseType'
               ? { values: sampleCaseTypes }
               : [CasesOverviewStats];
@@ -133,7 +134,7 @@
             .indexBy('value')
             .value();
 
-          crmApi.and.callFake((entity) => {
+          civicaseCrmApi.and.callFake((entity) => {
             const response = entity === 'CaseType'
               ? { values: [caseType] }
               : [CasesOverviewStats];

--- a/ang/test/civicase/case/list/directives/case-list-table.directive.spec.js
+++ b/ang/test/civicase/case/list/directives/case-list-table.directive.spec.js
@@ -105,8 +105,8 @@
     }
   });
 
-  fdescribe('CivicaseCaseListTableController', function () {
-    var $controller, $q, $scope, $route, CasesData, crmApi;
+  describe('CivicaseCaseListTableController', function () {
+    var $controller, $q, $scope, $route, CasesData, civicaseCrmApi;
 
     beforeEach(module('civicase', 'civicase.data', 'crmUtil', function ($provide) {
       $provide.value('$route', {

--- a/ang/test/civicase/case/list/directives/case-list-table.directive.spec.js
+++ b/ang/test/civicase/case/list/directives/case-list-table.directive.spec.js
@@ -122,13 +122,13 @@
     }));
 
     beforeEach(inject(function (_$controller_, _$q_, _$route_, $rootScope,
-      _CasesData_, _crmApi_, _formatCase_) {
+      _CasesData_, _civicaseCrmApi_, _formatCase_) {
       $controller = _$controller_;
       $q = _$q_;
       $route = _$route_;
       $scope = $rootScope.$new();
       CasesData = _CasesData_.get();
-      crmApi = _crmApi_;
+      civicaseCrmApi = _civicaseCrmApi_;
       // custom function added by civicrm:
       $scope.$bindToRoute = jasmine.createSpy('$bindToRoute');
       $scope.filters = {
@@ -163,20 +163,20 @@
           ['Case', 'getcaselistheaders']
         ];
 
-        crmApi.and.returnValue($q.resolve([_.cloneDeep(CasesData)]));
+        civicaseCrmApi.and.returnValue($q.resolve([_.cloneDeep(CasesData)]));
         initController();
         $scope.applyAdvSearch($scope.filters);
       });
 
       it('requests the cases data', function () {
-        expect(crmApi).toHaveBeenCalledWith(expectedApiCallParams);
+        expect(civicaseCrmApi).toHaveBeenCalledWith(expectedApiCallParams);
       });
     });
 
     describe('on page number has changed', function () {
       beforeEach(function () {
         addAdditionalMarkup();
-        crmApi.and.returnValue($q.resolve([_.cloneDeep(CasesData)]));
+        civicaseCrmApi.and.returnValue($q.resolve([_.cloneDeep(CasesData)]));
         initController();
         $scope.$digest();
         $('.civicase__case-list-panel').scrollTop(20);

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -2,15 +2,15 @@
 (($, _, crmCheckPerm) => {
   describe('civicaseSearch', () => {
     let $controller, $rootScope, $scope, $timeout, CaseFilters, CaseStatuses, caseTypeCategoriesMockData,
-      CaseTypes, crmApi, currentCaseCategory, customSearchFields, affixOriginalFunction,
+      CaseTypes, civicaseCrmApi, currentCaseCategory, customSearchFields, affixOriginalFunction,
       offsetOriginalFunction, originalParentScope, affixReturnValue, originalBindToRoute;
 
     const SEARCH_EVENT_NAME = 'civicase::case-search::filters-updated';
 
     beforeEach(module('civicase.templates', 'civicase', 'civicase.data', ($provide) => {
-      crmApi = jasmine.createSpy('crmApi');
+      civicaseCrmApi = jasmine.createSpy('civicaseCrmApi');
 
-      $provide.value('crmApi', crmApi);
+      $provide.value('civicaseCrmApi', civicaseCrmApi);
     }));
 
     beforeEach(inject((_$controller_, $q, _$rootScope_, _$timeout_, _CaseFilters_,
@@ -27,7 +27,7 @@
       customSearchFields = _CustomSearchField_.getAll();
       currentCaseCategory = _currentCaseCategory_;
 
-      crmApi.and.returnValue($q.resolve({ values: [] }));
+      civicaseCrmApi.and.returnValue($q.resolve({ values: [] }));
     }));
 
     beforeEach(() => {

--- a/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
+++ b/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
@@ -3,7 +3,7 @@
 ((_) => {
   describe('Contact Case Tab', () => {
     var $controller, $rootScope, $scope, CaseTypeCategoryTranslationService,
-      crmApi, mockContactId, mockContactService, AddCase;
+      civicaseCrmApi, mockContactId, mockContactService, AddCase;
 
     beforeEach(module('civicase.data', 'civicase', ($provide) => {
       mockContactService = jasmine.createSpyObj('Contact', ['getCurrentContactID']);
@@ -12,12 +12,12 @@
     }));
 
     beforeEach(inject((_$controller_, _$rootScope_, _CaseTypeCategoryTranslationService_,
-      _crmApi_, _AddCase_) => {
+      _civicaseCrmApi_, _AddCase_) => {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       CaseTypeCategoryTranslationService = _CaseTypeCategoryTranslationService_;
       AddCase = _AddCase_;
-      crmApi = _crmApi_;
+      civicaseCrmApi = _civicaseCrmApi_;
 
       spyOn(CaseTypeCategoryTranslationService, 'restoreTranslation');
       spyOn(CaseTypeCategoryTranslationService, 'storeTranslation');
@@ -48,7 +48,7 @@
 
     describe('when loading cases', () => {
       it('requests non deleted opened cases for the given contact', () => {
-        expect(crmApi.calls.allArgs()).toContain(jasmine.arrayContaining([
+        expect(civicaseCrmApi.calls.allArgs()).toContain(jasmine.arrayContaining([
           jasmine.objectContaining({
             cases: ['Case', 'getcaselist', jasmine.objectContaining({
               'status_id.grouping': 'Opened',
@@ -61,7 +61,7 @@
       });
 
       it('requests non deleted closed cases for the given contact', () => {
-        expect(crmApi.calls.allArgs()).toContain(jasmine.arrayContaining([
+        expect(civicaseCrmApi.calls.allArgs()).toContain(jasmine.arrayContaining([
           jasmine.objectContaining({
             cases: ['Case', 'getcaselist', jasmine.objectContaining({
               'status_id.grouping': 'Closed',
@@ -74,7 +74,7 @@
       });
 
       it('requests non deleted cases where the contact has a role other than client', () => {
-        expect(crmApi.calls.allArgs()).toContain(jasmine.arrayContaining([
+        expect(civicaseCrmApi.calls.allArgs()).toContain(jasmine.arrayContaining([
           jasmine.objectContaining({
             cases: ['Case', 'getcaselist', jasmine.objectContaining({
               exclude_for_client_id: $scope.contactId,

--- a/ang/test/civicase/contact/directives/contact-card.directive.spec.js
+++ b/ang/test/civicase/contact/directives/contact-card.directive.spec.js
@@ -1,15 +1,16 @@
 /* eslint-env jasmine */
 (function ($) {
   describe('contactCard', function () {
-    var element, crmApi, $q, $compile, $rootScope, $scope, ContactsData, ContactsCache;
+    var element, civicaseCrmApi, $q, $compile, $rootScope, $scope, ContactsData, ContactsCache;
 
     beforeEach(module('civicase.templates', 'civicase', 'civicase.data'));
 
-    beforeEach(inject(function (_$compile_, _$rootScope_, _$q_, _crmApi_, _ContactsData_, _ContactsCache_) {
+    beforeEach(inject(function (_$compile_, _$rootScope_, _$q_, _civicaseCrmApi_,
+      _ContactsData_, _ContactsCache_) {
       $q = _$q_;
       $compile = _$compile_;
       $rootScope = _$rootScope_;
-      crmApi = _crmApi_;
+      civicaseCrmApi = _civicaseCrmApi_;
       ContactsData = _ContactsData_;
       ContactsCache = _ContactsCache_;
       $scope = $rootScope.$new();
@@ -61,7 +62,7 @@
 
       describe('image url', function () {
         beforeEach(function () {
-          crmApi.and.returnValue($q.resolve(ContactsData));
+          civicaseCrmApi.and.returnValue($q.resolve(ContactsData));
           ContactsCache.add(ContactsData.values);
           compileDirective(true, ContactsData.values[0].contact_id, ContactsData.values[0].display_name);
         });
@@ -75,9 +76,9 @@
     /**
      * Compiles the contact card directive.
      *
-     * @param {Boolean} isAvatar
-     * @param {Number} contactID
-     * @param {String} contactDisplayName
+     * @param {boolean} isAvatar is avatar
+     * @param {number} contactID contact id
+     * @param {string} contactDisplayName contacts display name
      */
     function compileDirective (isAvatar, contactID, contactDisplayName) {
       element = $compile('<div civicase-contact-card contacts="contacts" avatar="isAvatar">')($scope);

--- a/ang/test/civicase/contact/services/contacts-cache.service.spec.js
+++ b/ang/test/civicase/contact/services/contacts-cache.service.spec.js
@@ -1,18 +1,18 @@
 /* eslint-env jasmine */
 (function (_) {
   describe('ContactsCache', function () {
-    var $q, $rootScope, ContactsCache, ContactsData, crmApi;
+    var $q, $rootScope, ContactsCache, ContactsData, civicaseCrmApi;
 
     beforeEach(function () {
       module('civicase', 'civicase.data');
     });
 
-    beforeEach(inject(function (_$q_, _$rootScope_, _ContactsCache_, _ContactsData_, _crmApi_) {
+    beforeEach(inject(function (_$q_, _$rootScope_, _ContactsCache_, _ContactsData_, _civicaseCrmApi_) {
       $q = _$q_;
       $rootScope = _$rootScope_;
       ContactsCache = _ContactsCache_;
       ContactsData = _.cloneDeep(_ContactsData_);
-      crmApi = _crmApi_;
+      civicaseCrmApi = _civicaseCrmApi_;
 
       spyOn($rootScope, '$broadcast');
     }));
@@ -32,7 +32,7 @@
       var expectedApiParams;
 
       beforeEach(function () {
-        crmApi.and.returnValue($q.resolve({
+        civicaseCrmApi.and.returnValue($q.resolve({
           values: []
         }));
         expectedApiParams = {
@@ -78,7 +78,7 @@
         });
 
         it('gets the details of sent contacts', function () {
-          expect(crmApi).toHaveBeenCalledWith('Contact', 'get', expectedApiParams);
+          expect(civicaseCrmApi).toHaveBeenCalledWith('Contact', 'get', expectedApiParams);
         });
 
         it('broadcasts an event when new contacts are added', function () {
@@ -99,7 +99,7 @@
         });
 
         it('gets the details of new contacts only', function () {
-          expect(crmApi.calls.mostRecent().args).toEqual(['Contact', 'get', expectedApiParams]);
+          expect(civicaseCrmApi.calls.mostRecent().args).toEqual(['Contact', 'get', expectedApiParams]);
         });
       });
 
@@ -126,7 +126,7 @@
         beforeEach(function () {
           ContactsData.values[0].tags = 'tag1,tag2,tag3';
 
-          crmApi.and.returnValue($q.resolve(ContactsData));
+          civicaseCrmApi.and.returnValue($q.resolve(ContactsData));
           ContactsCache.add(ContactsData.values);
           $rootScope.$digest();
 
@@ -154,7 +154,7 @@
 
       describe('when the contact does not exist', function () {
         beforeEach(function () {
-          crmApi.and.returnValue($q.resolve(ContactsData));
+          civicaseCrmApi.and.returnValue($q.resolve(ContactsData));
           ContactsCache.add(ContactsData.values);
           $rootScope.$digest();
 
@@ -171,7 +171,7 @@
       var returnValue;
 
       beforeEach(function () {
-        crmApi.and.returnValue($q.resolve(ContactsData));
+        civicaseCrmApi.and.returnValue($q.resolve(ContactsData));
         ContactsCache.add(ContactsData.values);
         $rootScope.$digest();
         returnValue = ContactsCache.getImageUrlOf(ContactsData.values[0].contact_id);
@@ -186,7 +186,7 @@
       var returnValue;
 
       beforeEach(function () {
-        crmApi.and.returnValue($q.resolve(ContactsData));
+        civicaseCrmApi.and.returnValue($q.resolve(ContactsData));
         ContactsCache.add(ContactsData.values);
         $rootScope.$digest();
         returnValue = ContactsCache.getContactIconOf(ContactsData.values[0].contact_id);

--- a/ang/test/civicase/dashboard/directives/dashboard-tab.directive.spec.js
+++ b/ang/test/civicase/dashboard/directives/dashboard-tab.directive.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env jasmine */
 (function ($, _, moment) {
   describe('dashboardTabController', function () {
-    var $controller, $rootScope, $scope, crmApi, formatActivity, formatCase,
+    var $controller, $rootScope, $scope, civicaseCrmApi, formatActivity, formatCase,
       mockedCases, ActivityStatusType;
 
     /**
@@ -14,11 +14,11 @@
     }
 
     beforeEach(module('civicase.templates', 'civicase', 'crmUtil'));
-    beforeEach(inject(function (_$controller_, _$rootScope_, _crmApi_,
+    beforeEach(inject(function (_$controller_, _$rootScope_, _civicaseCrmApi_,
       _formatActivity_, _formatCase_, _ActivityStatusType_) {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
-      crmApi = _crmApi_;
+      civicaseCrmApi = _civicaseCrmApi_;
       formatActivity = _formatActivity_;
       formatCase = _formatCase_;
       ActivityStatusType = _ActivityStatusType_;
@@ -32,7 +32,7 @@
 
     beforeEach(inject(function ($q) {
       generateMockedCases();
-      crmApi.and.returnValue($q.resolve({
+      civicaseCrmApi.and.returnValue($q.resolve({
         values: mockedCases
       }));
     }));
@@ -57,7 +57,7 @@
           $scope.filters.caseRelationshipType = 'is_involved';
           $scope.activityFilters.case_filter.foo = newFilterValue;
 
-          crmApi.calls.reset();
+          civicaseCrmApi.calls.reset();
           $scope.$digest();
         });
 

--- a/ang/test/civicase/shared/directives/file-uploader.directive.spec.js
+++ b/ang/test/civicase/shared/directives/file-uploader.directive.spec.js
@@ -2,29 +2,29 @@
 
 (function (_) {
   describe('civicaseFileUploader', function () {
-    var $q, $controller, $rootScope, $scope, crmApi, crmApiMock, TagsMockData;
+    var $q, $controller, $rootScope, $scope, civicaseCrmApi, civicaseCrmApiMock, TagsMockData;
 
     beforeEach(module('civicase', 'civicase.data', ($provide) => {
-      crmApiMock = jasmine.createSpy('crmApi');
+      civicaseCrmApiMock = jasmine.createSpy('civicaseCrmApi');
 
-      $provide.value('crmApi', crmApiMock);
+      $provide.value('civicaseCrmApi', civicaseCrmApiMock);
       $provide.value('FileUploader', function () {
         this.getNotUploadedItems = jasmine.createSpy('getNotUploadedItems');
         this.uploadAllWithPromise = jasmine.createSpy('uploadAllWithPromise');
       });
     }));
 
-    beforeEach(inject(function (_$q_, _$controller_, _$rootScope_, _crmApi_, _TagsMockData_) {
+    beforeEach(inject(function (_$q_, _$controller_, _$rootScope_, _civicaseCrmApi_, _TagsMockData_) {
       $q = _$q_;
       $controller = _$controller_;
       $rootScope = _$rootScope_;
-      crmApi = _crmApi_;
+      civicaseCrmApi = _civicaseCrmApi_;
       TagsMockData = _TagsMockData_;
     }));
 
     describe('displaying tags', function () {
       beforeEach(function () {
-        crmApiMock.and.returnValue($q.resolve({ values: TagsMockData.get() }));
+        civicaseCrmApiMock.and.returnValue($q.resolve({ values: TagsMockData.get() }));
         initController();
       });
 
@@ -33,7 +33,7 @@
       });
 
       it('fetches all tags for associated with activity', () => {
-        expect(crmApi).toHaveBeenCalledWith('Tag', 'get', {
+        expect(civicaseCrmApi).toHaveBeenCalledWith('Tag', 'get', {
           sequential: 1,
           used_for: { LIKE: '%civicrm_activity%' },
           options: { limit: 0 }
@@ -53,7 +53,7 @@
 
     describe('saving activity', function () {
       beforeEach(function () {
-        crmApiMock.and.callFake(function (entity, endpoint, params) {
+        civicaseCrmApiMock.and.callFake(function (entity, endpoint, params) {
           if (entity === 'Activity') {
             return $q.resolve({ id: '101' });
           } else if (entity === 'Tag') {
@@ -71,11 +71,11 @@
       });
 
       it('creates a new file type activity', () => {
-        expect(crmApi).toHaveBeenCalledWith('Activity', 'create', $scope.activity);
+        expect(civicaseCrmApi).toHaveBeenCalledWith('Activity', 'create', $scope.activity);
       });
 
       it('saves the selected tags with respect to the activity', () => {
-        expect(crmApi).toHaveBeenCalledWith('EntityTag', 'create', {
+        expect(civicaseCrmApi).toHaveBeenCalledWith('EntityTag', 'create', {
           entity_table: 'civicrm_activity',
           tag_id: ['102'],
           entity_id: '101'

--- a/ang/test/civicase/shared/directives/panel-query.directive.spec.js
+++ b/ang/test/civicase/shared/directives/panel-query.directive.spec.js
@@ -1,23 +1,23 @@
 /* eslint-env jasmine */
 (function ($, _) {
   describe('panelQuery', function () {
-    var element, $compile, $q, $rootScope, $scope, crmApi, panelQueryScope, mockedResults;
+    var element, $compile, $q, $rootScope, $scope, civicaseCrmApi, panelQueryScope, mockedResults;
     var NO_OF_RESULTS = 10;
 
     beforeEach(module('civicase.templates', 'civicase', 'crmUtil'));
 
-    beforeEach(inject(function (_$compile_, _$q_, _$rootScope_, _crmApi_) {
+    beforeEach(inject(function (_$compile_, _$q_, _$rootScope_, _civicaseCrmApi_) {
       $compile = _$compile_;
       $q = _$q_;
       $rootScope = _$rootScope_;
-      crmApi = _crmApi_;
+      civicaseCrmApi = _civicaseCrmApi_;
 
       $scope = $rootScope.$new();
       mockedResults = _.times(NO_OF_RESULTS, function () {
         return { id: _.random(1, 10) };
       });
 
-      crmApi.and.returnValue($q.resolve({
+      civicaseCrmApi.and.returnValue($q.resolve({
         get: { values: mockedResults },
         count: NO_OF_RESULTS
       }));
@@ -255,11 +255,11 @@
         };
         compileDirective();
 
-        requests = crmApi.calls.argsFor(0)[0];
+        requests = civicaseCrmApi.calls.argsFor(0)[0];
       });
 
       it('sends two api requests on init', function () {
-        expect(crmApi).toHaveBeenCalled();
+        expect(civicaseCrmApi).toHaveBeenCalled();
         expect(_.isObject(requests)).toEqual(true);
         expect(Object.keys(requests).length).toBe(2);
       });
@@ -292,10 +292,10 @@
             beforeEach(function () {
               $scope.queryData.action = 'customaction';
 
-              crmApi.calls.reset();
+              civicaseCrmApi.calls.reset();
               compileDirective();
 
-              requests = crmApi.calls.argsFor(0)[0];
+              requests = civicaseCrmApi.calls.argsFor(0)[0];
               request = requests[Object.keys(requests)[0]];
             });
 
@@ -339,10 +339,10 @@
                   sort: 'some_field ASC'
                 };
 
-                crmApi.calls.reset();
+                civicaseCrmApi.calls.reset();
                 compileDirective();
 
-                requests = crmApi.calls.argsFor(0)[0];
+                requests = civicaseCrmApi.calls.argsFor(0)[0];
                 request = requests[Object.keys(requests)[0]];
                 requestParams = request[2];
               });
@@ -400,10 +400,10 @@
           beforeEach(function () {
             $scope.queryData.countAction = 'customcountaction';
 
-            crmApi.calls.reset();
+            civicaseCrmApi.calls.reset();
             compileDirective();
 
-            requests = crmApi.calls.argsFor(0)[0];
+            requests = civicaseCrmApi.calls.argsFor(0)[0];
             request = requests[Object.keys(requests)[1]];
             action = request[1];
           });
@@ -420,7 +420,7 @@
 
       beforeEach(function () {
         compileDirective();
-        crmApi.calls.reset();
+        civicaseCrmApi.calls.reset();
       });
 
       describe('when the query params change', function () {
@@ -429,12 +429,12 @@
           $scope.queryData.params.baz = 'baz';
           $scope.$digest();
 
-          getRequest = crmApi.calls.argsFor(0)[0].get;
-          countRequest = crmApi.calls.argsFor(0)[0].count;
+          getRequest = civicaseCrmApi.calls.argsFor(0)[0].get;
+          countRequest = civicaseCrmApi.calls.argsFor(0)[0].count;
         });
 
         it('triggers the api requests again', function () {
-          expect(crmApi).toHaveBeenCalled();
+          expect(civicaseCrmApi).toHaveBeenCalled();
         });
 
         it('passes the new params to the api', function () {
@@ -448,14 +448,14 @@
 
         describe('cache', function () {
           beforeEach(function () {
-            crmApi.calls.reset();
+            civicaseCrmApi.calls.reset();
 
             panelQueryScope.pagination.page = 2;
             $scope.$digest();
           });
 
           it('clears the cache', function () {
-            expect(crmApi).toHaveBeenCalled();
+            expect(civicaseCrmApi).toHaveBeenCalled();
           });
         });
       });
@@ -465,12 +465,12 @@
           panelQueryScope.pagination.page = 2;
           panelQueryScope.$digest();
 
-          getRequest = crmApi.calls.argsFor(0)[0].get;
-          countRequest = crmApi.calls.argsFor(0)[0].count;
+          getRequest = civicaseCrmApi.calls.argsFor(0)[0].get;
+          countRequest = civicaseCrmApi.calls.argsFor(0)[0].count;
         });
 
         it('triggers an api request', function () {
-          expect(crmApi).toHaveBeenCalled();
+          expect(civicaseCrmApi).toHaveBeenCalled();
         });
 
         it('triggers the api request to fetch the data', function () {
@@ -492,7 +492,7 @@
           });
 
           it('makes an api request', function () {
-            expect(crmApi).toHaveBeenCalled();
+            expect(civicaseCrmApi).toHaveBeenCalled();
           });
         });
 
@@ -503,14 +503,14 @@
             panelQueryScope.pagination.page = 3;
             panelQueryScope.$digest();
 
-            crmApi.calls.reset();
+            civicaseCrmApi.calls.reset();
 
             panelQueryScope.pagination.page = 2;
             panelQueryScope.$digest();
           });
 
           it('does not make an api request', function () {
-            expect(crmApi).not.toHaveBeenCalled();
+            expect(civicaseCrmApi).not.toHaveBeenCalled();
           });
         });
       });
@@ -523,7 +523,7 @@
         });
 
         it('does not make an additional api call', function () {
-          expect(crmApi.calls.count()).toBe(0);
+          expect(civicaseCrmApi.calls.count()).toBe(0);
         });
       });
 
@@ -536,7 +536,7 @@
         });
 
         it('reloads the panel data', function () {
-          expect(crmApi.calls.count()).toBe(1);
+          expect(civicaseCrmApi.calls.count()).toBe(1);
         });
 
         it('resets the force reload flag', function () {
@@ -616,7 +616,7 @@
         $scope.panelName = panelName;
 
         compileDirective();
-        crmApi.calls.reset();
+        civicaseCrmApi.calls.reset();
       });
 
       describe('when the event passes the panel name', function () {
@@ -626,7 +626,7 @@
           });
 
           it('triggers the api requests again', function () {
-            expect(crmApi).toHaveBeenCalled();
+            expect(civicaseCrmApi).toHaveBeenCalled();
           });
         });
 
@@ -636,7 +636,7 @@
           });
 
           it('triggers the api requests again', function () {
-            expect(crmApi).toHaveBeenCalled();
+            expect(civicaseCrmApi).toHaveBeenCalled();
           });
         });
       });
@@ -647,7 +647,7 @@
         });
 
         it('does not trigger the api requests again', function () {
-          expect(crmApi).not.toHaveBeenCalled();
+          expect(civicaseCrmApi).not.toHaveBeenCalled();
         });
       });
     });

--- a/ang/test/mocks/services/crm-api.factory.mock.js
+++ b/ang/test/mocks/services/crm-api.factory.mock.js
@@ -1,11 +1,12 @@
 /* eslint-env jasmine */
 
 (function () {
-  var module = angular.module('crmUtil');
+  var module = angular.module('civicase');
 
-  module.factory('crmApi', ['$q', function ($q) {
-    var crmApi = jasmine.createSpy('crmApi');
-    crmApi.and.returnValue($q.resolve());
-    return crmApi;
+  module.factory('civicaseCrmApi', ['$q', function ($q) {
+    var civicaseCrmApi = jasmine.createSpy('civicaseCrmApi');
+    civicaseCrmApi.and.returnValue($q.resolve());
+
+    return civicaseCrmApi;
   }]);
 })();


### PR DESCRIPTION
## Overview
Replaced `crmApi` with `civicaseCrmApi` throughout the Civicase application.

## Before/After
No visual change occurred.

## Technical Details
In https://github.com/compucorp/uk.co.compucorp.civicase/pull/438, `civicaseCrmApi` was created. Now this has been applied throughout the application.
When `crmApi` is used with an array of api calls, it suppresses any error thrown by the backend. So errors go unnoticed. Now that we have switched to `civicaseCrmApi`, this will be resolved.