### PR TITLE
CATL-1572: Remove Title from Activity Card when showing Contact's Full Name

### DIFF
--- a/ang/civicase/contact/directives/contact-card.directive.html
+++ b/ang/civicase/contact/directives/contact-card.directive.html
@@ -25,7 +25,7 @@
         'civicase__contact-avatar--image': contacts[0].image_URL,
         'civicase__contact-avatar--has-full-name': showFullNameOnHover
       }"
-      title="{{contacts[0].display_name}}">
+      ng-attr-title="{{showFullNameOnHover ? '' : contacts[0].display_name}}">
       <img ng-if="contacts[0].image_URL" ng-src={{contacts[0].image_URL}}>
       <span ng-if="!contacts[0].image_URL">{{contacts[0].avatar}}</span>
       <span


### PR DESCRIPTION
## Overview
This PR removes the HTML title (tooltip) when the contact's full name is displayed on activity cards. 

Displaying the full name is controlled through a setting. For info refer to the original PR:
https://github.com/compucorp/uk.co.compucorp.civicase/pull/521

## Before
![gif](https://user-images.githubusercontent.com/1642119/88976189-a2afbc80-d289-11ea-91dd-4e246304923b.gif)

## After

### When the setting is ON
![gif](https://user-images.githubusercontent.com/1642119/88976065-611f1180-d289-11ea-850a-35f870a07f57.gif)

### When the setting is OFF
![gif](https://user-images.githubusercontent.com/1642119/88975868-05ed1f00-d289-11ea-8a36-24c4ccae917f.gif)

## Technical Details

We add an empty title when showing the contact's full name. This stops the title from showing.
