### PR TITLE
CATL-1852: Fix limit for adding roles

### DIFF
--- a/ang/civicase/case/details/people-tab/directives/roles-tab.directive.html
+++ b/ang/civicase/case/details/people-tab/directives/roles-tab.directive.html
@@ -130,7 +130,7 @@
           <label for="select-role-{{ $index }}">
             <div>
               <strong>{{ role.role }}</strong>
-              <span class="badge" ng-if="role.isPastRole">
+              <span class="badge" ng-if="role.is_active === '0'">
                 Past
               </span>
             </div>

--- a/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
+++ b/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
@@ -24,12 +24,19 @@
     roles.updateRolesList = updateRolesList;
 
     /**
-     * Assign number of roles present per type of relationship
+     * Assign number of roles present per type of relationship.
+     *
+     * For case roles, it will only count them if they are active.
      */
     function assignCountOfRolesPerType () {
       _.each(roles.caseTypeRoles, function (caseTypeRole) {
         caseTypeRole.count = _.filter(roles.list, function (role) {
-          return role.display_name && role.name === caseTypeRole.name;
+          var roleIsAssigned = !!role.display_name;
+          var roleBelongsToType = role.role === caseTypeRole.role;
+          var isClientRole = role.role === ts('Client');
+
+          return roleIsAssigned && roleBelongsToType &&
+            (isClientRole || !role.isPastRole);
         }).length;
       });
     }

--- a/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
+++ b/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
@@ -36,7 +36,7 @@
           var isClientRole = role.role === ts('Client');
 
           return roleIsAssigned && roleBelongsToType &&
-            (isClientRole || !role.isPastRole);
+            (isClientRole || role.is_active === '1');
         }).length;
       });
     }
@@ -137,7 +137,7 @@
               desc: caseRelation.description,
               display_name: contact.display_name,
               email: contact.email,
-              isPastRole: caseRelation.is_active === '0',
+              is_active: caseRelation.is_active,
               phone: contact.phone,
               relationship_type_id: caseTypeRole.relationship_type_id,
               role: caseTypeRole.role,

--- a/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
+++ b/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
@@ -134,6 +134,58 @@
       });
     });
 
+    describe('role types and counts', () => {
+      describe('when building the list of roles', () => {
+        let listOfCaseRoles;
+
+        beforeEach(() => {
+          listOfCaseRoles = caseType.definition.caseRoles
+            .map((caseRole) => jasmine.objectContaining({
+              role: caseRole.name
+            }));
+
+          peopleTabRoles.updateRolesList();
+        });
+
+        it('contains the full list of case role types', () => {
+          expect(peopleTabRoles.caseTypeRoles).toEqual(listOfCaseRoles);
+        });
+
+        it('adds a count for assigned roles', () => {
+          expect(peopleTabRoles.caseTypeRoles).toContain(jasmine.objectContaining({
+            role: caseType.definition.caseRoles[0].name,
+            count: 1
+          }));
+        });
+
+        it('does not add a count for unnasigned roles', () => {
+          expect(peopleTabRoles.caseTypeRoles).toContain(jasmine.objectContaining({
+            role: caseType.definition.caseRoles[1].name,
+            count: 0
+          }));
+        });
+      });
+
+      describe('when some case roles have been unnasigned', () => {
+        beforeEach(() => {
+          relationships = [
+            _.extend({}, relationships[0], { is_active: '0' }),
+            _.extend({}, relationships[0], { is_active: '1' })
+          ];
+
+          peopleTabRoles.setCaseRelationships(relationships);
+          peopleTabRoles.updateRolesList();
+        });
+
+        it('does not add a count for unnasigned roles', () => {
+          expect(peopleTabRoles.caseTypeRoles).toContain(jasmine.objectContaining({
+            role: caseType.definition.caseRoles[0].name,
+            count: 1
+          }));
+        });
+      });
+    });
+
     describe('filtering', () => {
       describe('when filtering roles by type', () => {
         beforeEach(() => {

--- a/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
+++ b/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
@@ -99,7 +99,7 @@
             desc: caseRelation.description,
             display_name: caseManager.display_name,
             email: caseManager.email,
-            isPastRole: caseRelation.is_active === '0',
+            is_active: caseRelation.is_active,
             phone: caseManager.phone,
             relationship_type_id: caseRelation.relationship_type_id,
             role: caseTypeRole.name,


### PR DESCRIPTION
## Overview
This PR fixes an issue when working with single case roles. https://github.com/compucorp/uk.co.compucorp.civicase/pull/574 introduced a regression where multiple case roles could be added even if the setting forbade this.

## Before
![gif](https://user-images.githubusercontent.com/1642119/95390408-5bfec400-08c3-11eb-99bc-45e1b5ddfa85.gif)

## After
![gif](https://user-images.githubusercontent.com/1642119/95391739-94070680-08c5-11eb-9798-5178478391d6.gif)

## Technical Details

Counting the number of case roles was already in place before refactoring the code into the role service. The count is used to know if more contacts can be assigned to a particular case role. There were two issues with the original approach:

1. We were using the field `name` instead of `role`. Name does not exist in either object.
2. Inactive case roles would be taken into consideration, a feature the previous implementation didn't have a problem with because it didn't support it. After allowing listing past case roles, we should only count the ones that are active.

Unit tests were missing in the original implementation. Tests have been added to cover the two scenarios discussed above.
