### PR TITLE
CATL-1804: Fix role date issue

### DIFF
--- a/CRM/Civicase/Setup/AddChangeCaseRoleDateActivityTypes.php
+++ b/CRM/Civicase/Setup/AddChangeCaseRoleDateActivityTypes.php
@@ -3,7 +3,7 @@
 /**
  * Creates the Change Case Role Date activity types.
  */
-class CRM_Civicase_Setup_ChangeCaseRoleDateActivityTypeSetup {
+class CRM_Civicase_Setup_AddChangeCaseRoleDateActivityTypes {
 
   /**
    * Runs the setup commands.

--- a/CRM/Civicase/Setup/ChangeCaseRoleDateActivityTypeSetup.php
+++ b/CRM/Civicase/Setup/ChangeCaseRoleDateActivityTypeSetup.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Creates the Change Case Role Date activity types.
+ */
+class CRM_Civicase_Setup_ChangeCaseRoleDateActivityTypeSetup {
+
+  /**
+   * Runs the setup commands.
+   */
+  public function apply() {
+    $this->insertUniqueActivityType(
+      'Change Case Role Start Date',
+      ts('Change Case Role Start Date')
+    );
+    $this->insertUniqueActivityType(
+      'Change Case Role End Date',
+      ts('Change Case Role End Date')
+    );
+
+    return TRUE;
+  }
+
+  /**
+   * Creates an activity type if it doesn't already exist.
+   *
+   * @param string $name
+   *   The activity type's name.
+   * @param string $label
+   *   The activity type's label.
+   */
+  private function insertUniqueActivityType($name, $label) {
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => 'activity_type',
+      'name' => $name,
+      'label' => $label,
+      'is_active' => TRUE,
+    ]);
+  }
+
+}

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -9,6 +9,7 @@ use CRM_Civicase_Setup_UpdateMenuLinks as MenuLinksSetup;
 use CRM_Civicase_Uninstall_RemoveCustomGroupSupportForCaseCategory as RemoveCustomGroupSupportForCaseCategory;
 use CRM_Civicase_Setup_ProcessCaseCategoryForCustomGroupSupport as ProcessCaseCategoryForCustomGroupSupport;
 use CRM_Civicase_Setup_CaseCategoryInstanceSupport as CaseCategoryInstanceSupport;
