### PR TITLE
CATL-1606: Application Performance Optimisation

### DIFF
--- a/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
+++ b/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
@@ -533,6 +533,9 @@
       if ($scope.caseParams) {
         params.case_filter = $scope.caseParams;
 
+        // modified date is always updated when updating a case
+        // so adding this improves the performance of the api call
+        // as unnecessary cases are filtered out
         params.case_filter.modified_date = {
           '>=': params.activity_date_time.BETWEEN[0]
         };

--- a/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
+++ b/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
@@ -409,8 +409,8 @@
         }
 
         return loadDaysWithActivities(date)
-          .then(function (data) {
-            updatesDatesByActivityStatusType(date, data);
+          .then(function (daysGroupedByStatusType) {
+            updatesDatesByActivityStatusType(date, daysGroupedByStatusType);
 
             $scope.$emit('civicase::ActivitiesCalendar::refreshDatepicker');
           });
@@ -552,17 +552,19 @@
     /**
      *
      * @param {Date} date date
-     * @param {object} data data returned from api
+     * @param {object} daysGroupedByStatusType data returned from api
      */
-    function updatesDatesByActivityStatusType (date, data) {
+    function updatesDatesByActivityStatusType (date, daysGroupedByStatusType) {
       var datesWithIncompleteStatuses = [];
       var datesWithCompleteStatuses = [];
 
-      _.each(data, function (val, key) {
-        if (incompleteActivityStatusTypes.indexOf(parseInt(key)) > -1) {
-          datesWithIncompleteStatuses = datesWithIncompleteStatuses.concat(val);
-        } else if (completeActivityStatusTypes.indexOf(parseInt(key)) > -1) {
-          datesWithCompleteStatuses = datesWithCompleteStatuses.concat(val);
+      _.each(daysGroupedByStatusType, function (datesList, statusTypeId) {
+        var statusTypeIdInt = parseInt(statusTypeId, 10);
+
+        if (_.includes(incompleteActivityStatusTypes, statusTypeIdInt)) {
+          datesWithIncompleteStatuses = datesWithIncompleteStatuses.concat(datesList);
+        } else if (_.includes(completeActivityStatusTypes, statusTypeIdInt)) {
+          datesWithCompleteStatuses = datesWithCompleteStatuses.concat(datesList);
         }
       });
 

--- a/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
+++ b/ang/civicase/activity/calendar/directives/activities-calendar.directive.js
@@ -517,6 +517,7 @@
       var dateMoment = moment(date);
 
       params.activity_type_id = { '!=': 'Bulk Email' };
+      params.is_deleted = '0';
       params.status_id = { IN: _.union(incompleteActivityStatusTypes, completeActivityStatusTypes) };
       params.activity_date_time = {
         BETWEEN: [
@@ -531,6 +532,10 @@
 
       if ($scope.caseParams) {
         params.case_filter = $scope.caseParams;
+
+        params.case_filter.modified_date = {
+          '>=': params.activity_date_time.BETWEEN[0]
+        };
       }
 
       params.options = { group_by_field: 'status_id' };

--- a/ang/civicase/activity/feed/directives/activity-feed.directive.html
+++ b/ang/civicase/activity/feed/directives/activity-feed.directive.html
@@ -9,7 +9,7 @@
 
   <civicase-bulk-actions-message
     selected-items="selectedActivities.length" total-count="totalCount"
-    is-select-all-available="true" show-checkboxes="showCheckboxes"
+    show-checkboxes="showCheckboxes"
     is-select-all="isSelectAll">
   </civicase-bulk-actions-message>
 

--- a/ang/civicase/activity/filters/directives/activity-filters.directive.html
+++ b/ang/civicase/activity/filters/directives/activity-filters.directive.html
@@ -22,7 +22,6 @@
     <civicase-bulk-actions-checkboxes
       everything-count="totalCount"
       displayed-count="displayedCount"
-      is-select-all-available="true"
       show-checkboxes="showCheckboxes"
       ng-show="bulkAllowed"/>
     <span

--- a/ang/civicase/bulk-action/directives/bulk-actions-checkboxes.directive.html
+++ b/ang/civicase/bulk-action/directives/bulk-actions-checkboxes.directive.html
@@ -17,10 +17,8 @@
     <li>
       <a
         href=""
-        ng-disabled="!isSelectAllAvailable"
-        ng-class="{'civicase__link-disabled disabled': !isSelectAllAvailable}"
         ng-click="select('all')"
-        ng-attr-title="{{isSelectAllAvailable ? 'Select everything that matches search.' : 'Loading, Please wait! ...'}}">
+        ng-attr-title="{{'Select everything that matches search.'}}">
         Everything ({{everythingCount}})
       </a>
     </li>

--- a/ang/civicase/bulk-action/directives/bulk-actions-checkboxes.directive.js
+++ b/ang/civicase/bulk-action/directives/bulk-actions-checkboxes.directive.js
@@ -9,7 +9,6 @@
       scope: {
         showCheckboxes: '=?',
         selectedItems: '=',
-        isSelectAllAvailable: '=',
         everythingCount: '=',
         displayedCount: '='
       }
@@ -37,7 +36,7 @@
      * - 'visible' :  Selects all visible selections
      * - 'none' : Deselects all
      *
-     * @params {String} condition
+     * @param {string} condition bulk selection event name
      */
     $scope.select = function (condition) {
       $scope.$emit('civicase::bulk-actions::bulk-selections', condition);

--- a/ang/civicase/bulk-action/directives/bulk-actions-message.directive.html
+++ b/ang/civicase/bulk-action/directives/bulk-actions-message.directive.html
@@ -8,14 +8,12 @@
     <a
       ng-show="totalCount !== selectedItems && isSelectAll === false"
       href=""
-      ng-class="{'civicase__link-disabled': !isSelectAllAvailable}"
       ng-click="select('all')">
       Select all {{totalCount}} that match the search
     </a>
     <a
       ng-show="totalCount === selectedItems || isSelectAll"
       href=""
-      ng-class="{'civicase__link-disabled': !isSelectAllAvailable}"
       ng-click="select('none')">
       Clear All
     </a>

--- a/ang/civicase/bulk-action/directives/bulk-actions-message.directive.js
+++ b/ang/civicase/bulk-action/directives/bulk-actions-message.directive.js
@@ -9,7 +9,6 @@
       scope: {
         selectedItems: '=',
         isSelectAll: '=',
-        isSelectAllAvailable: '=',
         totalCount: '=',
         showCheckboxes: '='
       }

--- a/ang/civicase/case/details/file-tab/directives/case-details-file-tab.directive.html
+++ b/ang/civicase/case/details/file-tab/directives/case-details-file-tab.directive.html
@@ -3,7 +3,6 @@
   <civicase-bulk-actions-checkboxes
     everything-count="totalCount"
     displayed-count="totalCount"
-    is-select-all-available="true"
     show-checkboxes="showCheckboxes"
     ng-show="bulkAllowed"/>
   <span
@@ -42,7 +41,7 @@
 
 <civicase-bulk-actions-message
   selected-items="selectedActivities.length" total-count="totalCount"
-  is-select-all-available="true" show-checkboxes="showCheckboxes"
+  show-checkboxes="showCheckboxes"
   is-select-all="isSelectAll">
 </civicase-bulk-actions-message>
 

--- a/ang/civicase/case/list/directives/case-list-table-first-column-header.html
+++ b/ang/civicase/case/list/directives/case-list-table-first-column-header.html
@@ -2,7 +2,6 @@
   ng-show="!viewingCase && selectedCases && bulkAllowed && !item.lock"
   class="pull-left"
   show-checkboxes="$parent.showCheckboxes"
-  is-select-all-available="true"
   selected-items="selectedCases.length"
   everything-count="totalCount"
   displayed-count="cases.length">

--- a/ang/civicase/case/list/directives/case-list-table-first-column-header.html
+++ b/ang/civicase/case/list/directives/case-list-table-first-column-header.html
@@ -2,7 +2,7 @@
   ng-show="!viewingCase && selectedCases && bulkAllowed && !item.lock"
   class="pull-left"
   show-checkboxes="$parent.showCheckboxes"
-  is-select-all-available="isSelectAllAvailable"
+  is-select-all-available="true"
   selected-items="selectedCases.length"
   everything-count="totalCount"
   displayed-count="cases.length">

--- a/ang/civicase/case/list/directives/case-list-table.directive.html
+++ b/ang/civicase/case/list/directives/case-list-table.directive.html
@@ -2,7 +2,7 @@
 <div class="civicase__case-list" ng-class="{'civicase__case-list--summary': viewingCase}">
   <civicase-bulk-actions-message
     selected-items="selectedCases.length" total-count="totalCount"
-    is-select-all-available="true" show-checkboxes="showCheckboxes"
+    show-checkboxes="showCheckboxes"
     ng-hide="viewingCase">
   </civicase-bulk-actions-message>
   <div ng-show="viewingCase"

--- a/ang/civicase/case/list/directives/case-list-table.directive.html
+++ b/ang/civicase/case/list/directives/case-list-table.directive.html
@@ -2,7 +2,7 @@
 <div class="civicase__case-list" ng-class="{'civicase__case-list--summary': viewingCase}">
   <civicase-bulk-actions-message
     selected-items="selectedCases.length" total-count="totalCount"
-    is-select-all-available="isSelectAllAvailable" show-checkboxes="showCheckboxes"
+    is-select-all-available="true" show-checkboxes="showCheckboxes"
     ng-hide="viewingCase">
   </civicase-bulk-actions-message>
   <div ng-show="viewingCase"

--- a/ang/civicase/shared/directives/panel-query.directive.js
+++ b/ang/civicase/shared/directives/panel-query.directive.js
@@ -135,6 +135,15 @@
         $scope.handlers.range($scope.selectedRange, paramsCopy);
       }
 
+      if (paramsCopy.case_filter) {
+        // modified date is always updated when updating a case
+        // so adding this improves the performance of the api call
+        // as unnecessary cases are filtered out
+        paramsCopy.case_filter.modified_date = {
+          '>=': paramsCopy.activity_date_time.BETWEEN[0]
+        };
+      }
+
       var apiCalls = {
         get: [$scope.query.entity, ($scope.query.action || 'get'), prepareGetParams(paramsCopy)],
         count: [$scope.query.entity, ($scope.query.countAction || 'getcount'), paramsCopy]

--- a/ang/test/civicase/activity/calendar/directives/activities-calendar.directive.spec.js
+++ b/ang/test/civicase/activity/calendar/directives/activities-calendar.directive.spec.js
@@ -97,14 +97,21 @@
       });
 
       describe('when case parameters are passed', function () {
+        var startOfMonth;
+
         beforeEach(function () {
+          startOfMonth = moment(dates.today).startOf('month').format('YYYY-MM-DD');
+
           commonControllerSetup({ caseParams: { a: 'b' } });
         });
 
         it('loads the days with activities from all the given cases', function () {
           var apiParams1 = civicaseCrmApi.calls.argsFor(0)[2];
 
-          expect(apiParams1.case_filter).toEqual({ a: 'b' });
+          expect(apiParams1.case_filter).toEqual({
+            a: 'b',
+            modified_date: { '>=': moment(startOfMonth).format('YYYY-MM-DD HH:mm:ss') }
+          });
         });
 
         describe('when selecting a date with activities', function () {
@@ -115,7 +122,10 @@
           it('loads activities from all the given cases when selecting a day', function () {
             var apiParams = civicaseCrmApi.calls.argsFor(0)[2];
 
-            expect(apiParams.case_filter).toEqual({ a: 'b' });
+            expect(apiParams.case_filter).toEqual({
+              a: 'b',
+              modified_date: { '>=': moment(startOfMonth).format('YYYY-MM-DD HH:mm:ss') }
+            });
           });
 
           describe('case info footer on activity card', function () {

--- a/ang/test/civicase/bulk-action/directives/bulk-actions-checkboxes.directive.spec.js
+++ b/ang/test/civicase/bulk-action/directives/bulk-actions-checkboxes.directive.spec.js
@@ -44,29 +44,6 @@
       });
     });
 
-    describe('isSelectAllAvailable', function () {
-      describe('when isSelectAllAvailable is true', function () {
-        beforeEach(function () {
-          $scope.isSelectAllAvailable = true;
-          $scope.$digest();
-        });
-
-        it('enables the everything menu link', function () {
-          expect(element.find('a[ng-disabled="!isSelectAllAvailable"]').hasClass('civicase__link-disabled')).toBe(false);
-        });
-      });
-      describe('when isSelectAllAvailable is false', function () {
-        beforeEach(function () {
-          $scope.isSelectAllAvailable = false;
-          $scope.$digest();
-        });
-
-        it('disables the everything menu link', function () {
-          expect(element.find('a[ng-disabled="!isSelectAllAvailable"]').hasClass('civicase__link-disabled')).toBe(true);
-        });
-      });
-    });
-
     describe('toggleCheckbox()', function () {
       describe('when showCheckboxes is true', function () {
         beforeEach(function () {
@@ -139,8 +116,7 @@
     function compileDirective () {
       $scope.selectedCasesLength = 10;
       $scope.showCheckboxes = true;
-      $scope.isSelectAllAvailable = false;
-      element = $compile('<div civicase-bulk-actions-checkboxes show-checkboxes="showCheckboxes" is-select-all-available="isSelectAllAvailable" selected-items="selectedCasesLength"></div>')($scope);
+      element = $compile('<div civicase-bulk-actions-checkboxes show-checkboxes="showCheckboxes" selected-items="selectedCasesLength"></div>')($scope);
       $scope.$digest();
     }
   });

--- a/ang/test/civicase/bulk-action/directives/bulk-actions-message.directive.spec.js
+++ b/ang/test/civicase/bulk-action/directives/bulk-actions-message.directive.spec.js
@@ -98,38 +98,6 @@ describe('BulkActionsMessage', function () {
     });
   });
 
-  describe('isSelectAllAvailable', function () {
-    describe('isSelectAllAvailable is true', function () {
-      beforeEach(function () {
-        element.isolateScope().isSelectAllAvailable = true;
-        $scope.$digest();
-      });
-
-      it('doesn\'t add class civicase__link-disabled to buttons', function () {
-        expect(element.find('a[ng-click*="select(\'all\')"]').hasClass('civicase__link-disabled')).toBe(false);
-      });
-
-      it('doesn\'t add class civicase__link-disabled to buttons', function () {
-        expect(element.find('a[ng-click*="select(\'none\')"]').hasClass('civicase__link-disabled')).toBe(false);
-      });
-    });
-
-    describe('isSelectAllAvailable is false', function () {
-      beforeEach(function () {
-        element.isolateScope().isSelectAllAvailable = false;
-        $scope.$digest();
-      });
-
-      it('adds class civicase__link-disabled to buttons', function () {
-        expect(element.find('a[ng-click*="select(\'all\')"]').hasClass('civicase__link-disabled')).toBe(true);
-      });
-
-      it('adds class civicase__link-disabled to buttons', function () {
-        expect(element.find('a[ng-click*="select(\'none\')"]').hasClass('civicase__link-disabled')).toBe(true);
-      });
-    });
-  });
-
   /**
    * Function responsible for setting up compilation of the directive
    */
@@ -137,9 +105,8 @@ describe('BulkActionsMessage', function () {
     $scope.selectedItems = 10;
     $scope.totalCount = 20;
     $scope.showCheckboxes = true;
-    $scope.isSelectAllAvailable = false;
     $scope.isSelectAll = false;
-    element = $compile('<civicase-bulk-actions-message selected-items="selectedItems" total-count="totalCount" is-select-all-available="isSelectAllAvailable" is-select-all="isSelectAll" show-checkboxes="showCheckboxes"></civicase-bulk-actions-message>')($scope);
+    element = $compile('<civicase-bulk-actions-message selected-items="selectedItems" total-count="totalCount" is-select-all="isSelectAll" show-checkboxes="showCheckboxes"></civicase-bulk-actions-message>')($scope);
     $scope.$digest();
   }
 });

--- a/ang/test/civicase/shared/directives/panel-query.directive.spec.js
+++ b/ang/test/civicase/shared/directives/panel-query.directive.spec.js
@@ -75,7 +75,7 @@
 
         beforeEach(function () {
           originalSource = $scope.queryData;
-          panelQueryScope.query = { baz: 'baz' };
+          panelQueryScope.query = { params: 'params' };
 
           $scope.$digest();
         });

--- a/api/v3/Activity/Getdayswithactivities.php
+++ b/api/v3/Activity/Getdayswithactivities.php
@@ -67,7 +67,7 @@ function civicrm_api3_activity_getdayswithactivities(array $params) {
       return civicrm_api3_create_success([], $params, 'Activity', 'getdayswithactivities');
     }
 
-    _join_to_case($query, ['IN' => _get_case_ids($params['case_filter'])]);
+    _join_to_case($query, ['IN' => $case_ids]);
   }
 
   $query->groupBy('a.activity_date_time');

--- a/api/v3/Activity/Getdayswithactivities.php
+++ b/api/v3/Activity/Getdayswithactivities.php
@@ -35,11 +35,15 @@ function civicrm_api3_activity_getdayswithactivities(array $params) {
   $query = CRM_Utils_SQL_Select::from('civicrm_activity a');
   $select = ['a.activity_date_time'];
   $groupByFields = ['status_id'];
-  $shouldGroupByField = !empty($params['options']['group_by_field']) && in_array($params['options']['group_by_field'], $groupByFields);
+  $shouldGroupByField = !empty($params['options']['group_by_field'])
+    && in_array($params['options']['group_by_field'], $groupByFields);
+
   if ($shouldGroupByField) {
     $select[] = $params['options']['group_by_field'];
   }
+
   $query->select($select);
+
   if (!empty($params['case_id']) && !empty($params['case_filter'])) {
     throw new API_Exception("case_id and case_filter cannot be present at the same time.");
   }
@@ -76,23 +80,27 @@ function civicrm_api3_activity_getdayswithactivities(array $params) {
 
   $query->groupBy('a.activity_date_time');
   $result = $query->execute()->fetchAll();
-  $data = [];
+  $dates = [];
+
   if ($shouldGroupByField) {
     foreach ($result as $row) {
       $activityDate = explode(' ', $row['activity_date_time'])[0];
-      if (isset($data[$row[$params['options']['group_by_field']]]) && array_search($activityDate, $data[$row[$params['options']['group_by_field']]]) !== FALSE) {
+
+      if (isset($dates[$row[$params['options']['group_by_field']]])
+        && array_search($activityDate, $dates[$row[$params['options']['group_by_field']]]) !== FALSE) {
         continue;
       }
-      $data[$row[$params['options']['group_by_field']]][] = explode(' ', $row['activity_date_time'])[0];
+
+      $dates[$row[$params['options']['group_by_field']]][] = explode(' ', $row['activity_date_time'])[0];
     }
   }
   else {
-    $data = array_unique(array_map(function ($row) {
+    $dates = array_unique(array_map(function ($row) {
       return explode(' ', $row['activity_date_time'])[0];
     }, $result));
     $params['sequential'] = 1;
   }
-  return civicrm_api3_create_success($data, $params, 'Activity', 'getdayswithactivities');
+  return civicrm_api3_create_success($dates, $params, 'Activity', 'getdayswithactivities');
 }
 
 /**

--- a/api/v3/Activity/Getdayswithactivities.php
+++ b/api/v3/Activity/Getdayswithactivities.php
@@ -56,6 +56,10 @@ function civicrm_api3_activity_getdayswithactivities(array $params) {
     _civicrm_api3_activity_getdayswithactivities_handle_id_param($params['activity_status_id'], 'a.status_id', $query);
   }
 
+  if (isset($params['is_deleted'])) {
+    _civicrm_api3_activity_getdayswithactivities_handle_id_param($params['is_deleted'], 'a.is_deleted', $query);
+  }
+
   if (!empty($params['case_id'])) {
     _join_to_case($query, $params['case_id']);
   }


### PR DESCRIPTION
## Overview
As part of this PR, few optimisations has been made to different parts of the Civicase Application, to make it faster.

## Optimisation 1
When loading the Manage Cases page, we were loading all the Cases, in order to make "Select All" Bulk action functionality to work. But loading all cases takes a lot of time if the system has many cases. And also the "Select All" is not used all the time. 
So now we have moved this loading logic, only on demand. When the user will select "Select All", at that time we are loading the cases.

## Optimisation 2
Previously, the Activity Calendar was making two separate calls to the `Activity.getdayswithactivities` api endpoint. Once to 
fetch dates for Completed Activities, and the other one to fetch Incomplete Activities.

But everytime this API is called, it fetches the full list of cases internally, which can decrease performance  when a large number of cases are present.

So a option parameter `group_by_field ` has been introduced. And the results are returned by the value mentioned in this parameter(Right now it only supports `status_id` parameter.)

So using this, we now only make a single call with both Completed and Incomplete status ids, and then the resulted are divided into Completed and Incomplete by their status.

This way, one API call has been reduced.
 
## Optimisation 3
Another optimisation has been made to `Activity.getdayswithactivities` api endpoint. 
In `api/v3/Activity/Getdayswithactivities.php`, `_get_case_ids` function was getting called twice, which fetches all cases. So now the same values are reused.

## Optimisation 4
In the activities calendar, previously we were not filtering the activities if they are deleted, which was wrong, and was not matching to `Activities.get` api call. So `is_deleted = '0'` is added to the API call.

Also we now add the `modified_date` to the `case_filter`. As the case modified date is always updated when you update a case or when you add/modify an activity for a case, adding this param ensures that search results does not include cases outside of the month range currently being viewed.

The same optimisation is done to Dashboard Activities block api calls also.