### PR TITLE
CPS-251: Fix Manage Case Relationship filter

### DIFF
--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -248,13 +248,17 @@
 
     /**
      * Executes the search as long as the component is not expanded.
+     *
+     * When `ng-change` is mentioned in `crm-ui-select` directive, the change
+     * listener gets fired before the ng-model is changed.
+     * This function is created to avoid this problem
      */
     function doSearchIfNotExpanded () {
       if ($scope.expanded) {
         return;
       }
 
-      doSearch();
+      $timeout(doSearch);
     }
 
     /**

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -241,6 +241,7 @@
           $scope.expanded = false;
 
           $scope.doSearchIfNotExpanded();
+          $timeout.flush();
         });
 
         it('executes the search', () => {
@@ -252,7 +253,6 @@
       describe('when the search is expanded', () => {
         beforeEach(() => {
           $scope.expanded = true;
-
           $scope.doSearchIfNotExpanded();
         });
 


### PR DESCRIPTION
## Overview
In Manage Case page, when a Relationship filter is applied, the case search gets initiated without applying the filter. But when the relationship filter is changed again, then the previous value gets applied.

## Before
![before](https://user-images.githubusercontent.com/5058867/85539203-38c14900-b633-11ea-84ff-011f296ee736.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/85539094-1d563e00-b633-11ea-9ae3-b77ba6aa8e2f.gif)

## Technical Details
This is a regression of https://github.com/compucorp/uk.co.compucorp.civicase/pull/457/files#diff-5debfe960193b84b126dbfbfe8cd35c4R26, the `crm-ui-select` directive from core has a flaw, when `ng-change` is mentioned in `crm-ui-select` directive, the change listener gets fired before the ng-model is changed. To avoid this `$timeout` is applied. 
On the long run we need to fix this by creating a core PR.