### PR TITLE
RSE-1199: Fix Errors When Installing Civicase

### DIFF
--- a/CRM/Civicase/Service/CaseCategoryCustomDataType.php
+++ b/CRM/Civicase/Service/CaseCategoryCustomDataType.php
@@ -22,7 +22,7 @@ class CRM_Civicase_Service_CaseCategoryCustomDataType {
       return;
     }
 
-    $caseCategoryOptions = array_flip(CRM_Case_BAO_CaseType::buildOptions('case_type_category', 'validate'));
+    $caseCategoryOptions = CRM_Core_OptionGroup::values('case_type_categories', TRUE, FALSE, TRUE, NULL, 'name');
 
     try {
       civicrm_api3('OptionValue', 'create', [

--- a/CRM/Civicase/Service/CaseCategorySetting.php
+++ b/CRM/Civicase/Service/CaseCategorySetting.php
@@ -1,7 +1,6 @@
 <?php
 
 use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
-use CRM_Case_BAO_CaseType as CaseType;
 
 /**
  * Class CRM_Civicase_Service_CaseCategorySetting.
@@ -15,7 +14,7 @@ class CRM_Civicase_Service_CaseCategorySetting {
    *   Array of webform settings.
    */
   public function getForWebform() {
-    $caseTypeCategories = CaseType::buildOptions('case_type_category', 'validate');
+    $caseTypeCategories = CRM_Core_OptionGroup::values('case_type_categories', TRUE, FALSE, TRUE, NULL, 'name');
     $caseCategorySettings = [];
     foreach ($caseTypeCategories as $caseCategoryName) {
       $caseCategorySettings = array_merge($caseCategorySettings, $this->getCaseWebformSetting($caseCategoryName));


### PR DESCRIPTION
## Overview
When Installing Civicase on a site for the first time or when running Civicase tests, some notices related to case type categories are shown in the terminal.

## Before
- Errors/Notices shown in terminal when installing Civicase fresh on a site.

<img width="928" alt="compucorpsites-dev varwwwcompuclient-rse-1137-92a compubox co ukhttpdocssites 2020-07-14 18-41-09" src="https://user-images.githubusercontent.com/6951813/87458282-a7c20a00-c601-11ea-9dca-b94d70c77fc0.png">


## After
<img width="923" alt="compucorpsites-dev varwwwcompuclient-rse-1137-92a compubox co ukhttpdocssites 2020-07-14 18-42-30" src="https://user-images.githubusercontent.com/6951813/87458402-d50eb800-c601-11ea-886a-c9da7d1bb827.png">

- Tests ran successfully after this without throwing these notices.

## Technical Details
 - The issue was because the `case_type_category` field is not originally part of the CaseType BAO but the field that is added to the CaseType BAO via a hook and the field is not available on the BAO at install. The Fix is to fetch the Case type categories using the Option Group BAO.
- Also the function for fetching the Case type categories was pointing to the `case_type_category` rather than the `case_type_categories` option group. 


