### PR TITLE
CATL-1605: Edit Cases Tags refactoring

### DIFF
--- a/ang/civicase/case/actions/directives/edit-tags.html
+++ b/ang/civicase/case/actions/directives/edit-tags.html
@@ -1,10 +1,8 @@
-<div>
-  <p>
-    <label>{{ model.ts('Tags') }}</label>
-    <input class="huge" ng-list crm-ui-select="{allowClear: true, multiple: true, data: model.colorTags}" ng-model="model.tags" />
-  </p>
-  <p ng-repeat="tagset in model.tagsets">
-    <label>{{ tagset.name }}</label>
-    <input class="huge" ng-list crm-entityref="{entity: 'Tag', create: true, api: {params: {is_selectable: 1, parent_id: tagset.id}}, select: {multiple: true}}" ng-model="model[tagset.id]" />
-  </p>
+<div id="bootstrap-theme" class="civicase__tags-modal">
+  <form class="form-horizontal">
+    <civicase-tags-selector
+      model="model.selectedTags"
+      all-tags="model.allTags">
+    </civicase-tags-selector>
+  </form>
 </div>

--- a/ang/civicase/case/actions/services/edit-tags-case-action.service.js
+++ b/ang/civicase/case/actions/services/edit-tags-case-action.service.js
@@ -5,10 +5,11 @@
 
   /**
    *
+   * @param {Function} ts translation service
    * @param {object} dialogService dialog service
    * @param {object} civicaseCrmApi service to use civicrm api
    */
