### PR TITLE
CATL-1675: Fix Clear Filters Button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 node_modules/
+coverage/
 bin/*
 !bin/install-php-linter
 *.css.map

--- a/ang/civicase/case/details/directives/case-details-clear-filters.html
+++ b/ang/civicase/case/details/directives/case-details-clear-filters.html
@@ -6,7 +6,7 @@
     Please click below to remove your filters.
   </div>
   <div>
-    <button type="button" class="btn btn-danger" ng-click="clearAllFilters()">
+    <button type="button" class="btn btn-danger" ng-click="clearAllFiltersToLoadSpecificCase()">
       <i class="fa fa-ban"></i> Clear Filters
     </button>
   </div>

--- a/ang/civicase/case/details/directives/case-details.directive.js
+++ b/ang/civicase/case/details/directives/case-details.directive.js
@@ -9,6 +9,7 @@
       scope: {
         activeTab: '=civicaseTab',
         isFocused: '=civicaseFocused',
+        viewingCaseId: '=',
         item: '=civicaseCaseDetails',
         showClearfiltersUi: '=',
         caseTypeCategory: '='
@@ -76,7 +77,7 @@
     $scope.isPlaceHolderVisible = isPlaceHolderVisible;
     $scope.markCompleted = markCompleted;
     $scope.onChangeSubject = onChangeSubject;
-    $scope.clearAllFilters = clearAllFilters;
+    $scope.clearAllFiltersToLoadSpecificCase = clearAllFiltersToLoadSpecificCase;
     $scope.addTimeline = addTimeline;
     $scope.caseGetParamsAsString = caseGetParamsAsString;
     $scope.createEmail = createEmail;
@@ -104,10 +105,12 @@
     }());
 
     /**
-     * Broadcast an event to show all cases.
+     * Broadcast an event to clear all filters and focus on a specific case.
      */
