### PR TITLE
CPS-302: Release v1.8.0

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/compucorp/uk.co.compucorp.civicase/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2020-08-14</releaseDate>
-  <version>1.7.0</version>
+  <releaseDate>2020-09-04</releaseDate>
+  <version>1.8.0</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.24</ver>


### PR DESCRIPTION
## Release Update - 4th September, 2020

### Bugs
- Fixes a bug where standalone email activities could not be resumed. https://github.com/compucorp/uk.co.compucorp.civicase/pull/548
- Fixed a bug where "Add Case" from Contact Record page was not redirecting to Webforms(if configured). https://github.com/compucorp/uk.co.compucorp.civicase/pull/567
- Fixed a bug where enabling any Drupal module on the latest Compuclient deployed sites running CiviCRM 5.28.0, displayed an error page. https://github.com/compucorp/uk.co.compucorp.civicase/pull/570

### Updates for Developers
- Backstop JS tests are configured through Github Actions. Means they can be run for any Pull Requests. https://github.com/compucorp/uk.co.compucorp.civicase/pull/537