### PR TITLE
CATL-1304: Show popup when clicking on Webform link

### DIFF
--- a/ang/civicase/case/actions/services/go-to-webform-case-action.service.js
+++ b/ang/civicase/case/actions/services/go-to-webform-case-action.service.js
@@ -26,6 +26,12 @@
         urlObject['cid' + action.clientID] = cases[0].client[0].contact_id;
       }
 
+      CRM.alert(
+        ts('Please refresh this page to view updates from the webform submission.'),
+        ts('Refresh'),
+        'info'
+      );
+
       window = $window.open(CRM.url(action.path, urlObject), '_blank');
       window.focus();
     }

--- a/ang/test/civicase/case/actions/services/go-to-webforms-case-action.service.spec.js
+++ b/ang/test/civicase/case/actions/services/go-to-webforms-case-action.service.spec.js
@@ -2,13 +2,14 @@
 
 (function (_, $) {
   describe('GoToWebformCaseAction', function () {
-    var GoToWebformCaseAction, CaseActionsData;
+    var GoToWebformCaseAction, CaseActionsData, CasesData;
 
     beforeEach(module('civicase', 'civicase.data'));
 
-    beforeEach(inject(function (_GoToWebformCaseAction_, _CaseActionsData_) {
+    beforeEach(inject(function (_GoToWebformCaseAction_, _CaseActionsData_, _CasesData_) {
       GoToWebformCaseAction = _GoToWebformCaseAction_;
       CaseActionsData = _CaseActionsData_;
+      CasesData = _CasesData_.get().values;
     }));
 
     describe('checkIfWebformVisible()', function () {
@@ -50,6 +51,27 @@
         it('displays the action link', function () {
           expect(GoToWebformCaseAction.checkIfWebformVisible(goToWebformAction, '2')).toBeTrue();
         });
+      });
+    });
+
+    describe('when clicking on the webform', function () {
+      beforeEach(function () {
+        spyOn(CRM, 'alert');
+
+        var cases = [CasesData[0]];
+        var goToWebformAction = _.find(CaseActionsData.get(), function (action) {
+          return action.action === 'Webforms';
+        }).items[0];
+
+        GoToWebformCaseAction.doAction(cases, goToWebformAction);
+      });
+
+      it('shows an information popup to refresh the page', function () {
+        expect(CRM.alert).toHaveBeenCalledWith(
+          ts('Please refresh this page to view updates from the webform submission.'),
+          ts('Refresh'),
+          'info'
+        );
       });
     });
   });


### PR DESCRIPTION
## Overview
When clicking on Webform link from the dropdown, we now show a popup, asking users to refresh the page to get latest data after submitting the webform

## How it looks?
![2020-07-07 at 4 11 PM](https://user-images.githubusercontent.com/5058867/86769319-9cecff80-c06c-11ea-822a-b3c9a1a18338.jpg)

## Technical Details
In `go-to-webform-case-action.service.js`, added `CRM.alert` function call to show the popup.