-  function EditTagsCaseAction (dialogService, civicaseCrmApi) {
+  function EditTagsCaseAction (ts, dialogService, civicaseCrmApi) {
     /**
      * Click event handler for the Action
      *
@@ -29,7 +30,7 @@
 
       getTags()
         .then(function (tags) {
-          var model = setModelObjectForModal(tags);
+          var model = getModelObjectForModal(tags);
 
           model.selectedTags = existingTags;
 
@@ -51,7 +52,7 @@
         width: '450px',
         title: title,
         buttons: [{
-          text: 'Save',
+          text: ts('Save'),
           icons: { primary: 'fa-check' },
           click: function () {
             editTagModalClickEvent.call(this, model, casesObj);
@@ -61,18 +62,16 @@
     }
 
     /**
-     * Set the model object to be used in the modal
+     * Get the model object to be used in the modal
      *
      * @param {Array} tags tags
      * @returns {object} model object for the dialog box
      */
-    function setModelObjectForModal (tags) {
-      var model = {};
-
-      model.allTags = tags;
-      model.selectedTags = [];
-
-      return model;
+    function getModelObjectForModal (tags) {
+      return {
+        allTags: tags,
+        selectedTags: []
+      };
     }
 
     /**

--- a/ang/civicase/case/list/directives/case-list-table.directive.js
+++ b/ang/civicase/case/list/directives/case-list-table.directive.js
@@ -391,6 +391,7 @@
       if (!params.is_deleted && !params.id) {
         params.is_deleted = 0;
       }
+
       return [
         ['Case', 'getcaselist', $.extend(true, returnCaseParams, params)],
         ['Case', 'getdetailscount', params]

--- a/ang/civicase/contact/directives/contact-card.directive.js
+++ b/ang/civicase/contact/directives/contact-card.directive.js
@@ -74,11 +74,17 @@
         if (typeof $scope.data === 'string') {
           return ContactsCache.add([$scope.data]);
         } else {
-          var contactIDs = $scope.data.map(function (contact) {
-            if (contact) {
-              return contact.contact_id;
-            }
-          });
+          var contactIDs;
+
+          if (_.isPlainObject($scope.data)) {
+            contactIDs = _.keys($scope.data);
+          } else {
+            contactIDs = $scope.data.map(function (contact) {
+              if (contact) {
+                return contact.contact_id;
+              }
+            });
+          }
 
           return ContactsCache.add(contactIDs);
         }

--- a/ang/civicase/contact/directives/contact-card.directive.js
+++ b/ang/civicase/contact/directives/contact-card.directive.js
@@ -71,23 +71,20 @@
        * @returns {Promise} promise
        */
       function fetchContactsInfo () {
+        var contactIds;
+
         if (typeof $scope.data === 'string') {
-          return ContactsCache.add([$scope.data]);
+          contactIds = [$scope.data];
+        } else if (_.isPlainObject($scope.data)) {
+          contactIds = _.keys($scope.data);
         } else {
-          var contactIDs;
-
-          if (_.isPlainObject($scope.data)) {
-            contactIDs = _.keys($scope.data);
-          } else {
-            contactIDs = $scope.data.map(function (contact) {
-              if (contact) {
-                return contact.contact_id;
-              }
-            });
-          }
-
-          return ContactsCache.add(contactIDs);
+          contactIds = _.chain($scope.data)
+            .compact()
+            .map('contact_id')
+            .value();
         }
+
+        return ContactsCache.add(contactIds);
       }
 
       /**

--- a/ang/test/civicase/case/actions/services/edit-tags-case-action.service.spec.js
+++ b/ang/test/civicase/case/actions/services/edit-tags-case-action.service.spec.js
@@ -1,0 +1,112 @@
+/* eslint-env jasmine */
+
+(function (_, $) {
+  describe('EditTagsCaseAction', function () {
+    var $q, $rootScope, EditTagsCaseAction, CasesData,
+      civicaseCrmApiMock, dialogServiceMock, TagsMockData;
+
+    beforeEach(module('civicase', 'civicase.data', ($provide) => {
+      civicaseCrmApiMock = jasmine.createSpy('civicaseCrmApi');
+      dialogServiceMock = jasmine.createSpyObj('dialogService', ['open']);
+
+      $provide.value('civicaseCrmApi', civicaseCrmApiMock);
+      $provide.value('dialogService', dialogServiceMock);
+    }));
+
+    beforeEach(inject(function (_$q_, _$rootScope_, _EditTagsCaseAction_,
+      _CasesData_, _TagsMockData_) {
+      $q = _$q_;
+      $rootScope = _$rootScope_;
+      EditTagsCaseAction = _EditTagsCaseAction_;
+      CasesData = _CasesData_.get().values;
+      TagsMockData = _TagsMockData_.get();
+
+      spyOn($.fn, 'dialog');
+    }));
+
+    describe('basic tests', function () {
+      let modalOpenCall, callBackFn;
+
+      beforeEach(() => {
+        callBackFn = jasmine.createSpy('callBackFn');
+        var editTagsCaseAction = {
+          title: 'Edit Tags',
+          action: 'EditTags'
+        };
+
+        civicaseCrmApiMock.and.returnValue($q.resolve({ values: TagsMockData }));
+
+        var caseObj = angular.copy(CasesData[0]);
+        caseObj.tag_id = {
+          1: { tag_id: 1 },
+          2: { tag_id: 2 }
+        };
+
+        EditTagsCaseAction.doAction([caseObj], editTagsCaseAction, callBackFn);
+
+        $rootScope.$digest();
+        modalOpenCall = dialogServiceMock.open.calls.mostRecent().args;
+      });
+
+      it('fetches the tags and shows on the UI', () => {
+        expect(civicaseCrmApiMock).toHaveBeenCalledWith('Tag', 'get', {
+          sequential: 1,
+          used_for: { LIKE: '%civicrm_case%' },
+          options: { limit: 0 }
+        });
+      });
+
+      it('opens the modal to show tags', () => {
+        expect(modalOpenCall[0]).toBe('EditTags');
+        expect(modalOpenCall[1]).toBe('~/civicase/case/actions/directives/edit-tags.html');
+        expect(modalOpenCall[3]).toEqual({
+          autoOpen: false,
+          height: 'auto',
+          width: '450px',
+          title: 'Edit Tags',
+          buttons: [{
+            text: 'Save',
+            icons: { primary: 'fa-check' },
+            click: jasmine.any(Function)
+          }]
+        });
+      });
+
+      it('displays the existing tags', () => {
+        expect(modalOpenCall[2]).toEqual({
+          allTags: TagsMockData,
+          selectedTags: [1, 2]
+        });
+      });
+
+      describe('when saving the tags', () => {
+        beforeEach(() => {
+          modalOpenCall[2].selectedTags = [1, 3];
+          modalOpenCall[3].buttons[0].click();
+        });
+
+        it('deletes the removed tags', () => {
+          expect(callBackFn.calls.mostRecent().args[0][0]).toEqual([
+            'EntityTag', 'deleteByQuery', { entity_id: '141', tag_id: [2], entity_table: 'civicrm_case' }
+          ]);
+        });
+
+        it('adds the newly added tags', () => {
+          expect(callBackFn.calls.mostRecent().args[0][1]).toEqual([
+            'EntityTag', 'createByQuery', { entity_id: '141', tag_id: [3], entity_table: 'civicrm_case' }
+          ]);
+        });
+
+        it('creates an activity', () => {
+          expect(callBackFn.calls.mostRecent().args[0][2]).toEqual([
+            'Activity', 'create', { case_id: '141', status_id: 'Completed', activity_type_id: 'Change Case Tags' }
+          ]);
+        });
+
+        it('closes the dialog', () => {
+          expect($.fn.dialog).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+})(CRM._, CRM.$);


### PR DESCRIPTION
## Overview
Similar to https://github.com/compucorp/uk.co.compucorp.civicase/pull/545, as part of this PR, permission errors has been fixed while adding/removing tags for a Case.
Also changed the UI of the tags selection modal, to align this with other tags selection modals

## Before
![before](https://user-images.githubusercontent.com/5058867/89388536-cce9fa00-d721-11ea-9c9a-b2fac5c8051b.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/89388642-ec812280-d721-11ea-9eb0-8b46accec4b7.gif)

## Technical Details
1. Used `civicase-tags-selector` directive in `ang/civicase/case/actions/directives/edit-tags.html`.
2. In `ang/civicase/case/actions/services/edit-tags-case-action.service.js`, changed the implementation to use `civicase-tags-selector`.


### Regression bug fixed
Also fixed a regression introduced in https://github.com/compucorp/uk.co.compucorp.civicase/pull/543, which resulted in "To" field not being shown in Activity Card. Also there were console errors.

**Before**
![2020-08-05 at 1 50 PM](https://user-images.githubusercontent.com/5058867/89389167-b7290480-d722-11ea-95f3-55c7e225505f.jpg)

**After**
![2020-08-05 at 1 51 PM](https://user-images.githubusercontent.com/5058867/89389225-c9a33e00-d722-11ea-918d-181ac779bae7.jpg)

**Technical Details**
In `ang/civicase/contact/directives/contact-card.directive.js`, the `fetchContactsInfo()` was not handling the situation when the `$scope.data` is plain object. The same has been fixed.
Ideally the `contact-card` should always get data in a single format. But right now it gets data in `string`, `array` and `object` format. But this could not be refactored because of time constraints, as this architecture is present from Civicase Core, and needs much more time to refactor.