### PR TITLE
CATL-1674: Allow Single Case Role Setting Only When Multiclient Case Setting Is Single

### DIFF
--- a/CRM/Civicase/Helper/CaseSetting.php
+++ b/CRM/Civicase/Helper/CaseSetting.php
@@ -3,7 +3,7 @@
 /**
  * Wrapper class for xml settings.
  */
-class CRM_Civicase_Helper_XmlProcessor {
+class CRM_Civicase_Helper_CaseSetting {
 
   /**
    * Fetches settings from xml file.
@@ -31,7 +31,7 @@ class CRM_Civicase_Helper_XmlProcessor {
    * @return mixed
    *   Value from xml setting file.
    */
-  public function get(string $key) {
+  public function getDefaultValue(string $key) {
     $xml = $this->xmlProcessor->retrieve("Settings");
     $value = NULL;
     if (!empty($xml->{$key})) {

--- a/CRM/Civicase/Helper/XmlProcessor.php
+++ b/CRM/Civicase/Helper/XmlProcessor.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Wrapper class for xml settings.
+ */
+class CRM_Civicase_Helper_XmlProcessor {
+
+  /**
+   * Fetches settings from xml file.
+   *
+   * @var CRM_Case_XMLProcessor_Process
+   */
+  private $xmlProcessor;
+
+  /**
+   * Initizlization.
+   *
+   * @param CRM_Case_XMLProcessor_Process $xmlProcessor
+   *   Xml processor object.
+   */
+  public function __construct(CRM_Case_XMLProcessor_Process $xmlProcessor) {
+    $this->xmlProcessor = $xmlProcessor;
+  }
+
+  /**
+   * Fetches the setting from xml file.
+   *
+   * @param string $key
+   *   Setting name.
+   *
+   * @return mixed
+   *   Value from xml setting file.
+   */
+  public function get(string $key) {
+    $xml = $this->xmlProcessor->retrieve("Settings");
+    $value = NULL;
+    if (!empty($xml->{$key})) {
+      $value = $xml->{$key}->__toString();
+    }
+
+    return $value;
+  }
+
+}

--- a/CRM/Civicase/Hook/PreProcess/AddCaseAdminSettings.php
+++ b/CRM/Civicase/Hook/PreProcess/AddCaseAdminSettings.php
@@ -18,20 +18,6 @@ class CRM_Civicase_Hook_PreProcess_AddCaseAdminSettings {
   const CIVICASE_ALLOW_MULTIPLE_CLIENTS = 'civicaseAllowMultipleClients';
 
   /**
-   * Fetches settings from xml file.
-   *
-   * @var CRM_Case_XMLProcessor_Process
-   */
-  private $xmlProcessor;
-
-  /**
-   * Initialize dependencies.
-   */
-  public function __construct() {
-    $this->xmlProcessor = new CRM_Case_XMLProcessor_Process();
-  }
-
-  /**
    * Sets the case admin settings.
    *
    * @param string $formName
@@ -48,7 +34,6 @@ class CRM_Civicase_Hook_PreProcess_AddCaseAdminSettings {
 
     $this->addCivicaseSettingsToForm($settings);
     $form->setVar('_settings', $settings);
-    $this->addDefaultMultipleCaseClientToForm($form);
     $this->addScriptFile();
   }
 
@@ -97,23 +82,6 @@ class CRM_Civicase_Hook_PreProcess_AddCaseAdminSettings {
     }
 
     return $settings;
-  }
-
-  /**
-   * Adds the default multiple case client to the form attributes.
-   *
-   * @param CRM_Core_Form $form
-   *   Form object class.
-   */
-  private function addDefaultMultipleCaseClientToForm(CRM_Core_Form $form) {
-    $attributes = $form->getAttributes();
-    $xml = $this->xmlProcessor->retrieve("Settings");
-    $allowMultipleClients = 0;
-    if (!empty($xml->AllowMultipleCaseClients)) {
-      $allowMultipleClients = $xml->AllowMultipleCaseClients->__toString();
-    }
-    $attributes['defaultMultipleCaseClient'] = $allowMultipleClients;
-    $form->setAttributes($attributes);
   }
 
   /**

--- a/js/civicase-settings-form.js
+++ b/js/civicase-settings-form.js
@@ -5,7 +5,7 @@
     var $singleCaseRoleParent = $('.crm-mail-form-block-civicaseSingleCaseRolePerType');
     var $singleCaseRole = $('#civicaseSingleCaseRolePerType_civicaseSingleCaseRolePerType');
 
-    (function init() {
+    (function init () {
       toggleVisibilityOnRadioButtonChange();
       toggleVisibilityForSingleCaseRole();
 
@@ -18,7 +18,7 @@
     /**
      * Toggles the visibility of civicase settings fields based on radio button values.
      */
-    function toggleVisibilityOnRadioButtonChange() {
+    function toggleVisibilityOnRadioButtonChange () {
       $radioButtonsThatToggleVisibility.filter(':checked')
         .each(function () {
           var $element = $(this);
@@ -33,7 +33,7 @@
     /**
      * Toggles the visibility of single case role.
      */
-    function toggleVisibilityForSingleCaseRole() {
+    function toggleVisibilityForSingleCaseRole () {
       var $defaultMultiCaseClientValue = $singleCaseRole.attr('defaultMultipleCaseClient')
         ? $singleCaseRole.attr('defaultMultipleCaseClient')
         : '0';
@@ -46,7 +46,7 @@
     /**
      * Shows single case role.
      */
-    function showSingleCaseRole() {
+    function showSingleCaseRole () {
       if ($singleCaseRoleParent.length) {
         $singleCaseRoleParent.show();
       }
@@ -55,7 +55,7 @@
     /**
      * Hides single case role.
      */
-    function hideSingleCaseRole() {
+    function hideSingleCaseRole () {
       if ($singleCaseRoleParent.length) {
         $singleCaseRoleParent.hide();
       }

--- a/js/civicase-settings-form.js
+++ b/js/civicase-settings-form.js
@@ -2,8 +2,10 @@
   $(document).on('crmLoad', function () {
     var $radioButtonsThatToggleVisibility = $('[data-toggles-visibility-for]');
     var $multiCaseClient = $('#civicaseAllowMultipleClients');
+    var $singleCaseRoleParent = $('.crm-mail-form-block-civicaseSingleCaseRolePerType');
+    var $singleCaseRole = $('#civicaseSingleCaseRolePerType_civicaseSingleCaseRolePerType');
 
-    (function init () {
+    (function init() {
       toggleVisibilityOnRadioButtonChange();
       toggleVisibilityForSingleCaseRole();
 
@@ -16,7 +18,7 @@
     /**
      * Toggles the visibility of civicase settings fields based on radio button values.
      */
-    function toggleVisibilityOnRadioButtonChange () {
+    function toggleVisibilityOnRadioButtonChange() {
       $radioButtonsThatToggleVisibility.filter(':checked')
         .each(function () {
           var $element = $(this);
@@ -31,12 +33,12 @@
     /**
      * Toggles the visibility of single case role.
      */
-    function toggleVisibilityForSingleCaseRole () {
-      var $defaultMultiCaseClientValue = $('.CRM_Admin_Form_Setting_Case').attr('defaultMultipleCaseClient')
-        ? $('.CRM_Admin_Form_Setting_Case').attr('defaultMultipleCaseClient')
-        : 0;
-      $multiCaseClient.val() === 0 ||
-      ($multiCaseClient.val().toLowerCase() === 'default' && $defaultMultiCaseClientValue === 0)
+    function toggleVisibilityForSingleCaseRole() {
+      var $defaultMultiCaseClientValue = $singleCaseRole.attr('defaultMultipleCaseClient')
+        ? $singleCaseRole.attr('defaultMultipleCaseClient')
+        : '0';
+      $multiCaseClient.val() === '0' ||
+      ($multiCaseClient.val().toLowerCase() === 'default' && $defaultMultiCaseClientValue === '0')
         ? showSingleCaseRole()
         : hideSingleCaseRole();
     }
@@ -44,21 +46,21 @@
     /**
      * Shows single case role.
      */
-    function showSingleCaseRole () {
-      if ($('.crm-mail-form-block-civicaseSingleCaseRolePerType').length) {
-        $('.crm-mail-form-block-civicaseSingleCaseRolePerType').show();
+    function showSingleCaseRole() {
+      if ($singleCaseRoleParent.length) {
+        $singleCaseRoleParent.show();
       }
     }
 
     /**
      * Hides single case role.
      */
-    function hideSingleCaseRole () {
-      if ($('.crm-mail-form-block-civicaseSingleCaseRolePerType').length) {
-        $('.crm-mail-form-block-civicaseSingleCaseRolePerType').hide();
+    function hideSingleCaseRole() {
+      if ($singleCaseRoleParent.length) {
+        $singleCaseRoleParent.hide();
       }
-      if ($('#civicaseSingleCaseRolePerType_civicaseSingleCaseRolePerType').length) {
-        $('#civicaseSingleCaseRolePerType_civicaseSingleCaseRolePerType').prop('checked', false);
+      if ($singleCaseRole.length) {
+        $singleCaseRole.prop('checked', false);
       }
     }
   });

--- a/js/civicase-settings-form.js
+++ b/js/civicase-settings-form.js
@@ -1,18 +1,23 @@
 (function ($) {
   $(document).on('crmLoad', function () {
-    var $elementsThatToggleVisibility = $('[data-toggles-visibility-for]');
+    var $radioButtonsThatToggleVisibility = $('[data-toggles-visibility-for]');
+    var $multiCaseClient = $('#civicaseAllowMultipleClients');
 
     (function init () {
-      toggleVisibility();
+      toggleVisibilityOnRadioButtonChange();
+      toggleVisibilityForSingleCaseRole();
 
-      $elementsThatToggleVisibility.change(toggleVisibility);
+      $radioButtonsThatToggleVisibility.change(toggleVisibilityOnRadioButtonChange);
+      if ($multiCaseClient.length) {
+        $multiCaseClient.change(toggleVisibilityForSingleCaseRole);
+      }
     })();
 
     /**
-     * Toggles the visibility of civicase settings fields based on value.
+     * Toggles the visibility of civicase settings fields based on radio button values.
      */
-    function toggleVisibility () {
-      $elementsThatToggleVisibility.filter(':checked')
+    function toggleVisibilityOnRadioButtonChange () {
+      $radioButtonsThatToggleVisibility.filter(':checked')
         .each(function () {
           var $element = $(this);
           var isAllowed = $element.val() === '1';
@@ -22,5 +27,40 @@
           isAllowed ? $elementToToggle.show() : $elementToToggle.hide();
         });
     }
+
+    /**
+     * Toggles the visibility of single case role.
+     */
+    function toggleVisibilityForSingleCaseRole () {
+      var $defaultMultiCaseClientValue = $('.CRM_Admin_Form_Setting_Case').attr('defaultMultipleCaseClient') ?
+        $('.CRM_Admin_Form_Setting_Case').attr('defaultMultipleCaseClient') :
+        0;
+      $multiCaseClient.val() == 0 ||
+      ($multiCaseClient.val().toLowerCase() == 'default' && $defaultMultiCaseClientValue == 0) ?
+        showSingleCaseRole() :
+        hideSingleCaseRole();
+    }
+
+    /**
+     * Shows single case role.
+     */
+    function showSingleCaseRole () {
+      if ($('.crm-mail-form-block-civicaseSingleCaseRolePerType').length) {
+        $('.crm-mail-form-block-civicaseSingleCaseRolePerType').show();
+      }
+    }
+
+    /**
+     * Hides single case role.
+     */
+    function hideSingleCaseRole () {
+      if ($('.crm-mail-form-block-civicaseSingleCaseRolePerType').length) {
+        $('.crm-mail-form-block-civicaseSingleCaseRolePerType').hide();
+      }
+      if ($('#civicaseSingleCaseRolePerType_civicaseSingleCaseRolePerType').length) {
+        $('#civicaseSingleCaseRolePerType_civicaseSingleCaseRolePerType').prop("checked", false);
+      }
+    }
+
   });
 })(CRM.$);

--- a/js/civicase-settings-form.js
+++ b/js/civicase-settings-form.js
@@ -32,13 +32,13 @@
      * Toggles the visibility of single case role.
      */
     function toggleVisibilityForSingleCaseRole () {
-      var $defaultMultiCaseClientValue = $('.CRM_Admin_Form_Setting_Case').attr('defaultMultipleCaseClient') ?
-        $('.CRM_Admin_Form_Setting_Case').attr('defaultMultipleCaseClient') :
-        0;
-      $multiCaseClient.val() == 0 ||
-      ($multiCaseClient.val().toLowerCase() == 'default' && $defaultMultiCaseClientValue == 0) ?
-        showSingleCaseRole() :
-        hideSingleCaseRole();
+      var $defaultMultiCaseClientValue = $('.CRM_Admin_Form_Setting_Case').attr('defaultMultipleCaseClient')
+        ? $('.CRM_Admin_Form_Setting_Case').attr('defaultMultipleCaseClient')
+        : 0;
+      $multiCaseClient.val() === 0 ||
+      ($multiCaseClient.val().toLowerCase() === 'default' && $defaultMultiCaseClientValue === 0)
+        ? showSingleCaseRole()
+        : hideSingleCaseRole();
     }
 
     /**
@@ -58,9 +58,8 @@
         $('.crm-mail-form-block-civicaseSingleCaseRolePerType').hide();
       }
       if ($('#civicaseSingleCaseRolePerType_civicaseSingleCaseRolePerType').length) {
-        $('#civicaseSingleCaseRolePerType_civicaseSingleCaseRolePerType').prop("checked", false);
+        $('#civicaseSingleCaseRolePerType_civicaseSingleCaseRolePerType').prop('checked', false);
       }
     }
-
   });
 })(CRM.$);

--- a/settings/CiviCase.setting.php
+++ b/settings/CiviCase.setting.php
@@ -5,6 +5,9 @@
  * CiviCase Setting file.
  */
 
+$xmlProcessor = new CRM_Case_XMLProcessor_Process();
+$xmlWrapper = new CRM_Civicase_Helper_XmlProcessor($xmlProcessor);
+
 $setting = [
   'civicaseAllowCaseLocks' => [
     'group_name' => 'CiviCRM Preferences',
@@ -126,6 +129,9 @@ $setting = [
     'type' => 'Boolean',
     'quick_form_type' => 'Element',
     'default' => 0,
+    'html_attributes' => [
+      'defaultMultipleCaseClient' => (int) $xmlWrapper->get('AllowMultipleCaseClients'),
+    ],
     'html_type' => 'checkbox',
     'add' => '4.7',
     'title' => ts('One active case role'),

--- a/settings/CiviCase.setting.php
+++ b/settings/CiviCase.setting.php
@@ -6,7 +6,7 @@
  */
 
 $xmlProcessor = new CRM_Case_XMLProcessor_Process();
-$xmlWrapper = new CRM_Civicase_Helper_CaseSetting($xmlProcessor);
+$caseSetting = new CRM_Civicase_Helper_CaseSetting($xmlProcessor);
 
 $setting = [
   'civicaseAllowCaseLocks' => [
@@ -130,7 +130,7 @@ $setting = [
     'quick_form_type' => 'Element',
     'default' => 0,
     'html_attributes' => [
-      'defaultMultipleCaseClient' => (int) $xmlWrapper->getDefaultValue('AllowMultipleCaseClients'),
+      'defaultMultipleCaseClient' => (int) $caseSetting->getDefaultValue('AllowMultipleCaseClients'),
     ],
     'html_type' => 'checkbox',
     'add' => '4.7',

--- a/settings/CiviCase.setting.php
+++ b/settings/CiviCase.setting.php
@@ -6,7 +6,7 @@
  */
 
 $xmlProcessor = new CRM_Case_XMLProcessor_Process();
-$xmlWrapper = new CRM_Civicase_Helper_XmlProcessor($xmlProcessor);
+$xmlWrapper = new CRM_Civicase_Helper_CaseSetting($xmlProcessor);
 
 $setting = [
   'civicaseAllowCaseLocks' => [
@@ -130,7 +130,7 @@ $setting = [
     'quick_form_type' => 'Element',
     'default' => 0,
     'html_attributes' => [
-      'defaultMultipleCaseClient' => (int) $xmlWrapper->get('AllowMultipleCaseClients'),
+      'defaultMultipleCaseClient' => (int) $xmlWrapper->getDefaultValue('AllowMultipleCaseClients'),
     ],
     'html_type' => 'checkbox',
     'add' => '4.7',


### PR DESCRIPTION
## Overview
Recently the single case role per type setting was introduced, however this setting is not applicable when the muliclient setting is on, hence we need to make sure that this setting does not show up when multiclient is on. This PR makes that happen.

## Before
Currently the Single Case role setting checkbox will show up irrespective of the value of the Multiclient Case setting field.

## After
Now the single case role and allow multiple clients settings has been placed with each other and a relationship between them has been added which will allow to tick single case role only if single client per case is selected as shown below.
![Screenshot from 2020-09-03 19-03-38](https://user-images.githubusercontent.com/68388745/92125636-adc1b380-ee18-11ea-96be-bc8c34fd787f.png)


## Technical Details
CRM_Civicase_Hook_PreProcess_AddCaseAdminSettings hook has been modified to place both the above mentioned settings with each other and js/civicase-settings-form.js file is responsible for maintaining the relationship between the fields and restricting user from ticking single case role with multiple clients per case.
