### PR TITLE
CATL-1637: Add Business Logic to Handle Pre and Post Processing Of Creating A Case Related Relationship

### DIFF
--- a/CRM/Civicase/Event/Listener/CaseRoleCreation.php
+++ b/CRM/Civicase/Event/Listener/CaseRoleCreation.php
@@ -1,0 +1,121 @@
+<?php
+
+use Civi\API\Event\PrepareEvent;
+use Civi\API\Event\RespondEvent;
+use CRM_Civicase_Service_CaseRoleCreationPostProcess as CaseRoleCreationPostProcess;
+use CRM_Civicase_Service_CaseRoleCreationPreProcess as CaseRoleCreationPreProcess;
+
+/**
+ * Class CRM_Civicase_Event_Listener_CaseRoleCreation.
+ */
+class CRM_Civicase_Event_Listener_CaseRoleCreation {
+
+  /**
+   * Runs the CaseRoleCreationPostProcess onCreate function.
+   *
+   * When the relationship to be created/updated is related to a case
+   * the case role post process function is ran.
+   *
+   * @param \Civi\API\Event\RespondEvent $event
+   *   API Respond Event Object.
+   */
+  public static function onRespond(RespondEvent $event) {
+    $apiRequest = (array) $event->getApiRequest();
+    if (!self::shouldRun($apiRequest)) {
+      return;
+    }
+
+    $caseId = self::getCaseId($apiRequest);
+    if (empty($caseId)) {
+      return;
+    }
+
+    $action = !empty($apiRequest['params']['id']) ? 'update' : 'create';
+    $responseParams = (array) $event->getResponse();
+    if ($action == 'create') {
+      $caseCreationPostProcess = new CaseRoleCreationPostProcess();
+      $caseCreationPostProcess->onCreate($apiRequest, $responseParams);
+    }
+  }
+
+  /**
+   * Runs the CaseRoleCreationPreProcess onCreate function.
+   *
+   * When the relationship to be created/updated is related to a case
+   * the case role pre process function is ran.
+   *
+   * @param \Civi\API\Event\PrepareEvent $event
+   *   API Prepare Event Object.
+   */
+  public static function onPrepare(PrepareEvent $event) {
+    $apiRequest = (array) $event->getApiRequest();
+    if (!self::shouldRun($apiRequest)) {
+      return;
+    }
+
+    $caseId = self::getCaseId($apiRequest);
+    if (empty($caseId)) {
+      return;
+    }
+
+    $action = !empty($apiRequest['params']['id']) ? 'update' : 'create';
+    if ($action == 'create') {
+      $caseCreationPreProcess = new CaseRoleCreationPreProcess();
+      $caseCreationPreProcess->onCreate($apiRequest);
+      $event->setApiRequest($apiRequest);
+    }
+  }
+
+  /**
+   * Determines if the processing will run.
+   *
+   * @param array $apiRequest
+   *   Api request data.
+   *
+   * @return bool
+   *   TRUE if processing should run, FALSE otherwise.
+   */
+  protected static function shouldRun(array $apiRequest) {
+    return $apiRequest['entity'] == 'Relationship' && $apiRequest['action'] == 'create' && empty($apiRequest['params']['skip_post_processing']);
+  }
+
+  /**
+   * Returns relationship Case Id.
+   *
+   * @param array $apiRequest
+   *   Api Request.
+   *
+   * @return int|null
+   *   Case Id.
+   */
+  private static function getCaseId(array $apiRequest) {
+    if (!empty($apiRequest['params']['id'])) {
+      $caseId = self::getRelationshipCase($apiRequest['params']['id']);
+    }
+    else {
+      $caseId = !empty($apiRequest['params']['case_id']) ? $apiRequest['params']['case_id'] : NULL;
+    }
+
+    return $caseId;
+  }
+
+  /**
+   * Gets the Case Id for a relationship.
+   *
+   * @param int $relId
+   *   Relationship Id.
+   *
+   * @return int|null
+   *   Case Id.
+   */
+  protected static function getRelationshipCase($relId) {
+    $result = civicrm_api3('Relationship', 'get', [
+      'sequential' => 1,
+      'return' => ['case_id'],
+      'id' => $relId,
+    ]);
+
+    return !empty($result['values'][0]['case_id']) ? $result['values'][0]['case_id'] : NULL;
+  }
+
+}

