### PR TITLE
CPS-245: Backstop JS GitHub Action

### DIFF
--- a/.github/workflows/backstop.yml
+++ b/.github/workflows/backstop.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies to run the server
         run: |
           apt-get update
-          apt-get install apache2 libapache2-mod-php7.2 php7.2-mysql php7.2-curl php7.2-simplexml -y
+          apt-get install apache2 libapache2-mod-php7.2 -y
           a2enmod rewrite
           apache2ctl restart
 
@@ -90,7 +90,6 @@ jobs:
         continue-on-error: true
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicase/tests/backstop_data
         run: |
-          git reset --hard
           git checkout "${{ github.head_ref }}"
           npx gulp backstopjs:reference
 
@@ -98,7 +97,6 @@ jobs:
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicase/tests/backstop_data
         continue-on-error: true
         run: |
-          git reset --hard
           git checkout "${{ github.head_ref }}"
           npx gulp backstopjs:test
 

--- a/.github/workflows/backstop.yml
+++ b/.github/workflows/backstop.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.label.name == 'run backstop'
     runs-on: ubuntu-latest
     container:
-      image: compucorp/civicrm-buildkit:1.0.0-chrome
+      image: compucorp/civicrm-buildkit:1.1.0-php7.2-chrome
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
@@ -69,7 +69,7 @@ jobs:
         run: |
           cp site-config.json.sample site-config.json
           sed -i 's+<url>+http://localhost:7979+' site-config.json
-          sed -i 's+<path-to-site-root>+/__w/uk.co.compucorp.civicase/uk.co.compucorp.civicase/site/web+' site-config.json
+          sed -i 's+<path-to-site-root>+'"$GITHUB_WORKSPACE"'/site/web+' site-config.json
           npm install
           npx gulp backstopjs:setup-data
 

--- a/.github/workflows/backstop.yml
+++ b/.github/workflows/backstop.yml
@@ -58,18 +58,14 @@ jobs:
           git clone https://github.com/compucorp/uk.co.compucorp.civicase.git
           git clone --depth 1 https://github.com/civicrm/org.civicrm.shoreditch.git
           cv en shoreditch civicase
-          drush cvapi Extension.upgrade
           drush en civicrmtheme -y
-          drush dl bootstrap -y
           drush en bootstrap -y
           drush vset theme_default bootstrap
 
       - name: Installing Shoreditch Companion Theme
         working-directory: ${{ env.DRUPAL_THEME_DIR }}
         run: |
-          mkdir shoreditch_companion_d7_theme
-          cd shoreditch_companion_d7_theme/
-          git clone https://github.com/compucorp/shoreditch-companion-d7-theme.git
+          git clone https://github.com/compucorp/shoreditch-companion-d7-theme.git depth=1
           drush en -y shoreditch_companion_d7_theme
           drush vset civicrmtheme_theme_admin shoreditch_companion_d7_theme
 

--- a/.github/workflows/backstop.yml
+++ b/.github/workflows/backstop.yml
@@ -1,0 +1,123 @@
+name: Backstop Tests
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+  run-backstop-tests:
+    if: github.event.label.name == 'run backstop'
+    runs-on: ubuntu-latest
+    container:
+      image: compucorp/civicrm-buildkit:1.0.0-chrome
+
+    env:
+      CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
+      DRUPAL_THEME_DIR: site/web/sites/all/themes
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+        - 3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
+      - name: Install dependencies to run the server
+        run: |
+          apt-get update
+          apt-get install apache2 libapache2-mod-php7.2 php7.2-mysql php7.2-curl php7.2-simplexml -y
+          a2enmod rewrite
+          apache2ctl restart
+
+      - name: Config mysql database as per CiviCRM requirement
+        run: echo "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));" | mysql -u root --password=root --host=mysql
+
+      - name: Config amp
+        run : |
+          amp config:set --db_type=mysql_dsn --mysql_dsn='mysql://root:root@mysql:3306' --httpd_type=apache24 --httpd_restart_command='sudo /usr/sbin/apache2ctl graceful' --perm_type=worldWritable --hosts_type=file
+          echo "IncludeOptional /github/home/.amp/apache.d/*.conf" >> /etc/apache2/apache2.conf
+          /usr/sbin/apache2ctl restart
+
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '10.15.3'
+
+      - name: Build Drupal site
+        run: |
+          civibuild create drupal-clean --civi-ver 5.24.6 --web-root $GITHUB_WORKSPACE/site
+          chmod -R 777 /__w/uk.co.compucorp.civicase/uk.co.compucorp.civicase
+
+      - name: Installing CiviCase and Shoreditch
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
+        run: |
+          git clone https://github.com/compucorp/uk.co.compucorp.civicase.git
+          git clone --depth 1 https://github.com/civicrm/org.civicrm.shoreditch.git
+          cv en shoreditch civicase
+          drush cvapi Extension.upgrade
+          drush en civicrmtheme -y
+          drush dl bootstrap -y
+          drush en bootstrap -y
+          drush vset theme_default bootstrap
+
+      - name: Installing Shoreditch Companion Theme
+        working-directory: ${{ env.DRUPAL_THEME_DIR }}
+        run: |
+          mkdir shoreditch_companion_d7_theme
+          cd shoreditch_companion_d7_theme/
+          git clone https://github.com/compucorp/shoreditch-companion-d7-theme.git
+          drush en -y shoreditch_companion_d7_theme
+          drush vset civicrmtheme_theme_admin shoreditch_companion_d7_theme
+
+          drush sql-query "UPDATE block SET status = 0 WHERE theme='shoreditch_companion_d7_theme' AND module='civicrm' AND delta IN ('1', '2', '3', '4', '5');" -y
+          drush sql-query "UPDATE block SET status = 0 WHERE theme='shoreditch_companion_d7_theme' AND module='search' AND delta='form';" -y
+          drush sql-query "UPDATE block SET status = 0 WHERE theme='shoreditch_companion_d7_theme' AND module='system' AND delta IN ('navigation', 'powered-by');" -y
+
+          drush cc all && drush cc civicrm
+
+      - name: Create site-config.json for Backstop tests
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicase
+        run: |
+          cd tests/backstop_data
+          touch site-config.json
+          echo "{" >> site-config.json
+          echo '"url": "http://localhost:7979",' >> site-config.json
+          echo '"drush_alias": "",' >> site-config.json
+          echo '"root": "/__w/uk.co.compucorp.civicase/uk.co.compucorp.civicase/site/web"' >> site-config.json
+          echo "}" >> site-config.json
+
+      - name: Reference Screenshots in "master" Branch
+        continue-on-error: true
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicase/tests/backstop_data
+        run: |
+          git reset --hard
+          git checkout "${{ github.head_ref }}"
+          npm install
+          npx gulp backstopjs:setup-data
+          npx gulp backstopjs:reference
+
+      - name: Test Screenshots in "${{ github.head_ref }}" Branch
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicase/tests/backstop_data
+        continue-on-error: true
+        run: |
+          git reset --hard
+          git checkout "${{ github.head_ref }}"
+          npx gulp backstopjs:test
+
+      - name: Prepare test report for download
+        if: ${{ always() }}
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicase/tests/backstop_data
+        run: |
+          mkdir backstop_report
+          cp -r html_report backstop_report
+          cp -r screenshots backstop_report
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: backstop-report
+          path: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicase/tests/backstop_data/backstop_report

