### PR TITLE
CATL-1462: Release v1.2.1

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/compucorp/uk.co.compucorp.civicase/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2020-06-18</releaseDate>
-  <version>1.2.0</version>
+  <releaseDate>2020-06-24</releaseDate>
+  <version>1.2.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.2.1</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>4.7</ver>
+    <ver>5.24</ver>
   </compatibility>
   <comments></comments>
   <classloader>


### PR DESCRIPTION
## Release Update - 24th June, 2020

### Bug Fixes
* Fixed a bug with Activity Type filter in Activity Feed, the filter had a Multi Select dropdown, but the feature was not supported by CiviCRM core, so it has been changed to a Single Select dropdown. Also, now that searching with Multiple Categories are not supported, the Hyperlink from "Other Cases" in case card has been removed. This feature never worked, because of the above reasons, so we are removing it. https://github.com/compucorp/uk.co.compucorp.civicase/pull/498

* Fixed a bug in Manage Case page, when a Relationship filter is applied, the case search gets initiated without applying the filter. But when the relationship filter is changed again, then the previous value gets applied. https://github.com/compucorp/uk.co.compucorp.civicase/pull/504

* Fixed a bug in Case Dashboard page, when scrolling the tabs affix functionality was not working properly, resulting in broken UI. https://github.com/compucorp/uk.co.compucorp.civicase/pull/503

* Fixed a bug in Case Dashboard page. When a Case Type has added a disabled Case Status, it resulted in console errors. https://github.com/compucorp/uk.co.compucorp.civicase/pull/505

### Notes

The minimum CiviCRM version supported changed to `5.24`