### PR TITLE
CATL-1460: Fix Case Dashboard console errors

### DIFF
--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -51,8 +51,8 @@
     CaseType, CaseTypeFilterer) {
     var BROWSER_CACHE_IDENTIFIER = 'civicase.CaseOverview.hiddenCaseStatuses';
     var MAXIMUM_CASE_TYPES_TO_DISPLAY_BREAKDOWN = 1;
-    var allCaseStatusNames = _.map(CaseStatus.getAll(), 'name');
-    var caseStatusesIndexedByName = _.indexBy(CaseStatus.getAll(), 'name');
+    var allCaseStatusNames = _.map(CaseStatus.getAll(true), 'name');
+    var caseStatusesIndexedByName = _.indexBy(CaseStatus.getAll(true), 'name');
 
     $scope.caseStatuses = [];
     $scope.caseTypes = [];


### PR DESCRIPTION
## Overview
In Case Dashboard, console errors are present.
This happens, when a Case Type has added a disabled Case Status.

## Before
![2020-06-24 at 5 19 PM](https://user-images.githubusercontent.com/5058867/85550778-eab24280-b63e-11ea-93d7-c31014c12fc9.jpg)


## After
![2020-06-24 at 5 18 PM](https://user-images.githubusercontent.com/5058867/85550565-b8a0e080-b63e-11ea-8705-9d9e2edcc5ca.jpg)

## Technical Details
In `case-overview.directive.js`, now requesting all case status's including the disabled.