+use CRM_Civicase_Setup_ChangeCaseRoleDateActivityTypeSetup as ChangeCaseRoleDateActivityTypeSetup;
 
 /**
  * Collection of upgrade steps.
@@ -75,6 +76,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
       new MoveCaseTypesToCasesCategory(),
       new CreateSafeFileExtensionOptionValue(),
       new ProcessCaseCategoryForCustomGroupSupport(),
+      new ChangeCaseRoleDateActivityTypeSetup(),
     ];
     foreach ($steps as $step) {
       $step->apply();

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -9,7 +9,7 @@ use CRM_Civicase_Setup_UpdateMenuLinks as MenuLinksSetup;
 use CRM_Civicase_Uninstall_RemoveCustomGroupSupportForCaseCategory as RemoveCustomGroupSupportForCaseCategory;
 use CRM_Civicase_Setup_ProcessCaseCategoryForCustomGroupSupport as ProcessCaseCategoryForCustomGroupSupport;
 use CRM_Civicase_Setup_CaseCategoryInstanceSupport as CaseCategoryInstanceSupport;
-use CRM_Civicase_Setup_ChangeCaseRoleDateActivityTypeSetup as ChangeCaseRoleDateActivityTypeSetup;
+use CRM_Civicase_Setup_AddChangeCaseRoleDateActivityTypes as AddChangeCaseRoleDateActivityTypes;
 
 /**
  * Collection of upgrade steps.
@@ -76,7 +76,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
       new MoveCaseTypesToCasesCategory(),
       new CreateSafeFileExtensionOptionValue(),
       new ProcessCaseCategoryForCustomGroupSupport(),
-      new ChangeCaseRoleDateActivityTypeSetup(),
+      new AddChangeCaseRoleDateActivityTypes(),
     ];
     foreach ($steps as $step) {
       $step->apply();

--- a/CRM/Civicase/Upgrader/Steps/Step0013.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0013.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_Civicase_Setup_ChangeCaseRoleDateActivityTypeSetup as ChangeCaseRoleDateActivityTypeSetup;
+use CRM_Civicase_Setup_AddChangeCaseRoleDateActivityTypes as AddChangeCaseRoleDateActivityTypes;
 
 /**
  * Creates the activity types for case role date changes.
@@ -14,7 +14,7 @@ class CRM_Civicase_Upgrader_Steps_Step0013 {
    *   Return value in boolean.
    */
   public function apply() {
-    $step = new ChangeCaseRoleDateActivityTypeSetup();
+    $step = new AddChangeCaseRoleDateActivityTypes();
     $step->apply();
 
     return TRUE;

--- a/CRM/Civicase/Upgrader/Steps/Step0013.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0013.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_Civicase_Setup_ChangeCaseRoleDateActivityTypeSetup as ChangeCaseRoleDateActivityTypeSetup;
+
 /**
  * Creates the activity types for case role date changes.
  */
@@ -12,33 +14,10 @@ class CRM_Civicase_Upgrader_Steps_Step0013 {
    *   Return value in boolean.
    */
   public function apply() {
-    $this->insertUniqueActivityType(
-      'Change Case Role Start Date',
-      ts('Change Case Role Start Date')
-    );
-    $this->insertUniqueActivityType(
-      'Change Case Role End Date',
-      ts('Change Case Role End Date')
-    );
+    $step = new ChangeCaseRoleDateActivityTypeSetup();
+    $step->apply();
 
     return TRUE;
-  }
-
-  /**
-   * Creates an activity type if it doesn't already exist.
-   *
-   * @param string $name
-   *   The activity type's name.
-   * @param string $label
-   *   The activity type's label.
-   */
-  private function insertUniqueActivityType($name, $label) {
-    CRM_Core_BAO_OptionValue::ensureOptionValueExists([
-      'option_group_id' => 'activity_type',
-      'name' => $name,
-      'label' => $label,
-      'is_active' => TRUE,
-    ]);
   }
 
 }

--- a/ang/civicase/case/details/people-tab/services/role-dates-updater.service.js
+++ b/ang/civicase/case/details/people-tab/services/role-dates-updater.service.js
@@ -28,19 +28,8 @@
     }
 
     /**
-     * @param {object} params List of parameters used for building the change
-     *   relationship date's API calls.
-     * @param {string} params.activityTypeId Name of the activity type that will
-     *   be used when recording the date change.
-     *   Ex: "Change Case Role End Date".
-     * @param {string} params.caseId The ID of the case the activity will belong
-     *   to.
-     * @param {string} params.dateFieldLabel Human readable name for the date
-     *   field. Example: "start date".
-     * @param {string} params.dateFieldName Name of the date field as defined
-     *   in the endpoint.
-     * @param {object} params.role Role object as returned by the People's tab
-     *   role service.
+     * @param {RoleDateChangeParams} params List of parameters used for building
+     *   the change role date's API calls.
      * @returns {Array} a list of API calls for updating the date for each case
      *   relation and also create an activity that records the change done to the
      *   date.
@@ -48,12 +37,9 @@
     function getApiCallsForDate (params) {
       var role = params.role;
       var caseId = params.caseId;
-      var previousDateValue = role.previousValues[params.dateFieldName];
       var currentDateValue = role.relationship[params.dateFieldName];
+      var subject = getRoleDateChangeActivitySubject(params);
       var relationshipApiCallParams = {};
-      var subject = role.display_name + ', with ' + role.role + ' case role,' +
-        ' had ' + params.dateFieldLabel + ' changed from ' +
-        formatDate(previousDateValue) + ' to ' + formatDate(currentDateValue);
       relationshipApiCallParams[params.dateFieldName] = currentDateValue;
 
       return _([])
@@ -104,6 +90,30 @@
     }
 
     /**
+     * @param {RoleDateChangeParams} params List of parameters used for building
+     *   the change role date's API calls.
+     * @returns {string} Returns the subject used for the activity that gets
+     *   recorded when the role's start or end date changes.
+     */
+    function getRoleDateChangeActivitySubject (params) {
+      var role = params.role;
+      var previousDateValue = role.previousValues[params.dateFieldName];
+      var currentDateValue = role.relationship[params.dateFieldName];
+      var subject = role.display_name + ', with ' + role.role + ' case role,' +
+        ' had ' + params.dateFieldLabel + ' changed';
+
+      if (previousDateValue) {
+        subject += ' from ' + formatDate(previousDateValue);
+      }
+
+      if (currentDateValue) {
+        subject += ' to ' + formatDate(currentDateValue);
+      }
+
+      return subject;
+    }
+
+    /**
      * @param {object} role A role object as provided by the roles service.
      * @param {object} extraParams Extra parameters to pass to each one of the
      *   relationship update api calls.
@@ -130,5 +140,20 @@
     function updatePreviousValue (role, fieldName) {
       role.previousValues[fieldName] = role.relationship[fieldName];
     }
+
+    /**
+     * @typedef {object} RoleDateChangeParams
+     * @param {string} activityTypeId Name of the activity type that will
+     *   be used when recording the date change.
+     *   Ex: "Change Case Role End Date".
+     * @param {string} caseId The ID of the case the activity will belong
+     *   to.
+     * @param {string} dateFieldLabel Human readable name for the date
+     *   field. Example: "start date".
+     * @param {string} dateFieldName Name of the date field as defined
+     *   in the endpoint.
+     * @param {object} role Role data as returned by the People's tab
+     *   role service.
+     */
   }
 })(CRM._, CRM.$, angular);

