### PR TITLE
RSE-1096: Awards Instance support - Frontend solution

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -20,7 +20,7 @@ jobs:
       run: git fetch -n origin ${GITHUB_BASE_REF}
             
     - name: Run phpcs linter 
-      run: git diff --diff-filter=d  origin/${GITHUB_BASE_REF} --name-only -- '*.php' -- . ':(exclude)CRM/Civicase/DAO/*' | xargs -r ./bin/phpcs.phar --standard=phpcs-ruleset.xml
+      run: git diff --diff-filter=d  origin/${GITHUB_BASE_REF} --name-only -- '*.php' | xargs -r ./bin/phpcs.phar --standard=phpcs-ruleset.xml
 
     - name: Run stylelint linter
       #This step will always run regardless of previous step's status

--- a/ang/civicase-base.ang.php
+++ b/ang/civicase-base.ang.php
@@ -23,11 +23,13 @@ $options = [
   'priority' => 'priority',
   'activityCategories' => 'activity_category',
   'caseTypeCategories' => 'case_type_categories',
+  'caseCategoryInstanceType' => 'case_category_instance_type',
 ];
 
 OptionValuesHelper::setToJsVariables($options);
 NewCaseWebform::addWebformDataToOptions($options, $caseCategorySetting);
 set_case_types_to_js_vars($options);
+set_case_category_instance_to_js_vars($options);
 set_relationship_types_to_js_vars($options);
 set_file_categories_to_js_vars($options);
 set_activity_status_types_to_js_vars($options);
@@ -36,6 +38,14 @@ set_tags_to_js_vars($options);
 expose_settings($options, [
   'caseCategoryName' => $caseCategoryName,
 ]);
