### PR TITLE
CPS-1304: Increase popup display time to 30 minutes

### DIFF
--- a/ang/civicase/case/actions/services/go-to-webform-case-action.service.js
+++ b/ang/civicase/case/actions/services/go-to-webform-case-action.service.js
@@ -29,7 +29,8 @@
       CRM.alert(
         ts('Please refresh this page to view updates from the webform submission.'),
         ts('Refresh'),
-        'info'
+        'info',
+        { expires: 1800000 }
       );
 
       window = $window.open(CRM.url(action.path, urlObject), '_blank');

--- a/ang/test/civicase/case/actions/services/go-to-webforms-case-action.service.spec.js
+++ b/ang/test/civicase/case/actions/services/go-to-webforms-case-action.service.spec.js
@@ -70,7 +70,8 @@
         expect(CRM.alert).toHaveBeenCalledWith(
           ts('Please refresh this page to view updates from the webform submission.'),
           ts('Refresh'),
-          'info'
+          'info',
+          { expires: 1800000 }
         );
       });
     });


### PR DESCRIPTION
## Overview
The popup about refreshing the page, when a webform was opened, was only visible for 10 seconds. Now it has been increased to 30 minutes.

## Technical Details
In `go-to-webform-case-action.service.js`, added 1800000ms as expire time.