### PR TITLE
CATL-1684: Add Case Webform Redirect

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/CaseTypeCategoryWebFormRedirect.php
+++ b/CRM/Civicase/Hook/BuildForm/CaseTypeCategoryWebFormRedirect.php
@@ -1,0 +1,64 @@
+<?php
+
+use CRM_Civicase_Service_CaseCategorySetting as CaseCategorySetting;
+use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+
+/**
+ * Fetches web form url if available for current case type category and redirects user to that web form.
+ */
+class CRM_Civicase_Hook_BuildForm_CaseTypeCategoryWebFormRedirect {
+
+  /**
+   * Case category Setting.
+   *
+   * @var CRM_Civicase_Service_CaseCategorySetting
+   *   CaseCategorySetting service.
+   */
+  private $caseCategorySetting;
+
+  /**
+   * Initialize dependencies.
+   */
+  public function __construct() {
+    $this->caseCategorySetting = new CaseCategorySetting();
+  }
+
+  /**
+   * Fetches web form url if available for current case type category and redirects user to that web form.
+   *
+   * @param CRM_Core_Form $form
+   *   Form object.
+   * @param string $formName
+   */
+  public function run(CRM_Core_Form &$form, $formName) {
+    if (!$this->shouldRun($formName)) {
+      return;
+    }
+    $this->redirectToWebForm();
+  }
+
+  /**
+   * Checks the form name and snippet parameter.
+   *
+   * @param string $formName
+   *
+   * @return boolean
+   */
+  private function shouldRun($formName) {
+    return (
+      $formName === CRM_Case_Form_Case::class &&
+      CRM_Utils_Array::value('snippet', $_GET, '') !== 'json'
+    );
+  }
+
+  /**
+   * Redirect to web form if available for current case type category.
+   */
+  private function redirectToWebForm() {
+    $caseTypeCategoryName = CRM_Utils_Array::value('case_type_category', $_GET, 'Cases');
+    $webFormUrl = CaseTypeCategoryHelper::getNewCaseCategoryWebformUrl($caseTypeCategoryName, $this->caseCategorySetting);
+    if ($webFormUrl) {
+      CRM_Utils_System::redirect(CRM_Utils_System::url(trim($webFormUrl, '/'), ['reset'=>1], false));
+    }
+  }
+}

