### PR TITLE
RSE-1309: Fix Issue With Case Category Webform Setting Displaying Category Value Instead Of Name

### DIFF
--- a/CRM/Civicase/BAO/CaseCategoryInstance.php
+++ b/CRM/Civicase/BAO/CaseCategoryInstance.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Class CRM_Civicase_BAO_CaseCategoryInstance.
+ * CaseCategoryInstance BAO.
  */
 class CRM_Civicase_BAO_CaseCategoryInstance extends CRM_Civicase_DAO_CaseCategoryInstance {
 

--- a/CRM/Civicase/Factory/CaseTypeCategoryEventHandler.php
+++ b/CRM/Civicase/Factory/CaseTypeCategoryEventHandler.php
@@ -6,6 +6,9 @@ use CRM_Civicase_Service_CaseCategoryCustomFieldExtends as CaseCategoryCustomFie
 
 /**
  * CaseTypeCategoryEventHandler Factory.
+ *
+ * This class helps to create a case category event handler object
+ * that can be used to respond to events on a case type category.
  */
 class CRM_Civicase_Factory_CaseTypeCategoryEventHandler {
 

--- a/CRM/Civicase/Factory/CaseTypeCategoryEventHandler.php
+++ b/CRM/Civicase/Factory/CaseTypeCategoryEventHandler.php
@@ -5,7 +5,7 @@ use CRM_Civicase_Service_CaseCategoryCustomDataType as CaseCategoryCustomDataTyp
 use CRM_Civicase_Service_CaseCategoryCustomFieldExtends as CaseCategoryCustomFieldExtends;
 
 /**
- * Class CRM_Civicase_Factory_CaseTypeCategoryEventHandler.
+ * CaseTypeCategoryEventHandler Factory.
  */
 class CRM_Civicase_Factory_CaseTypeCategoryEventHandler {
 

--- a/CRM/Civicase/Helper/CaseCategory.php
+++ b/CRM/Civicase/Helper/CaseCategory.php
@@ -6,7 +6,7 @@ use CRM_Civicase_Service_CaseManagementUtils as CaseManagementUtils;
 use CRM_Civicase_BAO_CaseCategoryInstance as CaseCategoryInstance;
 
 /**
- * CaseCategory Helper class.
+ * CaseCategory Helper class with useful functions for managing case categories.
  */
 class CRM_Civicase_Helper_CaseCategory {
 

--- a/CRM/Civicase/Helper/CaseCategory.php
+++ b/CRM/Civicase/Helper/CaseCategory.php
@@ -6,7 +6,7 @@ use CRM_Civicase_Service_CaseManagementUtils as CaseManagementUtils;
 use CRM_Civicase_BAO_CaseCategoryInstance as CaseCategoryInstance;
 
 /**
- * CRM_Civicase_Helper_CaseCategory class.
+ * CaseCategory Helper class.
  */
 class CRM_Civicase_Helper_CaseCategory {
 
@@ -244,7 +244,10 @@ class CRM_Civicase_Helper_CaseCategory {
   public static function getWhereUserCanAccessActivities($contactId = NULL) {
     $caseTypeCategories = CaseType::buildOptions('case_type_category', 'validate');
     $caseCategoryPermission = new CaseCategoryPermission();
-    $permissionsToCheck = ['access my cases and activities', 'access all cases and activities'];
+    $permissionsToCheck = [
+      'access my cases and activities',
+      'access all cases and activities',
+    ];
     $caseCategoryAccess = [];
     $contactId = $contactId ? $contactId : CRM_Core_Session::getLoggedInContactID();
     foreach ($caseTypeCategories as $id => $caseTypeCategoryName) {

--- a/CRM/Civicase/Hook/BuildForm/AddCaseCategoryInstanceField.php
+++ b/CRM/Civicase/Hook/BuildForm/AddCaseCategoryInstanceField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Class CRM_Civicase_Hook_BuildForm_AddCaseCategoryInstanceField.
+ * AddCaseCategoryInstanceField BuildForm Hook Class.
  */
 class CRM_Civicase_Hook_BuildForm_AddCaseCategoryInstanceField extends CRM_Civicase_Hook_CaseCategoryInstanceBase {
 

--- a/CRM/Civicase/Hook/CaseCategoryInstanceBase.php
+++ b/CRM/Civicase/Hook/CaseCategoryInstanceBase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Class CRM_Civicase_Hook_CaseCategoryInstanceBase.
+ * Base class for the CaseCategoryInstance hook classes.
  */
 class CRM_Civicase_Hook_CaseCategoryInstanceBase {
 

--- a/CRM/Civicase/Hook/CaseCategoryInstanceBase.php
+++ b/CRM/Civicase/Hook/CaseCategoryInstanceBase.php
@@ -2,6 +2,10 @@
 
 /**
  * Base class for the CaseCategoryInstance hook classes.
+ *
+ * This is implemented by hook classes responding to changes
+ * on the case category form page. It defines common functions
+ * that can be shared by the hook classes.
  */
 class CRM_Civicase_Hook_CaseCategoryInstanceBase {
 

--- a/CRM/Civicase/Hook/PostProcess/CaseCategoryPostProcessor.php
+++ b/CRM/Civicase/Hook/PostProcess/CaseCategoryPostProcessor.php
@@ -4,7 +4,7 @@ use CRM_Civicase_Factory_CaseTypeCategoryEventHandler as CaseTypeCategoryEventHa
 use CRM_Civicase_Helper_CaseCategory as CaseTypeCategoryHelper;
 
 /**
- * Class CRM_Civicase_Hook_PostProcess_CaseCategoryPostProcessor.
+ * Handles post processing for the case category form.
  */
 class CRM_Civicase_Hook_PostProcess_CaseCategoryPostProcessor {
 

--- a/CRM/Civicase/Hook/PostProcess/SaveCaseCategoryInstance.php
+++ b/CRM/Civicase/Hook/PostProcess/SaveCaseCategoryInstance.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Class CRM_Civicase_Hook_PostProcess_SaveCaseCategoryInstance.
+ * CaseCategoryInstance Post Process Hook class.
  */
 class CRM_Civicase_Hook_PostProcess_SaveCaseCategoryInstance extends CRM_Civicase_Hook_CaseCategoryInstanceBase {
 

--- a/CRM/Civicase/Service/CaseCategoryCaseTypeCustomFieldExtends.php
+++ b/CRM/Civicase/Service/CaseCategoryCaseTypeCustomFieldExtends.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Class CRM_Civicase_Service_CaseCategoryCaseTypeCustomFieldExtends.
+ * Overrides some properties in CaseCategoryCustomFieldExtends.
  */
 class CRM_Civicase_Service_CaseCategoryCaseTypeCustomFieldExtends extends CRM_Civicase_Service_CaseCategoryCustomFieldExtends {
 

--- a/CRM/Civicase/Service/CaseCategoryCustomDataType.php
+++ b/CRM/Civicase/Service/CaseCategoryCustomDataType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Class CRM_Civicase_Service_CaseCategoryCustomDataType.
+ * Helps to create the custom data option value for a case category.
  */
 class CRM_Civicase_Service_CaseCategoryCustomDataType {
 

--- a/CRM/Civicase/Service/CaseCategoryCustomFieldExtends.php
+++ b/CRM/Civicase/Service/CaseCategoryCustomFieldExtends.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Class CRM_Civicase_Service_CaseCategoryCustomFieldExtends.
+ * Class for managing support for case type category custom fields.
  */
 class CRM_Civicase_Service_CaseCategoryCustomFieldExtends {
 

--- a/CRM/Civicase/Service/CaseCategoryInstanceUtils.php
+++ b/CRM/Civicase/Service/CaseCategoryInstanceUtils.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Interface CRM_Civicase_Service_CaseCategoryInstanceUtilsInterface.
+ * Interface for the CaseCategoryInstances to implement.
  */
 abstract class CRM_Civicase_Service_CaseCategoryInstanceUtils {
 

--- a/CRM/Civicase/Service/CaseCategoryInstanceUtils.php
+++ b/CRM/Civicase/Service/CaseCategoryInstanceUtils.php
@@ -1,7 +1,12 @@
 <?php
 
 /**
- * Interface for the CaseCategoryInstances to implement.
+ * Base abstract for the CaseCategoryInstance classes to implement.
+ *
+ * This class contains some abstract methods that the case category
+ * instance classes should implement. These methods helps distinguish
+ * a category instance class for another. e.g There is a method to fetch
+ * the menu object which will not be same for the instance classes.
  */
 abstract class CRM_Civicase_Service_CaseCategoryInstanceUtils {
 

--- a/CRM/Civicase/Service/CaseCategoryMenu.php
+++ b/CRM/Civicase/Service/CaseCategoryMenu.php
@@ -186,7 +186,10 @@ class CRM_Civicase_Service_CaseCategoryMenu {
    *   Category details.
    */
   private function getCaseCategoryOptionDetailsByParams(array $params) {
-    $apiParams = ['sequential' => 1, 'option_group_id' => 'case_type_categories'];
+    $apiParams = [
+      'sequential' => 1,
+      'option_group_id' => 'case_type_categories',
+    ];
     $apiParams = array_merge($apiParams, $params);
     $result = civicrm_api3('OptionValue', 'get', $apiParams);
 

--- a/CRM/Civicase/Service/CaseCategorySetting.php
+++ b/CRM/Civicase/Service/CaseCategorySetting.php
@@ -3,7 +3,7 @@
 use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 
 /**
- * Class CRM_Civicase_Service_CaseCategorySetting.
+ * Case Category Setting class.
  */
 class CRM_Civicase_Service_CaseCategorySetting {
 
@@ -14,7 +14,7 @@ class CRM_Civicase_Service_CaseCategorySetting {
    *   Array of webform settings.
    */
   public function getForWebform() {
-    $caseTypeCategories = CRM_Core_OptionGroup::values('case_type_categories', TRUE, FALSE, TRUE, NULL, 'name');
+    $caseTypeCategories = array_flip(CRM_Core_OptionGroup::values('case_type_categories', TRUE, FALSE, TRUE, NULL, 'name'));
     $caseCategorySettings = [];
     foreach ($caseTypeCategories as $caseCategoryName) {
       $caseCategorySettings = array_merge($caseCategorySettings, $this->getCaseWebformSetting($caseCategoryName));

--- a/CRM/Civicase/Service/CaseCategorySetting.php
+++ b/CRM/Civicase/Service/CaseCategorySetting.php
@@ -4,6 +4,10 @@ use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 
 /**
  * Civicase settings class.
+ *
+ * This class is a generic setting class that contains functions to
+ * fetch civicase setting related to webforms and any other setting
+ * that may be added.
  */
 class CRM_Civicase_Service_CaseCategorySetting {
 

--- a/CRM/Civicase/Service/CaseCategorySetting.php
+++ b/CRM/Civicase/Service/CaseCategorySetting.php
@@ -3,7 +3,7 @@
 use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 
 /**
- * Case Category Setting class.
+ * Civicase settings class.
  */
 class CRM_Civicase_Service_CaseCategorySetting {
 

--- a/CRM/Civicase/Service/CaseManagementUtils.php
+++ b/CRM/Civicase/Service/CaseManagementUtils.php
@@ -3,7 +3,7 @@
 use CRM_Civicase_Service_CaseCategoryMenu as CaseCategoryMenu;
 
 /**
- * Class CRM_Civicase_Service_CaseManagementUtils.
+ * CaseManagementUtils class for case instance type.
  */
 class CRM_Civicase_Service_CaseManagementUtils extends CRM_Civicase_Service_CaseCategoryInstanceUtils {
 

--- a/CRM/Civicase/Service/CaseTypeCategoryEventHandler.php
+++ b/CRM/Civicase/Service/CaseTypeCategoryEventHandler.php
@@ -5,7 +5,7 @@ use CRM_Civicase_Service_CaseCategoryCustomFieldExtends as CaseCategoryCustomFie
 use CRM_Civicase_Service_CaseCategoryInstanceUtils as CaseCategoryInstance;
 
 /**
- * Class CRM_Civicase_Service_CaseTypeCategoryEventHandler.
+ * Handles events when case type category is created/updated/deleted.
  */
 class CRM_Civicase_Service_CaseTypeCategoryEventHandler {
 

--- a/CRM/Civicase/Setup/CaseCategoryInstanceSupport.php
+++ b/CRM/Civicase/Setup/CaseCategoryInstanceSupport.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Class CRM_Civicase_Setup_CaseCategoryInstanceSupport.
+ * Sets up Case Category Instance Support.
  */
 class CRM_Civicase_Setup_CaseCategoryInstanceSupport {
 

--- a/CRM/Civicase/Test/Fabricator/CaseCategory.php
+++ b/CRM/Civicase/Test/Fabricator/CaseCategory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Class CRM_Civicase_Test_Fabricator_CaseCategory.
+ * CaseCategory Fabricator class.
  */
 class CRM_Civicase_Test_Fabricator_CaseCategory {
 

--- a/CRM/Civicase/Upgrader/Steps/Step0012.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0012.php
@@ -3,7 +3,7 @@
 use CRM_Civicase_Setup_CaseCategoryInstanceSupport as CaseCategoryInstanceSupport;
 
 /**
- * Class CRM_Civicase_Upgrader_Steps_Step0012.
+ * Upgrader to add case category instamce support.
  */
 class CRM_Civicase_Upgrader_Steps_Step0012 {
 

--- a/tests/phpunit/CRM/Civicase/Service/CaseTypeCategoryEventHandlerTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseTypeCategoryEventHandlerTest.php
@@ -5,7 +5,7 @@ use CRM_Civicase_Test_Fabricator_CaseCategory as CaseCategoryFabricator;
 use CRM_Civicase_Service_CaseManagementUtils as CaseManagementUtils;
 
 /**
- * Class CRM_Civicase_Service_CaseTypeCategoryEventHandlerTest.
+ * Test class for the CaseTypeCategoryEventHandler.
  *
  * @group headless
  */


### PR DESCRIPTION
## Overview
The case category webform settings display the case category value rather than the case category name. This PR fixes that. 

## Before
![image-20200918-111119](https://user-images.githubusercontent.com/6951813/94016790-81a9aa80-fda6-11ea-9036-36a47825be91.png)


## After
The issue was introduced in this [commit](https://github.com/compucorp/uk.co.compucorp.civicase/pull/533/files#diff-827f957d95878344873e43d0ee49df39R17) when the function for fetching the case type category options was modified. The new function returns an array with the case category name as the key and the case category value as the Value which is the opposite of what the old function does. 
To fix the issue the array was flipped.


<img width="1271" alt="Settings - CiviCase  CaseLatest 2020-09-23 14-31-51" src="https://user-images.githubusercontent.com/6951813/94019425-af442300-fda9-11ea-9caf-6e89c52c39aa.png">

