### PR TITLE
FEMS-45: Fix resuming standalone draft email activities

### DIFF
--- a/ang/civicase/activity/activity-forms/services/draft-email-activity-form.service.js
+++ b/ang/civicase/activity/activity-forms/services/draft-email-activity-form.service.js
@@ -29,11 +29,11 @@
      */
     function getActivityFormUrl (activity, optionsWithoutDefaults) {
       var options = _.defaults({}, optionsWithoutDefaults, { action: 'add' });
-      var assigneeContactId = _.first(activity.assignee_contact_id);
+      var sourceContactId = _.first(activity.source_contact_id);
       var draftFormParameters = {
         action: options.action,
         atype: activity.activity_type_id,
-        cid: assigneeContactId,
+        cid: sourceContactId,
         draft_id: activity.id,
         id: activity.id,
         reset: '1'

--- a/ang/test/civicase/activity/activity-forms/services/draft-email-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/draft-email-activity-form.service.spec.js
@@ -53,7 +53,7 @@
           action: 'add',
           atype: activity.activity_type_id,
           caseid: activity.case_id,
-          cid: activity.assignee_contact_id[0],
+          cid: activity.source_contact_id[0],
           draft_id: activity.id,
           id: activity.id,
           reset: '1'


### PR DESCRIPTION
## Overview
This PR fixes a bug where standalone email activities could not be resumed.

## Before
![gif](https://user-images.githubusercontent.com/1642119/89234280-a6a94a80-d5b9-11ea-95c8-19add2cab617.gif)

## After
![gif](https://user-images.githubusercontent.com/1642119/89234675-7a41fe00-d5ba-11ea-8951-f2f801ef2d45.gif)

## Technical Details

The issue happens because we were referencing the activity's assignee contact and this contact is not defined for standalone activities, only for case activities. We replaced this to the source contact which is used by both standalone and case activities. For case activities the source contact and assignee are the same for draft emails.