### PR TITLE
CATL-1758: Update case role dates

### DIFF
--- a/CRM/Civicase/Upgrader/Steps/Step0012.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0012.php
@@ -1,12 +1,12 @@
 <?php
 
 /**
- * CRM_Civicase_Upgrader_Steps_Step0012 class.
+ * Creates the activity types for case role date changes.
  */
 class CRM_Civicase_Upgrader_Steps_Step0012 {
 
   /**
-   * Creates the activity types for case role date changes.
+   * Runs the upgrader changes.
    */
   public function apply() {
     $this->insertUniqueActivityType(

--- a/CRM/Civicase/Upgrader/Steps/Step0012.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0012.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * CRM_Civicase_Upgrader_Steps_Step0012 class.
+ */
+class CRM_Civicase_Upgrader_Steps_Step0012 {
+
+  /**
+   * Creates the activity types for case role date changes.
+   */
+  public function apply() {
+    $this->insertUniqueActivityType(
+      'Change Case Role Start Date',
+      ts('Change Case Role Start Date')
+    );
+    $this->insertUniqueActivityType(
+      'Change Case Role End Date',
+      ts('Change Case Role End Date')
+    );
+
+    return TRUE;
+  }
+
+  /**
+   * Creates an activity type if it doesn't already exist.
+   *
+   * @param string $name
+   *   The activity type's name.
+   * @param string $label
+   *   The activity type's label.
+   */
+  private function insertUniqueActivityType($name, $label) {
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => 'activity_type',
+      'name' => $name,
+      'label' => $label,
+      'is_active' => TRUE,
+    ]);
+  }
+
+}

--- a/ang/civicase-base/constants.js
+++ b/ang/civicase-base/constants.js
@@ -10,6 +10,7 @@
     .constant('includeActivitiesForInvolvedContact', configuration.includeActivitiesForInvolvedContact)
     .constant('civicaseSingleCaseRolePerType', configuration.civicaseSingleCaseRolePerType)
     .constant('dateInputFormatValue', civiCrmConfig.dateInputFormat)
+    .constant('loggedInContactId', civiCrmConfig.user_contact_id)
     .constant('webformsList', {
       isVisible: configuration.showWebformsListSeparately,
       buttonLabel: configuration.webformsDropdownButtonLabel

--- a/ang/civicase-base/directives/send-to-api-on-change.directive.js
+++ b/ang/civicase-base/directives/send-to-api-on-change.directive.js
@@ -1,0 +1,83 @@
+(function () {
+  var module = angular.module('civicase-base');
+
+  /**
+   * This directive can be attached to input elements and will trigger an API
+   * request after the model changes.
+   *
+   * It also makes the model change trigger happen on blur.
+   */
+  module.directive('civicaseSendToApiOnChange', function ($q, $parse, civicaseCrmApi,
+    crmStatus, crmThrottle) {
+    return {
+      restrict: 'A',
+      link: civicaseSendToApiOnChangeLink,
+      require: ['ngModel']
+    };
+
+    /**
+     * Send To Api On Change linking function.
+     *
+     * @param {object} scope The directive's scope.
+     * @param {object} element The directive's attached element.
+     * @param {object} attributes List of attributes associated to the element.
+     * @param {object[]} controllers List of controllers required by the directive.
+     */
+    function civicaseSendToApiOnChangeLink (scope, element, attributes, controllers) {
+      var model = controllers[0];
+
+      (function init () {
+        model.isSaving = false;
+
+        updateModelChangeBehaviour();
+        model.$viewChangeListeners.push(sendModelDataToApi);
+      })();
+
+      /**
+       * Sends the data stored in the "data-api-data" attribute to the CiviCRM
+       * API. It marks the model as saving, displays a saving status and when
+       * done it marks the model as not saving, displays a saved status and
+       * triggers the function defined in "data-on-api-data-sent".
+       */
+      function sendModelDataToApi () {
+        if (!model.$valid) {
+          return;
+        }
+
+        var params = $parse(attributes.apiData)(scope);
+
+        model.isSaving = true;
+
+        crmStatus(
+          {
+            start: 'Saving',
+            success: 'Saved'
+          },
+          crmThrottle(function () {
+            return civicaseCrmApi(params);
+          })
+        )
+          .then(function () {
+            $parse(attributes.onApiDataSent)(scope);
+          })
+          .finally(function () {
+            model.isSaving = false;
+          });
+      }
+
+      /**
+       * Updates the model change behaviour so it triggers on blur or 1 second
+       * after changing.
+       */
+      function updateModelChangeBehaviour () {
+        model.$$setOptions({
+          updateOn: 'blur change',
+          debounce: {
+            blur: 0,
+            change: 1000
+          }
+        });
+      }
+    }
+  });
+})(angular);

--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
@@ -55,6 +55,7 @@
    * @param {object} PeoplesTabMessageConstants Error message strings
    * @param {object} ts ts
    * @param {object} RelationshipType RelationshipType
+   * @param {object} civicaseRoleDatesUpdater Role Dates Updater service
    * @param {boolean} civicaseSingleCaseRolePerType if a single case role can be assigned per type
    * @param {object} dialogService A reference to the dialog service
    * @param {Function} removeDatePickerHrefs Removes date picker href attributes
@@ -63,7 +64,8 @@
     allowMultipleCaseClients,
     civicaseCrmApi, civicasePeopleTabRoles, DateHelper,
     PeoplesTabMessageConstants, ts, RelationshipType,
-    civicaseSingleCaseRolePerType, dialogService, removeDatePickerHrefs) {
+    civicaseRoleDatesUpdater, civicaseSingleCaseRolePerType, dialogService,
+    removeDatePickerHrefs) {
     // The ts() and hs() functions help load strings for this module.
     var clients = _.indexBy($scope.item.client, 'contact_id');
     var item = $scope.item;
@@ -83,6 +85,7 @@
     $scope.relationsAlphaFilter = '';
     $scope.relationsSelectionMode = '';
     $scope.relationsSelectedTask = '';
+    $scope.roleDatesUpdater = civicaseRoleDatesUpdater;
     $scope.showInactiveRoles = false;
     $scope.letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
     $scope.contactTasks = CRM.civicase.contactTasks;

--- a/ang/civicase/case/details/people-tab/directives/roles-tab.directive.html
+++ b/ang/civicase/case/details/people-tab/directives/roles-tab.directive.html
@@ -122,7 +122,13 @@
       </tr>
     </thead>
     <tbody class="civicase__people-tab__table-body">
-      <tr class="contact--{{role.contact_id}}" ng-repeat="role in roles.list track by $index" ng-if="!roles.isLoading" ng-class="{unassigned: !role.contact_id}">
+      <tr
+        class="contact--{{role.contact_id}}"
+        ng-class="{unassigned: !role.contact_id}"
+        ng-form="roleForm"
+        ng-if="!roles.isLoading"
+        ng-repeat="role in roles.list track by $index"
+      >
         <td class="civicase__people-tab__table-column civicase__people-tab__table-column--first">
           <span ng-if="role.contact_id" class="civicase__checkbox" >
             <input id="select-role-{{ $index }}" class="civicase__people-tab__table-checkbox" type="checkbox" ng-model="role.checked" ng-click="setSelectionMode('checked', 'roles')" />
@@ -146,18 +152,28 @@
         <td class="civicase__people-tab__table-column">
           <input
             civicase-inline-datepicker
+            civicase-send-to-api-on-change
             class="form-control"
-            ng-if="!!role.contact_id"
-            ng-model="role.start_date"
+            data-api-data="roleDatesUpdater.getApiCallsForStartDate(role, item.id)"
+            data-on-api-data-sent="roleDatesUpdater.updatePreviousValue(role, 'start_date')"
+            name="role_start_date"
+            ng-disabled="roleForm.role_start_date.isSaving"
+            ng-if="!!role.relationship"
+            ng-model="role.relationship.start_date"
             type="text"
           />
         </td>
         <td class="civicase__people-tab__table-column">
           <input
             civicase-inline-datepicker
+            civicase-send-to-api-on-change
             class="form-control"
-            ng-if="!!role.contact_id"
-            ng-model="role.end_date"
+            data-api-data="roleDatesUpdater.getApiCallsForEndDate(role, item.id)"
+            data-on-api-data-sent="roleDatesUpdater.updatePreviousValue(role, 'end_date')"
+            name="role_end_date"
+            ng-disabled="roleForm.role_end_date.isSaving"
+            ng-if="!!role.relationship"
+            ng-model="role.relationship.end_date"
             type="text"
           />
         </td>

--- a/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
+++ b/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
@@ -135,7 +135,12 @@
               phone: contact.phone,
               relationship_type_id: caseTypeRole.relationship_type_id,
               role: caseTypeRole.role,
-              start_date: caseRelation.start_date
+              relationship: caseRelation,
+              start_date: caseRelation.start_date,
+              previousValues: {
+                end_date: caseRelation.end_date,
+                start_date: caseRelation.start_date
+              }
             });
           });
         } else {
@@ -194,20 +199,24 @@
      * @returns {object[]} a unique list of case relationships.
      */
     function getUniqueCaseRelationships (relationships) {
-      return _.chain(relationships)
+      return _(relationships)
         .map(function (relationship) {
           return _.assign({}, relationship, {
             startDateTimestamp: moment(relationship.start_date).valueOf()
           });
         })
         .sortByAll(['is_active', 'startDateTimestamp'])
-        .filter(function (relationship, index, sortedRelationships) {
-          var similarRelationshipIndex = _.findLastIndex(sortedRelationships, {
-            contact_id_b: relationship.contact_id_b,
-            relationship_type_id: relationship.relationship_type_id
-          });
+        .groupBy(function (relationship) {
+          return [
+            relationship.contact_id_b,
+            relationship.relationship_type_id
+          ].join();
+        })
+        .map(function (relationships) {
+          var relationship = _.first(relationships);
+          relationship.relationship_ids = _.map(relationships, 'id');
 
-          return similarRelationshipIndex === index;
+          return relationship;
         })
         .value();
     }

--- a/ang/civicase/case/details/people-tab/services/role-dates-updater.service.js
+++ b/ang/civicase/case/details/people-tab/services/role-dates-updater.service.js
@@ -1,0 +1,122 @@
+(function (_, $, angular) {
+  var module = angular.module('civicase');
+
+  module.service('civicaseRoleDatesUpdater', civicaseRoleDatesUpdater);
+
+  /**
+   * Provides the data and handlers needed to update the date for a relationship.
+   *
+   * @param {string} dateInputFormatValue The Date Format according to CiviCRM configuration.
+   * @param {string} loggedInContactId The ID of the logged in user.
+   */
+  function civicaseRoleDatesUpdater (dateInputFormatValue, loggedInContactId) {
+    var API_DATE_FORMAT = 'yy-mm-dd';
+
+    this.getApiCallsForEndDate = getApiCallsForEndDate;
+    this.getApiCallsForStartDate = getApiCallsForStartDate;
+    this.updatePreviousValue = updatePreviousValue;
+
+    /**
+     * @param {string} dateString A date in a year-month-day format.
+     * @returns {string} A formatted date according to the CiviCRM settings.
+     */
+    function formatDate (dateString) {
+      return $.datepicker.formatDate(
+        dateInputFormatValue,
+        $.datepicker.parseDate(API_DATE_FORMAT, dateString)
+      );
+    }
+
+    /**
+     * @param {object} params List of parameters to use for return the API calls.
+     * @returns {Array} a list of API calls for updating the date for each case
+     *   relation and also create an activity that records the change done to the
+     *   date.
+     */
+    function getApiCallsForDate (params) {
+      var role = params.role;
+      var caseId = params.caseId;
+      var previousDateValue = role.previousValues[params.dateFieldName];
+      var currentDateValue = role.relationship[params.dateFieldName];
+      var relationshipApiCallParams = {};
+      var subject = role.display_name + ', with ' + role.role + ' case role,' +
+        ' had ' + params.dateFieldLabel + ' changed from ' +
+        formatDate(previousDateValue) + ' to ' + formatDate(currentDateValue);
+      relationshipApiCallParams[params.dateFieldName] = currentDateValue;
+
+      return _([])
+        .concat(getUpdateRelationshipCalls(role, relationshipApiCallParams))
+        .push(
+          ['Activity', 'create', {
+            activity_type_id: params.activityTypeId,
+            activity_date_time: 'now',
+            case_id: caseId,
+            source_contact_id: loggedInContactId,
+            status_id: 'Completed',
+            subject: subject
+          }]
+        )
+        .value();
+    }
+
+    /**
+     * @param {object} role A role object as provided by the roles service.
+     * @param {string} caseId The ID of the case the role belongs to.
+     * @returns {Array} Returns the API calls needed to update the role's end
+     *   date for each relation and record the change in an activity.
+     */
+    function getApiCallsForEndDate (role, caseId) {
+      return getApiCallsForDate({
+        activityTypeId: 'Change Case Role End Date',
+        caseId: caseId,
+        dateFieldName: 'end_date',
+        dateFieldLabel: 'end date',
+        role: role
+      });
+    }
+
+    /**
+     * @param {object} role A role object as provided by the roles service.
+     * @param {string} caseId The ID of the case the role belongs to.
+     * @returns {Array} Returns the API calls needed to update the role's start
+     *   date for each relation and record the change in an activity.
+     */
+    function getApiCallsForStartDate (role, caseId) {
+      return getApiCallsForDate({
+        activityTypeId: 'Change Case Role Start Date',
+        caseId: caseId,
+        dateFieldName: 'start_date',
+        dateFieldLabel: 'start date',
+        role: role
+      });
+    }
+
+    /**
+     * @param {object} role A role object as provided by the roles service.
+     * @param {object} extraParams Extra parameters to pass to each one of the
+     *   relationship update api calls.
+     * @returns {Array} A list of api calls to update all relationships assigned
+     *   to a role.
+     */
+    function getUpdateRelationshipCalls (role, extraParams) {
+      return _(role.relationship.relationship_ids)
+        .map(function (relationshipId) {
+          var apiParams = _.assign({ id: relationshipId }, extraParams);
+
+          return ['Relationship', 'create', apiParams];
+        })
+        .value();
+    }
+
+    /**
+     * Stores the current value of the role's relationship in the previous
+     * values object. Useful for storing the relationship date changes.
+     *
+     * @param {object} role A role object as provided by the roles service.
+     * @param {string} fieldName The name of the field to store.
+     */
+    function updatePreviousValue (role, fieldName) {
+      role.previousValues[fieldName] = role.relationship[fieldName];
+    }
+  }
+})(CRM._, CRM.$, angular);

--- a/ang/civicase/case/details/people-tab/services/role-dates-updater.service.js
+++ b/ang/civicase/case/details/people-tab/services/role-dates-updater.service.js
@@ -28,7 +28,19 @@
     }
 
     /**
-     * @param {object} params List of parameters to use for return the API calls.
+     * @param {object} params List of parameters used for building the change
+     *   relationship date's API calls.
+     * @param {string} params.activityTypeId Name of the activity type that will
+     *   be used when recording the date change.
+     *   Ex: "Change Case Role End Date".
+     * @param {string} params.caseId The ID of the case the activity will belong
+     *   to.
+     * @param {string} params.dateFieldLabel Human readable name for the date
+     *   field. Example: "start date".
+     * @param {string} params.dateFieldName Name of the date field as defined
+     *   in the endpoint.
+     * @param {object} params.role Role object as returned by the People's tab
+     *   role service.
      * @returns {Array} a list of API calls for updating the date for each case
      *   relation and also create an activity that records the change done to the
      *   date.

--- a/ang/test/civicase-base/directives/send-to-api-on-change.directive.spec.js
+++ b/ang/test/civicase-base/directives/send-to-api-on-change.directive.spec.js
@@ -1,0 +1,86 @@
+/* eslint-env jasmine */
+
+(($, _) => {
+  describe('civicaseInlineDatepicker', () => {
+    let $compile, $q, $rootScope, $scope, civicaseCrmApi, crmStatus, element;
+
+    beforeEach(module('civicase-base', 'civicase.data', ($provide) => {
+      civicaseCrmApi = jasmine.createSpy('civicaseCrmApi');
+      crmStatus = jasmine.createSpy('crmStatus');
+
+      $provide.value('civicaseCrmApi', civicaseCrmApi);
+      $provide.value('crmStatus', crmStatus);
+    }));
+
+    beforeEach(inject((_$compile_, _$q_, _$rootScope_,
+      _civicaseCrmApi_) => {
+      $compile = _$compile_;
+      $q = _$q_;
+      $rootScope = _$rootScope_;
+      $scope = $rootScope.$new();
+      civicaseCrmApi = _civicaseCrmApi_;
+    }));
+
+    beforeEach(() => {
+      $scope.handleDataSent = jasmine.createSpy('handleDataSent');
+      $scope.apiData = ['Contact', 'create', { id: 1, display_name: 'abc' }];
+      $scope.myModel = 123;
+
+      crmStatus.and.returnValue($q.resolve());
+      civicaseCrmApi.and.returnValue($q.resolve());
+      initDirective();
+    });
+
+    describe('when the input changes', () => {
+      beforeEach(() => {
+        element.val(456);
+        element.change();
+      });
+
+      it('does not send the data to the API', () => {
+        expect(civicaseCrmApi).not.toHaveBeenCalled();
+      });
+
+      describe('when the loses focus', () => {
+        beforeEach(() => {
+          element.blur();
+        });
+
+        it('displays a status message while the request is being completed', () => {
+          expect(crmStatus).toHaveBeenCalledWith(
+            {
+              start: 'Saving',
+              success: 'Saved'
+            },
+            jasmine.any(Object)
+          );
+        });
+
+        it('sends the data to the API', () => {
+          expect(civicaseCrmApi).toHaveBeenCalledWith($scope.apiData);
+        });
+
+        it('calls the api data sent handler', () => {
+          expect($scope.handleDataSent).toHaveBeenCalledWith();
+        });
+      });
+    });
+
+    /**
+     * Initialises the Inline Datepicker directive on an input element using
+     * the global $scope variable.
+     */
+    function initDirective () {
+      element = $compile(`
+        <input
+          civicase-send-to-api-on-change
+          data-api-data="apiData"
+          data-on-api-data-sent="handleDataSent()"
+          ng-model="myModel"
+          type="text"
+        />
+      `)($scope);
+      $scope.$digest();
+    }
+  });
+})(CRM.$, CRM._);

--- a/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
@@ -2,9 +2,9 @@
 
 describe('Case Details People Tab', () => {
   let $controller, $rootScope, $scope, CasesData, caseRoleSelectorContact,
-    ContactsData, crmConfirmDialog, crmConfirmYesEvent, originalCrmConfirm,
-    originalSelect2, dialogServiceMock, CaseTypesMockData,
-    PeoplesTabMessageConstants;
+    civicasePeopleTabRoles, civicaseRoleDatesUpdater, ContactsData,
+    crmConfirmDialog, crmConfirmYesEvent, originalCrmConfirm, originalSelect2,
+    dialogServiceMock, CaseTypesMockData, PeoplesTabMessageConstants;
 
   beforeEach(module('civicase', 'civicase.data', ($provide) => {
     dialogServiceMock = jasmine.createSpyObj('dialogService', ['open', 'close']);
@@ -13,11 +13,13 @@ describe('Case Details People Tab', () => {
   }));
 
   beforeEach(inject(function (_$controller_, _$q_, _$rootScope_,
-    _CasesData_, _ContactsData_, _CaseTypesMockData_,
-    _PeoplesTabMessageConstants_) {
+    _CasesData_, _civicasePeopleTabRoles_, _civicaseRoleDatesUpdater_,
+    _ContactsData_, _CaseTypesMockData_, _PeoplesTabMessageConstants_) {
     $controller = _$controller_;
     $rootScope = _$rootScope_;
     CasesData = _CasesData_;
+    civicasePeopleTabRoles = _civicasePeopleTabRoles_;
+    civicaseRoleDatesUpdater = _civicaseRoleDatesUpdater_;
     ContactsData = _ContactsData_;
     CaseTypesMockData = _CaseTypesMockData_;
     PeoplesTabMessageConstants = _PeoplesTabMessageConstants_;
@@ -60,6 +62,16 @@ describe('Case Details People Tab', () => {
 
     initController({
       $scope: $scope
+    });
+  });
+
+  describe('on init', () => {
+    it('stores a reference to the people tab roles service', () => {
+      expect($scope.roles).toBe(civicasePeopleTabRoles);
+    });
+
+    it('stores a reference to the role dates updater service', () => {
+      expect($scope.roleDatesUpdater).toBe(civicaseRoleDatesUpdater);
     });
   });
 

--- a/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
+++ b/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
@@ -15,14 +15,17 @@
     }));
 
     beforeEach(() => {
-      var relationshipType = _.find(relationshipTypes, {
-        name_b_a: caseItem.contacts[1].role
+      const clientContact = caseItem.contacts[0];
+      const roleContact = caseItem.contacts[1];
+      const relationshipType = _.find(relationshipTypes, {
+        name_b_a: roleContact.role
       });
+      roleContact.manager = '1';
       relationships = [
         {
-          'api.Contact.get': { count: 1, values: [caseItem.contacts[1]] },
-          contact_id_a: caseItem.contacts[0].contact_id,
-          contact_id_b: caseItem.contacts[1].contact_id,
+          'api.Contact.get': { count: 1, values: [roleContact] },
+          contact_id_a: clientContact.contact_id,
+          contact_id_b: roleContact.contact_id,
           is_active: '1',
           relationship_type_id: relationshipType.id
         }
@@ -105,7 +108,12 @@
             phone: caseManager.phone,
             relationship_type_id: caseRelation.relationship_type_id,
             role: caseTypeRole.name,
-            start_date: caseRelation.start_date
+            start_date: caseRelation.start_date,
+            relationship: jasmine.objectContaining(caseRelation),
+            previousValues: {
+              end_date: caseRelation.end_date,
+              start_date: caseRelation.start_date
+            }
           }));
         });
       });

--- a/ang/test/civicase/case/details/people-tab/services/role-dates-updater.service.spec.js
+++ b/ang/test/civicase/case/details/people-tab/services/role-dates-updater.service.spec.js
@@ -1,0 +1,135 @@
+/* eslint-env jasmine */
+
+((_) => {
+  describe('RoleDatesUpdater', () => {
+    let roleDatesUpdater, roleData, caseId, loggedInContactId, returnedApiCalls;
+
+    beforeEach(module('civicase', 'civicase.data'));
+
+    beforeEach(inject((_civicaseRoleDatesUpdater_, _loggedInContactId_) => {
+      loggedInContactId = _loggedInContactId_;
+      roleDatesUpdater = _civicaseRoleDatesUpdater_;
+    }));
+
+    beforeEach(() => {
+      caseId = _.uniqueId();
+      roleData = {
+        display_name: 'Jon Snow',
+        role: 'Ranger',
+        relationship: {
+          end_date: '1999-12-31',
+          relationship_ids: [_.uniqueId(), _.uniqueId(), _.uniqueId()],
+          start_date: '1999-01-31'
+        },
+        previousValues: {
+          end_date: '1999-12-31',
+          start_date: '1999-01-31'
+        }
+      };
+    });
+
+    describe('when getting the api calls for updating the end date of a role', () => {
+      beforeEach(() => {
+        roleData.relationship.end_date = '2000-12-31';
+        returnedApiCalls = roleDatesUpdater.getApiCallsForEndDate(
+          roleData,
+          caseId
+        );
+      });
+
+      it('updates the end date for each relationship in the role', () => {
+        expect(returnedApiCalls).toEqual(jasmine.arrayContaining([
+          ['Relationship', 'create', {
+            id: roleData.relationship.relationship_ids[0],
+            end_date: '2000-12-31'
+          }],
+          ['Relationship', 'create', {
+            id: roleData.relationship.relationship_ids[1],
+            end_date: '2000-12-31'
+          }],
+          ['Relationship', 'create', {
+            id: roleData.relationship.relationship_ids[2],
+            end_date: '2000-12-31'
+          }]
+        ]));
+      });
+
+      it('creates an activity for recording the end date change', () => {
+        expect(returnedApiCalls).toEqual(jasmine.arrayContaining([
+          ['Activity', 'create', {
+            activity_type_id: 'Change Case Role End Date',
+            activity_date_time: 'now',
+            case_id: caseId,
+            source_contact_id: loggedInContactId,
+            status_id: 'Completed',
+            subject: 'Jon Snow, with Ranger case role, had end date changed from 31/12/1999 to 31/12/2000'
+          }]
+        ]));
+      });
+    });
+
+    describe('when getting the api calls for updating the start date of a role', () => {
+      beforeEach(() => {
+        roleData.relationship.start_date = '2000-01-31';
+        returnedApiCalls = roleDatesUpdater.getApiCallsForStartDate(
+          roleData,
+          caseId
+        );
+      });
+
+      it('updates the start date for each relationship in the role', () => {
+        expect(returnedApiCalls).toEqual(jasmine.arrayContaining([
+          ['Relationship', 'create', {
+            id: roleData.relationship.relationship_ids[0],
+            start_date: '2000-01-31'
+          }],
+          ['Relationship', 'create', {
+            id: roleData.relationship.relationship_ids[1],
+            start_date: '2000-01-31'
+          }],
+          ['Relationship', 'create', {
+            id: roleData.relationship.relationship_ids[2],
+            start_date: '2000-01-31'
+          }]
+        ]));
+      });
+
+      it('creates an activity for recording the start date change', () => {
+        expect(returnedApiCalls).toEqual(jasmine.arrayContaining([
+          ['Activity', 'create', {
+            activity_type_id: 'Change Case Role Start Date',
+            activity_date_time: 'now',
+            case_id: caseId,
+            source_contact_id: loggedInContactId,
+            status_id: 'Completed',
+            subject: 'Jon Snow, with Ranger case role, had start date changed from 31/01/1999 to 31/01/2000'
+          }]
+        ]));
+      });
+    });
+
+    describe('when updating the previous end date value', () => {
+      beforeEach(() => {
+        roleData.relationship.end_date = '2000-12-31';
+
+        roleDatesUpdater.updatePreviousValue(roleData, 'end_date');
+      });
+
+      it('updates the previous end date value', () => {
+        expect(roleData.previousValues.end_date).toBe('2000-12-31');
+      });
+    });
+
+    describe('when updating the previous start date value', () => {
+      beforeEach(() => {
+        roleData.relationship.start_date = '2000-01-31';
+
+        roleDatesUpdater.updatePreviousValue(roleData, 'start_date');
+      });
+
+      it('updates the previous start date value', () => {
+        expect(roleData.previousValues.start_date).toBe('2000-01-31');
+      });
+    });
+  });
+})(CRM._);

--- a/ang/test/mocks/data/constants.data.js
+++ b/ang/test/mocks/data/constants.data.js
@@ -1,4 +1,4 @@
-((angular) => {
+((_, angular) => {
   const module = angular.module('civicase.data');
 
   CRM['civicase-base'].allowMultipleCaseClients = true;
@@ -19,5 +19,6 @@
     $provide.constant('caseCategoryWebformSettings', CRM['civicase-base'].caseCategoryWebformSettings);
     $provide.constant('includeActivitiesForInvolvedContact', CRM['civicase-base'].includeActivitiesForInvolvedContact);
     $provide.constant('showFullContactNameOnActivityFeed', CRM['civicase-base'].showFullContactNameOnActivityFeed);
+    $provide.constant('loggedInContactId', _.uniqueId());
   });
-})(angular);
+})(CRM._, angular);


### PR DESCRIPTION
## Overview
This PR allows case role dates to be updated. When a new date is selected, all relationships belonging to the role are updated with the new date and an activity is created to record the change.

## Before
![gif](https://user-images.githubusercontent.com/1642119/93612795-f4c5b200-f99d-11ea-867f-6c779eb9dccc.gif)
Nothing happens aftering changing the date.

## After
![gif](https://user-images.githubusercontent.com/1642119/93612658-c051f600-f99d-11ea-83aa-291126647805.gif)


## Technical Details

We split the logic to update the date into a service and a directive. The "Send To API On Change" directive takes care of sending the API data and managing the saving state, and the "Role Dates Updater" service which takes care of preparing the API data to send and updating the local date values after they have been updated on the API. The directive is meant to be generic so it can be used with other inline editor components. More info below.

A new upgrader was added to create the the "Change Case Role Start Date" and "Change Case Role End Date" activity types needed.

The roles tab service was refactored so the list of relationships are grouped, but all the IDs are stored in the resulting relationship. This is important because the start date is updated for all of the relationships. A single case role has one relationship for each case client, which means that there could be multiple relationships that need to be updated when the date changes.

### Send To API On Change directive

This directive sends data to the CiviCRM API when the model changes. This is helpful for implementing other inline editor components. A sample implementation is as follows:

```html
<input
  civicase-send-to-api-on-change
  data-api-data="['Activity', 'create', { id: 1, first_name: contact }]"
  data-on-api-data-sent="handleContactUpdated(contact)"
  ng-model="contact.first_name"
/>
```

When the input's value changes and loses focus, it will send the values defined on the `data-api-data` attribute to the CiviCRM API. It uses the `crmStatus` service to display a saving/saved status message on the top right.

The loading state of the request can also be exposed to the view through a `isSaving` property that is added to the model's controller. The model controller can be accessed through the form. An example implementation looks as follows:

```html
<div ng-form="contactForm">
  <input
    civicase-send-to-api-on-change
    data-api-data="['Activity', 'create', { id: 1, first_name: contact }]"
    data-on-api-data-sent="handleContactUpdated(contact)"
    name="first_name"
    ng-model="contact.first_name"
  />
  <i class="fa fa-spinner fa-spin" ng-if="contactForm.first_name.isSaving" />
</div>
```