+
+/**
+ * Sets the tags and tagsets to javascript global variable.
+ */
+function set_case_category_instance_to_js_vars(&$options) {
+  $result = civicrm_api3('CaseCategoryInstance', 'get')['values'];
+  $options['caseCategoryInstanceMapping'] = $result;
+}
 
 /**
  * Expose settings.

--- a/ang/civicase-base/providers/case-type-category.provider.js
+++ b/ang/civicase-base/providers/case-type-category.provider.js
@@ -45,7 +45,7 @@
      * Find all case type categories belonging to sent instance name
      *
      * @param {string} instanceName name of the instance
-     * @returns {Array} list of case type categories matching the sent instance
+     * @returns {object[]} list of case type categories matching the sent instance
      */
     function findAllByInstance (instanceName) {
       return _.filter(getAll(), function (caseTypeCategory) {
@@ -57,29 +57,29 @@
      * Check if the sent case type category is part of the sent instance
      *
      * @param {string} caseTypeCategoryName case type category name
-     * @param {*} instanceName instance name
+     * @param {string} instanceName instance name
      * @returns {boolean} if the sent case type category is part of the sent instance
      */
     function isInstance (caseTypeCategoryName, instanceName) {
-      var caseTypeCategory = findByName(caseTypeCategoryName);
+      var caseTypeCategoryObject = findByName(caseTypeCategoryName);
+
+      if (!caseTypeCategoryObject) {
+        return;
+      }
+
+      var caseTypeCategory = _.find(caseCategoryInstanceMapping, function (instanceMap) {
+        return instanceMap.category_id === caseTypeCategoryObject.value;
+      });
 
       if (!caseTypeCategory) {
         return;
       }
 
-      var sentCaseTypeCategory = _.find(caseCategoryInstanceMapping, function (instanceMap) {
-        return instanceMap.category_id === caseTypeCategory.value;
-      });
-
-      if (!sentCaseTypeCategory) {
-        return;
-      }
-
-      var sentInstanceID = _.find(caseCategoryInstanceType, function (instance) {
+      var instanceID = _.find(caseCategoryInstanceType, function (instance) {
         return instance.name === instanceName;
       }).value;
 
-      return sentCaseTypeCategory.instance_id === sentInstanceID;
+      return caseTypeCategory.instance_id === instanceID;
     }
 
     /**

--- a/ang/civicase-base/providers/case-type-category.provider.js
+++ b/ang/civicase-base/providers/case-type-category.provider.js
@@ -7,6 +7,8 @@
    * CaseTypeCategory Service Provider
    */
   function CaseTypeCategoryProvider () {
+    var caseCategoryInstanceMapping = civicaseBaseSettings.caseCategoryInstanceMapping;
+    var caseCategoryInstanceType = civicaseBaseSettings.caseCategoryInstanceType;
     var allCaseTypeCategories = civicaseBaseSettings.caseTypeCategories;
     var caseTypeCategoriesWhereUserCanAccessActivities =
       civicaseBaseSettings.caseTypeCategoriesWhereUserCanAccessActivities;
@@ -18,8 +20,10 @@
       .value();
 
     this.$get = $get;
-    this.getAll = getAll;
     this.findByName = findByName;
+    this.findAllByInstance = findAllByInstance;
+    this.getAll = getAll;
+    this.isInstance = isInstance;
 
     /**
      * Returns the case the category service.
@@ -29,9 +33,53 @@
     function $get () {
       return {
         getAll: getAll,
+        findById: findById,
         findByName: findByName,
-        getCategoriesWithAccessToActivity: getCategoriesWithAccessToActivity
+        findAllByInstance: findAllByInstance,
+        getCategoriesWithAccessToActivity: getCategoriesWithAccessToActivity,
+        isInstance: isInstance
       };
+    }
+
+    /**
+     * Find all case type categories belonging to sent instance name
+     *
+     * @param {string} instanceName name of the instance
+     * @returns {Array} list of case type categories matching the sent instance
+     */
+    function findAllByInstance (instanceName) {
+      return _.filter(getAll(), function (caseTypeCategory) {
+        return isInstance(caseTypeCategory.name, instanceName);
+      });
+    }
+
+    /**
+     * Check if the sent case type category is part of the sent instance
+     *
+     * @param {string} caseTypeCategoryName case type category name
+     * @param {*} instanceName instance name
+     * @returns {boolean} if the sent case type category is part of the sent instance
+     */
+    function isInstance (caseTypeCategoryName, instanceName) {
+      var caseTypeCategory = findByName(caseTypeCategoryName);
+
+      if (!caseTypeCategory) {
+        return;
+      }
+
+      var sentCaseTypeCategory = _.find(caseCategoryInstanceMapping, function (instanceMap) {
+        return instanceMap.category_id === caseTypeCategory.value;
+      });
+
+      if (!sentCaseTypeCategory) {
+        return;
+      }
+
+      var sentInstanceID = _.find(caseCategoryInstanceType, function (instance) {
+        return instance.name === instanceName;
+      }).value;
+
+      return sentCaseTypeCategory.instance_id === sentInstanceID;
     }
 
     /**
@@ -67,6 +115,18 @@
     function findByName (caseTypeCategoryName) {
       return _.find(allCaseTypeCategories, function (category) {
         return category.name.toLowerCase() === caseTypeCategoryName.toLowerCase();
+      });
+    }
+
+    /**
+     * Find case type category by id
+     *
+     * @param {string} caseTypeCategoryID case type category id
+     * @returns {object} case type category object
+     */
+    function findById (caseTypeCategoryID) {
+      return _.find(allCaseTypeCategories, function (category) {
+        return parseInt(category.value) === parseInt(caseTypeCategoryID);
       });
     }
   }

--- a/ang/test/civicase-base/providers/case-type-category.provider.spec.js
+++ b/ang/test/civicase-base/providers/case-type-category.provider.spec.js
@@ -66,6 +66,58 @@
         expect(CaseTypeCategory.getCategoriesWithAccessToActivity()).toEqual(expectedResults);
       });
     });
+
+    describe('when checking if a case type category is part of sent instance type', () => {
+      beforeEach(() => {
+        module('civicase-base');
+        injectDependencies();
+      });
+
+      it('returns true if the case type category belongs to the sent instance', () => {
+        expect(CaseTypeCategory.isInstance('Cases', 'case_management')).toBe(true);
+      });
+    });
+
+    describe('when searching for a case type category by its id', () => {
+      var expectedResult;
+
+      beforeEach(() => {
+        module('civicase-base');
+        injectDependencies();
+
+        expectedResult = {
+          value: '1',
+          label: 'Cases',
+          name: 'Cases',
+          is_active: '1'
+        };
+      });
+
+      it('returns the case type category which matches the sent id', () => {
+        expect(CaseTypeCategory.findById('1')).toEqual(expectedResult);
+      });
+    });
+
+    describe('when searching for all case type categories by instance', () => {
+      var expectedResult;
+
+      beforeEach(() => {
+        module('civicase-base');
+        injectDependencies();
+
+        expectedResult = [{
+          value: '3',
+          label: 'Awards',
+          name: 'awards',
+          is_active: '1'
+        }];
+      });
+
+      it('returns all the case type categories belonging to sent instance', () => {
+        expect(CaseTypeCategory.findAllByInstance('applicant_management')).toEqual(expectedResult);
+      });
+    });
+
     /**
      * Injects and hoists the dependencies needed by this spec.
      */

--- a/ang/test/mocks/data/case-category-instance-mapping.data.js
+++ b/ang/test/mocks/data/case-category-instance-mapping.data.js
@@ -1,0 +1,29 @@
+(function (angular, CRM, _) {
+  var module = angular.module('civicase.data');
+
+  CRM['civicase-base'].caseCategoryInstanceMapping = {
+    1: {
+      id: '1',
+      category_id: '3',
+      instance_id: '2'
+    },
+    2: {
+      id: '2',
+      category_id: '1',
+      instance_id: '1'
+    }
+  };
+
+  module.service('CaseCategoryInstanceMappingData', function () {
+    return {
+      /**
+       * Returns case category instance mapping data
+       *
+       * @returns {object} case category instance mapping data.
+       */
+      get: function () {
+        return _.clone(CRM['civicase-base'].caseCategoryInstanceMapping);
+      }
+    };
+  });
+})(angular, CRM, CRM._);

--- a/ang/test/mocks/data/case-category-instance-type.data.js
+++ b/ang/test/mocks/data/case-category-instance-type.data.js
@@ -1,0 +1,37 @@
+(function (angular, _) {
+  var module = angular.module('civicase.data');
+
+  CRM['civicase-base'].caseCategoryInstanceType = {
+    1: {
+      value: '1',
+      label: 'Case Management',
+      name: 'case_management',
+      grouping: 'CRM_Civicase_Service_CaseManagementUtils',
+      is_active: '1',
+      weight: '1',
+      filter: '0'
+    },
+    2: {
+      value: '2',
+      label: 'Applicant Management',
+      name: 'applicant_management',
+      grouping: 'CRM_CiviAwards_Service_ApplicantManagementUtils',
+      is_active: '1',
+      weight: '2',
+      filter: '0'
+    }
+  };
+
+  module.service('CaseCategoryInstanceTypeData', function () {
+    return {
+      /**
+       * Returns case category instance types
+       *
+       * @returns {object} case category instance types data.
+       */
+      get: function () {
+        return _.clone(CRM['civicase-base'].caseCategoryInstanceType);
+      }
+    };
+  });
+})(angular, CRM._);

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -16,6 +16,7 @@
     <!-- These files are mainly auto generated and has some rules we want to exclude -->
     <exclude-pattern>tests/phpunit/bootstrap.php</exclude-pattern>
     <exclude-pattern>civicase.civix.php</exclude-pattern>
+    <exclude-pattern>CRM/Civicase/DAO/*</exclude-pattern>
     <!-- Civicrm APi tests classes do have names beginning with lower case -->
     <!-- Hence the following rule is excluded -->
     <exclude name="Drupal.NamingConventions.ValidClassName.StartWithCaptial"/>


### PR DESCRIPTION
## Overview
As part of this PR( and https://github.com/compucorp/uk.co.compucorp.civiawards/pull/127 ), Frontend Solution to support Award Instance has been added.

## Technical Details
1. `case_category_instance_type` option group is exposed to the frontend.
2. Mapping of Case Category and Instance has been exposed to the frontend using `caseCategoryInstanceMapping` property.
3. In `case-type-category.provider.js`, added 2 new functions
    * `findAllByInstance` : Used to find all case type categories by the given instance name.
    * `isInstance` : Used to check, if the sent case type category is part of the sent instance.
4. Moved "exclude DAO files" linter rule to the ruleset file from `linter.xml`. This was done because otherwise the PHP linter was picking up JS files.