--- a/CRM/Civicase/Hook/BuildForm/CaseTypeCategoryWebFormRedirect.php
+++ b/CRM/Civicase/Hook/BuildForm/CaseTypeCategoryWebFormRedirect.php
@@ -4,7 +4,7 @@ use CRM_Civicase_Service_CaseCategorySetting as CaseCategorySetting;
 use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
 
 /**
- * Fetches web form url if available for current case type category and redirects user to that web form.
+ * Fetches and redirects user to web form url for current case type category.
  */
 class CRM_Civicase_Hook_BuildForm_CaseTypeCategoryWebFormRedirect {
 
@@ -24,11 +24,12 @@ class CRM_Civicase_Hook_BuildForm_CaseTypeCategoryWebFormRedirect {
   }
 
   /**
-   * Fetches web form url if available for current case type category and redirects user to that web form.
+   * Fetches and redirects user to web form url for current case type category.
    *
    * @param CRM_Core_Form $form
    *   Form object.
    * @param string $formName
+   *   Form name.
    */
   public function run(CRM_Core_Form &$form, $formName) {
     if (!$this->shouldRun($formName)) {
@@ -41,8 +42,10 @@ class CRM_Civicase_Hook_BuildForm_CaseTypeCategoryWebFormRedirect {
    * Checks the form name and snippet parameter.
    *
    * @param string $formName
+   *   Form name.
    *
-   * @return boolean
+   * @return bool
+   *   Whether this hook should run or not.
    */
   private function shouldRun($formName) {
     return (
@@ -58,7 +61,8 @@ class CRM_Civicase_Hook_BuildForm_CaseTypeCategoryWebFormRedirect {
     $caseTypeCategoryName = CRM_Utils_Array::value('case_type_category', $_GET, 'Cases');
     $webFormUrl = CaseTypeCategoryHelper::getNewCaseCategoryWebformUrl($caseTypeCategoryName, $this->caseCategorySetting);
     if ($webFormUrl) {
-      CRM_Utils_System::redirect(CRM_Utils_System::url(trim($webFormUrl, '/'), ['reset'=>1], false));
+      CRM_Utils_System::redirect(CRM_Utils_System::url(trim($webFormUrl, '/'), ['reset' => 1], FALSE));
     }
   }
+
 }

--- a/CRM/Civicase/Hook/NavigationMenu/AlterForCaseMenu.php
+++ b/CRM/Civicase/Hook/NavigationMenu/AlterForCaseMenu.php
@@ -1,7 +1,6 @@
 <?php
 
 use CRM_Civicase_Service_CaseCategorySetting as CaseCategorySetting;
-use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
 
 /**
  * Class CRM_Civicase_Hook_Navigation_AlterForCaseMenu.

--- a/CRM/Civicase/Hook/NavigationMenu/AlterForCaseMenu.php
+++ b/CRM/Civicase/Hook/NavigationMenu/AlterForCaseMenu.php
@@ -44,26 +44,13 @@ class CRM_Civicase_Hook_NavigationMenu_AlterForCaseMenu {
       'civicrm/case/search?reset=1' => 'civicrm/case/a/#/case/list?sx=1',
     ];
 
-    $addCaseUrl = 'civicrm/case/add';
-
-    $this->menuWalk($menu, function (&$item) use ($rewriteMap, $addCaseUrl) {
+    $this->menuWalk($menu, function (&$item) use ($rewriteMap) {
       if (!isset($item['url'])) {
         return;
       }
 
       if (isset($rewriteMap[$item['url']])) {
         $item['url'] = $rewriteMap[$item['url']];
-
-        return;
-      }
-
-      if (strpos($item['url'], $addCaseUrl) !== FALSE) {
-        $caseCategoryName = $this->getCaseCategoryName($item['url']);
-        $webformUrl = CaseTypeCategoryHelper::getNewCaseCategoryWebformUrl($caseCategoryName, $this->caseCategorySetting);
-
-        if (!empty($webformUrl)) {
-          $item['url'] = $webformUrl;
-        }
 
         return;
       }
@@ -107,19 +94,6 @@ class CRM_Civicase_Hook_NavigationMenu_AlterForCaseMenu {
         'active' => 1,
       ],
     ];
-  }
-
-  /**
-   * Gets the Case Category Name.
-   *
-   * @param string $url
-   *   Menu URL.
-   */
-  private function getCaseCategoryName($url) {
-    $urlParams = parse_url(htmlspecialchars_decode($url), PHP_URL_QUERY);
-    parse_str($urlParams, $urlParams);
-
-    return !empty($urlParams['case_type_category']) ? $urlParams['case_type_category'] : 'Cases';
   }
 
   /**

--- a/CRM/Civicase/Hook/PreProcess/CaseTypeCategoryWebFormRedirect.php
+++ b/CRM/Civicase/Hook/PreProcess/CaseTypeCategoryWebFormRedirect.php
@@ -6,7 +6,7 @@ use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
 /**
  * Fetches and redirects user to web form url for current case type category.
  */
-class CRM_Civicase_Hook_BuildForm_CaseTypeCategoryWebFormRedirect {
+class CRM_Civicase_Hook_PreProcess_CaseTypeCategoryWebFormRedirect {
 
   /**
    * Case category Setting.
@@ -26,12 +26,12 @@ class CRM_Civicase_Hook_BuildForm_CaseTypeCategoryWebFormRedirect {
   /**
    * Fetches and redirects user to web form url for current case type category.
    *
-   * @param CRM_Core_Form $form
-   *   Form object.
    * @param string $formName
    *   Form name.
+   * @param CRM_Core_Form $form
+   *   Form object.
    */
-  public function run(CRM_Core_Form &$form, $formName) {
+  public function run($formName, CRM_Core_Form &$form) {
     if (!$this->shouldRun($formName)) {
       return;
     }

--- a/CRM/Civicase/Hook/SummaryActions/AlterAddCaseAction.php
+++ b/CRM/Civicase/Hook/SummaryActions/AlterAddCaseAction.php
@@ -4,7 +4,7 @@ use CRM_Civicase_Service_CaseCategorySetting as CaseCategorySetting;
 use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
 
 /**
- * Changes add case link with web form if web form is available.
+ * Changes add case action with web form if web form is available.
  */
 class CRM_Civicase_Hook_SummaryActions_AlterAddCaseAction {
 
@@ -24,7 +24,7 @@ class CRM_Civicase_Hook_SummaryActions_AlterAddCaseAction {
   }
 
   /**
-   * Changes add case link with web form if web form is available.
+   * Changes add case action with web form if web form is available.
    *
    * @param array $actions
    *   List of actions.

--- a/CRM/Civicase/Hook/SummaryActions/AlterAddCaseAction.php
+++ b/CRM/Civicase/Hook/SummaryActions/AlterAddCaseAction.php
@@ -4,7 +4,7 @@ use CRM_Civicase_Service_CaseCategorySetting as CaseCategorySetting;
 use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
 
 /**
- * Changes add case action with web form if web form is available.
+ * Removes the popup for add case action if web form is available.
  */
 class CRM_Civicase_Hook_SummaryActions_AlterAddCaseAction {
 
@@ -24,7 +24,7 @@ class CRM_Civicase_Hook_SummaryActions_AlterAddCaseAction {
   }
 
   /**
-   * Changes add case action with web form if web form is available.
+   * Removes the popup for add case action if web form is available.
    *
    * @param array $actions
    *   List of actions.
@@ -56,7 +56,7 @@ class CRM_Civicase_Hook_SummaryActions_AlterAddCaseAction {
   }
 
   /**
-   * Changes add case action if web form is available for cases.
+   * Remove the popup for add case action.
    *
    * @param array $actions
    *   List of actions.

--- a/CRM/Civicase/Hook/SummaryActions/AlterAddCaseAction.php
+++ b/CRM/Civicase/Hook/SummaryActions/AlterAddCaseAction.php
@@ -65,7 +65,6 @@ class CRM_Civicase_Hook_SummaryActions_AlterAddCaseAction {
     $webFormUrl = CaseTypeCategoryHelper::getNewCaseCategoryWebformUrl('Cases', $this->caseCategorySetting);
     if ($webFormUrl) {
       $actions['case']['class'] = 'no-popup';
-      $actions['case']['href'] = CRM_Utils_System::url(trim($webFormUrl, '/'), ['reset' => 1], FALSE);
     }
   }
 

--- a/CRM/Civicase/Hook/SummaryActions/AlterAddCaseAction.php
+++ b/CRM/Civicase/Hook/SummaryActions/AlterAddCaseAction.php
@@ -1,0 +1,72 @@
+<?php
+
+use CRM_Civicase_Service_CaseCategorySetting as CaseCategorySetting;
+use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+
+/**
+ * Changes add case link with web form if web form is available.
+ */
+class CRM_Civicase_Hook_SummaryActions_AlterAddCaseAction {
+
+  /**
+   * Case category Setting.
+   *
+   * @var CRM_Civicase_Service_CaseCategorySetting
+   *   CaseCategorySetting service.
+   */
+  private $caseCategorySetting;
+
+  /**
+   * Initialize dependencies.
+   */
+  public function __construct() {
+    $this->caseCategorySetting = new CaseCategorySetting();
+  }
+
+  /**
+   * Changes add case link with web form if web form is available.
+   *
+   * @param array $actions
+   *   List of actions.
+   * @param int $contactID
+   *   Contact id.
+   */
+  public function run(array &$actions, $contactID) {
+    if (!$this->shouldRun($actions, $contactID)) {
+      return;
+    }
+    $this->changeAddCaseAction($actions);
+  }
+
+  /**
+   * Checks the form name and contact id.
+   *
+   * @param array $actions
+   *   List of actions.
+   * @param int $contactID
+   *   Contact id.
+   *
+   * @return bool
+   *   Whether this hook should run or not.
+   */
+  private function shouldRun(array $actions, $contactID) {
+    return (
+      !empty($actions['case']) && $contactID > 0
+    );
+  }
+
+  /**
+   * Changes add case action if web form is available for cases.
+   *
+   * @param array $actions
+   *   List of actions.
+   */
+  private function changeAddCaseAction(array &$actions) {
+    $webFormUrl = CaseTypeCategoryHelper::getNewCaseCategoryWebformUrl('Cases', $this->caseCategorySetting);
+    if ($webFormUrl) {
+      $actions['case']['class'] = 'no-popup';
+      $actions['case']['href'] = CRM_Utils_System::url(trim($webFormUrl, '/'), ['reset' => 1], FALSE);
+    }
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -211,6 +211,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_AddStyleFieldToCaseCustomGroups(),
     new CRM_Civicase_Hook_BuildForm_DisplayAllCustomGroupsInCaseForm(),
     new CRM_Civicase_Hook_BuildForm_LinkToCaseSearchByCaseId(),
+    new CRM_Civicase_Hook_BuildForm_CaseTypeCategoryWebFormRedirect(),
   ];
 
   foreach ($hooks as $hook) {

--- a/civicase.php
+++ b/civicase.php
@@ -211,7 +211,6 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_AddStyleFieldToCaseCustomGroups(),
     new CRM_Civicase_Hook_BuildForm_DisplayAllCustomGroupsInCaseForm(),
     new CRM_Civicase_Hook_BuildForm_LinkToCaseSearchByCaseId(),
-    new CRM_Civicase_Hook_BuildForm_CaseTypeCategoryWebFormRedirect(),
   ];
 
   foreach ($hooks as $hook) {
@@ -573,10 +572,24 @@ function civicase_civicrm_preProcess($formName, &$form) {
     new CRM_Civicase_Hook_PreProcess_CaseCategoryWordReplacementsForNewCase(),
     new CRM_Civicase_Hook_PreProcess_CaseCategoryWordReplacementsForChangeCase(),
     new CRM_Civicase_Hook_PreProcess_AddCaseAdminSettings(),
+    new CRM_Civicase_Hook_PreProcess_CaseTypeCategoryWebFormRedirect(),
   ];
 
   foreach ($hooks as $hook) {
     $hook->run($formName, $form);
+  }
+}
+
+/**
+ * Implements hook_civicrm_summaryActions().
+ */
+function civicase_civicrm_summaryActions(&$actions, $contactID) {
+  $hooks = [
+    new CRM_Civicase_Hook_SummaryActions_AlterAddCaseAction(),
+  ];
+
+  foreach ($hooks as $hook) {
+    $hook->run($actions, $contactID);
   }
 }
 


### PR DESCRIPTION
## Overview
If a web form is available for a case type category then all the add case links for that particular case type category should take the user to that web form.

## Before
There was a alter navigation menu hook placed to replace the url with web form url but that hook was not enough to cater all the places in html that had the link.

## After
Instead of changing the link urls a new pre process form hook has been added which will redirect the user to the web form if one is available for the current case type category. So this hook will add as a global redirect handler and there wont be any need for multiple hooks to change the urls in pages html. But this approach has one limitation that at the moment redirect to pages other than civicrm on popups cannot be achieved so redirect will only work for non ajax pages.