--- a/CRM/Civicase/Event/Listener/CaseRoleCreation.php
+++ b/CRM/Civicase/Event/Listener/CaseRoleCreation.php
@@ -6,7 +6,7 @@ use CRM_Civicase_Service_CaseRoleCreationPostProcess as CaseRoleCreationPostProc
 use CRM_Civicase_Service_CaseRoleCreationPreProcess as CaseRoleCreationPreProcess;
 
 /**
- * Class CRM_Civicase_Event_Listener_CaseRoleCreation.
+ * Case role creation listener class.
  */
 class CRM_Civicase_Event_Listener_CaseRoleCreation {
 

--- a/CRM/Civicase/Service/CaseRoleCreationBase.php
+++ b/CRM/Civicase/Service/CaseRoleCreationBase.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Class CRM_Civicase_Service_CaseRoleCreationBase.
+ */
+class CRM_Civicase_Service_CaseRoleCreationBase {
+
+  /**
+   * Whether the Case multiclient setting is active or not.
+   *
+   * @var bool
+   */
+  protected $isMultiClient;
+
+  /**
+   * Whether the single case role per type setting is active or not.
+   *
+   * @var bool
+   */
+  protected $isSingleCaseRole;
+
+  /**
+   * CRM_Civicase_Service_CaseRoleCreationBase constructor.
+   */
+  public function __construct() {
+    $this->isMultiClient = (bool) Civi::settings()->get('civicaseAllowMultipleClients');
+    $this->isSingleCaseRole = (bool) Civi::settings()->get('civicaseSingleCaseRolePerType');
+  }
+
+}

--- a/CRM/Civicase/Service/CaseRoleCreationBase.php
+++ b/CRM/Civicase/Service/CaseRoleCreationBase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Class CRM_Civicase_Service_CaseRoleCreationBase.
+ * Case role creation base class.
  */
 class CRM_Civicase_Service_CaseRoleCreationBase {
 

--- a/CRM/Civicase/Service/CaseRoleCreationPostProcess.php
+++ b/CRM/Civicase/Service/CaseRoleCreationPostProcess.php
@@ -1,0 +1,251 @@
+<?php
+
+/**
+ * Class CRM_Civicase_Service_CaseRoleCreationPostProcess.
+ */
+class CRM_Civicase_Service_CaseRoleCreationPostProcess extends CRM_Civicase_Service_CaseRoleCreationBase {
+
+  /**
+   * Function that handles post processing for a case related relationship.
+   *
+   * For when the single Case role  setting is active, on creation
+   * of a case role, all past case roles for that relationship type is set to
+   * inactive and the new case role is re-assigned.
+   *
+   * When the single case is inactive and the `reassign_rel_id` parameter is
+   * passed, the relationship Id passed is set inactive.
+   *
+   * In all scenarios, the Assign Case Role activity is created with the
+   * appropriate parameters.
+   *
+   * @param array $requestParams
+   *   API request parameters.
+   * @param array $responseParams
+   *   API response parameters.
+   */
+  public function onCreate(array $requestParams, array $responseParams) {
+    $currentRelContactName = $this->getContactNames([$requestParams['params']['contact_id_b']]);
+    $previousRelContactName = NULL;
+    $relTypeDetails = $this->getRelationshipTypeDetails($requestParams['params']['relationship_type_id']);
+    if ($this->isSingleCaseRole && !$this->isMultiClient) {
+      $existingRelationship = $this->getOtherActiveExistingRelationships($requestParams['params']['relationship_type_id'], $requestParams['params']['case_id'], $responseParams['id']);
+      if ($existingRelationship) {
+        $previousRelContacts = array_column($existingRelationship, 'contact_id_b');
+        $previousRelContactName = $this->getContactNames($previousRelContacts);
+      }
+    }
+    else {
+      $reassignRelId = !empty($requestParams['params']['reassign_rel_id']) ? $requestParams['params']['reassign_rel_id'] : [];
+      if ($reassignRelId) {
+        $existingRelationship = $this->getRelationshipDetails($reassignRelId);
+        $this->validateReassignRelationship($existingRelationship[0]['relationship_type_id'], $requestParams['params']['relationship_type_id']);
+        $previousRelContacts = array_column($existingRelationship, 'contact_id_b');
+        $previousRelContactName = $this->getContactNames($previousRelContacts);
+      }
+    }
+
+    if (!empty($existingRelationship)) {
+      $this->setRelationshipsInactive(array_column($existingRelationship, 'id'));
+    }
+    $activitySubject = $this->getActivitySubjectOnCreate($currentRelContactName, $relTypeDetails, $previousRelContactName);
+    $this->createCaseActivity($requestParams['params']['case_id'], 'Assign Case Role', $activitySubject);
+  }
+
+  /**
+   * Get relationship details.
+   *
+   * @param int $relId
+   *   Relationship Id.
+   *
+   * @return array
+   *   Relationship details.
+   */
+  private function getRelationshipDetails($relId) {
+    $result = civicrm_api3('Relationship', 'get', [
+      'sequential' => 1,
+      'id' => $relId,
+    ]);
+
+    if (empty($result['values'])) {
+      return [];
+    }
+
+    return $result['values'];
+  }
+
+  /**
+   * Get relationship type details.
+   *
+   * @param int $relTypeId
+   *   Relationship type Id.
+   *
+   * @return array
+   *   Relationship Type details.
+   */
+  private function getRelationshipTypeDetails($relTypeId) {
+    $result = civicrm_api3('RelationshipType', 'get', [
+      'sequential' => 1,
+      'id' => $relTypeId,
+    ]);
+
+    if (empty($result['values'])) {
+      return [];
+    }
+
+    return $result['values'][0];
+  }
+
+  /**
+   * Returns a concatenated string of contact names.
+   *
+   * @param array $contactIds
+   *   Array of contact Ids.
+   *
+   * @return string
+   *   Contact names.
+   */
+  private function getContactNames(array $contactIds) {
+    $result = civicrm_api3('Contact', 'get', [
+      'sequential' => 1,
+      'return' => ['display_name'],
+      'id' => ['IN' => $contactIds],
+    ]);
+
+    if (empty($result['values'])) {
+      return '';
+    }
+
+    $contactName = '';
+    foreach ($result['values'] as $contactDetails) {
+      $contactName .= $contactDetails['display_name'] . ', ';
+    }
+
+    return rtrim($contactName, ', ');
+  }
+
+  /**
+   * Returns relationship data.
+   *
+   * Returns relationship data for the case and relationship type ID excluding
+   * the current relationship Id just added.
+   *
+   * @param int $relTypeId
+   *   Relationship type Id.
+   * @param int $caseId
+   *   Case Id.
+   * @param int $currentRelId
+   *   Current relationship Id.
+   *
+   * @return array
+   *   Relationships data.
+   */
+  private function getOtherActiveExistingRelationships($relTypeId, $caseId, $currentRelId) {
+    $result = civicrm_api3('Relationship', 'get', [
+      'sequential' => 1,
+      'case_id' => $caseId,
+      'relationship_type_id' => $relTypeId,
+      'id' => ['!=' => $currentRelId],
+      'is_active' => 1,
+    ]);
+
+    return $result['values'];
+  }
+
+  /**
+   * Set the relationship Id's inactive and end date to be today.
+   *
+   * @param array $relIds
+   *   Relationship Ids.
+   */
+  private function setRelationshipsInactive(array $relIds) {
+    foreach ($relIds as $relId) {
+      civicrm_api3('Relationship', 'create', [
+        'id' => $relId,
+        'is_active' => 0,
+        'end_date' => date('Y-m-d'),
+        'skip_post_processing' => 1,
+      ]);
+    }
+  }
+
+  /**
+   * Creates the case activity.
+   *
+   * @param int $caseId
+   *   Case Id.
+   * @param string $activityType
+   *   Activity Type.
+   * @param string $subject
+   *   Activity Subject.
+   */
+  private function createCaseActivity($caseId, $activityType, $subject) {
+    civicrm_api3('Activity', 'create', [
+      'case_id' => $caseId,
+      'target_contact_id' => $this->getCaseClients($caseId),
+      'status_id' => 'Completed',
+      'activity_type_id' => $activityType,
+      'subject' => $subject,
+      'source_contact_id' => CRM_Core_Session::getLoggedInContactID(),
+    ]);
+  }
+
+  /**
+   * Gets the case clients for a case.
+   *
+   * @param int $caseId
+   *   Case Id.
+   *
+   * @return array
+   *   Array of case client contact Id's.
+   */
+  private function getCaseClients($caseId) {
+    $result = civicrm_api3('CaseContact', 'get', [
+      'case_id' => $caseId,
+    ]);
+
+    $clients = [];
+    foreach ($result['values'] as $caseContact) {
+      $clients[] = $caseContact['contact_id'];
+    }
+
+    return $clients;
+  }
+
+  /**
+   * Return Activity Subject.
+   *
+   * @param string $currentContactName
+   *   Contact name B of relationship just added.
+   * @param array $relTypeDetails
+   *   Relationship Type data.
+   * @param string|null $previousContactName
+   *   Contact name B of previous relationship.
+   *
+   * @return string
+   *   Activity subject.
+   */
+  private function getActivitySubjectOnCreate($currentContactName, array $relTypeDetails, $previousContactName = NULL) {
+    if (empty($previousContactName)) {
+      return "{$currentContactName} added as {$relTypeDetails['label_b_a']}";
+    }
+
+    return "{$currentContactName} replaced {$previousContactName} as {$relTypeDetails['label_b_a']}";
+  }
+
+  /**
+   * Validates that the Relationship Type Id of the two relationships match.
+   *
+   * @param int $reassignRelTypeId
+   *   Relationship type Id of reasssigned relationship.
+   * @param int $newRelTypeId
+   *   Relationship type Id of the new relationship.
+   */
+  private function validateReassignRelationship($reassignRelTypeId, $newRelTypeId) {
+    $isSameRelationshipType = $reassignRelTypeId == $newRelTypeId;
+
+    if (!$isSameRelationshipType) {
+      throw new Exception('The relationship type Id of the role to reassign must match the new relationship type Id');
+    }
+  }
+
+}

--- a/CRM/Civicase/Service/CaseRoleCreationPostProcess.php
+++ b/CRM/Civicase/Service/CaseRoleCreationPostProcess.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Class CRM_Civicase_Service_CaseRoleCreationPostProcess.
+ * Case role creation post process class.
  */
 class CRM_Civicase_Service_CaseRoleCreationPostProcess extends CRM_Civicase_Service_CaseRoleCreationBase {
 

--- a/CRM/Civicase/Service/CaseRoleCreationPreProcess.php
+++ b/CRM/Civicase/Service/CaseRoleCreationPreProcess.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Class CRM_Civicase_Service_CaseRoleCreationPreProcess.
+ */
+class CRM_Civicase_Service_CaseRoleCreationPreProcess extends CRM_Civicase_Service_CaseRoleCreationBase {
+
+  /**
+   * Function that handles pre-processing for a case related relationship.
+   *
+   * Basically, when the single case role per type setting is on and the
+   * multiclient case setting is off, the start date for a case related
+   * relationship is set to today's date.
+   *
+   * @param array $requestParams
+   *   API request parameters.
+   */
+  public function onCreate(array &$requestParams) {
+    if ($this->isSingleCaseRole && !$this->isMultiClient) {
+      $requestParams['params']['start_date'] = date('Y-m-d');
+    }
+
+  }
+
+}

--- a/CRM/Civicase/Service/CaseRoleCreationPreProcess.php
+++ b/CRM/Civicase/Service/CaseRoleCreationPreProcess.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Class CRM_Civicase_Service_CaseRoleCreationPreProcess.
+ * Case role creation pre-process class.
  */
 class CRM_Civicase_Service_CaseRoleCreationPreProcess extends CRM_Civicase_Service_CaseRoleCreationBase {
 

--- a/CRM/Civicase/Service/CaseRoleCreationPreProcess.php
+++ b/CRM/Civicase/Service/CaseRoleCreationPreProcess.php
@@ -19,7 +19,6 @@ class CRM_Civicase_Service_CaseRoleCreationPreProcess extends CRM_Civicase_Servi
     if ($this->isSingleCaseRole && !$this->isMultiClient) {
       $requestParams['params']['start_date'] = date('Y-m-d');
     }
-
   }
 
 }

--- a/CRM/Civicase/Test/Fabricator/Relationship.php
+++ b/CRM/Civicase/Test/Fabricator/Relationship.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Class CRM_Civicase_Test_Fabricator_Relationship.
+ */
+class CRM_Civicase_Test_Fabricator_Relationship {
+
+  /**
+   * Default parameters.
+   *
+   * @var array
+   */
+  private static $defaultParams = [
+    'is_active' => 1,
+    'start_date' => NULL,
+    'end_date' => NULL,
+  ];
+
+  /**
+   * Fabricate a relationship.
+   *
+   * @param array $params
+   *   Parameters.
+   *
+   * @return array
+   *   API results.
+   */
+  public static function fabricate(array $params = []) {
+    $params = array_merge(self::$defaultParams, $params);
+
+    $result = civicrm_api3('Relationship', 'create', $params);
+
+    return array_shift($result['values']);
+  }
+
+}

--- a/CRM/Civicase/Test/Fabricator/Relationship.php
+++ b/CRM/Civicase/Test/Fabricator/Relationship.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Class CRM_Civicase_Test_Fabricator_Relationship.
+ * Relationship Fabricator class.
  */
 class CRM_Civicase_Test_Fabricator_Relationship {
 

--- a/CRM/Civicase/Test/Fabricator/RelationshipType.php
+++ b/CRM/Civicase/Test/Fabricator/RelationshipType.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Class CRM_Civicase_Test_Fabricator_RelationshipType.
+ */
+class CRM_Civicase_Test_Fabricator_RelationshipType {
+
+  /**
+   * Default parameters.
+   *
+   * @var array
+   */
+  private static $defaultParams = [
+    'sequential' => 1,
+    'name_a_b' => 'test AB',
+    'name_b_a' => 'test BA',
+    'contact_type_a' => 'Individual',
+    'contact_type_b' => 'Individual',
+  ];
+
+  /**
+   * Fabricate a relationship type.
+   *
+   * @param array $params
+   *   Parameters.
+   *
+   * @return array
+   *   API results.
+   */
+  public static function fabricate(array $params = []) {
+    $params = array_merge(self::$defaultParams, $params);
+    $result = civicrm_api3(
+      'RelationshipType',
+      'create',
+      $params
+    );
+
+    return array_shift($result['values']);
+  }
+
+}

--- a/CRM/Civicase/Test/Fabricator/RelationshipType.php
+++ b/CRM/Civicase/Test/Fabricator/RelationshipType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Class CRM_Civicase_Test_Fabricator_RelationshipType.
+ * RelationshipType Fabricator class.
  */
 class CRM_Civicase_Test_Fabricator_RelationshipType {
 

--- a/civicase.php
+++ b/civicase.php
@@ -47,10 +47,29 @@ function civicase_civicrm_config(&$config) {
   }
   Civi::$statics[__FUNCTION__] = 1;
 
-  Civi::dispatcher()->addListener('civi.api.prepare', ['CRM_Civicase_Event_Listener_ActivityFilter', 'onPrepare'], 10);
-  Civi::dispatcher()->addListener('civi.api.respond', ['CRM_Civicase_Event_Listener_CaseTypeCategoryIsActiveToggler', 'onRespond'], 10);
-  Civi::dispatcher()->addListener('civi.api.respond', ['CRM_Civicase_Event_Listener_CaseRoleCreation', 'onRespond'], 10);
-  Civi::dispatcher()->addListener('civi.api.prepare', ['CRM_Civicase_Event_Listener_CaseRoleCreation', 'onPrepare'], 10);
+  Civi::dispatcher()->addListener(
+    'civi.api.prepare',
+    ['CRM_Civicase_Event_Listener_ActivityFilter', 'onPrepare'],
+    10
+  );
+  Civi::dispatcher()->addListener(
+    'civi.api.respond',
+    [
+      'CRM_Civicase_Event_Listener_CaseTypeCategoryIsActiveToggler',
+      'onRespond',
+    ],
+    10
+  );
+  Civi::dispatcher()->addListener(
+    'civi.api.respond',
+    ['CRM_Civicase_Event_Listener_CaseRoleCreation', 'onRespond'],
+    10
+  );
+  Civi::dispatcher()->addListener(
+    'civi.api.prepare',
+    ['CRM_Civicase_Event_Listener_CaseRoleCreation', 'onPrepare'],
+    10
+  );
 }
 
 /**
@@ -199,7 +218,11 @@ function civicase_civicrm_buildForm($formName, &$form) {
   }
 
   // Display category option for activity types and activity statuses.
-  if ($formName == 'CRM_Admin_Form_Options' && in_array($form->getVar('_gName'), ['activity_type', 'activity_status'])) {
+  if ($formName == 'CRM_Admin_Form_Options'
+    && in_array($form->getVar('_gName'), [
+      'activity_type',
+      'activity_status',
+    ])) {
     $options = civicrm_api3('optionValue', 'get', [
       'option_group_id' => 'activity_category',
       'is_active' => 1,
@@ -276,7 +299,10 @@ function civicase_civicrm_buildForm($formName, &$form) {
     $id = $form->getVar('_activityId');
     $status = NULL;
     if ($id) {
-      $status = civicrm_api3('Activity', 'getsingle', ['id' => $id, 'return' => 'status_id.name']);
+      $status = civicrm_api3('Activity', 'getsingle', [
+        'id' => $id,
+        'return' => 'status_id.name',
+      ]);
       $status = $status['status_id.name'];
     }
     $checkParams = [
@@ -299,7 +325,10 @@ function civicase_civicrm_buildForm($formName, &$form) {
       if ($status == 'Draft' && ($form->_action & CRM_Core_Action::VIEW)) {
         if (in_array($activityType, $specialTypes)) {
           $atype = $activityType == 'Email' ? 'email' : 'pdf';
-          $caseId = civicrm_api3('Activity', 'getsingle', ['id' => $id, 'return' => 'case_id']);
+          $caseId = civicrm_api3('Activity', 'getsingle', [
+            'id' => $id,
+            'return' => 'case_id',
+          ]);
           $composeUrl = CRM_Utils_System::url("civicrm/activity/$atype/add", [
             'action' => 'add',
             'reset' => 1,
@@ -331,7 +360,10 @@ function civicase_civicrm_buildForm($formName, &$form) {
         }
         // Set defaults for to email addresses.
         if ($formName == 'CRM_Contact_Form_Task_Email') {
-          $cids = CRM_Utils_Array::value('target_contact_id', civicrm_api3('Activity', 'getsingle', ['id' => $draft['id'], 'return' => 'target_contact_id']));
+          $cids = CRM_Utils_Array::value('target_contact_id', civicrm_api3('Activity', 'getsingle', [
+            'id' => $draft['id'],
+            'return' => 'target_contact_id',
+          ]));
           if ($cids) {
             $toContacts = civicrm_api3('Contact', 'get', [
               'id' => ['IN' => $cids],

--- a/civicase.php
+++ b/civicase.php
@@ -49,6 +49,8 @@ function civicase_civicrm_config(&$config) {
 
   Civi::dispatcher()->addListener('civi.api.prepare', ['CRM_Civicase_Event_Listener_ActivityFilter', 'onPrepare'], 10);
   Civi::dispatcher()->addListener('civi.api.respond', ['CRM_Civicase_Event_Listener_CaseTypeCategoryIsActiveToggler', 'onRespond'], 10);
+  Civi::dispatcher()->addListener('civi.api.respond', ['CRM_Civicase_Event_Listener_CaseRoleCreation', 'onRespond'], 10);
+  Civi::dispatcher()->addListener('civi.api.prepare', ['CRM_Civicase_Event_Listener_CaseRoleCreation', 'onPrepare'], 10);
 }
 
 /**

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -16,5 +16,8 @@
     <!-- These files are mainly auto generated and has some rules we want to exclude -->
     <exclude-pattern>tests/phpunit/bootstrap.php</exclude-pattern>
     <exclude-pattern>civicase.civix.php</exclude-pattern>
+    <!-- Civicrm APi tests classes do have names beginning with lower case -->
+    <!-- Hence the following rule is excluded -->
+    <exclude name="Drupal.NamingConventions.ValidClassName.StartWithCaptial"/>
   </rule>
 </ruleset>

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -13,5 +13,8 @@
 
     <!-- this was was added in drupal, but in civicrm we ignore this rule -->
     <exclude name="Drupal.Classes.UseGlobalClass.RedundantUseStatement"/>
+    <!-- These files are mainly auto generated and has some rules we want to exclude -->
+    <exclude-pattern>tests/phpunit/bootstrap.php</exclude-pattern>
+    <exclude-pattern>civicase.civix.php</exclude-pattern>
   </rule>
 </ruleset>

--- a/settings/CiviCase.setting.php
+++ b/settings/CiviCase.setting.php
@@ -119,6 +119,21 @@ $setting = [
     'description' => "Cases I'm involved in filter will include 'activities created by me' and 'activities assigned to me'.",
     'help_text' => '',
   ],
+  'civicaseSingleCaseRolePerType' => [
+    'group_name' => 'CiviCRM Preferences',
+    'group' => 'core',
+    'name' => 'civicaseSingleCaseRolePerType',
+    'type' => 'Boolean',
+    'quick_form_type' => 'Element',
+    'default' => 0,
+    'html_type' => 'checkbox',
+    'add' => '4.7',
+    'title' => ts('One active case role'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => ts('This setting will only allow one active instance of each case role for all case types.'),
+    'help_text' => '',
+  ],
 ];
 
 $caseSetting = new CRM_Civicase_Service_CaseCategorySetting();

--- a/tests/phpunit/CRM/Civicase/Helpers/CaseSettingsTrait.php
+++ b/tests/phpunit/CRM/Civicase/Helpers/CaseSettingsTrait.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Trait CRM_Civicase_Helpers_CaseSettingsTrait.
+ * Case setting helper trait.
  */
 trait CRM_Civicase_Helpers_CaseSettingsTrait {
 

--- a/tests/phpunit/CRM/Civicase/Helpers/CaseSettingsTrait.php
+++ b/tests/phpunit/CRM/Civicase/Helpers/CaseSettingsTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Trait CRM_Civicase_Helpers_CaseSettingsTrait.
+ */
+trait CRM_Civicase_Helpers_CaseSettingsTrait {
+
+  /**
+   * Toggle the single case role per type setting.
+   *
+   * @param bool $isActive
+   *   Whether active or not.
+   */
+  private function setSingleCaseRoleSetting($isActive = TRUE) {
+    Civi::settings()->set('civicaseSingleCaseRolePerType', $isActive);
+  }
+
+  /**
+   * Toggle the multi case client setting.
+   *
+   * @param bool $isActive
+   *   Whether active or not.
+   */
+  private function setMultiClientCaseSetting($isActive = TRUE) {
+    Civi::settings()->set('civicaseAllowMultipleClients', $isActive);
+  }
+
+}

--- a/tests/phpunit/CRM/Civicase/Helpers/SessionTrait.php
+++ b/tests/phpunit/CRM/Civicase/Helpers/SessionTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Trait CRM_Civicase_Helpers_SessionTrait.
+ */
+trait CRM_Civicase_Helpers_SessionTrait {
+
+  /**
+   * Register contact in session.
+   *
+   * @param int $contactID
+   *   Contact Id.
+   */
+  private function registerCurrentLoggedInContactInSession($contactID) {
+    $session = CRM_Core_Session::singleton();
+    $session->set('userID', $contactID);
+  }
+
+  /**
+   * Unregister contact from session.
+   */
+  private function unregisterCurrentLoggedInContactFromSession() {
+    $session = CRM_Core_Session::singleton();
+    $session->set('userID', NULL);
+  }
+
+  /**
+   * Set permissions in session.
+   *
+   * @param array $permissions
+   *   Permissions.
+   */
+  private function setPermissions(array $permissions = []) {
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = $permissions;
+  }
+
+}

--- a/tests/phpunit/CRM/Civicase/Helpers/SessionTrait.php
+++ b/tests/phpunit/CRM/Civicase/Helpers/SessionTrait.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Trait CRM_Civicase_Helpers_SessionTrait.
+ * Session Helper trait.
  */
 trait CRM_Civicase_Helpers_SessionTrait {
 

--- a/tests/phpunit/CRM/Civicase/Service/CaseRoleCreationPostProcessTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseRoleCreationPostProcessTest.php
@@ -210,12 +210,17 @@ class CRM_Civicase_Service_CaseRoleCreationPostProcessTest extends BaseHeadlessT
 
     $contactADetails = ['first_name' => 'First B', 'last_name' => 'Last B'];
     $contactCDetails = ['first_name' => 'First C', 'last_name' => 'Last C'];
-    $relationshipTypeAParams = ['name_a_b' => 'Manager is', 'name_b_a' => 'Manager'];
+    $relationshipTypeAParams = [
+      'name_a_b' => 'Manager is',
+      'name_b_a' => 'Manager',
+    ];
     $relationshipTypeA = RelationshipTypeFabricator::fabricate($relationshipTypeAParams);
-    $relationshipTypeBParams = ['name_a_b' => 'Regulator is', 'name_b_a' => 'Regulator'];
+    $relationshipTypeBParams = [
+      'name_a_b' => 'Regulator is',
+      'name_b_a' => 'Regulator',
+    ];
     $relationshipTypeB = RelationshipTypeFabricator::fabricate($relationshipTypeBParams);
     $contactA = ContactFabricator::fabricate($contactADetails);
-    $contactB = ContactFabricator::fabricate();
     $contactC = ContactFabricator::fabricate($contactCDetails);
 
     // Contact A is Manager to Client.
@@ -264,7 +269,10 @@ class CRM_Civicase_Service_CaseRoleCreationPostProcessTest extends BaseHeadlessT
       ]
     );
 
-    $relationshipTypeBParams = ['name_a_b' => 'Regulator is', 'name_b_a' => 'Regulator'];
+    $relationshipTypeBParams = [
+      'name_a_b' => 'Regulator is',
+      'name_b_a' => 'Regulator',
+    ];
     $contactCDetails = ['first_name' => 'First C', 'last_name' => 'Last C'];
     $relationshipTypeB = RelationshipTypeFabricator::fabricate($relationshipTypeBParams);
     $contactC = ContactFabricator::fabricate($contactCDetails);

--- a/tests/phpunit/CRM/Civicase/Service/CaseRoleCreationPostProcessTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseRoleCreationPostProcessTest.php
@@ -1,0 +1,396 @@
+<?php
+
+use CRM_Civicase_Test_Fabricator_Relationship as RelationshipFabricator;
+use CRM_Civicase_Test_Fabricator_RelationshipType as RelationshipTypeFabricator;
+use CRM_Civicase_Test_Fabricator_Contact as ContactFabricator;
+use CRM_Civicase_Service_CaseRoleCreationPostProcess as CaseRoleCreationPostProcess;
+use CRM_Civicase_Test_Fabricator_CaseType as CaseTypeFabricator;
+use CRM_Civicase_Test_Fabricator_Case as CaseFabricator;
+
+/**
+ * Runs tests on CaseRoleCreationPostProcess Service tests.
+ *
+ * @group headless
+ */
+class CRM_Civicase_Service_CaseRoleCreationPostProcessTest extends BaseHeadlessTest {
+
+  use CRM_Civicase_Helpers_CaseSettingsTrait;
+  use CRM_Civicase_Helpers_SessionTrait;
+
+  /**
+   * Setup data before tests run.
+   */
+  public function setUp() {
+    $contact = ContactFabricator::fabricate();
+    $this->registerCurrentLoggedInContactInSession($contact['id']);
+  }
+
+  /**
+   * Test All previous relationship set inactive when single case role on.
+   */
+  public function testAllPreviousRelationshipIsSetInActiveWhenSingleCaseRoleSettingIsOnAndMultiClientOff() {
+    $this->setSingleCaseRoleSetting(TRUE);
+    $this->setMultiClientCaseSetting(FALSE);
+    $caseType = CaseTypeFabricator::fabricate();
+    $client = ContactFabricator::fabricate();
+
+    $case = CaseFabricator::fabricate(
+      [
+        'case_type_id' => $caseType['id'],
+        'contact_id' => $client['id'],
+        'creator_id' => $client['id'],
+      ]
+    );
+
+    $relationshipTypeAParams = [
+      'name_a_b' => 'Manager is',
+      'name_b_a' => 'Manager',
+    ];
+    $relationshipTypeBParams = [
+      'name_a_b' => 'Regulator is',
+      'name_b_a' => 'Regulator',
+    ];
+    $contactBDetails = ['first_name' => 'First B', 'last_name' => 'Last B'];
+    $contactCDetails = ['first_name' => 'First C', 'last_name' => 'Last C'];
+    $relationshipTypeA = RelationshipTypeFabricator::fabricate($relationshipTypeAParams);
+    $relationshipTypeB = RelationshipTypeFabricator::fabricate($relationshipTypeBParams);
+    $contactA = ContactFabricator::fabricate();
+    $contactB = ContactFabricator::fabricate($contactBDetails);
+    $contactC = ContactFabricator::fabricate($contactCDetails);
+
+    // Contact A is Manager to Client.
+    $params = [
+      'contact_id_b' => $contactA['id'],
+      'contact_id_a' => $client['id'],
+      'relationship_type_id' => $relationshipTypeA['id'],
+      'case_id' => $case['id'],
+      'skip_post_processing' => 1,
+    ];
+    $relationship1 = RelationshipFabricator::fabricate($params);
+
+    // Contact B is Regulator to Client.
+    $params = [
+      'contact_id_b' => $contactB['id'],
+      'contact_id_a' => $client['id'],
+      'relationship_type_id' => $relationshipTypeB['id'],
+      'case_id' => $case['id'],
+      // This will prevent the On respond event from being triggered.
+      'skip_post_processing' => 1,
+    ];
+    $relationship2 = RelationshipFabricator::fabricate($params);
+
+    // Contact C is Regulator to Client.
+    $latestRelParams = [
+      'contact_id_b' => $contactC['id'],
+      'contact_id_a' => $client['id'],
+      'relationship_type_id' => $relationshipTypeB['id'],
+      'case_id' => $case['id'],
+      'skip_post_processing' => 1,
+    ];
+
+    $latestRelationship = RelationshipFabricator::fabricate($latestRelParams);
+    $caseRolePostProcess = new CaseRoleCreationPostProcess();
+    $caseRolePostProcess->onCreate(['params' => $latestRelParams], ['id' => $latestRelationship['id']]);
+
+    // Since the single role per type setting is on. Previous relationship
+    // i.e relationship2 will have been set inactive.
+    // Relationship 1 should be untouched.
+    $rel2Details = $this->getRelationshipDetails($relationship2['id']);
+    $isRel2InActive = $rel2Details['is_active'] == 0 && $rel2Details['end_date'] = date('Y-m-d');
+    $rel1Details = $this->getRelationshipDetails($relationship1['id']);
+    $isRel1Active = $rel1Details['is_active'] == 1 && empty($rel1Details['end_date']);
+    $this->assertTrue($isRel2InActive);
+    $this->assertTrue($isRel1Active);
+
+    // Check that the appropriate activity is created.
+    $activity = $this->getCreatedActivity($case['id']);
+    $this->assertCount(1, $activity['values']);
+    $this->assertEquals([$client['id']], $activity['values'][0]['target_contact_id']);
+    $expectedActivitySubject = "{$contactC['display_name']} replaced {$contactB['display_name']} as {$relationshipTypeBParams['name_b_a']}";
+    $this->assertEquals($expectedActivitySubject, $activity['values'][0]['subject']);
+  }
+
+  /**
+   * Test only reassigned relationship is set inactive when passed.
+   */
+  public function testOnlyReAssignRelIdIsSetInActiveWhenSingleCaseRoleSettingIsOff() {
+    $this->setSingleCaseRoleSetting(FALSE);
+    $this->setMultiClientCaseSetting(TRUE);
+    $caseType = CaseTypeFabricator::fabricate();
+    $client = ContactFabricator::fabricate();
+
+    $case = CaseFabricator::fabricate(
+      [
+        'case_type_id' => $caseType['id'],
+        'contact_id' => $client['id'],
+        'creator_id' => $client['id'],
+      ]
+    );
+
+    $relationshipTypeAParams = [
+      'name_a_b' => 'Manager is',
+      'name_b_a' => 'Manager',
+    ];
+    $contactADetails = ['first_name' => 'First B', 'last_name' => 'Last B'];
+    $contactCDetails = ['first_name' => 'First C', 'last_name' => 'Last C'];
+    $relationshipTypeA = RelationshipTypeFabricator::fabricate($relationshipTypeAParams);
+    $contactA = ContactFabricator::fabricate($contactADetails);
+    $contactB = ContactFabricator::fabricate();
+    $contactC = ContactFabricator::fabricate($contactCDetails);
+
+    // Contact A is Manager to Client.
+    $params = [
+      'contact_id_b' => $contactA['id'],
+      'contact_id_a' => $client['id'],
+      'relationship_type_id' => $relationshipTypeA['id'],
+      'case_id' => $case['id'],
+      'skip_post_processing' => 1,
+    ];
+    $relationship1 = RelationshipFabricator::fabricate($params);
+
+    // Contact B is Manager to Client.
+    $params = [
+      'contact_id_b' => $contactB['id'],
+      'contact_id_a' => $client['id'],
+      'relationship_type_id' => $relationshipTypeA['id'],
+      'case_id' => $case['id'],
+      // This will prevent the On respond event from being triggered.
+      'skip_post_processing' => 1,
+    ];
+    $relationship2 = RelationshipFabricator::fabricate($params);
+
+    // Contact C is Manager to Client.
+    $latestRelParams = [
+      'contact_id_b' => $contactC['id'],
+      'contact_id_a' => $client['id'],
+      'relationship_type_id' => $relationshipTypeA['id'],
+      'case_id' => $case['id'],
+      'reassign_rel_id' => $relationship1['id'],
+      'skip_post_processing' => 1,
+    ];
+
+    $latestRelationship = RelationshipFabricator::fabricate($latestRelParams);
+    $caseRolePostProcess = new CaseRoleCreationPostProcess();
+    $caseRolePostProcess->onCreate(['params' => $latestRelParams], ['id' => $latestRelationship['id']]);
+
+    // Single role per type setting is off. Only the relationship passed in
+    // assign_rel_id will be set inactive (i.e Rel1). Relationship 2
+    // should be untouched.
+    $rel1Details = $this->getRelationshipDetails($relationship1['id']);
+    $isRel1InActive = $rel1Details['is_active'] == 0 && $rel2Details['end_date'] = date('Y-m-d');
+    $rel2Details = $this->getRelationshipDetails($relationship2['id']);
+    $isRel2Active = $rel2Details['is_active'] == 1 && empty($rel12etails['end_date']);
+    $this->assertTrue($isRel1InActive);
+    $this->assertTrue($isRel2Active);
+
+    // Check that the appropriate activity is created.
+    $activity = $this->getCreatedActivity($case['id']);
+    $this->assertCount(1, $activity['values']);
+    $this->assertEquals([$client['id']], $activity['values'][0]['target_contact_id']);
+    $expectedActivitySubject = "{$contactC['display_name']} replaced {$contactA['display_name']} as {$relationshipTypeAParams['name_b_a']}";
+    $this->assertEquals($expectedActivitySubject, $activity['values'][0]['subject']);
+  }
+
+  /**
+   * Test exception is thrown when rel type Id's don't match for reassigned.
+   */
+  public function testExceptionIsThrownWhenRelTypeIdOfReassignRelationshipDoesNotMatchRelTypeIdOfNewRelationship() {
+    $this->setSingleCaseRoleSetting(FALSE);
+    $this->setMultiClientCaseSetting(TRUE);
+    $caseType = CaseTypeFabricator::fabricate();
+    $client = ContactFabricator::fabricate();
+
+    $case = CaseFabricator::fabricate(
+      [
+        'case_type_id' => $caseType['id'],
+        'contact_id' => $client['id'],
+        'creator_id' => $client['id'],
+      ]
+    );
+
+    $contactADetails = ['first_name' => 'First B', 'last_name' => 'Last B'];
+    $contactCDetails = ['first_name' => 'First C', 'last_name' => 'Last C'];
+    $relationshipTypeAParams = ['name_a_b' => 'Manager is', 'name_b_a' => 'Manager'];
+    $relationshipTypeA = RelationshipTypeFabricator::fabricate($relationshipTypeAParams);
+    $relationshipTypeBParams = ['name_a_b' => 'Regulator is', 'name_b_a' => 'Regulator'];
+    $relationshipTypeB = RelationshipTypeFabricator::fabricate($relationshipTypeBParams);
+    $contactA = ContactFabricator::fabricate($contactADetails);
+    $contactB = ContactFabricator::fabricate();
+    $contactC = ContactFabricator::fabricate($contactCDetails);
+
+    // Contact A is Manager to Client.
+    $params = [
+      'contact_id_b' => $contactA['id'],
+      'contact_id_a' => $client['id'],
+      'relationship_type_id' => $relationshipTypeB['id'],
+      'case_id' => $case['id'],
+      'skip_post_processing' => 1,
+    ];
+    $relationship1 = RelationshipFabricator::fabricate($params);
+
+    // Contact C is Manager to Client.
+    $latestRelParams = [
+      'contact_id_b' => $contactC['id'],
+      'contact_id_a' => $client['id'],
+      'relationship_type_id' => $relationshipTypeA['id'],
+      'case_id' => $case['id'],
+      'reassign_rel_id' => $relationship1['id'],
+      'skip_post_processing' => 1,
+    ];
+
+    $latestRelationship = RelationshipFabricator::fabricate($latestRelParams);
+    $caseRolePostProcess = new CaseRoleCreationPostProcess();
+    $this->setExpectedException(
+      'Exception',
+      'The relationship type Id of the role to reassign must match the new relationship type Id'
+    );
+    $caseRolePostProcess->onCreate(['params' => $latestRelParams], ['id' => $latestRelationship['id']]);
+  }
+
+  /**
+   * Test when single case role on and no previous relationships exist.
+   */
+  public function testCreateWhenSingleCaseRoleSettingIsOnAndMultiClientOffAndNoPreviousRelationshipExist() {
+    $this->setSingleCaseRoleSetting(TRUE);
+    $this->setMultiClientCaseSetting(FALSE);
+    $caseType = CaseTypeFabricator::fabricate();
+    $client = ContactFabricator::fabricate();
+
+    $case = CaseFabricator::fabricate(
+      [
+        'case_type_id' => $caseType['id'],
+        'contact_id' => $client['id'],
+        'creator_id' => $client['id'],
+      ]
+    );
+
+    $relationshipTypeBParams = ['name_a_b' => 'Regulator is', 'name_b_a' => 'Regulator'];
+    $contactCDetails = ['first_name' => 'First C', 'last_name' => 'Last C'];
+    $relationshipTypeB = RelationshipTypeFabricator::fabricate($relationshipTypeBParams);
+    $contactC = ContactFabricator::fabricate($contactCDetails);
+
+    // Contact C is Regulator to Client.
+    $latestRelParams = [
+      'contact_id_b' => $contactC['id'],
+      'contact_id_a' => $client['id'],
+      'relationship_type_id' => $relationshipTypeB['id'],
+      'case_id' => $case['id'],
+      'skip_post_processing' => 1,
+    ];
+
+    $latestRelationship = RelationshipFabricator::fabricate($latestRelParams);
+    $caseRolePostProcess = new CaseRoleCreationPostProcess();
+    $caseRolePostProcess->onCreate(['params' => $latestRelParams], ['id' => $latestRelationship['id']]);
+
+    // Check that the appropriate activity is created.
+    $activity = $this->getCreatedActivity($case['id']);
+    $this->assertCount(1, $activity['values']);
+    $this->assertEquals([$client['id']], $activity['values'][0]['target_contact_id']);
+
+    $expectedActivitySubject = "{$contactC['display_name']} added as {$relationshipTypeBParams['name_b_a']}";
+    $this->assertEquals($expectedActivitySubject, $activity['values'][0]['subject']);
+  }
+
+  /**
+   * Test when single case role setting is off and reassigned rel Id not passed.
+   */
+  public function testOtherRelationshipsNotSetInActiveWhenSingleCaseRoleSettingIsOffAndReAssignedRelIdNotPassed() {
+    $this->setSingleCaseRoleSetting(FALSE);
+    $this->setMultiClientCaseSetting(TRUE);
+    $caseType = CaseTypeFabricator::fabricate();
+    $client = ContactFabricator::fabricate();
+
+    $case = CaseFabricator::fabricate(
+      [
+        'case_type_id' => $caseType['id'],
+        'contact_id' => $client['id'],
+        'creator_id' => $client['id'],
+      ]
+    );
+
+    $relationshipTypeAParams = [
+      'name_a_b' => 'Manager is',
+      'name_b_a' => 'Manager',
+    ];
+    $contactCDetails = ['first_name' => 'First C', 'last_name' => 'Last C'];
+    $relationshipTypeA = RelationshipTypeFabricator::fabricate($relationshipTypeAParams);
+    $contactB = ContactFabricator::fabricate();
+    $contactC = ContactFabricator::fabricate($contactCDetails);
+
+    // Contact B is Manager to Client.
+    $params = [
+      'contact_id_b' => $contactB['id'],
+      'contact_id_a' => $client['id'],
+      'relationship_type_id' => $relationshipTypeA['id'],
+      'case_id' => $case['id'],
+      // This will prevent the On respond event from being triggered.
+      'skip_post_processing' => 1,
+    ];
+    $relationship2 = RelationshipFabricator::fabricate($params);
+
+    // Contact C is Manager to Client.
+    $latestRelParams = [
+      'contact_id_b' => $contactC['id'],
+      'contact_id_a' => $client['id'],
+      'relationship_type_id' => $relationshipTypeA['id'],
+      'case_id' => $case['id'],
+      'skip_post_processing' => 1,
+    ];
+
+    $latestRelationship = RelationshipFabricator::fabricate($latestRelParams);
+    $caseRolePostProcess = new CaseRoleCreationPostProcess();
+    $caseRolePostProcess->onCreate(['params' => $latestRelParams], ['id' => $latestRelationship['id']]);
+
+    // Relationship 2 should be untouched and still be active.
+    $rel2Details = $this->getRelationshipDetails($relationship2['id']);
+    $isRel2Active = $rel2Details['is_active'] == 1 && empty($rel12etails['end_date']);
+    $this->assertTrue($isRel2Active);
+
+    // Check that the appropriate activity is created.
+    $activity = $this->getCreatedActivity($case['id']);
+    $this->assertCount(1, $activity['values']);
+    $this->assertEquals([$client['id']], $activity['values'][0]['target_contact_id']);
+
+    $expectedActivitySubject = "{$contactC['display_name']} added as {$relationshipTypeAParams['name_b_a']}";
+    $this->assertEquals($expectedActivitySubject, $activity['values'][0]['subject']);
+  }
+
+  /**
+   * Get relationship details.
+   *
+   * @param int $relId
+   *   Relationship Id.
+   *
+   * @return array
+   *   Relationship details.
+   */
+  private function getRelationshipDetails($relId) {
+    $result = civicrm_api3('Relationship', 'getsingle', [
+      'id' => $relId,
+    ]);
+
+    return $result;
+  }
+
+  /**
+   * Get created case activity.
+   *
+   * @param int $caseId
+   *   Case Id.
+   *
+   * @return array
+   *   created activity data.
+   */
+  private function getCreatedActivity($caseId) {
+    $result = civicrm_api3('Activity', 'get', [
+      'sequential' => 1,
+      'case_id' => $caseId,
+      'activity_type_id' => 'Assign Case Role',
+      'status_id' => 'Completed',
+      'return' => ['target_contact_id', 'subject'],
+    ]);
+
+    return $result;
+  }
+
+}

--- a/tests/phpunit/CRM/Civicase/Service/CaseRoleCreationPreProcessTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseRoleCreationPreProcessTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use CRM_Civicase_Service_CaseRoleCreationPreProcess as CaseRoleCreationPreProcess;
+
+/**
+ * Runs tests on CaseRoleCreationPreProcess Service tests.
+ *
+ * @group headless
+ */
+class CRM_Civicase_Service_CaseRoleCreationPreProcessTest extends BaseHeadlessTest {
+  use CRM_Civicase_Helpers_CaseSettingsTrait;
+
+  /**
+   * Test start date is modified when single case role setting on.
+   */
+  public function testStartDateIsModifiedWhenSingleCaseRoleSettingIsOnAndMultiClientIsOff() {
+    $this->setSingleCaseRoleSetting(TRUE);
+    $this->setMultiClientCaseSetting(FALSE);
+
+    $params = [
+      'contact_id_b' => 1,
+      'contact_id_a' => 2,
+      'relationship_type_id' => 3,
+      'case_id' => 2,
+      'start_date' => '2020-6-05',
+      // This will prevent the On respond event from being triggered.
+      'skip_post_processing' => 1,
+    ];
+    $apiRequestParams = ['params' => $params];
+    $caseRolePostProcess = new CaseRoleCreationPreProcess();
+    $caseRolePostProcess->onCreate($apiRequestParams);
+
+    $this->assertEquals(date('Y-m-d'), $apiRequestParams['params']['start_date']);
+  }
+
+  /**
+   * Test start date not modified when single case role setting off.
+   */
+  public function testStartDateIsNotModifiedWhenSingleCaseRoleSettingIsOff() {
+    $this->setSingleCaseRoleSetting(FALSE);
+
+    $params = [
+      'contact_id_b' => 1,
+      'contact_id_a' => 2,
+      'relationship_type_id' => 3,
+      'case_id' => 2,
+      'start_date' => '2020-06-05',
+      // This will prevent the On respond event from being triggered.
+      'skip_post_processing' => 1,
+    ];
+    $apiRequestParams = ['params' => $params];
+    $caseRolePostProcess = new CaseRoleCreationPreProcess();
+    $caseRolePostProcess->onCreate($apiRequestParams);
+
+    $this->assertEquals($params['start_date'], $apiRequestParams['params']['start_date']);
+  }
+
+}

--- a/tests/phpunit/CRM/Civicase/Service/CaseRoleCreationPreProcessTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseRoleCreationPreProcessTest.php
@@ -16,19 +16,8 @@ class CRM_Civicase_Service_CaseRoleCreationPreProcessTest extends BaseHeadlessTe
   public function testStartDateIsModifiedWhenSingleCaseRoleSettingIsOnAndMultiClientIsOff() {
     $this->setSingleCaseRoleSetting(TRUE);
     $this->setMultiClientCaseSetting(FALSE);
-
-    $params = [
-      'contact_id_b' => 1,
-      'contact_id_a' => 2,
-      'relationship_type_id' => 3,
-      'case_id' => 2,
-      'start_date' => '2020-6-05',
-      // This will prevent the On respond event from being triggered.
-      'skip_post_processing' => 1,
-    ];
-    $apiRequestParams = ['params' => $params];
-    $caseRolePostProcess = new CaseRoleCreationPreProcess();
-    $caseRolePostProcess->onCreate($apiRequestParams);
+    $params = ['start_date' => '2020-06-05'];
+    $apiRequestParams = $this->callPreProcessCreate($params);
 
     $this->assertEquals(date('Y-m-d'), $apiRequestParams['params']['start_date']);
   }
@@ -39,7 +28,22 @@ class CRM_Civicase_Service_CaseRoleCreationPreProcessTest extends BaseHeadlessTe
   public function testStartDateIsNotModifiedWhenSingleCaseRoleSettingIsOff() {
     $this->setSingleCaseRoleSetting(FALSE);
 
-    $params = [
+    $params = ['start_date' => '2020-06-05'];
+    $apiRequestParams = $this->callPreProcessCreate($params);
+    $this->assertEquals($params['start_date'], $apiRequestParams['params']['start_date']);
+  }
+
+  /**
+   * Call the case role pre process and return results.
+   *
+   * @param array $params
+   *   API parameters.
+   *
+   * @return array
+   *   Modified API params.
+   */
+  private function callPreProcessCreate(array $params) {
+    $defaultParams = [
       'contact_id_b' => 1,
       'contact_id_a' => 2,
       'relationship_type_id' => 3,
@@ -48,11 +52,11 @@ class CRM_Civicase_Service_CaseRoleCreationPreProcessTest extends BaseHeadlessTe
       // This will prevent the On respond event from being triggered.
       'skip_post_processing' => 1,
     ];
-    $apiRequestParams = ['params' => $params];
+    $apiRequestParams = ['params' => array_merge($defaultParams, $params)];
     $caseRolePostProcess = new CaseRoleCreationPreProcess();
     $caseRolePostProcess->onCreate($apiRequestParams);
 
-    $this->assertEquals($params['start_date'], $apiRequestParams['params']['start_date']);
+    return $apiRequestParams;
   }
 
 }

--- a/tests/phpunit/api/v3/CaseRoleCreationTest.php
+++ b/tests/phpunit/api/v3/CaseRoleCreationTest.php
@@ -1,0 +1,139 @@
+<?php
+
+use CRM_Civicase_Test_Fabricator_Relationship as RelationshipFabricator;
+use CRM_Civicase_Test_Fabricator_RelationshipType as RelationshipTypeFabricator;
+use CRM_Civicase_Test_Fabricator_CaseType as CaseTypeFabricator;
+use CRM_Civicase_Test_Fabricator_Case as CaseFabricator;
+use CRM_Civicase_Test_Fabricator_Contact as ContactFabricator;
+
+/**
+ * Runs tests on api_v3_CaseRoleCreationTest tests.
+ *
+ * @group headless
+ */
+class api_v3_CaseRoleCreationTest extends BaseHeadlessTest {
+
+  use CRM_Civicase_Helpers_CaseSettingsTrait;
+  use CRM_Civicase_Helpers_SessionTrait;
+
+  /**
+   * Setup data before tests run.
+   */
+  public function setUp() {
+    $contact = ContactFabricator::fabricate();
+    $this->registerCurrentLoggedInContactInSession($contact['id']);
+  }
+
+  /**
+   * Test case role post processing is triggered.
+   */
+  public function testCaseRolePostProcessingIsTriggeredForCaseRelatedRelationshipApiCall() {
+    $this->setSingleCaseRoleSetting(TRUE);
+    $this->setMultiClientCaseSetting(FALSE);
+    $caseType = CaseTypeFabricator::fabricate();
+    $client = ContactFabricator::fabricate();
+
+    $case = CaseFabricator::fabricate(
+      [
+        'case_type_id' => $caseType['id'],
+        'contact_id' => $client['id'],
+        'creator_id' => $client['id'],
+      ]
+    );
+
+    $relationshipTypeAParams = [
+      'name_a_b' => 'Manager is',
+      'name_b_a' => 'Manager',
+    ];
+    $relationshipTypeA = RelationshipTypeFabricator::fabricate($relationshipTypeAParams);
+    $contactA = ContactFabricator::fabricate();
+
+    // Contact A is Manager to Client.
+    $params = [
+      'contact_id_b' => $contactA['id'],
+      'contact_id_a' => $client['id'],
+      'relationship_type_id' => $relationshipTypeA['id'],
+      'case_id' => $case['id'],
+      'start_date' => '2020-06-01',
+    ];
+
+    // PostProcessing Should Be Triggered Here.
+    $relationship1 = RelationshipFabricator::fabricate($params);
+
+    // Case start date should be set to today's date as the single
+    // case role setting is on.
+    $relStartDate = new DateTime($relationship1['start_date']);
+    $this->assertEquals(date('Y-m-d'), $relStartDate->format('Y-m-d'));
+
+    // Verify created activity.
+    $activity = $this->getCreatedActivity($case['id']);
+    $this->assertCount(1, $activity['values']);
+    $this->assertEquals([$client['id']], $activity['values'][0]['target_contact_id']);
+
+    $expectedActivitySubject = "{$contactA['display_name']} added as {$relationshipTypeAParams['name_b_a']}";
+    $this->assertEquals($expectedActivitySubject, $activity['values'][0]['subject']);
+
+  }
+
+  /**
+   * Test case role post processing is not triggered for non case related api.
+   */
+  public function testCaseRolePostProcessingIsNotTriggeredForNonCaseRelatedRelationshipApiCall() {
+    $this->setSingleCaseRoleSetting(TRUE);
+    $this->setMultiClientCaseSetting(FALSE);
+    $client = ContactFabricator::fabricate();
+
+    $relationshipTypeAParams = [
+      'name_a_b' => 'Manager is',
+      'name_b_a' => 'Manager',
+    ];
+    $relationshipTypeA = RelationshipTypeFabricator::fabricate($relationshipTypeAParams);
+    $contactA = ContactFabricator::fabricate();
+
+    // Contact A is Manager to Client.
+    $params = [
+      'contact_id_b' => $contactA['id'],
+      'contact_id_a' => $client['id'],
+      'relationship_type_id' => $relationshipTypeA['id'],
+      'start_date' => '2020-06-01',
+    ];
+
+    // PostProcessing will not be Triggered Here.
+    $relationship1 = RelationshipFabricator::fabricate($params);
+
+    // Case start date will not.
+    $relStartDate = new DateTime($relationship1['start_date']);
+    $this->assertEquals($params['start_date'], $relStartDate->format('Y-m-d'));
+
+    // No activity will be created.
+    $activity = $this->getCreatedActivity();
+    $this->assertCount(0, $activity['values']);
+  }
+
+  /**
+   * Get created activity data.
+   *
+   * @param int|null $caseId
+   *   Case Id.
+   *
+   * @return array
+   *   Activity data
+   */
+  private function getCreatedActivity($caseId = NULL) {
+    $params = [
+      'sequential' => 1,
+      'activity_type_id' => 'Assign Case Role',
+      'status_id' => 'Completed',
+      'return' => ['target_contact_id', 'subject'],
+    ];
+
+    if (!empty($caseId)) {
+      $params['case_id'] = $caseId;
+    }
+
+    $result = civicrm_api3('Activity', 'get', $params);
+
+    return $result;
+  }
+
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -4,6 +4,16 @@ ini_set('memory_limit', '2G');
 ini_set('safe_mode', 0);
 eval(cv('php:boot --level=classloader', 'phpcode'));
 
+// Allow autoloading of PHPUnit helper classes in this extension.
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->add('CRM_', __DIR__);
+$loader->add('Civi\\', __DIR__);
+$loader->add('api_', __DIR__);
+$loader->add('api\\', __DIR__);
+$loader->register();
+
+require_once 'BaseHeadlessTest.php';
+
 /**
  * Call the "cv" command.
  *


### PR DESCRIPTION
## Overview

Currently, when a case role is added using the Relationship.create API, the logic for creating the activity and reassigning the role resides in the Frontend, this is a disadvantage because if a case role is added via some other means, e.g webform, these logic is not activated. This PR moves these business logic to the backend so that when a case relationship is created from any source either via Webform or civicrm fronted, these post processing is triggered in all cases.
This PR also adds the `One active case role` setting to the civicrm settings page, what this settings does in essence is that it will only allow one active instance of each case role for all case types when turned on.

## Before
- The `One active case role` setting is not added.
- Business logic when creating/reassigning a case related relationship is handled on Civicrm frontend.

## After
- The `One active case role` setting is now added.

<img width="1278" alt="Settings - CiviCase  CaseLatest 2020-08-13 12-25-15" src="https://user-images.githubusercontent.com/6951813/90129208-25437c00-dd60-11ea-9270-1c429db0000f.png">

- Business logic when creating/reassigning a case related relationship is now handled at the backend.


## Technical Details
- The `CRM_Civicase_Event_Listener_CaseRoleCreation` listener class was created to listen to the `on prepare` and `on respond` event of the `Relationship.create` API.
- The `CRM_Civicase_Service_CaseRoleCreationPostProcess` was created to handle post processing logic after a case related relationship has been created.
- The `CRM_Civicase_Service_CaseRoleCreationPreProcess` class was create to handle pre processing before a case related relationship is created.

**Business Logic**

- When the `One active case role` setting is on and the multiclient case setting is off, Any case role with a contact which already holds that case role is set to be inactive and their end dates set as today's date, an appropriate activity of type `Assign Case Role` is also created. Also the start date of the new case role is set to be today's date.
- When the `One active case role` setting is off, the system behaves as it does currently, the main difference being that the when reassigning a case role, a `reassign_rel_id` parameter is passed which holds the relationship type to be set inactive. If the `reassign_rel_id` is not passed, the BE assumes the case role is being added and not resassigned.

