### PR TITLE
CATL-1807: Fix Add Case Role button

### DIFF
--- a/ang/civicase/case/details/people-tab/directives/roles-tab.directive.html
+++ b/ang/civicase/case/details/people-tab/directives/roles-tab.directive.html
@@ -8,7 +8,7 @@
         <li ng-if="allowMultipleCaseClients">
           <a href ng-click="assignRoleOrClient()">{{ ts('Client') }}</a>
         </li>
-        <li ng-repeat="role in allRoles" class="civicase__people-tab__add-role-dropdown">
+        <li ng-repeat="role in roles.caseTypeRoles" class="civicase__people-tab__add-role-dropdown">
           <a href
             ng-disabled="checkIfRoleIsDisabled(role)"
             ng-click="!checkIfRoleIsDisabled(role) && assignRoleOrClient(role)">


### PR DESCRIPTION
## Overview
This PR fixes the list of roles that is displayed when clicking the "Add Case Role" button in the People's Tab.

## Before
![Screen Shot 2020-09-24 at 10 26 00 PM](https://user-images.githubusercontent.com/1642119/94219491-f3701a00-feb4-11ea-8947-bd9ad6dbe30c.png)

## After
![gif](https://user-images.githubusercontent.com/1642119/94219350-a1c78f80-feb4-11ea-93db-a13308d66e5c.gif)

## Technical Details

This was a regression introduced by https://github.com/compucorp/uk.co.compucorp.civicase/pull/574. When updating the list of roles the previous parameter was updated instead of using the role service variable.