### PR TITLE
CATL-1466: Add links to email addresses on peoples tab

### DIFF
--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.html
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.html
@@ -113,7 +113,14 @@
           </td>
           <td class="civicase__people-tab__table-column">{{ role.start_date ? formatDate(role.start_date) : '' }}</td>
           <td class="civicase__people-tab__table-column">{{ role.phone }}</td>
-          <td class="civicase__people-tab__table-column">{{ role.email }}</td>
+          <td class="civicase__people-tab__table-column">
+            <a
+              class="crm-popup"
+              ng-href="{{ 'civicrm/activity/email/add' | civicaseCrmUrl:{ action: 'add', caseid: item.id, reset: 1, cid: role.contact_id } }}"
+            >
+              {{ role.email }}
+            </a>
+          </td>
           <td class="civicase__people-tab__table-column civicase__people-tab__table-column--last">
             <div class="civicase__people-tab__table-assign-icon"
               ng-if="!role.contact_id"
@@ -259,7 +266,14 @@
           <td class="civicase__people-tab__table-column">{{ contact.relationship_description }}</td>
           <td class="civicase__people-tab__table-column">{{ contact.client }}</td>
           <td class="civicase__people-tab__table-column">{{ contact.phone }}</td>
-          <td class="civicase__people-tab__table-column">{{ contact.email }}</td>
+          <td class="civicase__people-tab__table-column">
+            <a
+              class="crm-popup"
+              ng-href="{{ 'civicrm/activity/email/add' | civicaseCrmUrl:{ action: 'add', caseid: item.id, reset: 1, cid: contact.contact_id } }}"
+            >
+              {{ contact.email }}
+            </a>
+          </td>
           <td class="civicase__people-tab__table-column civicase__people-tab__table-column--last">
             <div class="btn-group btn-group-sm">
               <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
## Overview
This PR makes email addresses displayed on the People's tab to be interactive.

## Before
![gif](https://user-images.githubusercontent.com/1642119/86167907-57b55480-bae5-11ea-801b-e1fe04d5a916.gif)
*Note:* The email addresses links visible here are the contact's name that lead to the contact's page, not the actual contact's email address.

## After
![gif](https://user-images.githubusercontent.com/1642119/86167802-2f2d5a80-bae5-11ea-9d8f-693fd188415c.gif)

## Technical Details

The people's tab markup was updated so it uses `crm-popup` class to open the email form for the given contact and case.