### PR TITLE
CPS-320: Release v1.9.0

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/compucorp/uk.co.compucorp.civicase/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2020-09-04</releaseDate>
-  <version>1.8.0</version>
+  <releaseDate>2020-09-11</releaseDate>
+  <version>1.9.0</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.24</ver>


### PR DESCRIPTION
## Release Update - 11th September, 2020

### New Features

* Allow only a single user per case role. This can be configured through a setting. [CATL-1674](https://github.com/compucorp/uk.co.compucorp.civicase/pull/569) and [CATL-1579](https://github.com/compucorp/uk.co.compucorp.civicase/pull/568).

### Bug Fixes

* Fixed the bulk dropdown element. This element stopped working after updating the CiviCRM version. [CPS-326](https://github.com/compucorp/uk.co.compucorp.civicase/pull/576).

### Updates for developers

* Fixed the sample data generation for Backstop. This also helps fix the assets generated by the github action. [CPS-245](https://github.com/compucorp/uk.co.compucorp.civicase/pull/577).