### PR TITLE
CATL-1485: Fix for wrong Manager shown on Case Details

### DIFF
--- a/ang/civicase-base/directives/tags-selector.directive.js
+++ b/ang/civicase-base/directives/tags-selector.directive.js
@@ -18,8 +18,9 @@
   /**
    * @param {object} $scope the controller's scope
    * @param {Function} getSelect2Value function to get select 2 values
+   * @param {Function} isTruthy service to check if value is truthy
    */
-  function civicaseTagsSelectorController ($scope, getSelect2Value) {
+  function civicaseTagsSelectorController ($scope, getSelect2Value, isTruthy) {
     $scope.formatTags = formatTags;
     $scope.tags = {
       genericTags: '',
@@ -66,7 +67,7 @@
       parentID = typeof parent !== 'undefined' ? parentID : undefined;
 
       var filteredTags = _.filter(tags, function (child) {
-        return child.parent_id === parentID && child.is_tagset === '0';
+        return child.parent_id === parentID && !isTruthy(child.is_tagset);
       });
 
       if (_.isEmpty(filteredTags)) {
@@ -93,7 +94,7 @@
       var returnArray = [];
 
       var filteredTags = _.filter(tags, function (child) {
-        return !child.parent_id && child.is_tagset === '1';
+        return !child.parent_id && isTruthy(child.is_tagset);
       });
 
       if (_.isEmpty(filteredTags)) {
@@ -102,7 +103,7 @@
 
       _.each(filteredTags, function (tag) {
         var children = _.filter(tags, function (child) {
-          if (child.parent_id === tag.id && child.is_tagset === '0') {
+          if (child.parent_id === tag.id && !isTruthy(child.is_tagset)) {
             child.text = child.name;
             return true;
           }

--- a/ang/civicase-base/factories/is-truthy.factory.js
+++ b/ang/civicase-base/factories/is-truthy.factory.js
@@ -1,0 +1,23 @@
+(function (angular, _, CRM) {
+  var module = angular.module('civicase-base');
+
+  module.factory('isTruthy', function () {
+    return isTruthy;
+  });
+
+  /**
+   * Checks if the sent value is truthy or not.
+   * This is useful because civicrm backend returns truthy values as '1'
+   * and falsy values as '0'
+   *
+   * @param {boolean/number/string} value the value as provided by Select2.
+   * @returns {Array} value
+   */
+  function isTruthy (value) {
+    if (_.isString(value)) {
+      return value === '1';
+    } else {
+      return !!value;
+    }
+  }
+})(angular, CRM._, CRM);

--- a/ang/civicase-base/services/activity-category.service.js
+++ b/ang/civicase-base/services/activity-category.service.js
@@ -5,12 +5,14 @@
 
   /**
    * Activity Category Service
+   *
+   * @param {Function} isTruthy service to check if value is truthy
    */
-  function ActivityCategory () {
+  function ActivityCategory (isTruthy) {
     var allActivityCategories = CRM['civicase-base'].activityCategories;
     var activeActivityCategories = _.chain(allActivityCategories)
       .filter(function (activityCategory) {
-        return activityCategory.is_active === '1';
+        return isTruthy(activityCategory.is_active);
       })
       .indexBy('value')
       .value();

--- a/ang/civicase-base/services/activity-status.service.js
+++ b/ang/civicase-base/services/activity-status.service.js
@@ -5,12 +5,14 @@
 
   /**
    * Activity Status Service
+   *
+   * @param {Function} isTruthy service to check if value is truthy
    */
-  function ActivityStatus () {
+  function ActivityStatus (isTruthy) {
     var allActivityStatuses = CRM['civicase-base'].activityStatuses;
     var activeActivityStatuses = _.chain(allActivityStatuses)
       .filter(function (activityStatus) {
-        return activityStatus.is_active === '1';
+        return isTruthy(activityStatus.is_active);
       })
       .indexBy('value')
       .value();

--- a/ang/civicase-base/services/activity-type.service.js
+++ b/ang/civicase-base/services/activity-type.service.js
@@ -5,12 +5,14 @@
 
   /**
    * Activity Types Service
+   *
+   * @param {Function} isTruthy service to check if value is truthy
    */
-  function ActivityType () {
+  function ActivityType (isTruthy) {
     var allActivityTypes = CRM['civicase-base'].activityTypes;
     var activeActivityTypes = _.chain(allActivityTypes)
       .filter(function (activityType) {
-        return activityType.is_active === '1';
+        return isTruthy(activityType.is_active);
       })
       .indexBy('value')
       .value();

--- a/ang/civicase-base/services/case-status.service.js
+++ b/ang/civicase-base/services/case-status.service.js
@@ -5,12 +5,14 @@
 
   /**
    * Case Status Service
+   *
+   * @param {Function} isTruthy service to check if value is truthy
    */
-  function CaseStatus () {
+  function CaseStatus (isTruthy) {
     var allCaseStatuses = CRM['civicase-base'].caseStatuses;
     var activeCaseStatus = _.chain(allCaseStatuses)
       .filter(function (caseStatus) {
-        return caseStatus.is_active === '1';
+        return isTruthy(caseStatus.is_active);
       })
       .indexBy('value')
       .value();

--- a/ang/civicase-base/services/priority.service.js
+++ b/ang/civicase-base/services/priority.service.js
@@ -5,12 +5,14 @@
 
   /**
    * Priority Service
+   *
+   * @param {Function} isTruthy service to check if value is truthy
    */
-  function Priority () {
+  function Priority (isTruthy) {
     var allPriorities = CRM['civicase-base'].priority;
     var activePriorities = _.chain(allPriorities)
       .filter(function (priority) {
-        return priority.is_active === '1';
+        return isTruthy(priority.is_active);
       })
       .indexBy('value')
       .value();

--- a/ang/civicase/activity/card/directives/activity-card.directive.js
+++ b/ang/civicase/activity/card/directives/activity-card.directive.js
@@ -53,10 +53,11 @@
    * @param {object} DateHelper date helper service
    * @param {object} ts ts service
    * @param {Function} viewInPopup factory to view an activity in a popup
+   * @param {Function} isTruthy service to check if value is truthy
    */
   function caseActivityCardController ($filter, $scope, CaseType,
     CaseTypeCategory, dialogService, civicaseCrmApi, crmBlocker, crmStatus,
-    DateHelper, ts, viewInPopup) {
+    DateHelper, ts, viewInPopup, isTruthy) {
     var caseTypes = CaseType.getAll();
     var caseTypeCategories = CaseTypeCategory.getAll();
 
@@ -101,7 +102,7 @@
      */
     $scope.toggleActivityStar = function ($event, activity) {
       $event.stopPropagation();
-      activity.is_star = activity.is_star === '1' ? '0' : '1';
+      activity.is_star = isTruthy(activity.is_star) ? '0' : '1';
       // Setvalue api avoids messy revisioning issues
       $scope.refresh([['Activity', 'setvalue', {
         id: activity.id,

--- a/ang/civicase/activity/directives/add-activity-menu.directive.js
+++ b/ang/civicase/activity/directives/add-activity-menu.directive.js
@@ -15,8 +15,8 @@
     };
   });
 
-  module.controller('civicaseAddActivityMenuController', function ($scope, getCaseQueryParams, CaseType, ActivityType,
-    ActivityForms) {
+  module.controller('civicaseAddActivityMenuController', function ($scope,
+    getCaseQueryParams, CaseType, ActivityType, ActivityForms, isTruthy) {
     var definition = CaseType.getAll()[$scope.case.case_type_id].definition;
 
     (function init () {
@@ -44,7 +44,7 @@
       _.each(definition.activityTypes, function (actSpec) {
         if (exclude.indexOf(actSpec.name) < 0) {
           var actTypeId = _.findKey(ActivityType.getAll(true), { name: actSpec.name });
-          var ifActivityTypeIsActive = ActivityType.findById(actTypeId).is_active === '1';
+          var ifActivityTypeIsActive = isTruthy(ActivityType.findById(actTypeId).is_active);
 
           if (ifActivityTypeIsActive &&
             (!actSpec.max_instances || !activityCount[actTypeId] || (actSpec.max_instances > parseInt(activityCount[actTypeId])))) {

--- a/ang/civicase/activity/factories/format-activity.factory.js
+++ b/ang/civicase/activity/factories/format-activity.factory.js
@@ -18,9 +18,7 @@
       act.status_name = activityStatuses[act.status_id].name;
       act.status_type = getStatusType(act.status_id);
       act.is_completed = act.status_type !== 'incomplete'; // FIXME doesn't distinguish cancelled from completed
-      act.is_overdue = (typeof act.is_overdue === 'string')
-        ? isTruthy(act.is_overdue)
-        : act.is_overdue;
+      act.is_overdue = isTruthy(act.is_overdue);
       act.color = activityStatuses[act.status_id].color || '#42afcb';
       act.status_css = 'status-type-' + act.status_type + ' activity-status-' + act.status_name.toLowerCase().replace(' ', '-');
 

--- a/ang/civicase/activity/factories/format-activity.factory.js
+++ b/ang/civicase/activity/factories/format-activity.factory.js
@@ -1,21 +1,26 @@
 (function (angular, $, _, CRM) {
   var module = angular.module('civicase');
 
-  module.factory('formatActivity', function (ContactsCache, ActivityStatusType, ActivityStatus, ActivityType, CaseStatus, CaseType) {
+  module.factory('formatActivity', function (ContactsCache, ActivityStatusType,
+    ActivityStatus, ActivityType, CaseStatus, CaseType, isTruthy) {
     var activityTypes = ActivityType.getAll(true);
     var activityStatuses = ActivityStatus.getAll();
     var caseTypes = CaseType.getAll();
     var caseStatuses = CaseStatus.getAll();
 
     return function (act, caseId) {
-      act.category = (activityTypes[act.activity_type_id].grouping ? activityTypes[act.activity_type_id].grouping.split(',') : []);
+      act.category = (activityTypes[act.activity_type_id].grouping
+        ? activityTypes[act.activity_type_id].grouping.split(',')
+        : []);
       act.icon = activityTypes[act.activity_type_id].icon;
       act.type = activityTypes[act.activity_type_id].label;
       act.status = activityStatuses[act.status_id].label;
       act.status_name = activityStatuses[act.status_id].name;
       act.status_type = getStatusType(act.status_id);
       act.is_completed = act.status_type !== 'incomplete'; // FIXME doesn't distinguish cancelled from completed
-      act.is_overdue = (typeof act.is_overdue === 'string') ? (act.is_overdue === '1') : act.is_overdue;
+      act.is_overdue = (typeof act.is_overdue === 'string')
+        ? isTruthy(act.is_overdue)
+        : act.is_overdue;
       act.color = activityStatuses[act.status_id].color || '#42afcb';
       act.status_css = 'status-type-' + act.status_type + ' activity-status-' + act.status_name.toLowerCase().replace(' ', '-');
 
@@ -49,7 +54,7 @@
           if (!contact.relationship_type_id) {
             act.case.client.push(contact);
           }
-          if (contact.manager) {
+          if (isTruthy(contact.manager)) {
             act.case.manager = contact;
           }
         });

--- a/ang/civicase/case/actions/services/email-managers-case-action.service.js
+++ b/ang/civicase/case/actions/services/email-managers-case-action.service.js
@@ -7,8 +7,9 @@
    * EmailManagersCaseAction service callback function.
    *
    * @param {object} ts translation service
+   * @param {Function} isTruthy service to check if value is truthy
    */
-  function EmailManagersCaseAction (ts) {
+  function EmailManagersCaseAction (ts, isTruthy) {
     /**
      * Returns the configuration options to open up a mail popup to
      * communicate with the case managers. Displays an error message
@@ -24,7 +25,7 @@
       var managers = [];
 
       _.each(cases, function (item) {
-        if (item.manager) {
+        if (isTruthy(item.manager)) {
           managers.push(item.manager.contact_id);
         }
       });

--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
@@ -53,9 +53,10 @@
    * @param {object} DateHelper DateHelper
    * @param {object} ts ts
    * @param {object} RelationshipType RelationshipType
+   * @param {Function} isTruthy service to check if value is truthy
    */
   function civicaseViewPeopleController ($q, $scope, allowMultipleCaseClients,
-    civicaseCrmApi, DateHelper, ts, RelationshipType) {
+    civicaseCrmApi, DateHelper, ts, RelationshipType, isTruthy) {
     // The ts() and hs() functions help load strings for this module.
     var CONTACT_CANT_HAVE_ROLE_MESSAGE = ts('Case clients cannot be selected for a case role. Please select another contact.');
     var clients = _.indexBy($scope.item.client, 'contact_id');
@@ -656,7 +657,7 @@ included in the confirmation dialog.
       role.role = relType.label_b_a;
       role.contact_type = relType.contact_type_b;
       role.contact_sub_type = relType.contact_sub_type_b;
-      role.description = (role.manager === '1' ? (ts('Case Manager.') + ' ') : '') + (relType.description || '');
+      role.description = (isTruthy(role.manager) ? (ts('Case Manager.') + ' ') : '') + (relType.description || '');
       role.relationship_type_id = relType.id;
     }
 

--- a/ang/civicase/case/factories/format-case.factory.js
+++ b/ang/civicase/case/factories/format-case.factory.js
@@ -1,7 +1,8 @@
 (function (angular, $, _, CRM) {
   var module = angular.module('civicase');
 
-  module.factory('formatCase', function (formatActivity, ContactsCache, CaseStatus, CaseType) {
+  module.factory('formatCase', function (formatActivity, ContactsCache,
+    CaseStatus, CaseType, isTruthy) {
     var caseTypes = CaseType.getAll();
     var caseStatuses = CaseStatus.getAll(true);
 
@@ -12,7 +13,7 @@
       item.color = caseStatuses[item.status_id].color;
       item.case_type = caseTypes[item.case_type_id].title;
       item.selected = false;
-      item.is_deleted = item.is_deleted === '1';
+      item.is_deleted = isTruthy(item.is_deleted);
 
       countIncompleteOtherTasks(item);
 
@@ -33,7 +34,7 @@
           item.client.push(contact);
         }
 
-        if (contact.manager) {
+        if (isTruthy(contact.manager)) {
           item.manager = contact;
         }
       });

--- a/ang/test/civicase-base/factories/is-truthy.factory.spec.js
+++ b/ang/test/civicase-base/factories/is-truthy.factory.spec.js
@@ -1,0 +1,48 @@
+/* eslint-env jasmine */
+(() => {
+  describe('isTruthy', () => {
+    let isTruthy;
+
+    beforeEach(module('civicase-base'));
+
+    beforeEach(inject((_isTruthy_) => {
+      isTruthy = _isTruthy_;
+    }));
+
+    describe('when tested with "1"', () => {
+      it('returns true', () => {
+        expect(isTruthy('1')).toBe(true);
+      });
+    });
+
+    describe('when tested with "0"', () => {
+      it('returns false', () => {
+        expect(isTruthy('0')).toBe(false);
+      });
+    });
+
+    describe('when tested with 1', () => {
+      it('returns true', () => {
+        expect(isTruthy(1)).toBe(true);
+      });
+    });
+
+    describe('when tested with 0', () => {
+      it('returns false', () => {
+        expect(isTruthy(0)).toBe(false);
+      });
+    });
+
+    describe('when tested with "true"', () => {
+      it('returns false', () => {
+        expect(isTruthy(true)).toBe(true);
+      });
+    });
+
+    describe('when tested with "false"', () => {
+      it('returns false', () => {
+        expect(isTruthy(false)).toBe(false);
+      });
+    });
+  });
+})();

--- a/ang/test/civicase-base/factories/is-truthy.factory.spec.js
+++ b/ang/test/civicase-base/factories/is-truthy.factory.spec.js
@@ -34,7 +34,7 @@
     });
 
     describe('when tested with "true"', () => {
-      it('returns false', () => {
+      it('returns true', () => {
         expect(isTruthy(true)).toBe(true);
       });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3494,8 +3494,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3516,14 +3515,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3538,20 +3535,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3668,8 +3662,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3681,7 +3674,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3696,7 +3688,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3704,14 +3695,12 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3730,7 +3719,6 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -3792,8 +3780,7 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -3821,8 +3808,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3834,7 +3820,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3912,8 +3897,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3949,7 +3933,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3969,7 +3952,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4013,14 +3995,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },


### PR DESCRIPTION
## Overview
In Case Details section, wrong contact was shown as Case Manager. This PR fixes that.

## Before
![2020-07-01 at 1 37 PM](https://user-images.githubusercontent.com/5058867/86219644-1afa6380-bba0-11ea-979b-cdbb4b231808.jpg)

## After
![2020-07-01 at 1 38 PM](https://user-images.githubusercontent.com/5058867/86219712-306f8d80-bba0-11ea-81bb-b832972fc3f2.jpg)

## Technical Details
In `ang/civicase/case/factories/format-case.factory.js`, the manager was set with this condition
```javascript
if (contact.manager) {
  item.manager = contact;
}
```
But the backend sends value like `contact.manager = '0'`, above logic was setting that contact as true. Hence the error.
To fix this, a new factory `isTruthy` has been created, which checks strings as well as boolean values and return true, if `value === '1'`.
```
isTruthy('1') => true
isTruthy(true) => true
isTruthy(1) => true
isTruthy('0') => false
isTruthy(false) => false
isTruthy(0) => false
```

This function has been used throughout the application, to avoid such bugs.