### PR TITLE
CATL-1524: Update tags when model is changed

### DIFF
--- a/ang/civicase-base/directives/tags-selector.directive.js
+++ b/ang/civicase-base/directives/tags-selector.directive.js
@@ -38,6 +38,10 @@
       $scope.$watch('tags', function (tags) {
         $scope.model = prepareTagsForSave(tags);
       }, true);
+
+      $scope.$watch('model', function (model) {
+        $scope.tags = prepareTagsForEditing(model);
+      }, true);
     }());
 
     /**

--- a/ang/test/civicase-base/directives/tags-selector.directive.spec.js
+++ b/ang/test/civicase-base/directives/tags-selector.directive.spec.js
@@ -139,6 +139,25 @@
       });
     });
 
+    describe('when tags are reselected', () => {
+      beforeEach(() => {
+        initController(['1', '12', '15']);
+        $rootScope.$digest();
+        $scope.model = ['1'];
+        $rootScope.$digest();
+      });
+
+      it('resets the selected tags in the UI', () => {
+        expect($scope.tags).toEqual({
+          genericTags: ['1'],
+          tagSets: {
+            6: [],
+            14: []
+          }
+        });
+      });
+    });
+
     describe('when displaying tags', () => {
       let tagMarkup;
 


### PR DESCRIPTION
## Overview
In Case Files Tab, when a file is uploaded with some tags, and then another file is added for upload, the previously selected tabs still show up. This is fixed as part of this PR. Now the tags are cleared after completion of an upload.

## Before
![before](https://user-images.githubusercontent.com/5058867/87391178-e0dd8880-c5c7-11ea-9e8a-1f86d20a6e18.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/87391111-c60b1400-c5c7-11ea-87ea-9675b77eb7d1.gif)

## Technical Details
In `ang/civicase-base/directives/tags-selector.directive.js`, added a watcher for `$scope.model`, to reset the selected tags.