### PR TITLE
CATL-1495: Fix permission issue

### DIFF
--- a/CRM/Civicase/Hook/alterAPIPermissions/CaseCategory.php
+++ b/CRM/Civicase/Hook/alterAPIPermissions/CaseCategory.php
@@ -145,7 +145,7 @@ class CRM_Civicase_Hook_alterAPIPermissions_CaseCategory {
       return $this->getCaseCategoryNameFromCaseTypeCategory($params, 'case_type_category');
     }
 
-    if ($entity == 'custom_value' && $action == 'gettreevalues') {
+    if ($entity == 'custom_value' && ($action == 'gettreevalues' || $action == 'getalltreevalues')) {
       return $this->getCaseCategoryNameFromCaseId($params, 'entity_id');
     }
   }

--- a/CRM/Civicase/Hook/alterAPIPermissions/CaseCategory.php
+++ b/CRM/Civicase/Hook/alterAPIPermissions/CaseCategory.php
@@ -67,8 +67,6 @@ class CRM_Civicase_Hook_alterAPIPermissions_CaseCategory {
     ];
 
     $permissions['case']['get'] = [$basicCasePermissions];
-    $permissions['custom_value']['gettreevalues'] = [$basicCasePermissions];
-    $permissions['custom_value']['getalltreevalues'] = [$basicCasePermissions];
     $permissions['case']['update'] = [$basicCasePermissions];
     $locationTypePermissions = array_merge($permissions['default']['default'], ['access CiviCRM']);
     $permissions['location_type']['get'] = [$locationTypePermissions];
@@ -77,6 +75,7 @@ class CRM_Civicase_Hook_alterAPIPermissions_CaseCategory {
     $permissions['case_type']['get'] = [$basicCasePermissions];
     $permissions['casetype']['getcount'] = [$basicCasePermissions];
     $permissions['custom_value']['gettreevalues'] = [$basicCasePermissions];
+    $permissions['custom_value']['getalltreevalues'] = [$basicCasePermissions];
 
     $this->alterPermissionsForSpecificApiActions($entity, $permissionService, $permissions);
   }

--- a/api/v3/CustomValue/Getalltreevalues.php
+++ b/api/v3/CustomValue/Getalltreevalues.php
@@ -52,5 +52,5 @@ function civicrm_api3_custom_value_getalltreevalues(array $params) {
     );
   }
 
-  return civicrm_api3_create_success($result, $params, 'CustomValue', 'getallgroupstreevalues');
+  return civicrm_api3_create_success($result, $params, 'CustomValue', 'getalltreevalues');
 }


### PR DESCRIPTION
## Overview
This PR fixes a permission issue that happens when saving custom fields belonging to a custom case category.

## Before
![gif](https://user-images.githubusercontent.com/1642119/86639763-7a44e300-bfa7-11ea-8968-0c5b7561836f.gif)

## After
![gif](https://user-images.githubusercontent.com/1642119/86641772-64382200-bfa9-11ea-9ef4-d1ccd6a88ca5.gif)

## Technical Details

The error that was being thrown was 

```
Error in call to CustomValue_getalltreevalues : API permission check failed for CustomValue/getalltreevalues call;
insufficient permission: require ( access my cases and activities or access all cases and activities or basic case information )
```

The issue happened because the new `getalltreevalues` endpoint was trying to use the normal basic case permissions instead of the custom ones for the case category. To fix this we updated the `CRM_Civicase_Hook_alterAPIPermissions_CaseCategory` so the `getalltreevalues` uses the basic custom case permissions.

We also removed an extra permission assignment to `getalltreevalues` since it was duplicated and also defined the right success call for the same endpoint.
