### PR TITLE
CPS-270: Show webforms without any Case Types

### DIFF
--- a/ang/civicase/case/actions/services/go-to-webform-case-action.service.js
+++ b/ang/civicase/case/actions/services/go-to-webform-case-action.service.js
@@ -9,7 +9,7 @@
   function GoToWebformCaseAction ($window) {
     this.doAction = doAction;
     this.isActionAllowed = isActionAllowed;
-    this.checkIfWebformContainsCaseTypeId = checkIfWebformContainsCaseTypeId;
+    this.checkIfWebformVisible = checkIfWebformVisible;
 
     /**
      * Click event handler for the Action
@@ -40,7 +40,7 @@
      * @returns {boolean} - true if action is allowed, false otherwise.
      */
     function isActionAllowed (action, cases, attributes) {
-      return checkIfWebformContainsCaseTypeId(action, cases[0].case_type_id);
+      return checkIfWebformVisible(action, cases[0].case_type_id);
     }
 
     /**
@@ -48,8 +48,9 @@
      * @param {string} caseTypeID case type id
      * @returns {boolean} if webform contains sent case type id
      */
-    function checkIfWebformContainsCaseTypeId (webform, caseTypeID) {
-      return webform.case_type_ids.indexOf(caseTypeID) !== -1;
+    function checkIfWebformVisible (webform, caseTypeID) {
+      return webform.case_type_ids.length === 0 ||
+        webform.case_type_ids.indexOf(caseTypeID) !== -1;
     }
   }
 })(angular, CRM.$, CRM._);

--- a/ang/civicase/case/actions/services/go-to-webform-case-action.service.js
+++ b/ang/civicase/case/actions/services/go-to-webform-case-action.service.js
@@ -46,7 +46,7 @@
     /**
      * @param {object} webform webform action object
      * @param {string} caseTypeID case type id
-     * @returns {boolean} if webform contains sent case type id
+     * @returns {boolean} if sent webform is visible for sent case type id
      */
     function checkIfWebformVisible (webform, caseTypeID) {
       return webform.case_type_ids.length === 0 ||

--- a/ang/civicase/case/actions/services/webforms-case-action.service.js
+++ b/ang/civicase/case/actions/services/webforms-case-action.service.js
@@ -36,7 +36,7 @@
      */
     function checkIfWebformsExist (webforms, caseTypeID) {
       return !!_.find(webforms, function (webform) {
-        return GoToWebformCaseAction.checkIfWebformContainsCaseTypeId(webform, caseTypeID);
+        return GoToWebformCaseAction.checkIfWebformVisible(webform, caseTypeID);
       });
     }
   }

--- a/ang/test/civicase/case/actions/services/go-to-webforms-case-action.service.spec.js
+++ b/ang/test/civicase/case/actions/services/go-to-webforms-case-action.service.spec.js
@@ -1,0 +1,56 @@
+/* eslint-env jasmine */
+
+(function (_, $) {
+  describe('GoToWebformCaseAction', function () {
+    var GoToWebformCaseAction, CaseActionsData;
+
+    beforeEach(module('civicase', 'civicase.data'));
+
+    beforeEach(inject(function (_GoToWebformCaseAction_, _CaseActionsData_) {
+      GoToWebformCaseAction = _GoToWebformCaseAction_;
+      CaseActionsData = _CaseActionsData_;
+    }));
+
+    describe('checkIfWebformVisible()', function () {
+      let goToWebformAction;
+
+      describe('when webform has a case type id assigned', function () {
+        describe('and viewing a case type which is selected for the webform', () => {
+          beforeEach(function () {
+            goToWebformAction = _.find(CaseActionsData.get(), function (action) {
+              return action.action === 'Webforms';
+            }).items[0];
+          });
+
+          it('displays the action link', function () {
+            expect(GoToWebformCaseAction.checkIfWebformVisible(goToWebformAction, '3')).toBeTrue();
+          });
+        });
+
+        describe('and viewing a case type which is not selected for the webform', () => {
+          beforeEach(function () {
+            goToWebformAction = _.find(CaseActionsData.get(), function (action) {
+              return action.action === 'Webforms';
+            }).items[0];
+          });
+
+          it('does not display the action link', function () {
+            expect(GoToWebformCaseAction.checkIfWebformVisible(goToWebformAction, '5')).toBeFalse();
+          });
+        });
+      });
+
+      describe('when webform has no case type id assigned', function () {
+        beforeEach(function () {
+          goToWebformAction = _.find(CaseActionsData.get(), function (action) {
+            return action.action === 'Webforms';
+          }).items[2];
+        });
+
+        it('displays the action link', function () {
+          expect(GoToWebformCaseAction.checkIfWebformVisible(goToWebformAction, '2')).toBeTrue();
+        });
+      });
+    });
+  });
+})(CRM._, CRM.$);

