### PR TITLE
CATL-1785: Add Current User Contact Entity And Contact Custom Fields To Tokens

### DIFF
--- a/CRM/Civicase/Hook/Tokens/AddContactTokens.php
+++ b/CRM/Civicase/Hook/Tokens/AddContactTokens.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Add current user tokens.
+ */
+class CRM_Civicase_Hook_Tokens_AddContactTokens {
+
+  /**
+   * Key for token.
+   *
+   * @var string
+   */
+  const TOKEN_KEY = 'current_user';
+
+  /**
+   * Service for fetching contact fields.
+   *
+   * @var CRM_Civicase_Service_ContactFieldsProvider
+   */
+  private $contactFieldsService;
+
+  /**
+   * Service for fetching contact custom fields.
+   *
+   * @var CRM_Civicase_Service_ContactCustomFieldsProvider
+   */
+  private $contactCustomFieldsService;
+
+  /**
+   * CRM_Civicase_Hook_Tokens_AddContactTokens constructor.
+   *
+   * @param CRM_Civicase_Service_ContactFieldsProvider $contactFieldsService
+   *   Service for fetching contact fields.
+   * @param CRM_Civicase_Service_ContactCustomFieldsProvider $contactCustomFieldsService
+   *   Service for fetching contact custom fields.
+   */
+  public function __construct(
+    CRM_Civicase_Service_ContactFieldsProvider $contactFieldsService,
+    CRM_Civicase_Service_ContactCustomFieldsProvider $contactCustomFieldsService) {
+    $this->contactFieldsService = $contactFieldsService;
+    $this->contactCustomFieldsService = $contactCustomFieldsService;
+  }
+
+  /**
+   * Add current user tokens.
+   *
+   * @param array $tokens
+   *   List of tokens.
+   */
+  public function run(array &$tokens) {
+    $fields = array_merge($this->contactFieldsService->get(), $this->contactCustomFieldsService->get());
+    foreach ($fields as $field) {
+      $tokens[self::TOKEN_KEY]['current_user.contact_' . $field] =
+        ts('Current User ' . ucwords(str_replace("_", " ", $field)));
+    }
+  }
+
+}

