### PR TITLE
RSE-1296: Add a flag to notify when custom fields are not present

### DIFF
--- a/CRM/Civicase/Form/CaseCategoryTypeCustomField.php
+++ b/CRM/Civicase/Form/CaseCategoryTypeCustomField.php
@@ -63,6 +63,8 @@ abstract class CRM_Civicase_Form_CaseCategoryTypeCustomField extends CRM_Core_Fo
       $this
     );
 
+    $this->hasCustomFieldsAssigned = count($groupTree) !== 0;
+
     foreach ($groupTree as $groupValues) {
       $pageTitle = count($groupTree) > 1 ? 'Custom Group Fields' : $groupValues['title'];
       break;
@@ -80,6 +82,7 @@ abstract class CRM_Civicase_Form_CaseCategoryTypeCustomField extends CRM_Core_Fo
     $this->assign('entityID', $this->entityId);
     $this->assign('groupID', $this->groupId);
     $this->assign('subType', $this->subTypeId);
+    $this->assign('hasCustomFieldsAssigned', $this->hasCustomFieldsAssigned);
   }
 
   /**

--- a/CRM/Civicase/Form/CaseCategoryTypeCustomField.php
+++ b/CRM/Civicase/Form/CaseCategoryTypeCustomField.php
@@ -63,7 +63,7 @@ abstract class CRM_Civicase_Form_CaseCategoryTypeCustomField extends CRM_Core_Fo
       $this
     );
 
-    $this->hasCustomFieldsAssigned = count($groupTree) !== 0;
+    $hasCustomFieldsAssigned = count($groupTree) !== 0;
 
     foreach ($groupTree as $groupValues) {
       $pageTitle = count($groupTree) > 1 ? 'Custom Group Fields' : $groupValues['title'];
@@ -82,7 +82,7 @@ abstract class CRM_Civicase_Form_CaseCategoryTypeCustomField extends CRM_Core_Fo
     $this->assign('entityID', $this->entityId);
     $this->assign('groupID', $this->groupId);
     $this->assign('subType', $this->subTypeId);
-    $this->assign('hasCustomFieldsAssigned', $this->hasCustomFieldsAssigned);
+    $this->assign('hasCustomFieldsAssigned', $hasCustomFieldsAssigned);
   }
 
   /**


### PR DESCRIPTION
## Overview
This PR is related to https://github.com/compucorp/uk.co.compucorp.civiawards/pull/130.

Here we add a flag `hasCustomFieldsAssigned` to the `CRM/Civicase/Form/CaseCategoryTypeCustomField.php` file, when there are no Custom Field Sets available for the sent Entity ID.