### PR TITLE
Fix installation on a multilingual install

### DIFF
--- a/CRM/Civicase/Setup/CaseTypeCategorySupport.php
+++ b/CRM/Civicase/Setup/CaseTypeCategorySupport.php
@@ -15,13 +15,18 @@ class CRM_Civicase_Setup_CaseTypeCategorySupport {
    * Add Case Type Category Column to the Case Type table
    */
   private function addCaseCategoryDBColumn () {
+    global $dbLocale;
+
     $caseTypeTable = CRM_Case_BAO_CaseType::getTableName();
     $caseCategoryColumnName = 'case_type_category';
 
+    // Required for multilingual installations
+    if ($dbLocale) {
+      $caseTypeTable = substr($caseTypeTable, 0, -strlen($dbLocale));
+    }
+
     if (!SchemaHandler::checkIfFieldExists($caseTypeTable, $caseCategoryColumnName)) {
-      CRM_Core_DAO::executeQuery("
-        ALTER TABLE {$caseTypeTable}
-        ADD COLUMN {$caseCategoryColumnName} INT(10)");
+      CRM_Upgrade_Incremental_Base::addColumn(NULL, $caseTypeTable, $caseCategoryColumnName, 'INT(10)');
     }
   }
 


### PR DESCRIPTION
## Overview

* Enable multilingual on CiviCRM (CiviCRM > Admin > Locallzation > Languages; enable multilingual)
* Enable this civicase extension.

Result: fatal error (DB error)

## Technical Details

In multilingual, CiviCRM does automatic renaming of tables names so that queries run on the language-specific SQL views.

The `getTableName()` function on DAOs will return the localized table name.

This patch is a workaround. An alternative would be to hardcode the SQL table name instead of calling the DAO's getTableName().