### PR TITLE
RSE-1200: Case Category Custom Field Support Cleanup

### DIFF
--- a/CRM/Civicase/Service/CaseCategoryCaseTypeCustomFieldExtends.php
+++ b/CRM/Civicase/Service/CaseCategoryCaseTypeCustomFieldExtends.php
@@ -13,8 +13,8 @@ class CRM_Civicase_Service_CaseCategoryCaseTypeCustomFieldExtends extends CRM_Ci
   /**
    * {@inheritdoc}
    */
-  protected function getCustomEntityValue($caseCategoryName) {
-    return "{$caseCategoryName}Type";
+  protected function getCustomEntityValue($entityValue) {
+    return "{$entityValue}Type";
   }
 
 }

--- a/CRM/Civicase/Service/CaseCategoryCustomFieldExtends.php
+++ b/CRM/Civicase/Service/CaseCategoryCustomFieldExtends.php
@@ -15,15 +15,15 @@ class CRM_Civicase_Service_CaseCategoryCustomFieldExtends {
   /**
    * Creates the Custom field extend option group for case category.
    *
-   * @param string $caseCategoryName
-   *   Case Category Name.
+   * @param string $entityValue
+   *   Entity Value for the custom entity.
    * @param string $label
    *   Label.
    * @param string $entityTypeFunction
    *   Function to fetch entity types for the entity.
    */
-  public function create($caseCategoryName, $label, $entityTypeFunction = NULL) {
-    $result = $this->getCgExtendOptionValue($caseCategoryName);
+  public function create($entityValue, $label, $entityTypeFunction = NULL) {
+    $result = $this->getCgExtendOptionValue($entityValue);
 
     if ($result['count'] > 0) {
       return;
@@ -33,7 +33,7 @@ class CRM_Civicase_Service_CaseCategoryCustomFieldExtends {
       'option_group_id' => 'cg_extend_objects',
       'name' => $this->entityTable,
       'label' => $label,
-      'value' => $this->getCustomEntityValue($caseCategoryName),
+      'value' => $this->getCustomEntityValue($entityValue),
       'description' => $entityTypeFunction,
       'is_active' => TRUE,
       'is_reserved' => TRUE,
@@ -43,11 +43,11 @@ class CRM_Civicase_Service_CaseCategoryCustomFieldExtends {
   /**
    * Deletes the Custom field extend option group for case category.
    *
-   * @param string $caseCategoryName
-   *   Case Category Name.
+   * @param string $entityValue
+   *   Entity Value for the custom entity.
    */
-  public function delete($caseCategoryName) {
-    $result = $this->getCgExtendOptionValue($caseCategoryName);
+  public function delete($entityValue) {
+    $result = $this->getCgExtendOptionValue($entityValue);
 
     if ($result['count'] == 0) {
       return;
@@ -59,16 +59,16 @@ class CRM_Civicase_Service_CaseCategoryCustomFieldExtends {
   /**
    * Return CG Extend option value.
    *
-   * @param string $caseCategoryName
-   *   Case category name.
+   * @param string $entityValue
+   *   Entity Value for the custom entity.
    *
    * @return array
    *   Cg Extend option value.
    */
-  protected function getCgExtendOptionValue($caseCategoryName) {
+  protected function getCgExtendOptionValue($entityValue) {
     $result = civicrm_api3('OptionValue', 'get', [
       'sequential' => 1,
-      'value' => $this->getCustomEntityValue($caseCategoryName),
+      'value' => $this->getCustomEntityValue($entityValue),
       'option_group_id' => 'cg_extend_objects',
       'name' => $this->entityTable,
     ]);
@@ -79,14 +79,14 @@ class CRM_Civicase_Service_CaseCategoryCustomFieldExtends {
   /**
    * Returns the custom entity value.
    *
-   * @param string $caseCategoryName
-   *   Case category name.
+   * @param string $entityValue
+   *   Entity Value for the custom entity.
    *
    * @return string
    *   Custom entity value.
    */
-  protected function getCustomEntityValue($caseCategoryName) {
-    return $caseCategoryName;
+  protected function getCustomEntityValue($entityValue) {
+    return $entityValue;
   }
 
 }

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -4,7 +4,6 @@ use CRM_Civicase_Setup_CaseTypeCategorySupport as CaseTypeCategorySupport;
 use CRM_Civicase_Setup_CreateCasesOptionValue as CreateCasesOptionValue;
 use CRM_Civicase_Setup_AddCaseCategoryWordReplacementOptionGroup as AddCaseCategoryWordReplacementOptionGroup;
 use CRM_Civicase_Setup_MoveCaseTypesToCasesCategory as MoveCaseTypesToCasesCategory;
-use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 use CRM_Civicase_Setup_CreateSafeFileExtensionOptionValue as CreateSafeFileExtensionOptionValue;
 use CRM_Civicase_Setup_UpdateMenuLinks as MenuLinksSetup;
 use CRM_Civicase_Uninstall_RemoveCustomGroupSupportForCaseCategory as RemoveCustomGroupSupportForCaseCategory;
@@ -228,7 +227,6 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     }
 
     $this->removeNav('Manage Cases');
-    $this->restoreCaseCustomGroupExtendClassToDefault();
 
     $steps = [
       new RemoveCustomGroupSupportForCaseCategory(),
@@ -376,50 +374,6 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
   }
 
   /**
-   * Restores the Case Custom Group Extend Class To Default.
-   *
-   * When the civicase extension is installed, it modifies the class
-   * that returns the case types for cases to one that returns only the
-   * one in cases category. This function restores that original value.
-   */
-  private function restoreCaseCustomGroupExtendClassToDefault() {
-    $this->setCaseCustomGroupExtendClass('CRM_Case_PseudoConstant::caseType;');
-  }
-
-  /**
-   * Sets the Case Custom Group Extend Class For Case Type Category.
-   *
-   * Setting this class allows the case types when adding custom group
-   * that extend a case to return case types belonging only to the case
-   * category.
-   */
-  private function setCaseCustomGroupExtendClassForCaseTypeCategory() {
-    $this->setCaseCustomGroupExtendClass('CRM_Civicase_Helper_CaseCategory::getCaseTypesForCase;');
-  }
-
-  /**
-   * Sets the Case Custom Group Extend Class.
-   *
-   * @param string $caseTypeClass
-   *   Case Type class for retrieving case types.
-   */
-  private function setCaseCustomGroupExtendClass($caseTypeClass) {
-    $result = civicrm_api3('OptionValue', 'get', [
-      'option_group_id' => 'cg_extend_objects',
-      'label' => CaseCategoryHelper::CASE_TYPE_CATEGORY_NAME,
-    ]);
-
-    if (empty($result['id'])) {
-      return;
-    }
-
-    civicrm_api3('OptionValue', 'create', [
-      'id' => $result['id'],
-      'description' => $caseTypeClass,
-    ]);
-  }
-
-  /**
    * Remove nav.
    *
    * @param string $name
@@ -438,7 +392,6 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     $this->swapCaseMenuItems();
 
     $this->toggleNav('Manage Cases', TRUE);
-    $this->setCaseCustomGroupExtendClassForCaseTypeCategory();
   }
 
   /**
@@ -448,7 +401,6 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     $this->swapCaseMenuItems();
 
     $this->toggleNav('Manage Cases', FALSE);
-    $this->restoreCaseCustomGroupExtendClassToDefault();
   }
 
   /**


### PR DESCRIPTION
## Overview
The major work for adding custom fields support for case type has already been done in https://github.com/compucorp/uk.co.compucorp.civicase/pull/460. This PR only does some cleanup of deprecated functions that are called when enabling the civicase extension and also renames some variable.

## Before
The cleanups were not done.

## After
- Some cleanup was done in the extension and the case category variable in the `CaseCategoryCustomFieldExtends` and `CaseCategoryCaseTypeCustomFieldExtends` was renamed to some more better variable since the variable for creating the custom field entity does not necessarily have to be the case category name.
The deprecated functions/Classes were removed because initially the Civicase extension Custom field support was using a custom function to set case types for custom fields but after a recent change the custom function was no longer necessary and the default Core function is the only function required, the restriction was removed in an Upgrader here: https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/Upgrader/Steps/Step0010.php#L37-L53 but the deprecated functionality was not removed from the enable and disabled functions.
