### PR TITLE
CATL-1494: Fix multiple case details tabs issue

### DIFF
--- a/ang/civicase/case/details/directives/case-details.directive.js
+++ b/ang/civicase/case/details/directives/case-details.directive.js
@@ -69,7 +69,7 @@
     $scope.caseDetailsSummaryBlocks = CaseDetailsSummaryBlocks;
     $scope.caseTypesLength = _.size(caseTypes);
     $scope.CRM = CRM;
-    $scope.tabs = CaseDetailsTabs;
+    $scope.tabs = _.cloneDeep(CaseDetailsTabs);
     $scope.trustAsHtml = $sce.trustAsHtml;
     $scope.isMainContentVisible = isMainContentVisible;
     $scope.isPlaceHolderVisible = isPlaceHolderVisible;

--- a/ang/civicase/case/details/directives/case-details.directive.js
+++ b/ang/civicase/case/details/directives/case-details.directive.js
@@ -60,7 +60,6 @@
     var caseStatuses = $scope.caseStatuses = CaseStatus.getAll();
     var activityTypes = $scope.activityTypes = ActivityType.getAll(true);
     var panelLimit = 5;
-    var isDetailsTabIncluded = false;
 
     $scope.areDetailsLoaded = false;
     $scope.areRelatedCasesVisibleOnSummaryTab = false;
@@ -378,12 +377,11 @@
      */
     function includeDetailsTab () {
       var shouldAddDetailsTab = !_.isEmpty($scope.item.customData.Tab);
+      var isDetailsTabIncluded = !!_.find($scope.tabs, { name: 'Details' });
 
       if (!shouldAddDetailsTab || isDetailsTabIncluded) {
         return;
       }
-
-      isDetailsTabIncluded = true;
 
       $scope.tabs.splice(1, 0, {
         name: 'Details',

--- a/ang/test/civicase/case/details/directives/case-details.directive.spec.js
+++ b/ang/test/civicase/case/details/directives/case-details.directive.spec.js
@@ -540,6 +540,39 @@
           });
         });
 
+        describe('when there are data custom blocks and the case details are updated', () => {
+          let detailsTabsCount;
+
+          beforeEach(() => {
+            customDataBlocks = [
+              generateCustomDataBlock({ style: 'Inline' }),
+              generateCustomDataBlock({ style: 'Tab' }),
+              generateCustomDataBlock({ style: 'Inline' })
+            ];
+            caseItem['api.CustomValue.getalltreevalues'] = {
+              values: customDataBlocks
+            };
+            initController(caseItem);
+
+            // refresh case details:
+            caseItem['api.Case.getcaselist.relatedCasesByContact'] = { values: [] };
+            caseItem['api.Case.getcaselist.linkedCases'] = { values: [] };
+            caseItem['api.Activity.get.recentCommunication'] = { values: [] };
+            caseItem['api.Activity.get.tasks'] = { values: [] };
+            caseItem['api.Activity.get.nextActivitiesWhichIsNotMileStone'] = { values: [] };
+            caseItem['api.CustomValue.getalltreevalues'] = {
+              values: customDataBlocks
+            };
+            $scope.pushCaseData(caseItem);
+
+            detailsTabsCount = _.where($scope.tabs, { name: 'Details' }).length;
+          });
+
+          it('does not add the case details tab multiple times', () => {
+            expect(detailsTabsCount).toBe(1);
+          });
+        });
+
         /**
          * @param {object} defaultValues default values to use when generating the
          *   custom data block.


### PR DESCRIPTION
## Overview
This PR fixes an issue with the case details tabs where multiple tabs would be shown when refreshing the manage cases page.

## Before
![gif](https://user-images.githubusercontent.com/1642119/86419813-714fcb00-bca2-11ea-94d8-92ae87cff398.gif)

## After
![gif](https://user-images.githubusercontent.com/1642119/86419917-c25fbf00-bca2-11ea-958c-1a2f93ea50b2.gif)

## Technical Details

The issue happened because we kept track of the details tab insertion using a variable. The value of this variable would be forgotten each time the manage case page was reloaded. Another issue is that we were modifying the original list of case tabs and that is why the number of tabs was conserved even when the page was reloaded. 