--- a/.github/workflows/backstop.yml
+++ b/.github/workflows/backstop.yml
@@ -26,13 +26,6 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - name: Install dependencies to run the server
-        run: |
-          apt-get update
-          apt-get install apache2 libapache2-mod-php7.2 -y
-          a2enmod rewrite
-          apache2ctl restart
-
       - name: Config mysql database as per CiviCRM requirement
         run: echo "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));" | mysql -u root --password=root --host=mysql
 
@@ -41,11 +34,6 @@ jobs:
           amp config:set --db_type=mysql_dsn --mysql_dsn='mysql://root:root@mysql:3306' --httpd_type=apache24 --httpd_restart_command='sudo /usr/sbin/apache2ctl graceful' --perm_type=worldWritable --hosts_type=file
           echo "IncludeOptional /github/home/.amp/apache.d/*.conf" >> /etc/apache2/apache2.conf
           /usr/sbin/apache2ctl restart
-
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '10.15.3'
 
       - name: Build Drupal site
         run: |

--- a/.github/workflows/backstop.yml
+++ b/.github/workflows/backstop.yml
@@ -14,6 +14,7 @@ jobs:
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
+      CIVICASE_BACKSTOP_DIR: site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.civicase/tests/backstop_data
       DRUPAL_THEME_DIR: site/web/sites/all/themes
 
     services:
@@ -32,18 +33,18 @@ jobs:
       - name: Config amp
         run : |
           amp config:set --db_type=mysql_dsn --mysql_dsn='mysql://root:root@mysql:3306' --httpd_type=apache24 --httpd_restart_command='sudo /usr/sbin/apache2ctl graceful' --perm_type=worldWritable --hosts_type=file
-          echo "IncludeOptional /github/home/.amp/apache.d/*.conf" >> /etc/apache2/apache2.conf
+          echo "IncludeOptional $HOME/.amp/apache.d/*.conf" >> /etc/apache2/apache2.conf
           /usr/sbin/apache2ctl restart
 
       - name: Build Drupal site
         run: |
-          civibuild create drupal-clean --civi-ver 5.24.6 --web-root $GITHUB_WORKSPACE/site
-          chmod -R 777 /__w/uk.co.compucorp.civicase/uk.co.compucorp.civicase
+          civibuild create drupal-clean --civi-ver 5.28.3 --web-root $GITHUB_WORKSPACE/site
+          chmod -R 777 $GITHUB_WORKSPACE/site
 
       - name: Installing CiviCase and Shoreditch
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
-          git clone https://github.com/compucorp/uk.co.compucorp.civicase.git
+          git clone https://github.com/compucorp/uk.co.compucorp.civicase.git --branch "${{ github.head_ref }}"
           git clone --depth 1 https://github.com/civicrm/org.civicrm.shoreditch.git
           cv en shoreditch civicase
           drush en civicrmtheme -y
@@ -64,10 +65,8 @@ jobs:
           drush cc all && drush cc civicrm
 
       - name: Setup data and site-config.json for Backstop tests
-        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicase
+        working-directory: ${{ env.CIVICASE_BACKSTOP_DIR }}
         run: |
-          git checkout "${{ github.head_ref }}"
-          cd tests/backstop_data
           cp site-config.json.sample site-config.json
           sed -i 's+<url>+http://localhost:7979+' site-config.json
           sed -i 's+<path-to-site-root>+/__w/uk.co.compucorp.civicase/uk.co.compucorp.civicase/site/web+' site-config.json
@@ -76,13 +75,13 @@ jobs:
 
       - name: Reference Screenshots in "master" Branch
         continue-on-error: true
-        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicase/tests/backstop_data
+        working-directory: ${{ env.CIVICASE_BACKSTOP_DIR }}
         run: |
-          git checkout "${{ github.head_ref }}"
+          git checkout master
           npx gulp backstopjs:reference
 
       - name: Test Screenshots in "${{ github.head_ref }}" Branch
-        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicase/tests/backstop_data
+        working-directory: ${{ env.CIVICASE_BACKSTOP_DIR }}
         continue-on-error: true
         run: |
           git checkout "${{ github.head_ref }}"
@@ -90,7 +89,7 @@ jobs:
 
       - name: Prepare test report for download
         if: ${{ always() }}
-        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicase/tests/backstop_data
+        working-directory: ${{ env.CIVICASE_BACKSTOP_DIR }}
         run: |
           mkdir backstop_report
           cp -r html_report backstop_report
@@ -100,4 +99,4 @@ jobs:
         if: ${{ always() }}
         with:
           name: backstop-report
-          path: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicase/tests/backstop_data/backstop_report
+          path: ${{ env.CIVICASE_BACKSTOP_DIR }}/backstop_report

--- a/.github/workflows/backstop.yml
+++ b/.github/workflows/backstop.yml
@@ -75,16 +75,16 @@ jobs:
 
           drush cc all && drush cc civicrm
 
-      - name: Create site-config.json for Backstop tests
+      - name: Setup data and site-config.json for Backstop tests
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicase
         run: |
+          git checkout "${{ github.head_ref }}"
           cd tests/backstop_data
-          touch site-config.json
-          echo "{" >> site-config.json
-          echo '"url": "http://localhost:7979",' >> site-config.json
-          echo '"drush_alias": "",' >> site-config.json
-          echo '"root": "/__w/uk.co.compucorp.civicase/uk.co.compucorp.civicase/site/web"' >> site-config.json
-          echo "}" >> site-config.json
+          cp site-config.json.sample site-config.json
+          sed -i 's+<url>+http://localhost:7979+' site-config.json
+          sed -i 's+<path-to-site-root>+/__w/uk.co.compucorp.civicase/uk.co.compucorp.civicase/site/web+' site-config.json
+          npm install
+          npx gulp backstopjs:setup-data
 
       - name: Reference Screenshots in "master" Branch
         continue-on-error: true
@@ -92,8 +92,6 @@ jobs:
         run: |
           git reset --hard
           git checkout "${{ github.head_ref }}"
