### PR TITLE
CATL-1642:  Single Case Role Bug Fixes

### DIFF
--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
@@ -249,6 +249,8 @@
         if (!role.relationship_type_id) {
           apiCalls = [unassignClientCall(role)];
           getApiParamsToSetRelationshipsAsInactiveWhenClientIsRemoved(role, apiCalls);
+        } else {
+          apiCalls = [unassignRoleCall(role)];
         }
 
         apiCalls.push(['Activity', 'create', {
@@ -631,6 +633,22 @@ included in the confirmation dialog.
         case_id: item.id,
         contact_id: role.contact_id,
         'api.CaseContact.delete': {}
+      }];
+    }
+
+    /**
+     * Unassign role
+     *
+     * @param {object} role role
+     * @returns {Array} API call
+     */
+    function unassignRoleCall (role) {
+      return ['Relationship', 'get', {
+        relationship_type_id: role.relationship_type_id,
+        contact_id_b: role.contact_id,
+        case_id: item.id,
+        is_active: 1,
+        'api.Relationship.create': { is_active: 0, end_date: 'now' }
       }];
     }
 

--- a/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
@@ -114,15 +114,21 @@ describe('Case Details People Tab', () => {
 
       it('creates a new relationship between the case client and the selected contact using the given role', () => {
         expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
-          ['Relationship', 'create', {
-            relationship_type_id: relationshipTypeId,
-            start_date: 'now',
-            end_date: null,
-            contact_id_b: contact.contact_id,
+          ['Relationship', 'get', {
             case_id: $scope.item.id,
-            description: roleDescription,
-            contact_id_a: $scope.item.client[0].contact_id,
-            reassign_rel_id: previousContact.contact_id
+            contact_id_b: previousContact.contact_id,
+            is_active: 1,
+            relationship_type_id: relationshipTypeId,
+            'api.Relationship.create': {
+              relationship_type_id: relationshipTypeId,
+              start_date: 'now',
+              end_date: null,
+              contact_id_b: contact.contact_id,
+              case_id: $scope.item.id,
+              description: roleDescription,
+              contact_id_a: $scope.item.client[0].contact_id,
+              reassign_rel_id: '$value.id'
+            }
           }]
         ]));
       });

--- a/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
@@ -344,6 +344,39 @@ describe('Case Details People Tab', () => {
         }]]));
       });
     });
+
+    describe('when unassigning a role', () => {
+      let sampleContact, relationshipTypeId;
+
+      beforeEach(() => {
+        sampleContact = CRM._.sample(ContactsData.values);
+        relationshipTypeId = CRM._.uniqueId();
+
+        $scope.unassignRole({
+          contact_id: sampleContact.contact_id,
+          display_name: sampleContact.display_name,
+          relationship_type_id: relationshipTypeId,
+          role: 'Role'
+        });
+
+        crmConfirmDialog.trigger(crmConfirmYesEvent);
+        $rootScope.$digest();
+      });
+
+      it('marks the current role relationship as finished', () => {
+        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
+          ['Relationship', 'get', {
+            relationship_type_id: relationshipTypeId,
+            contact_id_b: sampleContact.contact_id,
+            case_id: $scope.item.id,
+            is_active: 1,
+            'api.Relationship.create': {
+              is_active: 0, end_date: 'now'
+            }
+          }]
+        ]));
+      });
+    });
   });
 
   describe('bulk action', () => {


### PR DESCRIPTION
## Overview
This PR fixes the following bugs related to single case role selection:

* Removing an existing role was removed unintentionally in https://github.com/compucorp/uk.co.compucorp.civicase/pull/556 and this was restored.
* Whe pass the right parameter value to the relationship endpoint when reassigning a relation. Previously we were passing the contact ID instead of the relationship ID.

## Removing an existing role

### Before
![gif](https://user-images.githubusercontent.com/1642119/90207826-3b2f5c00-ddb5-11ea-8426-530c3d93c386.gif)

### After
![gif](https://user-images.githubusercontent.com/1642119/90207622-be03e700-ddb4-11ea-8199-714cbceb309d.gif)

### Technical details

To restore this functionality we looked into the previous code removed by https://github.com/compucorp/uk.co.compucorp.civicase/pull/556 and only included the part that removes the case role.

## Reassigning a role

### Before
![gif](https://user-images.githubusercontent.com/1642119/90207863-5b5f1b00-ddb5-11ea-9d45-7c724f6148d3.gif)

### After
![gif](https://user-images.githubusercontent.com/1642119/90207667-dd9b0f80-ddb4-11ea-878b-7c03be0baa50.gif)

### Technical details

The list of roles and list of contacts don't include the relationship ID so when we need to replace a relationship we make a chained API call to first get the relationship ID and then do the replacing as normal.


