### PR TITLE
FEMS-37: Fix change case status

### DIFF
--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
@@ -47,7 +47,7 @@
               <li>
                 <span class="list-group-item-info">{{ ts("Change status to:") }}</span>
               </li>
-              <li ng-repeat="(id, status) in allowedCaseStatuses" ng-if="id !== item.status_id">
+              <li ng-repeat="status in allowedCaseStatuses" ng-if="status.value !== item.status_id">
                 <a
                   crm-popup-form-success="pushCaseData($data.civicase_reload[0]); refreshCases()"
                   class="crm-popup"
@@ -59,7 +59,7 @@
                         cid: item.client[0].contact_id,
                         caseid: item.id,
                         atype: getActivityType('Change Case Status'),
-                        case_status_id: id,
+                        case_status_id: status.value,
                         civicase_reload: caseGetParams()
                       }
                     }}">

--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
@@ -109,7 +109,6 @@
                   cid: item.client[0].contact_id,
                   caseid: item.id,
                   atype: getActivityType('Change Case Type'),
-                  case_status_id: id,
                   civicase_reload: caseGetParams()
                 }
               }}">


### PR DESCRIPTION
## Overview
This PR fixes an issue where changing a case status from the contact's case tab would fail. This would happen when some case statuses have been deleted.

## Before & After
We created some case statuses (A, B, C), deleted one of them (A), and try to change the status to one of the remaining ones (B or C)

### Before
![gif](https://user-images.githubusercontent.com/1642119/86517720-21cfe300-bdf9-11ea-8388-c43067011053.gif)


### After
![gif](https://user-images.githubusercontent.com/1642119/86517747-53e14500-bdf9-11ea-8392-fdddfd7bc542.gif)

## Technical Details

The problem is that we were using the index of the case status as the `id` for it. In certain cases this works, but it breaks as soon as some statuses get deleted since the wrong id would be assigned to the index. To fix this we use `status.value` which holds the right status id.

We have also removed an extra `case_status_id: id,` parameter that was being sent when changing the case type. There are two reasons for removing this parameter: 1 - we don't need to send the status ID when changing the case type, and 2 - the `id` parameter was empty all the time. This was probably copied straight from the change status parameters. As can be seen from the **after** screen, changing the type works as normal.