-    function clearAllFilters () {
-      $rootScope.$broadcast('civicase::case-details::show-all-cases');
+    function clearAllFiltersToLoadSpecificCase () {
+      $rootScope.$broadcast('civicase::case-details::clear-filter-and-focus-specific-case', {
+        caseId: $scope.viewingCaseId
+      });
     }
 
     /**

--- a/ang/civicase/case/list/directives/case-list-table.directive.html
+++ b/ang/civicase/case/list/directives/case-list-table.directive.html
@@ -111,6 +111,7 @@
   <div
     class="panel panel-default civicase__case-details-panel"
     ng-class="{'civicase__case-details-panel--focused': caseIsFocused, 'civicase__case-details-panel--summary': viewingCase}"
+    viewing-case-id="viewingCase"
     civicase-case-details="viewingCaseDetails"
     civicase-tab="viewingCaseTab"
     show-clearfilters-ui="caseNotFound"

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -18,7 +18,7 @@
   /**
    * Controller Function for civicase-search directive
    */
-  module.controller('civicaseSearchController', function ($scope, $rootScope,
+  module.controller('civicaseSearchController', function ($scope, $rootScope, $window,
     $timeout, civicaseCrmApi, getSelect2Value, ts, CaseStatus, CaseTypeCategory,
     CaseType, currentCaseCategory, CustomSearchField, includeActivitiesForInvolvedContact) {
     var caseTypes = CaseType.getAll();
@@ -332,18 +332,20 @@
      * All watchers are initiated here
      */
     function initiateWatchers () {
-      $scope.$on('civicase::case-details::show-all-cases', showAllCases);
+      $scope.$on('civicase::case-details::clear-filter-and-focus-specific-case', focusSpecificCase);
       $scope.$watch('expanded', expandedWatcher);
       $scope.$watch('relationshipType', relationshipTypeWatcher);
       $scope.$watchCollection('contactRoleFilter', caseRoleWatcher);
     }
 
     /**
-     * Clear all filters and show all cases
+     * Clear all filters and focus on specific case
+     *
+     * @param {object} event event
+     * @param {string} data sent data
      */
-    function showAllCases () {
-      $scope.showCasesFromAllStatuses = true;
-      clearSearch();
+    function focusSpecificCase (event, data) {
+      $window.location.href = '#/case/list?caseId=' + data.caseId + '&all_statuses=1';
     }
 
     /**

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -345,7 +345,9 @@
      * @param {string} data sent data
      */
     function focusSpecificCase (event, data) {
-      $window.location.href = '#/case/list?caseId=' + data.caseId + '&all_statuses=1';
+      var caseTypeCategory = $scope.filters.case_type_category;
+
+      $window.location.href = 'case_type_category=' + caseTypeCategory + '#/case/list?caseId=' + data.caseId + '&all_statuses=1&cf=%7B"case_type_category":"' + caseTypeCategory + '"%7D';
     }
 
     /**

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -347,7 +347,11 @@
     function focusSpecificCase (event, data) {
       var caseTypeCategory = $scope.filters.case_type_category;
 
-      $window.location.href = 'case_type_category=' + caseTypeCategory + '#/case/list?caseId=' + data.caseId + '&all_statuses=1&cf=%7B"case_type_category":"' + caseTypeCategory + '"%7D';
+      $window.location.href =
+        'case_type_category=' + caseTypeCategory +
+        '#/case/list?caseId=' + data.caseId +
+        '&all_statuses=1' +
+        '&cf=%7B"case_type_category":"' + caseTypeCategory + '"%7D';
     }
 
     /**

--- a/ang/test/civicase/case/actions/directives/case-actions.directive.spec.js
+++ b/ang/test/civicase/case/actions/directives/case-actions.directive.spec.js
@@ -1,25 +1,115 @@
 /* eslint-env jasmine */
 
-describe('Action', function () {
-  var $compile, $rootScope;
+(function (_) {
+  describe('case actions', function () {
+    beforeEach(module('civicase', 'civicase.data', 'civicase.templates'));
 
-  beforeEach(module('civicase', 'civicase.templates'));
+    let element, $compile, $rootScope, CaseActionsData;
 
-  beforeEach(inject(function (_$compile_, _$rootScope_) {
-    $compile = _$compile_;
-    $rootScope = _$rootScope_;
-  }));
+    beforeEach(inject(function (_$compile_, _$rootScope_, _CaseActionsData_) {
+      $compile = _$compile_;
+      $rootScope = _$rootScope_;
+      CaseActionsData = _CaseActionsData_;
+    }));
 
-  describe('basic tests', function () {
-    var element;
+    describe('basic tests', () => {
+      beforeEach(() => {
+        compileDirective();
+      });
 
-    beforeEach(function () {
+      it('compiles the case action directive', () => {
+        expect(element.html()).toContain('ng-repeat="action in caseActions');
+      });
+    });
+
+    describe('sub menus', () => {
+      var action;
+
+      describe('when the menu has sub items', function () {
+        beforeEach(() => {
+          compileDirective();
+
+          action = _.find(CaseActionsData.get(), (action) => {
+            return action.items;
+          });
+        });
+
+        it('shows the submenu', () => {
+          expect(element.isolateScope().hasSubMenu(action)).toBe(true);
+        });
+      });
+
+      describe('when the menu does not have sub items', function () {
+        beforeEach(() => {
+          compileDirective();
+
+          action = _.find(CaseActionsData.get(), (action) => {
+            return !action.items;
+          });
+        });
+
+        it('hides the submenu', () => {
+          expect(element.isolateScope().hasSubMenu(action)).toBe(false);
+        });
+      });
+    });
+
+    describe('disabling of the action', () => {
+      var action;
+
+      describe('when action can only be enabled for any number of cases', function () {
+        beforeEach(() => {
+          compileDirective();
+
+          action = _.find(CaseActionsData.get(), (action) => {
+            return !action.number;
+          });
+        });
+
+        it('enables the action', () => {
+          expect(element.isolateScope().isActionEnabled(action)).toBe(true);
+        });
+      });
+
+      describe('when action can only be enabled for a defined number of cases and number of cases match', function () {
+        beforeEach(() => {
+          compileDirective();
+
+          action = _.find(CaseActionsData.get(), (action) => {
+            return action.number;
+          });
+          element.isolateScope().cases = [{ id: 1 }];
+        });
+
+        it('enables the action', () => {
+          expect(element.isolateScope().isActionEnabled(action)).toBe(true);
+        });
+      });
+
+      describe('when action can only be enabled for a defined number of cases and number of cases does not match', function () {
+        beforeEach(() => {
+          compileDirective();
+
+          action = _.find(CaseActionsData.get(), (action) => {
+            return action.number;
+          });
+          element.isolateScope().cases = [{ id: 1 }, { id: 2 }];
+        });
+
+        it('disables the action', () => {
+          expect(element.isolateScope().isActionEnabled(action)).toBe(false);
+        });
+      });
+    });
+
+    // TODO: FINISH REST of the unit test
+
+    /**
+     * Compiles the directive
+     */
+    function compileDirective () {
       element = $compile('<div civicase-case-actions=[]></div>')($rootScope);
       $rootScope.$digest();
-    });
-
-    it('complies the Action directive', function () {
-      expect(element.html()).toContain('ng-repeat="action in caseActions');
-    });
+    }
   });
-});
+})(CRM._);

--- a/ang/test/civicase/case/details/directives/case-details.directive.spec.js
+++ b/ang/test/civicase/case/details/directives/case-details.directive.spec.js
@@ -359,7 +359,13 @@
       $scope.viewingCaseId = caseObj.id;
       $scope.viewingCaseDetails = formatCase(caseObj);
       $scope.caseTypeCategory = 'cases';
-      element = $compile('<div civicase-case-details="viewingCaseDetails" viewing-case-id="viewingCaseId" case-type-category="caseTypeCategory"></div>')($scope);
+      element = $compile(`
+        <div
+          civicase-case-details="viewingCaseDetails"
+          viewing-case-id="viewingCaseId"
+          case-type-category="caseTypeCategory">
+        </div>`
+      )($scope);
       $scope.$digest();
     }
 

--- a/ang/test/civicase/case/details/directives/case-details.directive.spec.js
+++ b/ang/test/civicase/case/details/directives/case-details.directive.spec.js
@@ -340,11 +340,13 @@
         spyOn($rootScope, '$broadcast');
         compileDirective();
 
-        element.isolateScope().clearAllFilters();
+        element.isolateScope().clearAllFiltersToLoadSpecificCase();
       });
 
-      it('displays all cases', function () {
-        expect($rootScope.$broadcast).toHaveBeenCalledWith('civicase::case-details::show-all-cases');
+      it('clears all filters and focuses on current case', function () {
+        expect($rootScope.$broadcast).toHaveBeenCalledWith('civicase::case-details::clear-filter-and-focus-specific-case', {
+          caseId: '141'
+        });
       });
     });
 
@@ -352,9 +354,12 @@
      * Compiles the civicase-case-details directive.
      */
     function compileDirective () {
-      $scope.viewingCaseDetails = formatCase(CasesData.get().values[0]);
+      var caseObj = CasesData.get().values[0];
+
+      $scope.viewingCaseId = caseObj.id;
+      $scope.viewingCaseDetails = formatCase(caseObj);
       $scope.caseTypeCategory = 'cases';
-      element = $compile('<div civicase-case-details="viewingCaseDetails" case-type-category="caseTypeCategory"></div>')($scope);
+      element = $compile('<div civicase-case-details="viewingCaseDetails" viewing-case-id="viewingCaseId" case-type-category="caseTypeCategory"></div>')($scope);
       $scope.$digest();
     }
 

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -1,9 +1,11 @@
 /* eslint-env jasmine */
 (($, _, crmCheckPerm) => {
   describe('civicaseSearch', () => {
-    let $controller, $rootScope, $scope, $timeout, CaseFilters, CaseStatuses, caseTypeCategoriesMockData,
-      CaseTypes, civicaseCrmApi, currentCaseCategory, customSearchFields, affixOriginalFunction,
-      offsetOriginalFunction, originalParentScope, affixReturnValue, originalBindToRoute;
+    let $controller, $rootScope, $scope, $window, $timeout, CaseFilters,
+      CaseStatuses, caseTypeCategoriesMockData, CaseTypes, civicaseCrmApi,
+      currentCaseCategory, customSearchFields, affixOriginalFunction,
+      offsetOriginalFunction, originalParentScope, affixReturnValue,
+      originalBindToRoute;
 
     const SEARCH_EVENT_NAME = 'civicase::case-search::filters-updated';
 
@@ -11,15 +13,17 @@
       civicaseCrmApi = jasmine.createSpy('civicaseCrmApi');
 
       $provide.value('civicaseCrmApi', civicaseCrmApi);
+      $provide.value('$window', { location: {} });
     }));
 
-    beforeEach(inject((_$controller_, $q, _$rootScope_, _$timeout_, _CaseFilters_,
-      _CaseStatuses_, _caseTypeCategoriesMockData_, _CaseTypesMockData_, _currentCaseCategory_,
-      _CustomSearchField_) => {
+    beforeEach(inject((_$controller_, $q, _$rootScope_, _$timeout_, _$window_,
+      _CaseFilters_, _CaseStatuses_, _caseTypeCategoriesMockData_,
+      _CaseTypesMockData_, _currentCaseCategory_, _CustomSearchField_) => {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       $scope = $rootScope.$new();
       $timeout = _$timeout_;
+      $window = _$window_;
       CaseFilters = _CaseFilters_;
       CaseStatuses = _CaseStatuses_.values;
       CaseTypes = _CaseTypesMockData_.get();
@@ -206,18 +210,15 @@
 
       describe('when show all cases button is presser', () => {
         beforeEach(() => {
-          $rootScope.$broadcast('civicase::case-details::show-all-cases');
+          $rootScope.$broadcast(
+            'civicase::case-details::clear-filter-and-focus-specific-case', {
+              caseId: 10
+            }
+          );
         });
 
-        it('displays all cases', () => {
-          expect($scope.showCasesFromAllStatuses).toBe(true);
-          expect($rootScope.$broadcast).toHaveBeenCalledWith(
-            'civicase::case-search::filters-updated', {
-              selectedFilters: {
-                is_deleted: false,
-                showCasesFromAllStatuses: true
-              }
-            });
+        it('shows the cases', () => {
+          expect($window.location.href).toBe('#/case/list?caseId=10&all_statuses=1');
         });
       });
     });

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -218,7 +218,11 @@
         });
 
         it('shows the cases', () => {
-          expect($window.location.href).toBe('case_type_category=cases#/case/list?caseId=10&all_statuses=1&cf=%7B"case_type_category":"cases"%7D');
+          const expectedURL = 'case_type_category=cases#/case/list?' +
+            'caseId=10&all_statuses=1&cf=%7B"case_type_category":"cases"%7D';
+
+          expect($window.location.href)
+            .toBe(expectedURL);
         });
       });
     });

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -218,7 +218,7 @@
         });
 
         it('shows the cases', () => {
-          expect($window.location.href).toBe('#/case/list?caseId=10&all_statuses=1');
+          expect($window.location.href).toBe('case_type_category=cases#/case/list?caseId=10&all_statuses=1&cf=%7B"case_type_category":"cases"%7D');
         });
       });
     });

