### PR TITLE
CATL-1487: Fix send mail to case client

### DIFF
--- a/ang/civicase/case/services/cases-utils.service.js
+++ b/ang/civicase/case/services/cases-utils.service.js
@@ -1,7 +1,7 @@
 (function (angular, _) {
   var module = angular.module('civicase');
 
-  module.service('CasesUtils', function (ContactsCache) {
+  module.service('CasesUtils', function (ContactsCache, ts) {
     /**
      * Fetch additional information about the contacts
      *
@@ -27,7 +27,7 @@
     this.getAllCaseClientContactIds = function (contacts) {
       return _.chain(contacts)
         .filter(function (contact) {
-          return contact.role === 'Client';
+          return contact.role === ts('Client');
         })
         .map(function (client) {
           return client.contact_id;

--- a/ang/test/civicase/case/services/cases-utils.service.spec.js
+++ b/ang/test/civicase/case/services/cases-utils.service.spec.js
@@ -2,9 +2,17 @@
 
 ((_) => {
   describe('CasesUtils', () => {
-    var CasesData, ContactsCache, CasesUtils;
+    var CasesData, ContactsCache, CasesUtils, mockTs;
 
-    beforeEach(module('civicase', 'civicase.data'));
+    beforeEach(module('civicase', 'civicase.data', ($provide) => {
+      mockTs = jasmine.createSpy('ts');
+
+      mockTs.and.callFake((string) => {
+        return string;
+      });
+
+      $provide.value('ts', mockTs);
+    }));
 
     beforeEach(inject((_ContactsCache_, _CasesData_, _CasesUtils_) => {
       ContactsCache = _ContactsCache_;
@@ -42,6 +50,30 @@
 
       it('fetches all client contact ids of the case', () => {
         expect(CasesUtils.getAllCaseClientContactIds(cases.contacts)).toEqual(['170']);
+      });
+
+      describe('when the client word has been translated to a different one', () => {
+        beforeEach(() => {
+          cases.contacts = cases.contacts
+            .map((contact) => ({
+              ...contact,
+              role: contact.role === 'Client'
+                ? 'Member'
+                : contact.role
+            }));
+
+          mockTs.and.callFake((string) => {
+            if (string === 'Client') {
+              return 'Member';
+            }
+
+            return string;
+          });
+        });
+
+        it('returns clients even when their roles have been translated', () => {
+          expect(CasesUtils.getAllCaseClientContactIds(cases.contacts)).toEqual(['170']);
+        });
       });
     });
   });


### PR DESCRIPTION
## Overview
This PR fixes an issue where send an email to the case's client would fail when the word "Client" is replaced by a different word.

## Before & After
Note: The word `Client` has been replaced to `Member`.

### Before
![gif](https://user-images.githubusercontent.com/1642119/86505174-78083c00-bd8f-11ea-9cac-0a212a030d08.gif)

### After
![gif](https://user-images.githubusercontent.com/1642119/86505124-1647d200-bd8f-11ea-87c4-c39e0ff2cb87.gif)

## Technical Details

The issue happened because the `getAllCaseClientContactIds` method in the case utils service was checking using the hardcoded `Client` value, but this value could have already been translated to `Member` and so when sending an email no client is found and the email form breaks.

To fix this we simply wrap the word `Client` in a `ts` function before we do the check.