### PR TITLE
CATL-1803: Use provided start date when reassigning roles

### DIFF
--- a/CRM/Civicase/Service/CaseRoleCreationPreProcess.php
+++ b/CRM/Civicase/Service/CaseRoleCreationPreProcess.php
@@ -16,7 +16,11 @@ class CRM_Civicase_Service_CaseRoleCreationPreProcess extends CRM_Civicase_Servi
    *   API request parameters.
    */
   public function onCreate(array &$requestParams) {
-    if ($this->isSingleCaseRole && !$this->isMultiClient) {
+    if (
+      ($this->isSingleCaseRole && !$this->isMultiClient) &&
+      (!isset($requestParams['params']['start_date']) ||
+      empty($requestParams['params']['start_date']))
+    ) {
       $requestParams['params']['start_date'] = date('Y-m-d');
     }
   }

--- a/CRM/Civicase/Service/CaseRoleCreationPreProcess.php
+++ b/CRM/Civicase/Service/CaseRoleCreationPreProcess.php
@@ -17,9 +17,8 @@ class CRM_Civicase_Service_CaseRoleCreationPreProcess extends CRM_Civicase_Servi
    */
   public function onCreate(array &$requestParams) {
     if (
-      ($this->isSingleCaseRole && !$this->isMultiClient) &&
-      (!isset($requestParams['params']['start_date']) ||
-      empty($requestParams['params']['start_date']))
+      $this->isSingleCaseRole && !$this->isMultiClient &&
+      empty($requestParams['params']['start_date'])
     ) {
       $requestParams['params']['start_date'] = date('Y-m-d');
     }

--- a/tests/phpunit/CRM/Civicase/Service/CaseRoleCreationPreProcessTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseRoleCreationPreProcessTest.php
@@ -12,14 +12,28 @@ class CRM_Civicase_Service_CaseRoleCreationPreProcessTest extends BaseHeadlessTe
 
   /**
    * Test start date is modified when single case role setting on.
+   *
+   * Start date must be empty or NULL.
    */
   public function testStartDateIsModifiedWhenSingleCaseRoleSettingIsOnAndMultiClientIsOff() {
     $this->setSingleCaseRoleSetting(TRUE);
     $this->setMultiClientCaseSetting(FALSE);
-    $params = ['start_date' => '2020-06-05'];
+    $params = ['start_date' => ''];
     $apiRequestParams = $this->callPreProcessCreate($params);
 
     $this->assertEquals(date('Y-m-d'), $apiRequestParams['params']['start_date']);
+  }
+
+  /**
+   * Test the start date is not modified when it is present.
+   */
+  public function testStartDateNotModifiedWhenPresent() {
+    $this->setSingleCaseRoleSetting(TRUE);
+    $this->setMultiClientCaseSetting(FALSE);
+
+    $params = ['start_date' => '2020-06-05'];
+    $apiRequestParams = $this->callPreProcessCreate($params);
+    $this->assertEquals($params['start_date'], $apiRequestParams['params']['start_date']);
   }
 
   /**

--- a/tests/phpunit/api/v3/CaseRoleCreationTest.php
+++ b/tests/phpunit/api/v3/CaseRoleCreationTest.php
@@ -54,7 +54,7 @@ class api_v3_CaseRoleCreationTest extends BaseHeadlessTest {
       'contact_id_a' => $client['id'],
       'relationship_type_id' => $relationshipTypeA['id'],
       'case_id' => $case['id'],
-      'start_date' => '2020-06-01',
+      'start_date' => '',
     ];
 
     // PostProcessing Should Be Triggered Here.


### PR DESCRIPTION
## Overview
This PR fixes an issue where the role start date is always set to today, even if a different date is provided. This happens when creating or reassigning a case role.

## Before
![gif](https://user-images.githubusercontent.com/1642119/95362823-a6207f00-089c-11eb-9fb6-2f55e41ba917.gif)

## After
![gif](https://user-images.githubusercontent.com/1642119/95363034-eb44b100-089c-11eb-9b60-bc8006597d23.gif)

## Technical Details

This issue was introduced by the `CRM_Civicase_Service_CaseRoleCreationPreProcess` class which was added in https://github.com/compucorp/uk.co.compucorp.civicase/pull/557

The reason for this class was to automatically set the default date as today and fixes issues with webforms, specifically when dealing with single case roles.

To fix this we only set the current date to today when working with single case roles, but also the start date is empty.