--- a/CRM/Civicase/Hook/Tokens/AddContactTokensValues.php
+++ b/CRM/Civicase/Hook/Tokens/AddContactTokensValues.php
@@ -56,10 +56,10 @@ class CRM_Civicase_Hook_Tokens_AddContactTokensValues {
     $customFields = $this->contactCustomFieldsService->get();
     try {
       $contactId = CRM_Core_Session::singleton()->getLoggedInContactID();
-      $contactValues = civicrm_api3('contact', 'getsingle', array(
+      $contactValues = civicrm_api3('contact', 'getsingle', [
         'id' => $contactId,
         'return' => array_merge($contactFields, array_keys($customFields)),
-      ));
+      ]);
       $currentUsersContact = [];
       foreach ($contactValues as $k => $value) {
         if (strpos($k, 'civicrm_value_') !== FALSE) {

--- a/CRM/Civicase/Hook/Tokens/AddContactTokensValues.php
+++ b/CRM/Civicase/Hook/Tokens/AddContactTokensValues.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Add current user token values.
+ */
+class CRM_Civicase_Hook_Tokens_AddContactTokensValues {
+
+  /**
+   * Service for fetching contact fields.
+   *
+   * @var CRM_Civicase_Service_ContactFieldsProvider
+   */
+  private $contactFieldsService;
+
+  /**
+   * Service for fetching contact custom fields.
+   *
+   * @var CRM_Civicase_Service_ContactCustomFieldsProvider
+   */
+  private $contactCustomFieldsService;
+
+  /**
+   * CRM_Civicase_Hook_Tokens_AddContactTokens constructor.
+   *
+   * @param CRM_Civicase_Service_ContactFieldsProvider $contactFieldsService
+   *   Service for fetching contact fields.
+   * @param CRM_Civicase_Service_ContactCustomFieldsProvider $contactCustomFieldsService
+   *   Service for fetching contact custom fields.
+   */
+  public function __construct(
+    CRM_Civicase_Service_ContactFieldsProvider $contactFieldsService,
+    CRM_Civicase_Service_ContactCustomFieldsProvider $contactCustomFieldsService) {
+    $this->contactFieldsService = $contactFieldsService;
+    $this->contactCustomFieldsService = $contactCustomFieldsService;
+  }
+
+  /**
+   * Add current user token values.
+   *
+   * @param array $values
+   *   Token values.
+   * @param array $cids
+   *   Contact ids.
+   * @param int $job
+   *   Job id.
+   * @param array $tokens
+   *   Token names that are used actually.
+   * @param string $context
+   *   Context name.
+   */
+  public function run(array &$values, array $cids, $job, array $tokens, $context) {
+    if (!$this->shouldRun($tokens)) {
+      return;
+    }
+    $contactFields = $this->contactFieldsService->get();
+    $customFields = $this->contactCustomFieldsService->get();
+    try {
+      $contactId = CRM_Core_Session::singleton()->getLoggedInContactID();
+      $contactValues = civicrm_api3('contact', 'getsingle', array(
+        'id' => $contactId,
+        'return' => array_merge($contactFields, array_keys($customFields)),
+      ));
+      $currentUsersContact = [];
+      foreach ($contactValues as $k => $value) {
+        if (strpos($k, 'civicrm_value_') !== FALSE) {
+          continue;
+        }
+        $k = (strpos($k, 'custom_') !== FALSE) ? $customFields[$k] : $k;
+        if (in_array($k, array_merge($contactFields, $customFields))) {
+          $key = 'current_user.contact_' . $k;
+          $currentUsersContact[$key] = $value;
+        }
+      }
+
+      foreach ($cids as $cid) {
+        $values[$cid] = empty($values[$cid]) ? $currentUsersContact : array_merge($values[$cid], $currentUsersContact);
+      }
+    }
+    catch (Throwable $ex) {
+    }
+  }
+
+  /**
+   * Decides whether the hook should run or not.
+   *
+   * @param array $tokens
+   *   List of tokens that are used.
+   *
+   * @return bool
+   *   Whether this hook should run or not.
+   */
+  private function shouldRun(array $tokens) {
+    return !empty($tokens[CRM_Civicase_Hook_Tokens_AddContactTokens::TOKEN_KEY]);
+  }
+
+}

--- a/CRM/Civicase/Service/ContactCustomFieldsProvider.php
+++ b/CRM/Civicase/Service/ContactCustomFieldsProvider.php
@@ -13,22 +13,35 @@ class CRM_Civicase_Service_ContactCustomFieldsProvider {
    */
   public function get() {
     $fields = [];
+    $customFields = $this->getCustomFields();
+    if (!empty($customFields['values'])) {
+      foreach ($customFields['values'] as $id => $item) {
+        $fields['custom_' . $id] = $item['name'];
+      }
+    }
+
+    return $fields;
+  }
+
+  /**
+   * Provides contacts custom fields.
+   *
+   * @return array
+   *   List of custom fields that extends contacts.
+   */
+  public function getCustomFields() {
+    $customFields = [];
     try {
       $customFields = civicrm_api3('CustomField', 'get', [
         'custom_group_id.extends' => [
           'IN' => ['Contact', 'Individual', 'Household', 'Organization'],
         ],
       ]);
-      if ($customFields['values']) {
-        foreach ($customFields['values'] as $k => $item) {
-          $fields['custom_' . $k] = $item['name'];
-        }
-      }
     }
     catch (Throwable $ex) {
     }
 
-    return $fields;
+    return $customFields;
   }
 
 }

--- a/CRM/Civicase/Service/ContactCustomFieldsProvider.php
+++ b/CRM/Civicase/Service/ContactCustomFieldsProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Provides contacts custom fields.
+ */
+class CRM_Civicase_Service_ContactCustomFieldsProvider {
+
+  /**
+   * Provides contacts custom fields.
+   *
+   * @return array
+   *   List of custom fields that extends contacts.
+   */
+  public function get() {
+    $fields = [];
+    try {
+      $customFields = civicrm_api3('CustomField', 'get', [
+        'custom_group_id.extends' => [
+          'IN' => ['Contact', 'Individual', 'Household', 'Organization'],
+        ],
+      ]);
+      if ($customFields['values']) {
+        foreach ($customFields['values'] as $k => $item) {
+          $fields['custom_' . $k] = $item['name'];
+        }
+      }
+    }
+    catch (Throwable $ex) {
+    }
+
+    return $fields;
+  }
+
+}

--- a/CRM/Civicase/Service/ContactFieldsProvider.php
+++ b/CRM/Civicase/Service/ContactFieldsProvider.php
@@ -15,9 +15,9 @@ class CRM_Civicase_Service_ContactFieldsProvider {
     $fields = [];
     try {
       $contactId = CRM_Core_Session::singleton()->getLoggedInContactID();
-      $contact = civicrm_api3('contact', 'getsingle', array(
+      $contact = civicrm_api3('contact', 'getsingle', [
         'id' => $contactId,
-      ));
+      ]);
       if ($contact) {
         $fields = array_keys($contact);
       }

--- a/CRM/Civicase/Service/ContactFieldsProvider.php
+++ b/CRM/Civicase/Service/ContactFieldsProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Provides contact fields.
+ */
+class CRM_Civicase_Service_ContactFieldsProvider {
+
+  /**
+   * Provides contact fields.
+   *
+   * @return array
+   *   List of contact fields.
+   */
+  public function get() {
+    $fields = [];
+    try {
+      $contactId = CRM_Core_Session::singleton()->getLoggedInContactID();
+      $contact = civicrm_api3('contact', 'getsingle', array(
+        'id' => $contactId,
+      ));
+      if ($contact) {
+        $fields = array_keys($contact);
+      }
+    }
+    catch (Throwable $ex) {
+    }
+
+    return $fields;
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -497,7 +497,7 @@ function civicase_civicrm_tokens(&$tokens) {
 /**
  * Implements hook_civicrm_tokenValues().
  */
-function civicase_civicrm_tokenValues(&$values, $cids, $job = NULL, $tokens = array(), $context = NULL) {
+function civicase_civicrm_tokenValues(&$values, $cids, $job = NULL, $tokens = [], $context = NULL) {
   $contactFieldsService = new CRM_Civicase_Service_ContactFieldsProvider();
   $contactCustomFieldsService = new CRM_Civicase_Service_ContactCustomFieldsProvider();
   $hooks = [

--- a/civicase.php
+++ b/civicase.php
@@ -481,6 +481,34 @@ function civicase_civicrm_alterAPIPermissions($entity, $action, &$params, &$perm
 }
 
 /**
+ * Implements hook_civicrm_tokens().
+ */
+function civicase_civicrm_tokens(&$tokens) {
+  $contactFieldsService = new CRM_Civicase_Service_ContactFieldsProvider();
+  $contactCustomFieldsService = new CRM_Civicase_Service_ContactCustomFieldsProvider();
+  $hooks = [
+    new CRM_Civicase_Hook_Tokens_AddContactTokens($contactFieldsService, $contactCustomFieldsService),
+  ];
+  foreach ($hooks as &$hook) {
+    $hook->run($tokens);
+  }
+}
+
+/**
+ * Implements hook_civicrm_tokenValues().
+ */
+function civicase_civicrm_tokenValues(&$values, $cids, $job = NULL, $tokens = array(), $context = NULL) {
+  $contactFieldsService = new CRM_Civicase_Service_ContactFieldsProvider();
+  $contactCustomFieldsService = new CRM_Civicase_Service_ContactCustomFieldsProvider();
+  $hooks = [
+    new CRM_Civicase_Hook_Tokens_AddContactTokensValues($contactFieldsService, $contactCustomFieldsService),
+  ];
+  foreach ($hooks as &$hook) {
+    $hook->run($values, $cids, $job, $tokens, $context);
+  }
+}
+
+/**
  * Implements hook_civicrm_pageRun().
  */
 function civicase_civicrm_pageRun(&$page) {

--- a/tests/phpunit/CRM/Civicase/Hook/Tokens/AddContactTokenValuesTest.php
+++ b/tests/phpunit/CRM/Civicase/Hook/Tokens/AddContactTokenValuesTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use CRM_Civicase_Hook_Tokens_AddContactTokensValues as AddContactTokenValues;
+
+/**
+ * Test class for the CRM_Civicase_Hook_Tokens_AddContactTokensValues.
+ *
+ * @group headless
+ */
+class CRM_Civicase_Hook_AddContactTokenValuesTest extends BaseHeadlessTest {
+
+  /**
+   * Test the run method.
+   *
+   * @param array $contactFields
+   *   List of contact fields.
+   * @param array $customFields
+   *   List of contact custom fields.
+   * @param array $values
+   *   Contact field values.
+   * @param array $result
+   *   Expected result.
+   *
+   * @dataProvider getTestDataForRunMethod
+   */
+  public function testGet(array $contactFields, array $customFields, array $values, array $result) {
+    $contactValues = [];
+    $customFieldService = $this->getMockBuilder(CRM_Civicase_Service_ContactCustomFieldsProvider::class)
+      ->setMethods(['get'])
+      ->disableOriginalConstructor()
+      ->getMock();
+    $customFieldService->method('get')
+      ->willReturn($customFields);
+    $contactFieldService = $this->getMockBuilder(CRM_Civicase_Service_ContactFieldsProvider::class)
+      ->setMethods(['get'])
+      ->disableOriginalConstructor()
+      ->getMock();
+    $contactFieldService->method('get')
+      ->willReturn($contactFields);
+    $service = $this->getMockBuilder(AddContactTokenValues::class)
+      ->setMethods(['getContactValues'])
+      ->setConstructorArgs([$contactFieldService, $customFieldService])
+      ->getMock();
+    $service->method('getContactValues')
+      ->willReturn($values);
+
+    $service->run($contactValues, [1], 1, [CRM_Civicase_Hook_Tokens_AddContactTokens::TOKEN_KEY => ['contact_id']], '');
+
+    $this->assertEquals($result, $contactValues);
+  }
+
+  /**
+   * Provides data for run method testing.
+   *
+   * @return array
+   *   List of fields and result for get method.
+   */
+  public function getTestDataForRunMethod() {
+    return [
+      [
+        [
+          'contact_id',
+          'contact_type',
+          'contact_sub_type',
+        ],
+        [
+          'custom_11' => 'Eligible_for_Gift_Aid',
+          'custom_12' => 'Address',
+          'custom_13' => 'Post_Code',
+        ],
+        [
+          'contact_id' => 2,
+          'contact_type' => 'Individual',
+          'contact_sub_type' => '',
+          'custom_11' => 'test value',
+          'custom_12' => 'test address',
+          'custom_13' => 'test value',
+        ],
+        [
+          1 => [
+            'current_user.contact_contact_id' => 2,
+            'current_user.contact_contact_type' => 'Individual',
+            'current_user.contact_contact_sub_type' => '',
+            'current_user.contact_Eligible_for_Gift_Aid' => 'test value',
+            'current_user.contact_Address' => 'test address',
+            'current_user.contact_Post_Code' => 'test value',
+          ],
+        ],
+      ],
+      [
+        [],
+        [],
+        [],
+        [
+          1 => [],
+        ],
+      ],
+
+    ];
+  }
+
+}

--- a/tests/phpunit/CRM/Civicase/Service/ContactCustomFieldsProviderTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/ContactCustomFieldsProviderTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use CRM_Civicase_Service_ContactCustomFieldsProvider as ContactCustomFieldsProvider;
+
+/**
+ * Test class for the CRM_Civicase_Service_ContactCustomFieldsProvider.
+ *
+ * @group headless
+ */
+class CRM_Civicase_Service_ContactCustomFieldsProviderTest extends BaseHeadlessTest {
+
+  /**
+   * Test the get method.
+   *
+   * @param array $fields
+   *   List of fields.
+   * @param array $result
+   *   Expected result.
+   *
+   * @dataProvider getTestDataForGetMethod
+   */
+  public function testGet(array $fields, array $result) {
+    $service = $this->getMockBuilder(ContactCustomFieldsProvider::class)
+      ->setMethods(['getCustomFields'])
+      ->disableOriginalConstructor()
+      ->getMock();
+    $service->method('getCustomFields')
+      ->willReturn($fields);
+
+    $this->assertEquals($result, $service->get());
+  }
+
+  /**
+   * Provides data for get method testing.
+   *
+   * @return array
+   *   List of fields and result for get method.
+   */
+  public function getTestDataForGetMethod() {
+    return [
+      [
+        [],
+        [],
+      ],
+      [
+        [
+          'values' => [
+            11 => [
+              'name' => 'First test field',
+            ],
+            12 => [
+              'name' => 'Second test field',
+            ],
+          ],
+        ],
+        [
+          'custom_11' => 'First test field',
+          'custom_12' => 'Second test field',
+        ],
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
## Overview
Adds contact entity fields to tokens for currently logged in user.In addition to contact fields it also adds to tokens the custom fields that extends contact, individual, organization and household.

## Before
Previously there were core tokens for contact but that belonged to the target contact of the document.

## After
In addition to contact fields that refers to target contact there are new tokens added that belongs to currently logged in user. They follow naming convention of current_user.contact_field_name and resides in current user tokens.

## Technical Details
This pr utilizes two hooks namely hook_civicrm_token and hook_civicrm_tokenvalues. First one is used to define custom tokens that can target current user and second one is used to define values for the tokens.