### PR TITLE
CPS-326: Fix self closing html custom tags

### DIFF
--- a/ang/civicase/activity/filters/directives/activity-filters.directive.html
+++ b/ang/civicase/activity/filters/directives/activity-filters.directive.html
@@ -23,7 +23,8 @@
       everything-count="totalCount"
       displayed-count="displayedCount"
       show-checkboxes="showCheckboxes"
-      ng-show="bulkAllowed"/>
+      ng-show="bulkAllowed">
+    </civicase-bulk-actions-checkboxes>
     <span
       ng-if="bulkAllowed"
       class="civicase__bulkactions-actions-dropdown btn-group btn-group-sm">

--- a/ang/civicase/case/details/file-tab/directives/case-details-file-tab.directive.html
+++ b/ang/civicase/case/details/file-tab/directives/case-details-file-tab.directive.html
@@ -4,7 +4,8 @@
     everything-count="totalCount"
     displayed-count="totalCount"
     show-checkboxes="showCheckboxes"
-    ng-show="bulkAllowed"/>
+    ng-show="bulkAllowed">
+  </civicase-bulk-actions-checkboxes>
   <span
     ng-if="bulkAllowed"
     class="civicase__bulkactions-actions-dropdown btn-group btn-group-sm">


### PR DESCRIPTION
## Overview
The Bulk Action and Activity Filters inside the Activity Feed stopped working when using with latest version of Civicrm(v 5.28.3).

## Before
![2020-09-10 at 3 33 PM](https://user-images.githubusercontent.com/5058867/92715311-f29a9c80-f37a-11ea-882c-da60b8a82a06.jpg)
![2020-09-10 at 3 33 PM](https://user-images.githubusercontent.com/5058867/92715346-fc240480-f37a-11ea-9447-f81bc8c73967.jpg)
![2020-09-10 at 3 33 PM](https://user-images.githubusercontent.com/5058867/92715372-06de9980-f37b-11ea-837b-4944cc7807f1.jpg)

## After
![2020-09-10 at 3 34 PM](https://user-images.githubusercontent.com/5058867/92715460-1fe74a80-f37b-11ea-9992-fb0c53fb878d.jpg)
![2020-09-10 at 3 34 PM](https://user-images.githubusercontent.com/5058867/92715503-2b3a7600-f37b-11ea-8307-ee9ace372470.jpg)
![2020-09-10 at 3 35 PM](https://user-images.githubusercontent.com/5058867/92715536-368da180-f37b-11ea-8bb3-8a6f454dab68.jpg)

## Technical Details
Recently in Civicrm Core(https://github.com/civicrm/civicrm-core/commit/dfe20f626c7d6e9eb2b80d9f19b9d5a7c0dfc2fd#diff-d8719e8d406c65259e59e38cfe10efbeR1663) the following function was added `$.htmlPrefilter`. This function removed self closing tags from the markup.

More details can be found here https://github.com/civicrm/civicrm-core/commit/dfe20f626c7d6e9eb2b80d9f19b9d5a7c0dfc2fd#diff-d8719e8d406c65259e59e38cfe10efbeR1664-R1725.

So as part of this PR, `<civicase-bulk-actions-checkboxes>` tags has been fixed. As it was self closing before.