-          npm install
-          npx gulp backstopjs:setup-data
           npx gulp backstopjs:reference
 
       - name: Test Screenshots in "${{ github.head_ref }}" Branch

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tests/backstop_data/screenshots
 tests/backstop_data/*_report
 tests/backstop_data/backstop.temp.json
 tests/backstop_data/site-config.json
+tests/backstop_data/sample.txt

--- a/tests/backstop_data/Readme.md
+++ b/tests/backstop_data/Readme.md
@@ -1,20 +1,3 @@
-# Data Setup/Requirements
- The backstopJS test suite needs following to be setup in prior
-
-## Dashboard Section
-* The current calendar month has at least one day with some activities.
-* Have at least that many acitivities on activity panel, so that it shows load more button.
-
-## Contact Section
-* Make sure 'admin' contact have atleast one activity and atleast 4 cases for itself.
-
-## Activities Section
-* Make sure that there exists at least one tag and one tagset for activities.
-
-## Cases
-* Make sure there is a `sample.txt` file in the root of the folder. This is to test file upload functionality of files tab.
----
-
 # Covered Screens
 The backstop test suite for Civicase 5.1 extension covers following screens
 

--- a/tests/backstop_data/backstop.tpl.json
+++ b/tests/backstop_data/backstop.tpl.json
@@ -17,7 +17,10 @@
   "report": ["CLI", "browser"],
   "engine": "puppeteer",
   "engineOptions": {
-    "waitTimeout": 120000
+    "waitTimeout": 120000,
+    "args": [
+      "--no-sandbox"
+    ]
   },
   "asyncCaptureLimit": 1,
   "asyncCompareLimit": 50,

--- a/tests/backstop_data/backstop.tpl.json
+++ b/tests/backstop_data/backstop.tpl.json
@@ -22,7 +22,7 @@
       "--no-sandbox"
     ]
   },
-  "asyncCaptureLimit": 1,
+  "asyncCaptureLimit": 3,
   "asyncCompareLimit": 50,
   "debug": false,
   "debugWindow": false

--- a/tests/backstop_data/engine_scripts/puppet/activity-feed-panel/bulk-actions-add-tag.js
+++ b/tests/backstop_data/engine_scripts/puppet/activity-feed-panel/bulk-actions-add-tag.js
@@ -4,4 +4,6 @@ module.exports = async (page, scenario, vp) => {
   await require('./bulk-actions')(page, scenario, vp);
 
   await page.click('.civicase__bulkactions-actions-dropdown .dropdown-menu li:nth-child(3) a');
+
+  await page.waitFor(500);
 };

--- a/tests/backstop_data/engine_scripts/puppet/activity-feed-panel/bulk-actions-remove-tag.js
+++ b/tests/backstop_data/engine_scripts/puppet/activity-feed-panel/bulk-actions-remove-tag.js
@@ -4,4 +4,6 @@ module.exports = async (page, scenario, vp) => {
   await require('./bulk-actions')(page, scenario, vp);
 
   await page.click('.civicase__bulkactions-actions-dropdown .dropdown-menu li:nth-child(4) a');
+
+  await page.waitFor(500);
 };

--- a/tests/backstop_data/engine_scripts/puppet/manage-cases/people-tab-add-case-role-dropdown.js
+++ b/tests/backstop_data/engine_scripts/puppet/manage-cases/people-tab-add-case-role-dropdown.js
@@ -6,7 +6,7 @@ module.exports = async (page, scenario, vp) => {
   const utility = new Utility(page, scenario, vp);
 
   await utility.waitForAngular();
-  await utility.waitForLoadingComplete();
+  await utility.waitForLoadingComplete(".civicase__people-tab__sub-tab:not([ng-show=\"tab == 'relations'\"])");
 
   // For some reason page.click is not working for this dom element. So, we
   // have used evalute and triggered click using DOM events separately.

--- a/tests/backstop_data/engine_scripts/puppet/manage-cases/people-tab-add-case-role-to-client.js
+++ b/tests/backstop_data/engine_scripts/puppet/manage-cases/people-tab-add-case-role-to-client.js
@@ -6,7 +6,7 @@ module.exports = async (page, scenario, vp) => {
   const utility = new Utility(page, scenario, vp);
 
   await utility.waitForAngular();
-  await utility.waitForLoadingComplete();
+  await utility.waitForLoadingComplete(".civicase__people-tab__sub-tab:not([ng-show=\"tab == 'relations'\"])");
 
   // For some reason page.click is not working for this dom element. So, we
   // have used evalute and triggered click using DOM events separately.

--- a/tests/backstop_data/engine_scripts/puppet/manage-cases/people-tab-add-case-role-to-non-client.js
+++ b/tests/backstop_data/engine_scripts/puppet/manage-cases/people-tab-add-case-role-to-non-client.js
@@ -6,7 +6,7 @@ module.exports = async (page, scenario, vp) => {
   const utility = new Utility(page, scenario, vp);
 
   await utility.waitForAngular();
-  await utility.waitForLoadingComplete();
+  await utility.waitForLoadingComplete(".civicase__people-tab__sub-tab:not([ng-show=\"tab == 'relations'\"])");
 
   // For some reason page.click is not working for this dom element. So, we
   // have used evalute and triggered click using DOM events separately.

--- a/tests/backstop_data/engine_scripts/puppet/manage-cases/people-tab-other-relationships-loading.js
+++ b/tests/backstop_data/engine_scripts/puppet/manage-cases/people-tab-other-relationships-loading.js
@@ -6,13 +6,13 @@ module.exports = async (page, scenario, vp) => {
   const utility = new Utility(page, scenario, vp);
 
   await utility.waitForAngular();
-  await utility.waitForLoadingComplete();
+  await utility.waitForLoadingComplete(".civicase__people-tab__sub-tab:not([ng-show=\"tab == 'relations'\"])");
 
   // Intercepts the server response before switching tabs so we can capture the loading state
   page.setRequestInterception(true);
-  page.on('response', (response) => {
-    response.abort();
+  page.on('request', (request) => {
+    request.abort();
   });
 
-  await page.click(`.civicase__people-tab .nav-tabs .civicase__people-tab-link[ng-click="setTab('relations')"]`);
+  await page.click('.civicase__people-tab .nav-tabs .civicase__people-tab-link[ng-click="setTab(\'relations\')"]');
 };

--- a/tests/backstop_data/gulp-tasks/backstopjs.js
+++ b/tests/backstop_data/gulp-tasks/backstopjs.js
@@ -27,7 +27,6 @@ var CACHE = {
   contactIdsMap: {}
 };
 var FILES = {
-  sampleUploadFile: 'sample.txt',
   siteConfig: 'site-config.json',
   siteConfigSample: 'site-config.json.sample',
   temp: 'backstop.temp.json',
@@ -39,7 +38,7 @@ var RECORD_IDENTIFIERS = {
   caseSubject: 'Backstop Case',
   caseTag: 'Backstop Case Tag',
   emptyCaseSubject: 'Backstop Empty Case',
-  emptyCaseTypeName: 'backstop_case_type',
+  caseTypeName: 'backstop_case_type',
   emptyContactDisplayName: 'Emil Backstop',
   emptyContactEmail: 'emil@backstop.com',
   fileUploadActivitySubject: 'Backstop File Upload',
@@ -400,7 +399,7 @@ function runBackstopJS (command) {
  */
 function setupData () {
   var caseType = createUniqueCaseType({
-    name: RECORD_IDENTIFIERS.emptyCaseTypeName,
+    name: RECORD_IDENTIFIERS.caseTypeName,
     case_type_category: 'Cases',
     title: 'Backstop Case Type',
     definition: {
@@ -531,7 +530,7 @@ function setupData () {
  * Create Sample Upload File
  */
 function createSampleUploadFile () {
-  fs.writeFileSync(FILES.sampleUploadFile, 'Sample Text');
+  fs.writeFileSync('sample.txt', 'Sample Text');
 }
 
 /**

--- a/tests/backstop_data/gulp-tasks/backstopjs.js
+++ b/tests/backstop_data/gulp-tasks/backstopjs.js
@@ -51,6 +51,11 @@ var RECORD_IDENTIFIERS = {
       fieldLabel: 'Backstop Case Tab Custom Field',
       groupTitle: 'Backstop Case Tab Custom Group'
     }
+  },
+  relationshipTypes: {
+    homelessCoordinator: 'Homeless Services Coordinator is',
+    healthServiceCoordinator: 'Health Services Coordinator',
+    benefitsSpecialist: 'Benefits Specialist is'
   }
 };
 var URL_VAR_REPLACERS = [
@@ -65,7 +70,8 @@ var createUniqueAttachment = createUniqueRecordFactory('Attachment', ['entity_id
 var createUniqueCase = createUniqueRecordFactory('Case', ['subject']);
 var createUniqueEmail = createUniqueRecordFactory('Email', ['email']);
 var createUniqueCaseType = createUniqueRecordFactory('CaseType', ['name']);
-var createUniqueRelationship = createUniqueRecordFactory('Relationship', ['description']);
+var createUniqueRelationship = createUniqueRecordFactory('Relationship', ['contact_id_a', 'contact_id_b', 'relationship_type_id']);
+var createUniqueRelationshipType = createUniqueRecordFactory('RelationshipType', ['name_a_b']);
 var createUniqueContact = createUniqueRecordFactory('Contact', ['display_name']);
 var createUniqueCustomField = createUniqueRecordFactory('CustomField', ['label']);
 var createUniqueCustomGroup = createUniqueRecordFactory('CustomGroup', ['title']);
@@ -398,6 +404,13 @@ function runBackstopJS (command) {
  * @returns {Promise} An empty promise that is resolved when the task is done.
  */
 function setupData () {
+  var homelessCoordinatorRelType = createUniqueRelationshipType({
+    name_a_b: RECORD_IDENTIFIERS.relationshipTypes.homelessCoordinator
+  });
+  var benefitsSpecialistRelType = createUniqueRelationshipType({
+    name_a_b: RECORD_IDENTIFIERS.relationshipTypes.benefitsSpecialist
+  });
+
   var caseType = createUniqueCaseType({
     name: RECORD_IDENTIFIERS.caseTypeName,
     case_type_category: 'Cases',
@@ -414,14 +427,14 @@ function setupData () {
       activitySets: [],
       caseRoles: [
         {
-          name: 'Homeless Services Coordinator',
+          name: RECORD_IDENTIFIERS.relationshipTypes.homelessCoordinator,
           creator: '1',
           manager: '0'
         }, {
-          name: 'Health Services Coordinator',
+          name: RECORD_IDENTIFIERS.relationshipTypes.healthServiceCoordinator,
           manager: '0'
         }, {
-          name: 'Benefits Specialist',
+          name: RECORD_IDENTIFIERS.relationshipTypes.benefitsSpecialist,
           manager: '1'
         }
       ],
@@ -452,7 +465,7 @@ function setupData () {
 
   createUniqueRelationship({
     contact_id_a: activeContact.id,
-    relationship_type_id: '14',
+    relationship_type_id: benefitsSpecialistRelType.id,
     start_date: 'now',
     end_date: null,
     contact_id_b: emptyContact.id,
@@ -462,7 +475,7 @@ function setupData () {
 
   createUniqueRelationship({
     contact_id_a: activeContact.id,
-    relationship_type_id: '11',
+    relationship_type_id: homelessCoordinatorRelType.id,
     start_date: 'now',
     end_date: null,
     contact_id_b: emptyContact.id,

--- a/tests/backstop_data/gulp-tasks/backstopjs.js
+++ b/tests/backstop_data/gulp-tasks/backstopjs.js
@@ -32,16 +32,20 @@ var CONFIG_TPL = {
   root: '%{path-to-site-root}'
 };
 var FILES = {
+  sampleUploadFile: 'sample.txt',
   siteConfig: 'site-config.json',
   temp: 'backstop.temp.json',
   tpl: 'backstop.tpl.json'
 };
 var RECORD_IDENTIFIERS = {
   activeContactDisplayName: 'Arnold Backstop',
+  activeContactEmail: 'arnold@backstop.com',
+  caseSubject: 'Backstop Case',
   caseTag: 'Backstop Case Tag',
   emptyCaseSubject: 'Backstop Empty Case',
-  emptyCaseTypeName: 'backstop_empty_case_type',
+  emptyCaseTypeName: 'backstop_case_type',
   emptyContactDisplayName: 'Emil Backstop',
+  emptyContactEmail: 'emil@backstop.com',
   fileUploadActivitySubject: 'Backstop File Upload',
   customGroups: {
     inline: {
@@ -64,7 +68,9 @@ var URL_VAR_REPLACERS = [
 var createUniqueActivity = createUniqueRecordFactory('Activity', ['subject']);
 var createUniqueAttachment = createUniqueRecordFactory('Attachment', ['entity_id', 'entity_table']);
 var createUniqueCase = createUniqueRecordFactory('Case', ['subject']);
+var createUniqueEmail = createUniqueRecordFactory('Email', ['email']);
 var createUniqueCaseType = createUniqueRecordFactory('CaseType', ['name']);
+var createUniqueRelationship = createUniqueRecordFactory('Relationship', ['description']);
 var createUniqueContact = createUniqueRecordFactory('Contact', ['display_name']);
 var createUniqueCustomField = createUniqueRecordFactory('CustomField', ['label']);
 var createUniqueCustomGroup = createUniqueRecordFactory('CustomGroup', ['title']);
@@ -165,7 +171,7 @@ function createUniqueRecordFactory (entityName, matchingFields) {
    * @returns {object} the returned value from the API.
    */
   return function createUniqueRecord (recordData) {
-    var filter = { options: { limit: 1 } };
+    var filter = { options: { limit: 1 }, sequential: 1 };
 
     matchingFields.forEach((matchingField) => {
       filter[matchingField] = recordData[matchingField];
@@ -375,6 +381,7 @@ function runBackstopJS (command) {
       .on('end', async () => {
         try {
           (typeof argv.skipCookies === 'undefined') && await writeCookies();
+
           await backstopjs(command, { configPath: FILES.temp, filter: argv.filter });
 
           success = true;
@@ -396,32 +403,85 @@ function runBackstopJS (command) {
  * @returns {Promise} An empty promise that is resolved when the task is done.
  */
 function setupData () {
-  var activeCaseId = getActiveCaseId();
   var caseType = createUniqueCaseType({
     name: RECORD_IDENTIFIERS.emptyCaseTypeName,
     case_type_category: 'Cases',
-    title: 'Backstop Empty Case Type',
+    title: 'Backstop Case Type',
     definition: {
-      activityTypes: [],
+      activityTypes: [{
+        name: 'Open Case',
+        max_instances: '1'
+      }, {
+        name: 'Follow up'
+      }, {
+        name: 'File Upload'
+      }],
       activitySets: [],
-      caseRoles: [{ name: 'Case Coordinator is', manager: '1', creator: '1' }],
+      caseRoles: [
+        {
+          name: 'Homeless Services Coordinator',
+          creator: '1',
+          manager: '0'
+        }, {
+          name: 'Health Services Coordinator',
+          manager: '0'
+        }, {
+          name: 'Benefits Specialist',
+          manager: '1'
+        }
+      ],
       timelineActivityTypes: []
     }
   });
+
   var activeContact = createUniqueContact({
     contact_type: 'Individual',
     display_name: RECORD_IDENTIFIERS.activeContactDisplayName
   });
+  createUniqueEmail({
+    contact_id: activeContact.id,
+    email: RECORD_IDENTIFIERS.activeContactEmail
+  });
   var emptyContact = createUniqueContact({
     contact_type: 'Individual',
-    display_name: RECORD_IDENTIFIERS.emptyContactDisplayName
+    display_name: RECORD_IDENTIFIERS.emptyContactDisplayName,
+    email: RECORD_IDENTIFIERS.emptyContactEmail
   });
+  createUniqueEmail({
+    contact_id: emptyContact.id,
+    email: RECORD_IDENTIFIERS.emptyContactEmail
+  });
+
+  var caseIds = createCases(caseType, activeContact, emptyContact);
+  createActivities(caseIds[0], activeContact);
+
+  createUniqueRelationship({
+    contact_id_a: activeContact.id,
+    relationship_type_id: '14',
+    start_date: 'now',
+    end_date: null,
+    contact_id_b: emptyContact.id,
+    case_id: caseIds[0],
+    description: 'Manager Role Assigned'
+  });
+
+  createUniqueRelationship({
+    contact_id_a: activeContact.id,
+    relationship_type_id: '11',
+    start_date: 'now',
+    end_date: null,
+    contact_id_b: emptyContact.id,
+    case_id: caseIds[0],
+    description: 'Homeless Coordinator Assigned'
+  });
+
   var fileUploadActivity = createUniqueActivity({
     activity_type_id: 'File Upload',
-    case_id: activeCaseId,
+    case_id: caseIds[0],
     source_contact_id: activeContact.id,
     subject: RECORD_IDENTIFIERS.fileUploadActivitySubject
   });
+
   var inlineCustomGroup = createUniqueCustomGroup({
     extends: 'Case',
     style: 'Inline',
@@ -433,6 +493,20 @@ function setupData () {
     title: RECORD_IDENTIFIERS.customGroups.tab.groupTitle
   });
 
+  createUniqueCustomField({
+    custom_group_id: inlineCustomGroup.id,
+    label: RECORD_IDENTIFIERS.customGroups.inline.fieldLabel,
+    data_type: 'String',
+    html_type: 'Text'
+  });
+
+  createUniqueCustomField({
+    custom_group_id: tabCustomGroup.id,
+    label: RECORD_IDENTIFIERS.customGroups.tab.fieldLabel,
+    data_type: 'String',
+    html_type: 'Text'
+  });
+
   createUniqueAttachment({
     content: '',
     entity_id: fileUploadActivity.id,
@@ -440,36 +514,81 @@ function setupData () {
     name: 'backstop-file-upload.png',
     mime_type: 'image/png'
   });
-  createUniqueCase({
-    case_type_id: caseType.id,
-    contact_id: emptyContact.id,
-    creator_id: emptyContact.id,
-    subject: RECORD_IDENTIFIERS.emptyCaseSubject
-  });
-  createUniqueCustomField({
-    custom_group_id: inlineCustomGroup.id,
-    label: RECORD_IDENTIFIERS.customGroups.inline.fieldLabel,
-    data_type: 'String',
-    html_type: 'Text'
-  });
-  createUniqueCustomField({
-    custom_group_id: tabCustomGroup.id,
-    label: RECORD_IDENTIFIERS.customGroups.tab.fieldLabel,
-    data_type: 'String',
-    html_type: 'Text'
-  });
+
   createUniqueTag({
     is_selectable: 1,
     name: RECORD_IDENTIFIERS.caseTag,
     used_for: 'Cases'
   });
   createUniqueEntityTag({
-    entity_id: activeCaseId,
+    entity_id: caseIds[0],
     entity_table: 'civicrm_case',
     tag_id: RECORD_IDENTIFIERS.caseTag
   });
 
+  createSampleUploadFile();
+
   return Promise.resolve();
+}
+
+/**
+ * Create Sample Upload File
+ */
+function createSampleUploadFile () {
+  fs.writeFileSync(FILES.sampleUploadFile, 'Sample Text');
+}
+
+/**
+ * Create Activities
+ *
+ * @param {number} caseId case id
+ * @param {object} activeContact active contact
+ * @returns {Array} list of activity ids
+ */
+function createActivities (caseId, activeContact) {
+  var activityIds = [];
+
+  for (var i = 1; i <= 30; i++) {
+    activityIds.push(createUniqueActivity({
+      activity_type_id: 'Follow up',
+      case_id: caseId,
+      source_contact_id: activeContact.id,
+      subject: 'Follow Up ' + i,
+      activity_date_time: moment().startOf('month').format('YYYY-MM-DD')
+    }).id);
+  }
+
+  return activityIds;
+}
+
+/**
+ * Create Cases
+ *
+ * @param {object} caseType case type
+ * @param {object} activeContact active contact
+ * @param {object} emptyContact empty contact
+ * @returns {Array} list of case ids
+ */
+function createCases (caseType, activeContact, emptyContact) {
+  var caseIds = [];
+
+  for (var i = 1; i <= 17; i++) {
+    caseIds.push(createUniqueCase({
+      case_type_id: caseType.id,
+      contact_id: activeContact.id,
+      creator_id: activeContact.id,
+      subject: RECORD_IDENTIFIERS.caseSubject + i
+    }).id);
+  }
+
+  caseIds.push(createUniqueCase({
+    case_type_id: caseType.id,
+    contact_id: emptyContact.id,
+    creator_id: emptyContact.id,
+    subject: RECORD_IDENTIFIERS.emptyCaseSubject
+  }).id);
+
+  return caseIds;
 }
 
 /**
@@ -532,9 +651,11 @@ async function writeCookies () {
   var config = siteConfig();
   var command = `drush ${config.drush_alias} uli --name=admin --uri=${config.url} --browser=0`;
   var loginUrl = execSync(command, { encoding: 'utf8', cwd: config.root });
-  var browser = await puppeteer.launch();
+  var browser = await puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox']
+  });
   var page = await browser.newPage();
-
   await page.goto(loginUrl);
 
   var cookies = await page.cookies();

--- a/tests/backstop_data/gulp-tasks/backstopjs.js
+++ b/tests/backstop_data/gulp-tasks/backstopjs.js
@@ -26,14 +26,10 @@ var CACHE = {
   emptyCaseId: null,
   contactIdsMap: {}
 };
-var CONFIG_TPL = {
-  url: 'http://%{site-host}',
-  drush_alias: '',
-  root: '%{path-to-site-root}'
-};
 var FILES = {
   sampleUploadFile: 'sample.txt',
   siteConfig: 'site-config.json',
+  siteConfigSample: 'site-config.json.sample',
   temp: 'backstop.temp.json',
   tpl: 'backstop.tpl.json'
 };
@@ -611,7 +607,9 @@ function touchSiteConfigFile () {
   try {
     fs.readFileSync(FILES.siteConfig);
   } catch (err) {
-    fs.writeFileSync(FILES.siteConfig, JSON.stringify(CONFIG_TPL, null, 2));
+    // fs.createReadStream(FILES.siteConfigSample).pipe(fs.createWriteStream(FILES.siteConfig));
+    fs.copyFileSync(FILES.siteConfigSample, FILES.siteConfig);
+    // fs.writeFileSync(FILES.siteConfig, JSON.stringify(CONFIG_TPL, null, 2));
 
     created = true;
   }

--- a/tests/backstop_data/package-lock.json
+++ b/tests/backstop_data/package-lock.json
@@ -1753,12 +1753,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1773,17 +1775,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1900,7 +1905,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1912,6 +1918,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1926,6 +1933,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1933,12 +1941,14 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1957,6 +1967,7 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -2018,7 +2029,8 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -2046,7 +2058,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2058,6 +2071,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2171,6 +2185,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/tests/backstop_data/package-lock.json
+++ b/tests/backstop_data/package-lock.json
@@ -642,6 +642,17 @@
         "supports-color": "^2.0.0"
       }
     },
+    "child-process-promise": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/child-process-promise/-/child-process-promise-2.2.1.tgz",
+      "integrity": "sha1-RzChHvYQ+tRQuPIjx50x172tgHQ=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^4.0.2",
+        "node-version": "^1.0.0",
+        "promise-polyfill": "^6.0.1"
+      }
+    },
     "chokidar": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -705,6 +716,15 @@
         "chrome-remote-interface": "^0.25.5",
         "jimp": "^0.2.28",
         "uuid": "^3.2.1"
+      }
+    },
+    "civicrm-cv": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/civicrm-cv/-/civicrm-cv-0.1.2.tgz",
+      "integrity": "sha1-prn+pVahci1Km3ChHGSHVXGmNKg=",
+      "dev": true,
+      "requires": {
+        "child-process-promise": "^2.1.3"
       }
     },
     "class-utils": {
@@ -920,6 +940,16 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cross-spawn": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "which": "^1.2.9"
+      }
     },
     "d": {
       "version": "1.0.1",
@@ -1702,7 +1732,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2119,7 +2150,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2175,6 +2207,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2218,12 +2251,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3372,6 +3407,16 @@
         "lodash._reinterpolate": "^3.0.0"
       }
     },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
     "make-iterator": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
@@ -3600,6 +3645,12 @@
         }
       }
     },
+    "moment": {
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
+      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==",
+      "dev": true
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -3680,6 +3731,12 @@
           "dev": true
         }
       }
+    },
+    "node-version": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/node-version/-/node-version-1.2.0.tgz",
+      "integrity": "sha512-ma6oU4Sk0qOoKEAymVoTvk8EdXEobdS7m/mAGhDJ8Rouugho48crHBORAmy5BoOcv8wraPM6xumapQp5hl4iIQ==",
+      "dev": true
     },
     "node.extend": {
       "version": "2.0.2",
@@ -4203,6 +4260,12 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise-polyfill": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.1.0.tgz",
+      "integrity": "sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc=",
+      "dev": true
+    },
     "proxy-addr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -4217,6 +4280,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "psl": {
@@ -5514,6 +5583,12 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yargs": {

--- a/tests/backstop_data/package-lock.json
+++ b/tests/backstop_data/package-lock.json
@@ -1732,8 +1732,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1754,14 +1753,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1776,20 +1773,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1906,8 +1900,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1919,7 +1912,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1934,7 +1926,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1942,14 +1933,12 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1968,7 +1957,6 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -2030,8 +2018,7 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -2059,8 +2046,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2072,7 +2058,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2150,8 +2135,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2187,7 +2171,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2207,7 +2190,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2251,14 +2233,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/tests/backstop_data/scenarios/activity-feed-panel.json
+++ b/tests/backstop_data/scenarios/activity-feed-panel.json
@@ -1,26 +1,26 @@
-  {
+{
   "scenarios": [{
     "label": "Activity Feed Panel - Main Section",
-    "url": "{url}/civicrm/case/a/#/case?dtab=1"
+    "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&dtab=1&drel=all"
   },
   {
     "label": "Activity Feed Panel - Loading State",
-    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&dtab=1&drel=all",
     "captureLoadingScreen": true
   },
   {
     "label": "Activity Feed Panel - Bulk Actions",
-    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&dtab=1&drel=all",
     "onReadyScript": "activity-feed-panel/bulk-actions.js"
   },
   {
     "label": "Activity Feed Panel - Load more clicked",
-    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&dtab=1&drel=all",
     "onReadyScript": "activity-feed-panel/load-more-clicked.js"
   },
   {
     "label": "Activity Feed Panel - Filters",
-    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&dtab=1&drel=all",
     "clickSelectors": [
       ".civicase__activity-filter__more",
       ".civicase__activity-filter__others:first-of-type input"
@@ -28,73 +28,73 @@
   },
   {
     "label": "Activity Feed Panel - Activity Details - Activity Panel visible",
-    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&dtab=1&drel=all",
     "onReadyScript": "activity-feed-panel/activity-detail.js"
   },
   {
     "label": "Activity Feed Panel - Activity Details - Selected Activity - Details",
-    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&dtab=1&drel=all",
     "onReadyScript": "activity-feed-panel/activity-detail.js",
     "selectors": [".CRM_Activity_Form_Activity"]
   },
   {
     "label": "Activity Feed Panel - Selected Activity - Details - Maximise",
-    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&dtab=1&drel=all",
     "onReadyScript": "activity-feed-panel/activity-detail-maximize.js"
   },
   {
     "label": "Activity Feed Panel - Selected Activity - Details - Status Dropdown",
-    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&dtab=1&drel=all",
     "onReadyScript": "activity-feed-panel/activity-detail-status-dropdown.js"
   },
   {
     "label": "Activity Feed Panel - Selected Activity - Details - Priority Dropdown",
-    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&dtab=1&drel=all",
     "onReadyScript": "activity-feed-panel/activity-detail-priority-dropdown.js"
   },
   {
     "label": "Activity Feed Panel - Activity Card Menu",
-    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&dtab=1&drel=all",
     "clickSelector": ".civicase__activity-feed__list:first-child .civicase__activity-card .civicase__activity-card-menu"
   },
   {
     "label": "Activity Feed Panel - Activity Details - Edit Activity",
-    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&dtab=1&drel=all",
     "onReadyScript": "activity-feed-panel/activity-edit-details.js"
   },
   {
     "label": "Activity Feed Panel - On Manage Cases",
-    "url": "{url}/civicrm/case/a/#/case/list",
+    "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D",
     "onReadyScript": "activity-feed-panel/on-manage-cases.js"
   },
   {
     "label": "Activity Feed Panel - On Contact Page",
-    "url": "{url}/civicrm/contact/view?cid={contactName:admin}&selectedChild=activity",
+    "url": "{url}/civicrm/contact/view?reset=1&cid={contactName:Arnold Backstop}&selectedChild=activity#/?af=%7B%22case_type_category%22:%22Cases%22,%22@involvingContact%22:%22%22%7D&ado=%7B%22followup_nested%22:true,%22overdue_first%22:true,%22include_case%22:true%7D",
     "onReadyScript": "activity-feed-panel/on-contact-page.js"
   },
   {
     "label": "Activity Feed Panel - Bulk Actions - Move to case",
-    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&dtab=1&drel=all",
     "onReadyScript": "activity-feed-panel/bulk-actions-move-to-case.js"
   },
   {
     "label": "Activity Feed Panel - Bulk Actions - Copy to case",
-    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&dtab=1&drel=all",
     "onReadyScript": "activity-feed-panel/bulk-actions-copy-to-case.js"
   },
   {
     "label": "Activity Feed Panel - Bulk Actions - Add tags",
-    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&dtab=1&drel=all",
     "onReadyScript": "activity-feed-panel/bulk-actions-add-tag.js"
   },
   {
     "label": "Activity Feed Panel - Bulk Actions - Remove tags",
-    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&dtab=1&drel=all",
     "onReadyScript": "activity-feed-panel/bulk-actions-remove-tag.js"
   },
   {
     "label": "Activity Feed Panel - Bulk Actions - Delete",
-    "url": "{url}/civicrm/case/a/#/case?dtab=1",
+    "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&dtab=1&drel=all",
     "onReadyScript": "activity-feed-panel/bulk-actions-delete.js"
   }]
 }

--- a/tests/backstop_data/scenarios/contact-case-tab.json
+++ b/tests/backstop_data/scenarios/contact-case-tab.json
@@ -2,29 +2,29 @@
   "scenarios": [
     {
       "label": "Contact - Case Tab",
-      "url": "{url}/civicrm/contact/view?cid={contactName:admin}&selectedChild=case",
+      "url": "{url}/civicrm/contact/view?cid={contactName:Arnold Backstop}&selectedChild=case",
       "readySelector": ".civicase__contact-cases-tab-container"
     },
     {
       "label": "Contact - Case Tab - loading",
-      "url": "{url}/civicrm/contact/view?cid={contactName:admin}&selectedChild=case",
+      "url": "{url}/civicrm/contact/view?cid={contactName:Arnold Backstop}&selectedChild=case",
       "readySelector": ".civicase__contact-cases-tab-container",
       "captureLoadingScreen": true
     },
     {
       "label": "Contact - Case Tab - Load More loading icon",
-      "url": "{url}/civicrm/contact/view?cid={contactName:admin}&selectedChild=case",
+      "url": "{url}/civicrm/contact/view?cid={contactName:Arnold Backstop}&selectedChild=case",
       "clickSelector": ".civicase__contact-case-tab__case-list__footer button"
     },
     {
       "label": "Contact - Case Tab - Action Dropdown",
-      "url": "{url}/civicrm/contact/view?cid={contactName:admin}&selectedChild=case",
+      "url": "{url}/civicrm/contact/view?cid={contactName:Arnold Backstop}&selectedChild=case",
       "readySelector": ".civicase__contact-cases-tab-container",
       "clickSelector": ".civicase__case-header__action-icon"
     },
     {
       "label": "Contact - Case Tab - Status Dropdown",
-      "url": "{url}/civicrm/contact/view?cid={contactName:admin}&selectedChild=case",
+      "url": "{url}/civicrm/contact/view?cid={contactName:Arnold Backstop}&selectedChild=case",
       "onReadyScript": "contacts/contact-case-tab-status-dropdown.js"
     }
   ]

--- a/tests/backstop_data/scenarios/dashboard.json
+++ b/tests/backstop_data/scenarios/dashboard.json
@@ -2,14 +2,14 @@
   "scenarios": [
     {
       "label": "Civicase - Dashboard - With overview table expanded and tooltip visible on one of the titles",
-      "url": "{url}/civicrm/case/a/#/case",
+      "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&drel=all",
       "clickSelector": ".civicase__case-overview__flow-status-settings + .civicase__case-overview__flow-status__icon",
       "hoverSelector": ".civicase__case-overview__flow-status--hoverable",
       "isUIBPopover": true
     },
     {
       "label": "Civicase - Dashboard - With overview table expanded, gear icon opened and case filter dropdown opened",
-      "url": "{url}/civicrm/case/a/#/case",
+      "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&drel=all",
       "clickSelectors": [
         ".civicase__case-overview__flow-status-settings + .civicase__case-overview__flow-status__icon",
         ".civicase__case-overview__flow-status-settings",
@@ -18,24 +18,24 @@
     },
     {
       "label": "Civicase - Dashboard - Loading State",
-      "url": "{url}/civicrm/case/a/#/case",
+      "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&drel=all",
       "captureLoadingScreen": true
     },
     {
       "label": "Civicase - Dashboard - Calendar - Activity Card",
-      "url": "{url}/civicrm/case/a/#/case",
+      "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&drel=all",
       "clickSelector": ".civicase__activities-calendar__day-status",
       "waitForAjaxComplete": true
     },
     {
       "label": "Civicase - Dashboard - Calendar - Activity Card - Loading state",
-      "url": "{url}/civicrm/case/a/#/case",
+      "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&drel=all",
       "clickSelector": ".civicase__activities-calendar__day-status"
     },
     {
       "label": "Civicase - Dashboard - Add case modal",
-      "url": "{url}/civicrm/case/a/#/case",
-      "clickSelector": ".civicase__affix__activity-filters .pull-right > span:nth-of-type(2) .civicase__dashboard__action-btn",
+      "url": "{url}/civicrm/case/a/#/case?case_type_category=cases&drel=all",
+      "clickSelector": ".civicase__dashboard__action-btn[ng-controller='AddCaseDashboardActionButtonController']",
       "waitForUIModalLoad": true
     }
   ]

--- a/tests/backstop_data/scenarios/manage-cases.json
+++ b/tests/backstop_data/scenarios/manage-cases.json
@@ -2,23 +2,23 @@
   "scenarios": [
     {
       "label": "Manage Cases - List Loading",
-      "url": "{url}/civicrm/case/a/#/case/list",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D",
       "captureLoadingScreen": true
     },
     {
       "label": "Manage Cases - List",
-      "url": "{url}/civicrm/case/a/#/case/list",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D",
       "waitForLoadingComplete": ".civicase__case-list-panel"
     },
     {
       "label": "Manage Cases - Other Criterion/Find Case",
-      "url": "{url}/civicrm/case/a/#/case/list",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D",
       "waitForLoadingComplete": ".civicase__case-list-panel",
       "clickSelector": ".civicase__case-filter-panel__button[ng-show=\"!expanded\"]"
     },
     {
       "label": "Manage Cases - Case Overview",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}",
       "waitForLoadingComplete": ".civicase__summary-tab",
       "apiCalls": [
         "setting.create civicaseAllowLinkedCasesTab=0"
@@ -33,32 +33,32 @@
     },
     {
       "label": "Manage Cases - Case Overview - Loading",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}",
       "captureLoadingScreen": true
     },
     {
       "label": "Manage Cases - Case Overview - Full Screen",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}",
       "clickSelector": ".civicase__case-header__expand_button",
       "delay": 300
     },
     {
       "label": "Manage Cases - Case Overview - Empty Case",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={emptyCaseId}"
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={emptyCaseId}"
     },
     {
       "label": "Manage Cases - Case Overview - Activity Calendar open",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}",
       "clickSelector": ".civicase__activities-calendar__day-status"
     },
     {
       "label": "Manage Cases - Case Overview - Edit Custom Data",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}",
       "clickSelector": ".civicase__case-custom-fields__container .crm-editable-enabled"
     },
     {
       "label": "Manage Cases - Case Overview - Add New menu",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}",
       "clickSelectors": [
         ".civicase__case-details__add-new-dropdown .btn-primary",
         ".civicase__activity-dropdown",
@@ -71,39 +71,41 @@
     },
     {
       "label": "Manage Cases - Case Overview - People tab",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}&tab=People"
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}&tab=People",
+      "waitForLoadingComplete": ".civicase__people-tab__sub-tab:not([ng-show=\"tab == 'relations'\"])"
     },
     {
       "label": "Manage Cases - Case Overview - People tab - Loading",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}&tab=People",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}&tab=People",
       "captureLoadingScreen": true
     },
     {
       "label": "Manage Cases - Case Overview - People tab - Other Relationships",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}&tab=People&peopleTab=relations"
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}&tab=People&peopleTab=relations",
+      "waitForLoadingComplete": ".civicase__people-tab__sub-tab:not([ng-show=\"tab == 'roles'\"])"
     },
     {
       "label": "Manage Cases - Case Overview - People tab - Other Relationships - Loading",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}&tab=People",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}&tab=People",
       "onReadyScript": "manage-cases/people-tab-other-relationships-loading.js"
     },
     {
       "label": "Manage Cases - Case Overview - Files tab - Loading",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}&tab=Files",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}&tab=Files",
       "captureLoadingScreen": true
     },
     {
       "label": "Manage Cases - Case Overview - Files tab",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}&tab=Files"
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}&tab=Files"
     },
     {
       "label": "Manage Cases - Case Overview - Files tab - Upload File",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}&tab=Files",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}&tab=Files",
       "onReadyScript": "manage-cases/files-tab-upload-file.js"
     },
     {
       "label": "Manage Cases - Case Overview - Linked Cases Tab",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}&tab=LinkedCases",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}&tab=LinkedCases",
       "waitForLoadingComplete": "#crm-main-content-wrapper",
       "apiCalls": [
         "setting.create civicaseAllowLinkedCasesTab=1"
@@ -111,92 +113,93 @@
     },
     {
       "label": "Manage Cases - List - Bulk action with checkbox selected and dropdown opened",
-      "url": "{url}/civicrm/case/a/#/case/list",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D",
       "onReadyScript": "manage-cases/bulk-actions.js"
     },
     {
       "label": "Manage Cases - List - Sort Dropdown",
-      "url": "{url}/civicrm/case/a/#/case/list",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D",
       "onReadyScript": "manage-cases/sort-dropdown.js"
     },
     {
       "label": "Manage Cases - Case Overview - Action Dropdown",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}",
       "onReadyScript": "manage-cases/action-dropdown.js"
     },
     {
       "label": "Manage Cases - Case Overview - Action Dropdown - Change case status",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}",
       "onReadyScript": "manage-cases/action-dropdown-change-status.js"
     },
     {
       "label": "Manage Cases - Case Overview - Action Dropdown - Edit tags",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}",
       "onReadyScript": "manage-cases/action-dropdown-edit-tags.js"
     },
     {
       "label": "Manage Cases - Case Overview - Action Dropdown - Email Case Manager",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}",
       "onReadyScript": "manage-cases/action-dropdown-email-case-manager.js"
     },
     {
       "label": "Manage Cases - Case Overview - Action Dropdown - Print/Merge Document",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}",
       "onReadyScript": "manage-cases/action-dropdown-print-merge.js"
     },
     {
       "label": "Manage Cases - Case Overview - Action Dropdown - Export cases",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}",
       "onReadyScript": "manage-cases/action-dropdown-export.js"
     },
     {
       "label": "Manage Cases - Case Overview - Action Dropdown - Link cases",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}",
       "onReadyScript": "manage-cases/action-dropdown-link.js"
     },
     {
       "label": "Manage Cases - Case Overview - Action Dropdown - Lock case",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}",
       "onReadyScript": "manage-cases/action-dropdown-lock.js"
     },
     {
       "label": "Manage Cases - Case Overview - Action Dropdown - Delete case",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}",
       "onReadyScript": "manage-cases/action-dropdown-delete.js"
     },
     {
       "label": "Manage Cases - Case Overview - Status Dropdown",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}",
       "onReadyScript": "manage-cases/status-dropdown.js"
     },
     {
       "label": "Manage Cases - Case Overview - Status Dropdown - Change status",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}",
       "onReadyScript": "manage-cases/status-dropdown-change-status.js"
     },
     {
       "label": "Manage Cases - Case Overview - Status Dropdown - Change status",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}",
       "onReadyScript": "manage-cases/status-dropdown-change-status.js"
     },
     {
       "label": "Manage Cases - Case Overview - People tab - Case role dropdown",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}&tab=People",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}&tab=People",
       "onReadyScript": "manage-cases/people-tab-add-case-role-dropdown.js"
     },
     {
       "label": "Manage Cases - Case Overview - People tab - Assign role to a client",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}&tab=People",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}&tab=People",
       "onReadyScript": "manage-cases/people-tab-add-case-role-to-client.js"
     },
     {
       "label": "Manage Cases - Case Overview - People tab - Assign role to a non client",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}&tab=People",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}&tab=People",
       "onReadyScript": "manage-cases/people-tab-add-case-role-to-non-client.js"
     },
     {
       "label": "Manage Cases - Case Overview - People tab - Remove role",
-      "url": "{url}/civicrm/case/a/#/case/list?caseId={caseId}&tab=People",
+      "url": "{url}/civicrm/case/a/?case_type_category=cases#/case/list?cf=%7B\"case_type_category\":\"cases\"%7D&caseId={caseId}&tab=People",
+      "waitForLoadingComplete": ".civicase__people-tab__sub-tab:not([ng-show=\"tab == 'relations'\"])",
       "clickSelectors": [
         ".civicase__people-tab__table-body tr:first-child .btn",
         ".civicase__people-tab__table-body tr:first-child .dropdown-menu li:nth-child(3) a"

--- a/tests/backstop_data/site-config.json.sample
+++ b/tests/backstop_data/site-config.json.sample
@@ -1,0 +1,5 @@
+{
+  "url": "<url>",
+  "drush_alias": "",
+  "root": "<path-to-site-root>"
+}


### PR DESCRIPTION
## Overview
As part of this PR, Backstop JS tests are configured through Github Actions.

## Why this is needed?
At the moment, backstop js is run on our local. And the problem with this is, 
  1. Setting up backstop tests, is not nice experience, as we need to make sure all the data is setup properly.
  2. Also running the tests take at least an hour, and if some data is missing, then we need to re run.

So the idea is to run Backstop tests through Github Actions, with data being set up automatically using code.

## How to Run the Test
To run the test, Add "run backstop" label to the Pull Request.
If needed to rerun backstop tests in the same Pull Request, just remove the "run backstop" label and add it again.

![2020-07-21 at 5 14 PM](https://user-images.githubusercontent.com/5058867/88051125-bebeaa00-cb75-11ea-8b52-80eb34e8b75c.jpg)

## How to get the BackstopJS Test Report
1. One "run backstop" label is added to the Pull Request, the github action will start running.
![2020-07-21 at 5 15 PM](https://user-images.githubusercontent.com/5058867/88051196-dbf37880-cb75-11ea-809c-ab5ade4d12ad.jpg)

2. After 15-20 mins, when all the tests are done, there will be a Green Dot beside the Backstop Tests job.
![2020-07-21 at 5 17 PM](https://user-images.githubusercontent.com/5058867/88051344-13622500-cb76-11ea-9485-fbc9f1e93bdc.jpg)

3. At this moment, click on the "Details" link, next to the Backstop Tests job.
![2020-07-21 at 5 17 PM](https://user-images.githubusercontent.com/5058867/88051393-27a62200-cb76-11ea-83b1-b5adf3d8726d.jpg)

4. Download the Backstop Report
![2020-07-21 at 5 18 PM](https://user-images.githubusercontent.com/5058867/88051462-46a4b400-cb76-11ea-80dd-e6d330e1a78e.jpg)

5. Extract the downloaded Zip file, and open `html_report/index.html`.  The report will be visible on the browser, and screenshots can be compared within the browser itself.

## Technical Details
1. `.github/workflows/backstop.yml` contains the steps for the Backstop JS github action.
2. In `tests/backstop_data/backstop.tpl.json`, added `--no-sandbox` argument, which are essential to run tests on Headless Chrome inside github.
3. In `tests/backstop_data/gulp-tasks/backstopjs.js`, added more steps to setup all the data required for running backstop.
4. Updated the backstop scenarios which were in a broken state.