### PR TITLE
CATL-1590: Specify reassign role date in people's tab

### DIFF
--- a/CRM/Civicase/Service/CaseRoleCreationPostProcess.php
+++ b/CRM/Civicase/Service/CaseRoleCreationPostProcess.php
@@ -45,7 +45,7 @@ class CRM_Civicase_Service_CaseRoleCreationPostProcess extends CRM_Civicase_Serv
     }
 
     if (!empty($existingRelationship)) {
-      $this->setRelationshipsInactive(array_column($existingRelationship, 'id'));
+      $this->setRelationshipsInactive(array_column($existingRelationship, 'id'), $requestParams['params']);
     }
     $activitySubject = $this->getActivitySubjectOnCreate($currentRelContactName, $relTypeDetails, $previousRelContactName);
     $this->createCaseActivity($requestParams['params']['case_id'], 'Assign Case Role', $activitySubject);
@@ -156,13 +156,15 @@ class CRM_Civicase_Service_CaseRoleCreationPostProcess extends CRM_Civicase_Serv
    *
    * @param array $relIds
    *   Relationship Ids.
+   * @param array $params
+   *   API request parameters.
    */
-  private function setRelationshipsInactive(array $relIds) {
+  private function setRelationshipsInactive(array $relIds, array $params) {
     foreach ($relIds as $relId) {
       civicrm_api3('Relationship', 'create', [
         'id' => $relId,
         'is_active' => 0,
-        'end_date' => date('Y-m-d'),
+        'end_date' => !empty($params['start_date']) ? $params['start_date'] : date('Y-m-d'),
         'skip_post_processing' => 1,
       ]);
     }

--- a/ang/civicase/case/details/people-tab/directives/contact-prompt-dialog.html
+++ b/ang/civicase/case/details/people-tab/directives/contact-prompt-dialog.html
@@ -1,5 +1,6 @@
 <div id="bootstrap-theme">
   <div class="civicrm__contact-prompt-dialog form-horizontal">
+    <!-- start date -->
     <div class="row form-group" ng-if="model.showStartDate">
       <label class="col-sm-12">
         Relationship Start Date
@@ -15,6 +16,9 @@
           }" />
       </div>
     </div>
+    <!-- end - start date -->
+
+    <!-- end date -->
     <div class="row form-group" ng-if="model.endDate.show">
       <label class="col-sm-12">
         Relationship End Date
@@ -31,6 +35,28 @@
           }" />
       </div>
     </div>
+    <!-- end - end date -->
+
+    <!-- reassign date -->
+    <div class="row form-group" ng-if="model.reassignmentDate.show">
+      <label class="col-sm-12">
+        Relationship Reassignment Date
+      </label>
+      <div class="col-md-12">
+        <input
+          ng-model="model.reassignmentDate.value"
+          placeholder="Reassignment Date"
+          crm-ui-datepicker="{
+            time: false,
+            minDate: model.reassignmentDate.minDate,
+            beforeShow: model.removeDatePickerHrefs,
+            onChangeMonthYear: model.removeDatePickerHrefs
+          }" />
+      </div>
+    </div>
+    <!-- end - reassign date -->
+
+    <!-- contact selection dropdown -->
     <div
       ng-if="!model.hideContactField"
       class="row form-group"
@@ -66,6 +92,9 @@
         {{model.contactSelectionErrorMessage}}
       </div>
     </div>
+    <!-- end - contact selection dropdown -->
+
+    <!-- description field -->
     <div class="row form-group" ng-if="model.showDescriptionField">
       <div class="col-md-12">
         <textarea
@@ -76,5 +105,6 @@
         ></textarea>
       </div>
     </div>
+    <!-- end - description field -->
   </div>
 </div>

--- a/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
@@ -108,7 +108,8 @@ describe('Case Details People Tab', () => {
           contact_id: previousContact.contact_id,
           display_name: previousContact.display_name,
           relationship_type_id: relationshipTypeId,
-          role: roleName
+          role: roleName,
+          id: '101'
         });
         selectDialogContact(contact);
         updateDialogModel({
@@ -119,24 +120,18 @@ describe('Case Details People Tab', () => {
       });
 
       it('creates a new relationship between the case client and the selected contact using the given role', () => {
-        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
-          ['Relationship', 'get', {
-            case_id: $scope.item.id,
-            contact_id_b: previousContact.contact_id,
-            is_active: 1,
+        expect($scope.refresh).toHaveBeenCalledWith([
+          ['Relationship', 'create', {
+            contact_id_a: $scope.item.client[0].contact_id,
             relationship_type_id: relationshipTypeId,
-            'api.Relationship.create': {
-              relationship_type_id: relationshipTypeId,
-              start_date: 'now',
-              end_date: null,
-              contact_id_b: contact.contact_id,
-              case_id: $scope.item.id,
-              description: roleDescription,
-              contact_id_a: $scope.item.client[0].contact_id,
-              reassign_rel_id: '$value.id'
-            }
+            start_date: getDialogModel().reassignmentDate.value,
+            end_date: null,
+            contact_id_b: contact.id,
+            case_id: $scope.item.id,
+            description: roleDescription,
+            reassign_rel_id: '101'
           }]
-        ]));
+        ]);
       });
 
       it('closes the contact selection dialog', () => {


### PR DESCRIPTION
## Overview
As part of this PR, specifying reassignment date while reassigning role in people's tab is now supported.

## Before
![2020-08-28 at 1 06 PM](https://user-images.githubusercontent.com/5058867/91535850-6c6d6780-e931-11ea-9199-5b37c4a31f3a.jpg)

## After
![2020-08-28 at 1 06 PM](https://user-images.githubusercontent.com/5058867/91534547-5363b700-e92f-11ea-90b3-6b88b8d68603.jpg)

## Technical Details
Also fixed a regression with when reassigning roles. It happened in https://github.com/compucorp/uk.co.compucorp.civicase/pull/560. As we choose to use Chained api calls, it always passes the relationship id to the chained api call, so it became a "Update" call instead of "Create". Hence it was not setting the old relation as inactive, instead it was just updating the old relationship. This is fixed now.
