### PR TITLE
CATL-1514: Make File Upload Subject Required

### DIFF
--- a/ang/civicase/shared/directives/file-uploader.directive.html
+++ b/ang/civicase/shared/directives/file-uploader.directive.html
@@ -1,4 +1,4 @@
-<form class="panel panel-default civicase__panel-transparent-header">
+<form name="fileUploadForm" class="panel panel-default civicase__panel-transparent-header" ng-submit="saveActivity()">
   <fieldset class="panel-body" ng-disabled="block.check()">
     <div crm-ui-debug="activity"></div>
     <div crm-ui-debug="uploader.queue.length"></div>
@@ -15,7 +15,7 @@
       <div class="civicase__file-upload-details civicase__file-upload-item pull-right">
         <div class="form-group">
           <label for="uploadSubject">{{ts('Activity Subject')}}</label>
-          <input type="text" class="form-control" id="uploadSubject" placeholder="" ng-model="activity.subject">
+          <input type="text" class="form-control" id="uploadSubject" required placeholder="" ng-model="activity.subject">
         </div>
         <div class="row">
           <div class="civicase__file-upload-name col-md-8"><label>{{ts('Name')}}</label></div>
@@ -50,7 +50,7 @@
           <div class="pull-right">
             <button type="button" class="btn btn-default cancel" ng-click="deleteActivity()" >
               <span class="btn-icon"></span> {{ts('Cancel')}}</button>
-            <button type="button" class="btn btn-primary" ng-click="saveActivity()" >
+            <button type="submit" class="btn btn-primary">
               <span class="btn-icon"></span> {{ts('Upload File(s)')}}</button>
           </div>
         </div>

--- a/ang/civicase/shared/directives/file-uploader.directive.html
+++ b/ang/civicase/shared/directives/file-uploader.directive.html
@@ -14,7 +14,10 @@
       </div>
       <div class="civicase__file-upload-details civicase__file-upload-item pull-right">
         <div class="form-group">
-          <label for="uploadSubject">{{ts('Activity Subject')}}</label>
+          <label for="uploadSubject">
+            {{ts('Activity Subject')}}
+            <span class="crm-marker" title="This field is required.">*</span>
+          </label>
           <input type="text" class="form-control" id="uploadSubject" required placeholder="" ng-model="activity.subject">
         </div>
         <div class="row">

--- a/ang/civicase/shared/directives/file-uploader.directive.html
+++ b/ang/civicase/shared/directives/file-uploader.directive.html
@@ -14,9 +14,8 @@
       </div>
       <div class="civicase__file-upload-details civicase__file-upload-item pull-right">
         <div class="form-group">
-          <label for="uploadSubject">
+          <label for="uploadSubject" class="required-mark">
             {{ts('Activity Subject')}}
-            <span class="crm-marker" title="This field is required.">*</span>
           </label>
           <input type="text" class="form-control" id="uploadSubject" required placeholder="" ng-model="activity.subject">
         </div>

--- a/ang/civicase/shared/directives/file-uploader.directive.js
+++ b/ang/civicase/shared/directives/file-uploader.directive.js
@@ -121,6 +121,7 @@
           return delayPromiseBy(1000); // Let the user absorb what happened.
         }).then(function () {
           $scope.uploader.clearQueue();
+          $scope.fileUploadForm.$setPristine();
           initActivity();
           if ($scope.onUpload) {
             $scope.$parent.$eval($scope.onUpload);

--- a/ang/test/civicase/shared/directives/file-uploader.directive.spec.js
+++ b/ang/test/civicase/shared/directives/file-uploader.directive.spec.js
@@ -2,7 +2,8 @@
 
 (function (_) {
   describe('civicaseFileUploader', function () {
-    var $q, $controller, $rootScope, $scope, civicaseCrmApi, civicaseCrmApiMock, TagsMockData;
+    var $q, $controller, $rootScope, $scope, $timeout, civicaseCrmApi,
+      civicaseCrmApiMock, TagsMockData;
 
     beforeEach(module('civicase', 'civicase.data', ($provide) => {
       civicaseCrmApiMock = jasmine.createSpy('civicaseCrmApi');
@@ -14,10 +15,12 @@
       });
     }));
 
-    beforeEach(inject(function (_$q_, _$controller_, _$rootScope_, _civicaseCrmApi_, _TagsMockData_) {
+    beforeEach(inject(function (_$q_, _$controller_, _$rootScope_, _$timeout_,
+      _civicaseCrmApi_, _TagsMockData_) {
       $q = _$q_;
       $controller = _$controller_;
       $rootScope = _$rootScope_;
+      $timeout = _$timeout_;
       civicaseCrmApi = _civicaseCrmApi_;
       TagsMockData = _TagsMockData_;
     }));
@@ -65,9 +68,13 @@
 
         $scope.block = jasmine.createSpy('block');
         $scope.tags.selected = ['102'];
+        $scope.fileUploadForm = jasmine.createSpyObj(['$setPristine']);
+        $scope.uploader = jasmine.createSpyObj([
+          'clearQueue', 'getNotUploadedItems', 'uploadAllWithPromise']);
 
         $scope.saveActivity();
         $scope.$digest();
+        $timeout.flush();
       });
 
       it('creates a new file type activity', () => {
@@ -80,6 +87,14 @@
           tag_id: ['102'],
           entity_id: '101'
         });
+      });
+
+      it('clears the upload queue', () => {
+        expect($scope.uploader.clearQueue).toHaveBeenCalledWith();
+      });
+
+      it('sets the upload form as pristine', () => {
+        expect($scope.fileUploadForm.$setPristine).toHaveBeenCalledWith();
       });
     });
 


### PR DESCRIPTION
## Overview
This PR makes the subject field for the Case's file upload form to be required.

## Before
![gif](https://user-images.githubusercontent.com/1642119/87094568-191e4900-c20d-11ea-9065-d9144fc2574e.gif)

## After
![gif](https://user-images.githubusercontent.com/1642119/87474785-ab4d9500-c5f1-11ea-8983-4079dade834f.gif)

## Technical Details

* We used angular forms to make the field required.
* We made the `Upload File(s)` button a proper submit button.
* We handle the file upload when the form is submitted using `ng-submit="saveActivity()"`.
* The form is set to pristine after it has been submitted using `$scope.fileUploadForm.$setPristine();`
