### PR TITLE
CATL-1806: Fix active case relationship

### DIFF
--- a/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
+++ b/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
@@ -205,7 +205,7 @@
             startDateTimestamp: moment(relationship.start_date).valueOf()
           });
         })
-        .sortByAll(['is_active', 'startDateTimestamp'])
+        .sortBy('startDateTimestamp')
         .groupBy(function (relationship) {
           return [
             relationship.contact_id_b,
@@ -213,7 +213,12 @@
           ].join();
         })
         .map(function (relationships) {
-          var relationship = _.first(relationships);
+          var relationship = _.find(relationships, { is_active: '1' });
+
+          if (!relationship) {
+            relationship = _.first(relationships);
+          }
+
           relationship.relationship_ids = _.map(relationships, 'id');
 
           return relationship;

--- a/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
+++ b/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
@@ -142,6 +142,47 @@
           }));
         });
       });
+
+      describe('when the same contact holds multiple active and inactive roles', () => {
+        beforeEach(() => {
+          const mixedRelationships = [
+            _.extend({}, relationships[0], { is_active: '0' }),
+            _.extend({}, relationships[0], { contact_id_b: _.unique(), is_active: '0' }),
+            _.extend({}, relationships[0], { is_active: '1' })
+          ];
+
+          peopleTabRoles.setCaseRelationships(mixedRelationships);
+          peopleTabRoles.updateRolesList();
+        });
+
+        it('includes the role relationship and marks it as active', () => {
+          expect(peopleTabRoles.list).toContain(jasmine.objectContaining({
+            contact_id: relationships[0].contact_id_b,
+            relationship: jasmine.objectContaining({
+              is_active: '1'
+            })
+          }));
+        });
+      });
+
+      describe('when the same contact holds multiple inactive roles', () => {
+        beforeEach(() => {
+          const inactiveRelationships = [
+            _.extend({}, relationships[0], { is_active: '0' }),
+            _.extend({}, relationships[0], { contact_id_b: _.unique(), is_active: '0' }),
+            _.extend({}, relationships[0], { is_active: '0' })
+          ];
+
+          peopleTabRoles.setCaseRelationships(inactiveRelationships);
+          peopleTabRoles.updateRolesList();
+        });
+
+        it('does not include the contact relation since all of its relationships to the case are not active', () => {
+          expect(peopleTabRoles.list).not.toContain(jasmine.objectContaining({
+            contact_id: relationships[0].contact_id_b
+          }));
+        });
+      });
     });
 
     describe('filtering', () => {


### PR DESCRIPTION
## Overview
This PR fixes an issue where active case relationships would not be properly displayed if the contact had a previous inactive relationship to the case.

## Before
![gif](https://user-images.githubusercontent.com/1642119/95151540-e4ad2100-0758-11eb-8578-260fcc858488.gif)

## After
![gif](https://user-images.githubusercontent.com/1642119/95152306-c5af8e80-075a-11eb-9aae-718392e68377.gif)


## Technical Details

The issue happened because when we were grouping the case role relationships in the `getUniqueCaseRelationships`, we were sorting them by the `is_active` field. Since some of the values would contain `0`, this would be sorted first and would be the value used as the representative of the group even if there was another active case for the same contact. This in turn meant that the contact would not be displayed.

To fix the issue we don't sort by the active field, but find the active role when grouping them. If no active role is displayed, we select the first in the group.
