### PR TITLE
RSE-1393: Add unit tests badge

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -29,7 +29,7 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.24.6 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.28.3 --web-root $GITHUB_WORKSPACE/site
 
       - uses: actions/checkout@v2
         with:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,4 @@
-# Build Status
 [![Build Status](https://github.com/compucorp/uk.co.compucorp.civicase/workflows/Tests/badge.svg)](https://github.com/compucorp/uk.co.compucorp.civicase/workflows/Tests/badge.svg)
-
-*Dependent Civicrm Extentions Build Status*
-| CiviAwards  | CiviProspect |
-| ------------- | ------------- |
-| [![CiviAwards](https://github.com/compucorp/uk.co.compucorp.civiawards/workflows/Tests/badge.svg)](https://github.com/compucorp/uk.co.compucorp.civiawards/)  | [![CiviProspect](https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/workflows/Tests/badge.svg)](https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/)  |
-
 
 # CiviCase ReadMe
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# Build Status
+[![Build Status](https://github.com/compucorp/uk.co.compucorp.civicase/workflows/Tests/badge.svg)](https://github.com/compucorp/uk.co.compucorp.civicase/workflows/Tests/badge.svg)
+
+*Dependent Civicrm Extentions Build Status*
+| CiviAwards  | CiviProspect |
+| ------------- | ------------- |
+| [![CiviAwards](https://github.com/compucorp/uk.co.compucorp.civiawards/workflows/Tests/badge.svg)](https://github.com/compucorp/uk.co.compucorp.civiawards/)  | [![CiviProspect](https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/workflows/Tests/badge.svg)](https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/)  |
+
+
 # CiviCase ReadMe
 
 The new CiviCase is a major redesign of the Case Management interface for CiviCRM, with a cleaner look, improved functionality


### PR DESCRIPTION
## Overview
As part of this PR
1. Added Github Action badges to the readme.md file, so that the status of the tests can be seen in the Repositories home page.
![2020-10-01 at 5 12 PM](https://user-images.githubusercontent.com/5058867/94804948-409a4180-0409-11eb-90d5-fc892e70ab4f.png)

2. Update Civicrm version to 5.28.3 in unit test github action.