--- a/ang/test/civicase/case/details/people-tab/services/role-dates-updater.service.spec.js
+++ b/ang/test/civicase/case/details/people-tab/services/role-dates-updater.service.spec.js
@@ -108,6 +108,46 @@
       });
     });
 
+    describe('when the previous role date is not defined', () => {
+      beforeEach(() => {
+        delete roleData.previousValues.start_date;
+
+        roleData.relationship.start_date = '2000-01-31';
+        returnedApiCalls = roleDatesUpdater.getApiCallsForStartDate(
+          roleData,
+          caseId
+        );
+      });
+
+      it('does not add the previous role date to the activity subject', () => {
+        expect(returnedApiCalls).toEqual(jasmine.arrayContaining([
+          ['Activity', 'create', jasmine.objectContaining({
+            subject: 'Jon Snow, with Ranger case role, had start date changed to 31/01/2000'
+          })]
+        ]));
+      });
+    });
+
+    describe('when the current role date is not defined', () => {
+      beforeEach(() => {
+        delete roleData.relationship.start_date;
+
+        roleData.previousValues.start_date = '2000-01-31';
+        returnedApiCalls = roleDatesUpdater.getApiCallsForStartDate(
+          roleData,
+          caseId
+        );
+      });
+
+      it('does not add the current role date to the activity subject', () => {
+        expect(returnedApiCalls).toEqual(jasmine.arrayContaining([
+          ['Activity', 'create', jasmine.objectContaining({
+            subject: 'Jon Snow, with Ranger case role, had start date changed from 31/01/2000'
+          })]
+        ]));
+      });
+    });
+
     describe('when updating the previous end date value', () => {
       beforeEach(() => {
         roleData.relationship.end_date = '2000-12-31';

--- a/package-lock.json
+++ b/package-lock.json
@@ -3517,7 +3517,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3934,7 +3935,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3990,6 +3992,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4033,12 +4036,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
## Overview

This PR fixes an issue related to the role date change introduced in https://github.com/compucorp/uk.co.compucorp.civicase/pull/581 If the previous date role was missing, it would throw an error.

## Before
![gif](https://user-images.githubusercontent.com/1642119/95147471-cf32f980-074e-11eb-910c-0c84bf44368e.gif)


## After
![gif](https://user-images.githubusercontent.com/1642119/95147970-4026e100-0750-11eb-8329-a8147b5ffc9e.gif)


## Technical Details

The issue happened because we use jQuery's parser function to parse the previous role date. Since the date was not defined the parser would throw an error. To avoid this we modified the function so it would omit the dates that are missing from the activity's subject. This also improves the subject's structure.

## Comments

* The package lock file was updated so it now is similar to the output produced by the right NPM version, which is defined by the NVM config file in the repo.
* The upgrader that added the activity types for the change role date was refactored so it can run on new installations and existing ones. This is how the result look in a new site:
![Screen Shot 2020-10-06 at 10 00 22 AM](https://user-images.githubusercontent.com/1642119/95211904-1ce54b80-07bb-11eb-8c46-f0818040e024.png)

