### PR TITLE
CATL-1444: Include inline and tab custom groups when creating cases

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/DisplayAllCustomGroupsInCaseForm.php
+++ b/CRM/Civicase/Hook/BuildForm/DisplayAllCustomGroupsInCaseForm.php
@@ -29,17 +29,21 @@ class CRM_Civicase_Hook_BuildForm_DisplayAllCustomGroupsInCaseForm {
     $formattedCustomGroups = [];
 
     foreach ($customGroups['values'] as $customGroup) {
-      // Will return the right custom fields for the given case type:
-      $customGroupsTree = CRM_Core_BAO_CustomGroup::getTree(
+      // Will return the right custom fields for the given case type.
+      // Fields belonging to other case types are removed.
+      $customGroupTree = CRM_Core_BAO_CustomGroup::getTree(
         self::CASE_ENTITY_NAME,
         NULL,
         $caseId,
         $customGroup['id'],
         $caseType
       );
-      $customGroupsTree = CRM_Core_BAO_CustomGroup::formatGroupTree($customGroupsTree);
-      unset($customGroupsTree['info']);
-      $formattedCustomGroups = array_merge($formattedCustomGroups, $customGroupsTree);
+
+      // Removes extra data not used for displaying the custom fields:
+      $customGroupTree = CRM_Core_BAO_CustomGroup::formatGroupTree($customGroupTree);
+      unset($customGroupTree['info']);
+
+      $formattedCustomGroups = array_merge($formattedCustomGroups, $customGroupTree);
     }
 
     // Adds the actual field element to each custom field:

--- a/CRM/Civicase/Hook/BuildForm/DisplayAllCustomGroupsInCaseForm.php
+++ b/CRM/Civicase/Hook/BuildForm/DisplayAllCustomGroupsInCaseForm.php
@@ -51,6 +51,9 @@ class CRM_Civicase_Hook_BuildForm_DisplayAllCustomGroupsInCaseForm {
    *   True when updating the case form's custom groups.
    */
   private function shouldRun ($form) {
-    return get_class($form) === CRM_Custom_Form_CustomDataByType::class;
+    $isCaseEntity = CRM_Utils_Request::retrieve('type', 'String') === 'Case';
+    $isCustomDataForm = get_class($form) === CRM_Custom_Form_CustomDataByType::class;
+
+    return $isCaseEntity && $isCustomDataForm;
   }
 }

--- a/CRM/Civicase/Hook/BuildForm/DisplayAllCustomGroupsInCaseForm.php
+++ b/CRM/Civicase/Hook/BuildForm/DisplayAllCustomGroupsInCaseForm.php
@@ -6,6 +6,11 @@
 class CRM_Civicase_Hook_BuildForm_DisplayAllCustomGroupsInCaseForm {
 
   /**
+   * The name for the Case entity.
+   */
+  const CASE_ENTITY_NAME = 'Case';
+
+  /**
    * Adds all custom groups (inline/tabs) to the case form.
    *
    * @param CRM_Core_Form $form
@@ -16,15 +21,17 @@ class CRM_Civicase_Hook_BuildForm_DisplayAllCustomGroupsInCaseForm {
       return;
     }
 
-    $caseCategory = $form->getVar('_type');
     $caseId = CRM_Utils_Request::retrieve('entityID', 'Positive');
     $caseType = CRM_Utils_Request::retrieve('subType', 'Positive');
-    $customGroups = CRM_Civicase_APIHelpers_CustomGroups::getAllActiveGroupsForEntity($caseCategory);
+    $customGroups = CRM_Civicase_APIHelpers_CustomGroups::getAllActiveGroupsForEntity(
+      self::CASE_ENTITY_NAME
+    );
     $formattedCustomGroups = [];
 
     foreach ($customGroups['values'] as $customGroup) {
+      // Will return the right custom fields for the given case type:
       $customGroupsTree = CRM_Core_BAO_CustomGroup::getTree(
-        $caseCategory,
+        self::CASE_ENTITY_NAME,
         NULL,
         $caseId,
         $customGroup['id'],
@@ -51,7 +58,7 @@ class CRM_Civicase_Hook_BuildForm_DisplayAllCustomGroupsInCaseForm {
    *   True when updating the case form's custom groups.
    */
   private function shouldRun(CRM_Core_Form $form) {
-    $isCaseEntity = CRM_Utils_Request::retrieve('type', 'String') === 'Case';
+    $isCaseEntity = $form->getVar('_type') === self::CASE_ENTITY_NAME;
     $isCustomDataForm = get_class($form) === CRM_Custom_Form_CustomDataByType::class;
 
     return $isCaseEntity && $isCustomDataForm;

--- a/CRM/Civicase/Hook/BuildForm/DisplayAllCustomGroupsInCaseForm.php
+++ b/CRM/Civicase/Hook/BuildForm/DisplayAllCustomGroupsInCaseForm.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Display all custom groups in case form hook.
+ */
+class CRM_Civicase_Hook_BuildForm_DisplayAllCustomGroupsInCaseForm {
+
+  /**
+   * Adds all custom groups (inline/tabs) to the case form.
+   *
+   * @param CRM_Core_Form $from
+   *   CiviCRM Form
+   */
+  public function run ($form) {
+    if (!$this->shouldRun($form)) {
+      return;
+    }
+
+    $caseCategory = $form->getVar('_type');
+    $caseId = CRM_Utils_Request::retrieve('entityID', 'Positive');
+    $caseType = CRM_Utils_Request::retrieve('subType', 'Positive');
+    $customGroups = CRM_Civicase_APIHelpers_CustomGroups::getAllActiveGroupsForEntity($caseCategory);
+    $formattedCustomGroups = [];
+
+    foreach ($customGroups['values'] as $customGroup) {
+      $customGroupsTree = CRM_Core_BAO_CustomGroup::getTree(
+        $caseCategory,
+        NULL,
+        $caseId,
+        $customGroup['id'],
+        $caseType
+      );
+      $customGroupsTree = CRM_Core_BAO_CustomGroup::formatGroupTree($customGroupsTree);
+      unset($customGroupsTree['info']);
+      $formattedCustomGroups = array_merge($formattedCustomGroups, $customGroupsTree);
+    }
+
+    // Adds the actual field element to each custom field:
+    CRM_Core_BAO_CustomGroup::buildQuickForm($form, $formattedCustomGroups);
+
+    $form->setVar('_groupTree', $formattedCustomGroups);
+  }
+
+  /**
+   * Determines if the hook should run.
+   *
+   * @param CRM_Core_Form $from
+   *   CiviCRM Form
+   *
+   * @return bool
+   *   True when updating the case form's custom groups.
+   */
+  private function shouldRun ($form) {
+    return get_class($form) === CRM_Custom_Form_CustomDataByType::class;
+  }
+}

--- a/CRM/Civicase/Hook/BuildForm/DisplayAllCustomGroupsInCaseForm.php
+++ b/CRM/Civicase/Hook/BuildForm/DisplayAllCustomGroupsInCaseForm.php
@@ -21,8 +21,8 @@ class CRM_Civicase_Hook_BuildForm_DisplayAllCustomGroupsInCaseForm {
       return;
     }
 
-    $caseId = CRM_Utils_Request::retrieve('entityID', 'Positive');
-    $caseType = CRM_Utils_Request::retrieve('subType', 'Positive');
+    $caseId = $form->getVar('_entityId');
+    $caseType = $form->getVar('_subType');
     $customGroups = CRM_Civicase_APIHelpers_CustomGroups::getAllActiveGroupsForEntity(
       self::CASE_ENTITY_NAME
     );
@@ -55,17 +55,23 @@ class CRM_Civicase_Hook_BuildForm_DisplayAllCustomGroupsInCaseForm {
   /**
    * Determines if the hook should run.
    *
+   * The Case Form is targeted to support validation for custom fields. The
+   * Custom Data form is targeted to add the actual fields.
+   *
    * @param CRM_Core_Form $form
    *   CiviCRM Form.
    *
    * @return bool
-   *   True when updating the case form's custom groups.
+   *   True when updating the case form or case form's custom groups.
    */
   private function shouldRun(CRM_Core_Form $form) {
     $isCaseEntity = $form->getVar('_type') === self::CASE_ENTITY_NAME;
     $isCustomDataForm = get_class($form) === CRM_Custom_Form_CustomDataByType::class;
+    $isCaseForm = get_class($form) === CRM_Case_Form_Case::class;
 
-    return $isCaseEntity && $isCustomDataForm;
+    return $isCaseEntity && (
+      $isCustomDataForm || $isCaseForm
+    );
   }
 
 }

--- a/CRM/Civicase/Hook/BuildForm/DisplayAllCustomGroupsInCaseForm.php
+++ b/CRM/Civicase/Hook/BuildForm/DisplayAllCustomGroupsInCaseForm.php
@@ -8,10 +8,10 @@ class CRM_Civicase_Hook_BuildForm_DisplayAllCustomGroupsInCaseForm {
   /**
    * Adds all custom groups (inline/tabs) to the case form.
    *
-   * @param CRM_Core_Form $from
-   *   CiviCRM Form
+   * @param CRM_Core_Form $form
+   *   CiviCRM Form.
    */
-  public function run ($form) {
+  public function run(CRM_Core_Form $form) {
     if (!$this->shouldRun($form)) {
       return;
     }
@@ -44,16 +44,17 @@ class CRM_Civicase_Hook_BuildForm_DisplayAllCustomGroupsInCaseForm {
   /**
    * Determines if the hook should run.
    *
-   * @param CRM_Core_Form $from
-   *   CiviCRM Form
+   * @param CRM_Core_Form $form
+   *   CiviCRM Form.
    *
    * @return bool
    *   True when updating the case form's custom groups.
    */
-  private function shouldRun ($form) {
+  private function shouldRun(CRM_Core_Form $form) {
     $isCaseEntity = CRM_Utils_Request::retrieve('type', 'String') === 'Case';
     $isCustomDataForm = get_class($form) === CRM_Custom_Form_CustomDataByType::class;
 
     return $isCaseEntity && $isCustomDataForm;
   }
+
 }

--- a/civicase.php
+++ b/civicase.php
@@ -188,6 +188,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_CaseCategoryCustomGroupDisplay(),
     new CRM_Civicase_Hook_BuildForm_ModifyCaseTypesForAdvancedSearch(),
     new CRM_Civicase_Hook_BuildForm_AddStyleFieldToCaseCustomGroups(),
+    new CRM_Civicase_Hook_BuildForm_DisplayAllCustomGroupsInCaseForm(),
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview
This PR displays both inline and tab custom groups when creating new cases. Previously, inline custom groups where the only ones being displayed.

## Before
![Open_Case_c8008 (1)](https://user-images.githubusercontent.com/1642119/85808672-9a60e080-b723-11ea-94ad-523254744b1a.png)

## After
![Open_Case_c8008](https://user-images.githubusercontent.com/1642119/85808677-9e8cfe00-b723-11ea-84c2-b6aaf69a424a.png)
![gif](https://user-images.githubusercontent.com/1642119/86154978-c8527600-bad1-11ea-8afe-4dce145302ee.gif)

## Technical Details

We created a new `DisplayAllCustomGroupsInCaseForm` hook that runs when preparing the form used to display custom fields for different entities. The form only runs when updating cases (and their respective case categories).

The custom groups and their fields are stored in the form's `_groupTree` property, but only inline ones. To include all groups we first call `CRM_Civicase_APIHelpers_CustomGroups::getAllActiveGroupsForEntity` to fetch all custom groups for a given case category, then we proceed to prepare the custom group data by passing each element to `CRM_Core_BAO_CustomGroup::formatGroupTree`. Finally, we pass this result to `CRM_Core_BAO_CustomGroup::buildQuickForm` which is what adds the actual field HTML elements.
