### PR TITLE
CATL-1523: Fix permission error in Files Tab while adding tags

### DIFF
--- a/ang/civicase/shared/directives/file-uploader.directive.js
+++ b/ang/civicase/shared/directives/file-uploader.directive.js
@@ -139,7 +139,7 @@
      * @returns {Promise} promise
      */
     function saveTags (activityID) {
-      return civicaseCrmApi('EntityTag', 'create', {
+      return civicaseCrmApi('EntityTag', 'createByQuery', {
         entity_table: 'civicrm_activity',
         tag_id: $scope.tags.selected,
         entity_id: activityID

--- a/ang/test/civicase/shared/directives/file-uploader.directive.spec.js
+++ b/ang/test/civicase/shared/directives/file-uploader.directive.spec.js
@@ -82,7 +82,7 @@
       });
 
       it('saves the selected tags with respect to the activity', () => {
-        expect(civicaseCrmApi).toHaveBeenCalledWith('EntityTag', 'create', {
+        expect(civicaseCrmApi).toHaveBeenCalledWith('EntityTag', 'createByQuery', {
           entity_table: 'civicrm_activity',
           tag_id: ['102'],
           entity_id: '101'


### PR DESCRIPTION
## Overview
In Case Files tab, when uploading a file with Tags, the tags were not added unless the "edit all contacts" permission is added.

## Before
![before](https://user-images.githubusercontent.com/5058867/88909399-ad158a80-d278-11ea-9ee7-5d943f94d392.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/88909394-aa1a9a00-d278-11ea-9d19-d085573ed4eb.gif)

## Technical Details
Permission error is with `EntityTag.create`, which is a Core API.
It was decided to switch to custom `EntityTag.createByQuery`endpoint to bypass the permission error, which was created in civicase. And it does not check the "edit all contacts" permission.
