### PR TITLE
CATL-1511: Enable search by caseID in Linked Cases

### DIFF
--- a/CRM/Civicase/Api/Wrapper/CaseGetList.php
+++ b/CRM/Civicase/Api/Wrapper/CaseGetList.php
@@ -33,6 +33,8 @@ class CRM_Civicase_Api_Wrapper_CaseGetList implements API_Wrapper {
       ];
     }
 
+    $this->allowSearchByCaseId($apiRequest);
+
     return $apiRequest;
   }
 
@@ -42,6 +44,28 @@ class CRM_Civicase_Api_Wrapper_CaseGetList implements API_Wrapper {
   public function toApiOutput($apiRequest, $result) {
 
     return $result;
+  }
+
+  /**
+   * Allows search by Case ID in addition to the contact name.
+   *
+   * This is done by setting the case ID to the input and adding
+   * and 'OR' condition between the contact name and case Id field.
+   *
+   * @param array $apiRequest
+   *   API Request.
+   */
+  private function allowSearchByCaseId(array &$apiRequest) {
+    $isInputNumeric = !empty($apiRequest['params']['input']) && is_numeric($apiRequest['params']['input']);
+    if (!$isInputNumeric || empty($apiRequest['params']['params']['search_by_case_id'])) {
+      return;
+    }
+    $input = $apiRequest['params']['input'];
+    $excludedCaseIds = !empty($apiRequest['params']['params']['case_id']['NOT IN']) ? $apiRequest['params']['params']['case_id']['NOT IN'] : [];
+    if (!in_array($input, $excludedCaseIds)) {
+      $apiRequest['params']['params']['case_id'] = $input;
+      $apiRequest['params']['params']['options'] = ['or' => [['case_id', 'contact_id.sort_name']]];
+    }
   }
 
   /**

--- a/CRM/Civicase/Hook/BuildForm/LinkToCaseSearchByCaseId.php
+++ b/CRM/Civicase/Hook/BuildForm/LinkToCaseSearchByCaseId.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Class CRM_Civicase_Hook_BuildForm_LinkToCaseSearchByCaseId.
+ */
+class CRM_Civicase_Hook_BuildForm_LinkToCaseSearchByCaseId {
+
+  /**
+   * Adds a parameter that allows to search by Case Id.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   * @param string $formName
+   *   Form Name.
+   */
+  public function run(CRM_Core_Form &$form, $formName) {
+    if (!$this->shouldRun($formName, $form)) {
+      return;
+    }
+
+    $this->setSearchByCaseIdParams($form);
+  }
+
+  /**
+   * Sets the search by Case ID parameter.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   */
+  private function setSearchByCaseIdParams(CRM_Core_Form $form) {
+    $linkToCase = &$form->getElement('link_to_case_id');
+    $dataApiParams = $linkToCase->_attributes['data-api-params'];
+    if (empty($dataApiParams)) {
+      return;
+    }
+    $dataApiParams = json_decode($dataApiParams, TRUE);
+    $dataApiParams['params']['search_by_case_id'] = TRUE;
+    $linkToCase->_attributes['data-api-params'] = json_encode($dataApiParams);
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * Will run if the form is the Link Case activity form.
+   *
+   * @param string $formName
+   *   Form name.
+   * @param CRM_Core_Form $form
+   *   Form class object.
+   *
+   * @return bool
+   *   returns a boolean to determine if hook will run or not.
+   */
+  private function shouldRun($formName, CRM_Core_Form $form) {
+    return $formName == CRM_Case_Form_Activity::class && $form->_activityTypeName == 'Link Cases';
+  }
+
+}

--- a/ang/civicase/activity/actions/services/move-copy-activity-action.service.js
+++ b/ang/civicase/activity/actions/services/move-copy-activity-action.service.js
@@ -85,7 +85,9 @@
      * @returns {object} api parameters for Case.getlist
      */
     function getCaseListApiParams () {
-      return {};
+      return {
+        params: { search_by_case_id: true }
+      };
     }
 
     /**

--- a/ang/test/civicase/activity/actions/services/move-copy-activity-action.service.spec.js
+++ b/ang/test/civicase/activity/actions/services/move-copy-activity-action.service.spec.js
@@ -107,13 +107,19 @@
 
         describe('when fetching list of cases', () => {
           let getCaseListApiParams;
+          let expectedApiParams;
 
           beforeEach(() => {
             getCaseListApiParams = modalOpenCall[2].getCaseListApiParams;
+            expectedApiParams = {
+              params: {
+                search_by_case_id: true
+              }
+            };
           });
 
           it('displays cases from those case type categories for which user has "basic case information" permission', () => {
-            expect(getCaseListApiParams()).toEqual({});
+            expect(getCaseListApiParams()).toEqual(expectedApiParams);
           });
         });
 
@@ -375,13 +381,19 @@
 
         describe('when fetching list of cases', () => {
           let getCaseListApiParams;
+          let expectedApiParams;
 
           beforeEach(() => {
             getCaseListApiParams = modalOpenCall[2].getCaseListApiParams;
+            expectedApiParams = {
+              params: {
+                search_by_case_id: true
+              }
+            };
           });
 
           it('displays cases from those case type categories for which user has "basic case information" permission', () => {
-            expect(getCaseListApiParams()).toEqual({});
+            expect(getCaseListApiParams()).toEqual(expectedApiParams);
           });
         });
 

--- a/civicase.php
+++ b/civicase.php
@@ -189,6 +189,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_ModifyCaseTypesForAdvancedSearch(),
     new CRM_Civicase_Hook_BuildForm_AddStyleFieldToCaseCustomGroups(),
     new CRM_Civicase_Hook_BuildForm_DisplayAllCustomGroupsInCaseForm(),
+    new CRM_Civicase_Hook_BuildForm_LinkToCaseSearchByCaseId(),
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview
This PR allows searching by Case ID as well as Case client name when searching for cases on the Linked Cases form and on the Move to Case popup form. The default behaviour only allows to search by case client name.

## Before
User can only search by case client name.

![MoveBefore](https://user-images.githubusercontent.com/6951813/87970399-95414800-cabb-11ea-9bcc-ab79554d6906.gif)
![LinkBefore](https://user-images.githubusercontent.com/6951813/87970411-983c3880-cabb-11ea-8136-9bdee9f06b33.gif)


## After
User can only search by case client name and case id.

![MoveToCaseAfter](https://user-images.githubusercontent.com/6951813/87965101-24962d80-cab3-11ea-8ae0-b8cb3f8d02de.gif)


![LinkCaseAfter](https://user-images.githubusercontent.com/6951813/87965113-2829b480-cab3-11ea-9061-afce877ad4ea.gif)


### Technical Details

The default search field for the Case.getList API which the case search field uses is the Case client name, [see](https://github.com/civicrm/civicrm-core/blob/master/api/v3/Case.php#L746).

A new parameter `search_by_case_id` is introduced as part of the parameter the Case.getList API accepts so that when this parameter is present, the search is done on both the client name and the case Id. The reason for this is that the API might be used else where and we don't want to alter the default behaviour of this API.

To allow the Case ID to be part of the search query, the case_id is set to the input parameter and the `OR` condition is set between the case client name and the case Id in the CaseGetList API wrapper class.

```php
$apiRequest['params']['params']['options'] = ['or' => [['case_id', 'contact_id.sort_name']]];
```

The Link To Case form field is added [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Case/Form/Activity/LinkCases.php#L74-L83) and the excluded case ID's is also taken into consideration when implementing the API wrapper so that those Case Id's are not part of the search results as intended by the original field.

```php

    if (!in_array($input, $excludedCaseIds)) {
      $apiRequest['params']['params']['case_id'] = $input;
      $apiRequest['params']['params']['options'] = ['or' => [['case_id', 'contact_id.sort_name']]];
    }
```