### PR TITLE
CPS-319: Fix Error Page When Enabling Drupal Module

### DIFF
--- a/CRM/Civicase/Event/Listener/ActivityFilter.php
+++ b/CRM/Civicase/Event/Listener/ActivityFilter.php
@@ -28,6 +28,10 @@ class CRM_Civicase_Event_Listener_ActivityFilter {
   public static function onPrepare(PrepareEvent $e) {
     $apiRequest = $e->getApiRequest();
 
+    if ($apiRequest['version'] != 3) {
+      return;
+    }
+
     // Only apply to `Activity.get case_filter=...`
     if ($apiRequest['entity'] !== 'Activity'
       || $apiRequest['action'] !== 'get'

--- a/CRM/Civicase/Event/Listener/ActivityFilter.php
+++ b/CRM/Civicase/Event/Listener/ActivityFilter.php
@@ -3,7 +3,7 @@
 use Civi\API\Event\PrepareEvent;
 
 /**
- * Class CRM_Civicase_Event_Listener_ActivityFilter
+ * Activity Filter Event Listener Class.
  *
  * Enhance the `Activity.get` API by allowing the option `case_filter`.
  * This accepts any argument supported by `Case.getdetails`.
@@ -19,11 +19,13 @@ use Civi\API\Event\PrepareEvent;
 class CRM_Civicase_Event_Listener_ActivityFilter {
 
   /**
+   * Respond to prepare events when entity is activity and case filter present.
+   *
    * Whenever there's a call for `Activity.get case_filter=...`, translate
    * the `case_filter=...` expression to a concrete list of `case_id=1,2,3,...`.
    *
    * @param \Civi\API\Event\PrepareEvent $e
-   * @throws \API_Exception
+   *   Prepare Event.
    */
   public static function onPrepare(PrepareEvent $e) {
     $apiRequest = $e->getApiRequest();
@@ -32,7 +34,7 @@ class CRM_Civicase_Event_Listener_ActivityFilter {
       return;
     }
 
-    // Only apply to `Activity.get case_filter=...`
+    // Only apply to `Activity.get case_filter=...`.
     if ($apiRequest['entity'] !== 'Activity'
       || $apiRequest['action'] !== 'get'
       || !isset($apiRequest['params']['case_filter'])
@@ -49,20 +51,24 @@ class CRM_Civicase_Event_Listener_ActivityFilter {
   }
 
   /**
-   * Translates `case_filter=...` expression to a concrete list of `case_id=1,2,3,...`.
+   * Update the Case ID paramete with Case Ids.
    *
-   * @param {Array} $params
+   * Translates `case_filter=...` expression to a concrete list of
+   * `case_id=1,2,3,...`.
+   *
+   * @param array $params
+   *   API parameters.
    */
-  public static function updateParams (&$params) {
-    // Look up matching `case_id`
-    $caseParams = array(
+  public static function updateParams(array &$params) {
+    // Look up matching `case_id`.
+    $caseParams = [
       'is_deleted' => 0,
-      'options' => array(
+      'options' => [
         'offset' => 0,
         'limit' => 0,
-      ),
-      'return' => array('id'),
-    );
+      ],
+      'return' => ['id'],
+    ];
     CRM_Utils_Array::extend($caseParams, $params['case_filter']);
 
     if (!empty($params['check_permissions'])) {
@@ -71,9 +77,10 @@ class CRM_Civicase_Event_Listener_ActivityFilter {
 
     $caseResult = civicrm_api3('Case', 'getdetails', $caseParams);
 
-    // Revise the Activity.get call
+    // Revise the Activity.get call.
     unset($params['case_filter']);
-    // Add case ids to the query or else a bogus value to ensure no results
-    $params['case_id'] = empty($caseResult['values']) ? -1 : array('IN' => array_keys($caseResult['values']));
+    // Add case ids to the query or else a bogus value to ensure no results.
+    $params['case_id'] = empty($caseResult['values']) ? -1 : ['IN' => array_keys($caseResult['values'])];
   }
+
 }

--- a/CRM/Civicase/Event/Listener/CaseRoleCreation.php
+++ b/CRM/Civicase/Event/Listener/CaseRoleCreation.php
@@ -20,7 +20,12 @@ class CRM_Civicase_Event_Listener_CaseRoleCreation {
    *   API Respond Event Object.
    */
   public static function onRespond(RespondEvent $event) {
-    $apiRequest = (array) $event->getApiRequest();
+    $apiRequest = $event->getApiRequest();
+
+    if ($apiRequest['version'] != 3) {
+      return;
+    }
+
     if (!self::shouldRun($apiRequest)) {
       return;
     }
@@ -48,7 +53,11 @@ class CRM_Civicase_Event_Listener_CaseRoleCreation {
    *   API Prepare Event Object.
    */
   public static function onPrepare(PrepareEvent $event) {
-    $apiRequest = (array) $event->getApiRequest();
+    $apiRequest = $event->getApiRequest();
+    if ($apiRequest['version'] != 3) {
+      return;
+    }
+
     if (!self::shouldRun($apiRequest)) {
       return;
     }

--- a/CRM/Civicase/Event/Listener/CaseTypeCategoryIsActiveToggler.php
+++ b/CRM/Civicase/Event/Listener/CaseTypeCategoryIsActiveToggler.php
@@ -18,7 +18,12 @@ class CRM_Civicase_Event_Listener_CaseTypeCategoryIsActiveToggler {
    *   Event data.
    */
   public static function onRespond(RespondEvent $e) {
-    $apiRequest = (array) $e->getApiRequest();
+    $apiRequest = $e->getApiRequest();
+
+    if ($apiRequest['version'] != 3) {
+      return;
+    }
+
     if (!self::shouldRun($apiRequest)) {
       return;
     }


### PR DESCRIPTION
## Overview
On enabling any Drupal module on the latest Compuclient deployed sites running CiviCRM 5.28.0, an error page is displayed with the Configuration saved message. This is not happening on sites with CiviCRM 5.24.6.

## Before
Error when enabling a drupal module on sites running CiviCRM 5.28.0.

![image-2020-08-18-18-21-14-954](https://user-images.githubusercontent.com/6951813/92125941-81496f80-edf7-11ea-9c26-3966c0c4371b.png)

## After
No errors when enabling a drupal module on sites running CiviCRM 5.28.0.
<img width="1282" alt="Modules  CaseLatest 2020-09-03 15-11-27" src="https://user-images.githubusercontent.com/6951813/92126357-fb79f400-edf7-11ea-9a5b-2cf3b50d0bc8.png">


## Technical Details

When enabling a module in drupal, some internal functions will be called to refresh some data cached in memory. At some point this will call a CiviCRM function, that, in the past would call the ContactType BAO. After the change in CiviCRM 5.28.0, this now calls the API V4. This will dispatch an event, that will be captured by the listener in civicase. The civicase event listener tries to convert the `$apiRequest` variable to an array [here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/Event/Listener/CaseTypeCategoryIsActiveToggler.php#L21), this gives no problem for API3 events but for API4 events, this causes an issue with this [line](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/Event/Listener/CaseTypeCategoryIsActiveToggler.php#L44) as the properties `entity` and `action` does not exist in the converted array and causes a notice which is logged as an error will captured by Drupal's watchdog. Hooks related to the watchog will be triggered. One of these will try to load rules and that's what results in the error display in the screenshot attached to the PR above.

This error only happens in Event listener classes that tries to convert the `$apiRequest` to an array, for event listener classes such as `CRM_Civicase_Event_Listener_ActivityFilter` that does not convert this object to an array, this error is not observed. Conversion to an array is actually not necessary because `$apiRequest` is a child of `ArrayAccess` and access to properties has been made available via the `offsetGet` method.
The `$apiRequest` variable is an array for APIV3 events but is an object of class `Civi\Api4\Generic\DAOGetAction` for APIV4 events. However the `DAOGetAction` class has the `ArrayAccess` class as one of it's parent and the `AbstractAction` class which this object also belongs to has already defined the offsetGet function which allows to pass in parameters recognised by API3 and will return the parameter values, [See](https://github.com/civicrm/civicrm-core/blob/master/Civi/Api4/Generic/AbstractAction.php#L339-L359).
For both API3 and API4, properties like `entity`, `action`, `params`, `version` are available directly using the `$apiRequest` variable`.

Even though the properties mentioned above are available in the request variable for both APIv4 and APIv3 events, the parameter format for creating/fetching an entity is different for APIv4 and APIv3. 
Creating an entity via the API for V4 passes the parameters in a format similar to what an SQL query expects:

<img width="1280" alt="case-latest  VagrantProjectscase-latest  -  profilescompuclientmodulescontribcivicrmCiviAPIKernel php 2020-09-03 12-33-44" src="https://user-images.githubusercontent.com/6951813/92125228-b1dcd980-edf6-11ea-96dd-7b7df0d522b6.png">

For Fetching an entity details, the parameter format also passed for APIV4 is different from the one passed for APIV3.

Due to these differences and because the API calls made from Civicase are all APIv3 calls and most of the event listeners we have depends on checking if a particular parameter is passed to the API or not, the short time fix in this PR is to not handle APIv4 events for now. The long term solution will be to create a Service that will handle setting and retrieving the API parameters passed to the API depending on the API version.