--- a/ang/test/karma.conf.js
+++ b/ang/test/karma.conf.js
@@ -68,7 +68,11 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     coverageReporter: {
-      type: 'text-summary'
+      dir: extPath + '/coverage',
+      reporters: [
+        { type: 'text-summary' },
+        { type: 'lcov', subdir: 'js-lcov' }
+      ]
     },
     browsers: ['ChromeHeadlessBrowser'],
     customLaunchers: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3517,7 +3517,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3934,7 +3935,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3990,6 +3992,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4033,12 +4036,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3517,8 +3517,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3935,8 +3934,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3992,7 +3990,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4036,14 +4033,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/tests/backstop_data/package-lock.json
+++ b/tests/backstop_data/package-lock.json
@@ -1732,7 +1732,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2149,7 +2150,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2205,6 +2207,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2248,12 +2251,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
## Overview
In Manage Case page, when a case from the (n +1) page is selected, and then the filter is changed so that the current case is no longer part of the filtering. In this stage, when page is refreshed and "Clear Filters" button is pressed, the UI was still not showing the requested case. This PR fixes the same.

## Before
![before](https://user-images.githubusercontent.com/5058867/93985768-23c79380-fda3-11ea-881e-77b07f105b4e.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/93985778-26c28400-fda3-11ea-9221-4ac009aca57f.gif)

## Technical Details
1. Added `lcov` coverage reporter to karma js, so that the same can be used by IDEs to find uncovered source code.
2. Previously, if the requested case was in the 2nd page(or any page other than the first page), the error happened because in https://github.com/compucorp/uk.co.compucorp.civicase/blob/ed5f60375e8d9ba3400a70299f48c8bda71fa8c9/ang/civicase/case/list/directives/case-list-table.directive.js#L445
the `page_of_record`, only gets applied when loading the page for the first time,
```javascript
if (firstLoad && $scope.viewingCase) {
  params[0][2].options.page_of_record = $scope.viewingCase;
}
```

Hence now we reload the page to get through this issue

```
$window.location.href = '#/case/list?caseId=<caseid>&all_statuses=1';
```