### PR TITLE
CATL-1494: Fix active tab issue

### DIFF
--- a/ang/civicase/case/details/directives/case-details.directive.js
+++ b/ang/civicase/case/details/directives/case-details.directive.js
@@ -447,7 +447,7 @@
      * placeholder and content template.
      */
     function activeTabWatcher () {
-      var activeCaseTab = _.find(CaseDetailsTabs, {
+      var activeCaseTab = _.find($scope.tabs, {
         name: $scope.activeTab
       });
 

--- a/ang/test/civicase/case/details/directives/case-details.directive.spec.js
+++ b/ang/test/civicase/case/details/directives/case-details.directive.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env jasmine */
 (function (_) {
   describe('civicaseCaseDetails', function () {
-    var element, controller, activitiesMockData, $controller, $compile,
+    var $httpBackend, element, controller, activitiesMockData, $controller, $compile,
       $document, $rootScope, $scope, $provide, civicaseCrmApi, civicaseCrmApiMock, $q,
       formatCase, CasesData, CasesUtils, $route;
 
@@ -27,13 +27,14 @@
       $provide.value('formatCase', formatCaseMock);
     }));
 
-    beforeEach(inject(function (_$compile_, _$controller_, _$rootScope_,
-      _$document_, _activitiesMockData_, _CasesData_, _civicaseCrmApi_, _$q_,
-      _formatCase_, _CasesUtils_) {
+    beforeEach(inject(function (_$compile_, _$controller_, _$httpBackend_,
+      _$rootScope_, _$document_, _activitiesMockData_, _CasesData_, _civicaseCrmApi_,
+      _$q_, _formatCase_, _CasesUtils_) {
       $compile = _$compile_;
       $document = _$document_;
       $controller = _$controller_;
       $rootScope = _$rootScope_;
+      $httpBackend = _$httpBackend_;
       activitiesMockData = _activitiesMockData_;
       CasesData = _CasesData_;
       CasesUtils = _CasesUtils_;
@@ -57,14 +58,37 @@
     });
 
     describe('activeTab watcher', function () {
-      beforeEach(function () {
-        compileDirective();
-        element.isolateScope().activeTab = 'People';
-        element.isolateScope().$digest();
+      describe('when switching to an existing tab', () => {
+        beforeEach(function () {
+          compileDirective();
+          element.isolateScope().activeTab = 'People';
+          element.isolateScope().$digest();
+        });
+
+        it('should return active tab content url', function () {
+          expect(element.isolateScope().activeTabContentUrl).toEqual('~/civicase/case/details/directives/tab-content/people.html');
+        });
       });
 
-      it('should return active tab content url', function () {
-        expect(element.isolateScope().activeTabContentUrl).toEqual('~/civicase/case/details/directives/tab-content/people.html');
+      describe('when switching to a custom active tab', () => {
+        beforeEach(function () {
+          $httpBackend.when('GET', '~/civicase/custom-tab.html')
+            .respond(200, '');
+          compileDirective();
+          element.isolateScope().tabs.push({
+            name: 'CustomTab',
+            label: ts('Custom Tab'),
+            service: {
+              activeTabContentUrl: () => '~/civicase/custom-tab.html'
+            }
+          });
+          element.isolateScope().activeTab = 'CustomTab';
+          element.isolateScope().$digest();
+        });
+
+        it('should return active tab content url', function () {
+          expect(element.isolateScope().activeTabContentUrl).toEqual('~/civicase/custom-tab.html');
+        });
       });
     });
 


### PR DESCRIPTION
## Overview
This PR fixes an issue introduced by https://github.com/compucorp/uk.co.compucorp.civicase/pull/513 where it would not be possible to switch to the Details tabs.

## Before
![gif](https://user-images.githubusercontent.com/1642119/86922830-2fd47b00-c0fb-11ea-8cad-59f78a555a68.gif)

## After
![gif](https://user-images.githubusercontent.com/1642119/86922680-fbf95580-c0fa-11ea-945e-5c77579a61b7.gif)

## Technical Details

The issue happened because we were reading the list of tabs from `CaseDetailsTabs` instead of `$scope.tabs`. The former is the list of tabs included by civicase and other extensions, and the later includes these tabs as well, plus any custom tabs added by the case details directive. In this scenario we added the `Details` tab to `$scope.tabs` and that's why we should use this variable when trying to access tabs.