--- a/ang/test/mocks/data/case-actions.data.js
+++ b/ang/test/mocks/data/case-actions.data.js
@@ -32,6 +32,13 @@
       case_type_ids: ['4'],
       clientID: '1',
       icon: 'fa-link'
+    }, {
+      title: 'Not Assigned Webform',
+      action: 'GoToWebform',
+      path: 'content/not-assigned-webform',
+      case_type_ids: [],
+      clientID: '1',
+      icon: 'fa-link'
     }]
   }];
 

--- a/api/v3/Case/Getwebforms.php
+++ b/api/v3/Case/Getwebforms.php
@@ -30,17 +30,17 @@ function _civicrm_api3_case_getwebforms_spec(array &$spec) {
  * @throws API_Exception
  */
 function civicrm_api3_case_getwebforms(array $params) {
-  $webforms = array();
+  $webforms = [];
   $sysInfo = civicrm_api3('System', 'get')['values'][0];
 
   if (!isset($sysInfo['uf']) || $sysInfo['uf'] != 'Drupal') {
-    $out = civicrm_api3_create_success(array());
+    $out = civicrm_api3_create_success([]);
     $out['warning_message'] = 'Only Drupal CMS is supported!';
     return $out;
   }
 
   if (!module_exists('webform_civicrm')) {
-    $out = civicrm_api3_create_success(array());
+    $out = civicrm_api3_create_success([]);
     $out['warning_message'] = '<p>Webform CiviCRM Drupal module is not installed</p>
       <ul><li>In order to link Drupal Webforms directly from CiviCase you need to install the following Drupal module:
       <a href="https://www.drupal.org/project/webform_civicrm">webform_civicrm</a>.</li></ul>';
@@ -59,12 +59,12 @@ function civicrm_api3_case_getwebforms(array $params) {
     $data = unserialize($dao->data);
 
     if ($data['case']['number_of_case'] >= 0) {
-      $webforms[] = array(
+      $webforms[] = [
         'nid' => $dao->nid,
         'title' => $dao->title,
         'case_type_ids' => _get_case_type_ids_from_webform($data),
         'path' => drupal_get_path_alias('node/' . $dao->nid),
-      );
+      ];
     }
   }
 
@@ -88,7 +88,9 @@ function _get_case_type_ids_from_webform(array $webform) {
 
   foreach ($webform['case'] as $cases) {
     foreach ($cases['case'] as $case) {
-      array_push($caseTypeIds, $case['case_type_id']);
+      if (!empty($case['case_type_id'])) {
+        array_push($caseTypeIds, $case['case_type_id']);
+      }
     }
   }
 


### PR DESCRIPTION
## Overview
If a webform does not have any case type assigned to it, we now show that for every case type.

## Before
![2020-07-03 at 12 27 PM](https://user-images.githubusercontent.com/5058867/86440742-a141b180-bd28-11ea-82a9-9cf551744381.jpg)

## After
![2020-07-03 at 12 27 PM](https://user-images.githubusercontent.com/5058867/86440700-8ec77800-bd28-11ea-878e-78a34489712c.jpg)

## Technical Details
1. In `api/v3/Case/Getwebforms.php`, when no case types were assigned, the api used to return `[null]`, instead of an empty array. This is now fixed.
2. In `ang/civicase/case/actions/services/go-to-webform-case-action.service.js`, renamed `checkIfWebformContainsCaseTypeId` to `checkIfWebformVisible`. Now it returns true if the webform does not have any case type assigned.