### PR TITLE
RSE-1209: Make Word Replacements To Be At Category Instance Level

### DIFF
--- a/CRM/Civicase/Helper/CaseCategory.php
+++ b/CRM/Civicase/Helper/CaseCategory.php
@@ -3,6 +3,7 @@
 use CRM_Case_BAO_CaseType as CaseType;
 use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
 use CRM_Civicase_Service_CaseManagementUtils as CaseManagementUtils;
+use CRM_Civicase_BAO_CaseCategoryInstance as CaseCategoryInstance;
 
 /**
  * CRM_Civicase_Helper_CaseCategory class.
@@ -112,7 +113,8 @@ class CRM_Civicase_Helper_CaseCategory {
    *   The word to be replaced and replacement array.
    */
   public static function getWordReplacements($caseTypeCategoryName) {
-    $optionName = $caseTypeCategoryName . "_word_replacement";
+    $instanceName = self::getInstanceName($caseTypeCategoryName);
+    $optionName = $instanceName . '_word_replacement';
     try {
       $result = civicrm_api3('OptionValue', 'getsingle', [
         'option_group_id' => 'case_type_category_word_replacement_class',
@@ -319,6 +321,27 @@ class CRM_Civicase_Helper_CaseCategory {
     $instanceClass = $instanceClasses[$instanceValue];
 
     return new $instanceClass($caseCategoryInstance->id);
+  }
+
+  /**
+   * Returns the Category Instance for the Case category.
+   *
+   * @param string $caseCategoryName
+   *   Case category Name.
+   */
+  public static function getInstanceName($caseCategoryName) {
+    try {
+      $result = civicrm_api3('CaseCategoryInstance', 'getsingle', [
+        'category_id' => $caseCategoryName,
+      ]);
+    }
+    catch (Exception $e) {
+      return NULL;
+    }
+
+    $instances = CaseCategoryInstance::buildOptions('instance_id', 'validate');
+
+    return $instances[$result['instance_id']];
   }
 
 }


### PR DESCRIPTION
## Overview
Currently, the word replacements done at the case category level, i.e each case category has it's own word replacement configuration, however since a set of case type categories can share a case category instance, the word replacements now need to be at the instance level. 

## Before
Word replacements is done as the case category level. 

## After
Word replacements is now done at the case category instance level.
Rather than checking for the case category word replacement class, the Instance class is now checked.