### PR TITLE
RSE-1375: Create New Permissions to access Workflows List page

### DIFF
--- a/CRM/Civicase/Service/CaseCategoryPermission.php
+++ b/CRM/Civicase/Service/CaseCategoryPermission.php
@@ -3,7 +3,7 @@
 use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 
 /**
- * Class CRM_Civicase_Service_CaseCategoryPermission.
+ * Helper class for case category permissions.
  */
 class CRM_Civicase_Service_CaseCategoryPermission {
 
@@ -49,6 +49,11 @@ class CRM_Civicase_Service_CaseCategoryPermission {
         'name' => $this->replaceWords('basic case information', $caseCategoryName),
         'label' => $this->replaceWords('CiviCase: basic case information', $caseCategoryName),
         'description' => $this->replaceWords('Allows a user to view only basic information of cases.', $caseCategoryName),
+      ],
+      'ADMINISTER_CASE_CATEGORY' => [
+        'name' => $this->replaceWords('administer CiviCase', $caseCategoryName),
+        'label' => $this->replaceWords('CiviCase: administer CiviCase', $caseCategoryName),
+        'description' => 'Allows a user to manage case types for this instance of CiviCase only',
       ],
     ];
   }

--- a/ang/civicase-base/services/crm-load-form.service.js
+++ b/ang/civicase-base/services/crm-load-form.service.js
@@ -1,0 +1,7 @@
+(function (loadForm, angular) {
+  var module = angular.module('civicase-base');
+
+  module.service('civicaseCrmLoadForm', function () {
+    return loadForm;
+  });
+})(CRM.loadForm, angular);

--- a/ang/civicase-base/services/crm-url.service.js
+++ b/ang/civicase-base/services/crm-url.service.js
@@ -1,0 +1,7 @@
+(function (url, angular) {
+  var module = angular.module('civicase-base');
+
+  module.service('civicaseCrmUrl', function () {
+    return url;
+  });
+})(CRM.url, angular);

--- a/ang/civicase/case/actions/directives/case-actions.directive.js
+++ b/ang/civicase/case/actions/directives/case-actions.directive.js
@@ -2,7 +2,7 @@
   var module = angular.module('civicase');
 
   module.directive('civicaseCaseActions', function ($rootScope,
-    $injector, allowCaseLocks, CaseActions) {
+    $injector, allowCaseLocks, CaseActions, civicaseCrmLoadForm) {
     return {
       restrict: 'A',
       templateUrl: '~/civicase/case/actions/directives/case-actions.directive.html',
@@ -109,7 +109,7 @@
 
           // Mimic the behavior of CRM.popup()
           var formData = false;
-          var dialog = CRM.loadForm(url)
+          var dialog = civicaseCrmLoadForm(url)
             // Listen for success events and buffer them so we only trigger once
             .on('crmFormSuccess crmPopupFormSuccess', function (e, data) {
               formData = data;

--- a/ang/test/civicase-base/services/crm-load-form.service.spec.js
+++ b/ang/test/civicase-base/services/crm-load-form.service.spec.js
@@ -1,0 +1,23 @@
+/* eslint-env jasmine */
+
+((loadForm) => {
+  describe('crm load form service', () => {
+    let civicaseCrmLoadForm;
+
+    beforeEach(module('civicase-base'));
+
+    beforeEach(inject((_civicaseCrmLoadForm_) => {
+      civicaseCrmLoadForm = _civicaseCrmLoadForm_;
+    }));
+
+    describe('when calling service', () => {
+      beforeEach(() => {
+        civicaseCrmLoadForm('param1', 'param2');
+      });
+
+      it('calls the loadform function defined in core with same parameters', () => {
+        expect(loadForm).toHaveBeenCalledWith('param1', 'param2');
+      });
+    });
+  });
+})(CRM.loadForm);

--- a/ang/test/civicase-base/services/crm-url.service.spec.js
+++ b/ang/test/civicase-base/services/crm-url.service.spec.js
@@ -1,0 +1,23 @@
+/* eslint-env jasmine */
+
+((url) => {
+  describe('crm url service', () => {
+    let civicaseCrmUrl;
+
+    beforeEach(module('civicase-base'));
+
+    beforeEach(inject((_civicaseCrmUrl_) => {
+      civicaseCrmUrl = _civicaseCrmUrl_;
+    }));
+
+    describe('when calling service', () => {
+      beforeEach(() => {
+        civicaseCrmUrl('param1', 'param2');
+      });
+
+      it('calls the url function defined in core with same parameters', () => {
+        expect(url).toHaveBeenCalledWith('param1', 'param2');
+      });
+    });
+  });
+})(CRM.url);

--- a/ang/test/civicase/case/actions/directives/case-actions.directive.spec.js
+++ b/ang/test/civicase/case/actions/directives/case-actions.directive.spec.js
@@ -1,18 +1,55 @@
 /* eslint-env jasmine */
 
-(function (_) {
+(function (_, $) {
   describe('case actions', function () {
-    let element, $provide, $compile, $rootScope, CaseActionsData;
+    let element, $provide, $compile, $rootScope, CaseActionsData,
+      PrintCaseAction, loadFormOnListener, crmFormSuccessFunction,
+      dialogCloseFunction, originalTriggerFunction, civicaseCrmLoadForm;
 
     beforeEach(module('civicase', 'civicase.data', 'civicase.templates', (_$provide_) => {
       $provide = _$provide_;
+
+      $provide.service('PrintCaseAction', function () {
+        this.doAction = jasmine.createSpy('doAction');
+        this.refreshData = jasmine.createSpy('refreshData');
+        this.isActionAllowed = jasmine.createSpy('isActionAllowed');
+        this.isActionAllowed.and.returnValue(true);
+      });
+
+      var civicaseCrmLoadFormSpy = jasmine.createSpy('loadForm');
+      loadFormOnListener = jasmine.createSpyObj('', ['on']);
+      loadFormOnListener.on.and.callFake(function () {
+        if (arguments[0] === 'crmFormSuccess crmPopupFormSuccess') {
+          crmFormSuccessFunction = arguments[1];
+        } else if (arguments[0] === 'dialogclose.crmPopup') {
+          dialogCloseFunction = arguments[1];
+        }
+
+        return loadFormOnListener;
+      });
+      civicaseCrmLoadFormSpy.and.returnValue(loadFormOnListener);
+      $provide.service('civicaseCrmLoadForm', function () {
+        return civicaseCrmLoadFormSpy;
+      });
     }));
 
-    beforeEach(inject(function (_$compile_, _$rootScope_, _CaseActionsData_) {
+    beforeEach(inject(function (_$compile_, _$rootScope_, _CaseActionsData_,
+      _PrintCaseAction_, _civicaseCrmLoadForm_) {
       $compile = _$compile_;
       $rootScope = _$rootScope_;
       CaseActionsData = _CaseActionsData_;
+      PrintCaseAction = _PrintCaseAction_;
+      civicaseCrmLoadForm = _civicaseCrmLoadForm_;
+
+      spyOn($rootScope, '$broadcast');
+
+      originalTriggerFunction = $.fn.trigger;
+      spyOn($.fn, 'trigger');
     }));
+
+    afterEach(function () {
+      $.fn.trigger = originalTriggerFunction;
+    });
 
     describe('basic tests', () => {
       beforeEach(() => {
@@ -106,6 +143,20 @@
 
     describe('visibility of the action', () => {
       var action;
+
+      describe('basic test', () => {
+        beforeEach(() => {
+          compileDirective();
+
+          action = _.find(CaseActionsData.get(), (action) => {
+            return action.action === 'Print';
+          });
+        });
+
+        it('calls the individual service of the action', () => {
+          expect(PrintCaseAction.isActionAllowed).toHaveBeenCalled();
+        });
+      });
 
       describe('when lock cases action', () => {
         describe('and cases can be locked', () => {
@@ -217,6 +268,139 @@
         });
       });
     });
+
+    describe('when clicking on an action', () => {
+      var action;
+
+      describe('if the action is not enabled', () => {
+        beforeEach(() => {
+          compileDirective();
+
+          action = _.find(CaseActionsData.get(), (action) => {
+            return action.action === 'Print';
+          });
+
+          spyOn(element.isolateScope(), 'isActionEnabled');
+          element.isolateScope().isActionEnabled.and.returnValue(false);
+
+          element.isolateScope().doAction(action);
+        });
+
+        it('does not allow clicking on the action', () => {
+          expect(PrintCaseAction.doAction).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('if the action is enabled', () => {
+        beforeEach(() => {
+          compileDirective();
+
+          action = _.find(CaseActionsData.get(), (action) => {
+            return action.action === 'Print';
+          });
+
+          spyOn(element.isolateScope(), 'isActionEnabled');
+          element.isolateScope().isActionEnabled.and.returnValue(true);
+        });
+
+        describe('basic test', () => {
+          beforeEach(() => {
+            element.isolateScope().doAction(action);
+          });
+
+          it('allows clicking on the action', () => {
+            expect(PrintCaseAction.doAction).toHaveBeenCalled();
+          });
+        });
+
+        describe('when the action returns an object', () => {
+          beforeEach(() => {
+            PrintCaseAction.doAction.and.returnValue({
+              query: {
+                civicase_reload: ''
+              },
+              path: 'some_path'
+            });
+            CRM.url.and.returnValue('CRM Mock URL');
+            element.isolateScope().popupParams = jasmine.createSpy('popupParams');
+            element.isolateScope().popupParams.and.returnValue('some_params');
+
+            element.isolateScope().doAction(action);
+          });
+
+          it('opens a new form based on returned parameters', () => {
+            expect(civicaseCrmLoadForm)
+              .toHaveBeenCalledWith('CRM Mock URL');
+          });
+
+          it('listenes for the form success event', () => {
+            expect(loadFormOnListener.on)
+              .toHaveBeenCalledWith('crmFormSuccess crmPopupFormSuccess', jasmine.any(Function));
+          });
+
+          it('listenes for the popup close event', () => {
+            expect(loadFormOnListener.on)
+              .toHaveBeenCalledWith('dialogclose.crmPopup', jasmine.any(Function));
+          });
+
+          describe('when form is submitted succesfully', () => {
+            beforeEach(() => {
+              crmFormSuccessFunction(jasmine.any(Object), 'somedata');
+            });
+
+            it('refreshes the case information', () => {
+              expect($rootScope.$broadcast)
+                .toHaveBeenCalledWith('updateCaseData');
+              expect(PrintCaseAction.refreshData).toHaveBeenCalled();
+            });
+          });
+
+          describe('when form is closed', () => {
+            describe('and form data is available', () => {
+              beforeEach(() => {
+                crmFormSuccessFunction(jasmine.any(Object), 'someformdata');
+                dialogCloseFunction(jasmine.any(Object), 'somedata');
+              });
+
+              it('closes the popup', () => {
+                expect(element.trigger)
+                  .toHaveBeenCalledWith('crmPopupClose', [
+                    loadFormOnListener, 'somedata'
+                  ]);
+              });
+
+              it('refreshes the case', () => {
+                expect(element.trigger)
+                  .toHaveBeenCalledWith('crmPopupFormSuccess', [
+                    loadFormOnListener, 'someformdata'
+                  ]);
+              });
+            });
+
+            describe('and form data is not available', () => {
+              beforeEach(() => {
+                dialogCloseFunction(jasmine.any(Object), 'somedata');
+              });
+
+              it('closes the popup', () => {
+                expect(element.trigger)
+                  .toHaveBeenCalledWith('crmPopupClose', [
+                    loadFormOnListener, 'somedata'
+                  ]);
+              });
+
+              it('does not refresh the case', () => {
+                expect(element.trigger)
+                  .not.toHaveBeenCalledWith('crmPopupFormSuccess', [
+                    loadFormOnListener, 'someformdata'
+                  ]);
+              });
+            });
+          });
+        });
+      });
+    });
+
     // TODO: FINISH REST of the unit test
 
     /**
@@ -239,4 +423,4 @@
       $rootScope.$digest();
     }
   });
-})(CRM._);
+})(CRM._, CRM.$);

--- a/ang/test/workflow/action-links/controllers/workflow-duplicate.controller.spec.js
+++ b/ang/test/workflow/action-links/controllers/workflow-duplicate.controller.spec.js
@@ -108,8 +108,8 @@
 
             it('shows saving notification while save is in progress', () => {
               expect(crmStatus).toHaveBeenCalledWith({
-                start: 'Saving Workflow...',
-                success: 'Saved'
+                start: 'Duplicating Workflow...',
+                success: 'Duplicate created successfully'
               }, jasmine.any(Object));
             });
 

--- a/ang/workflow/action-links/controllers/workflow-duplicate.controller.js
+++ b/ang/workflow/action-links/controllers/workflow-duplicate.controller.js
@@ -98,8 +98,8 @@
         });
 
       return crmStatus({
-        start: $scope.ts('Saving Workflow...'),
-        success: $scope.ts('Saved')
+        start: $scope.ts('Duplicating Workflow...'),
+        success: $scope.ts('Duplicate created successfully')
       }, promise);
     }
 

--- a/config/urls/case_category_url.php
+++ b/config/urls/case_category_url.php
@@ -20,6 +20,10 @@ return [
     'url_type' => CaseCategoryFromUrl::CASE_CATEGORY_TYPE_URL,
     'param' => 'case_type_category',
   ],
+  'civicrm/workflow/a' => [
+    'url_type' => CaseCategoryFromUrl::CASE_CATEGORY_TYPE_URL,
+    'param' => 'case_type_category',
+  ],
   'civicrm/ajax/rest' => [
     'url_type' => CaseCategoryFromUrl::AJAX_TYPE_URL,
     'param' => 'case_type_id.case_type_category',

--- a/xml/Menu/civicase.xml
+++ b/xml/Menu/civicase.xml
@@ -20,7 +20,7 @@
   <item>
     <path>civicrm/workflow/a</path>
     <page_callback>CRM_Civicase_Page_WorkflowAngular</page_callback>
-    <access_arguments>access all cases and activities,access my cases and activities</access_arguments>
+    <access_arguments>administer CiviCase</access_arguments>
   </item>
   <item>
     <path>civicrm/case/webforms</path>


### PR DESCRIPTION
## Overview
As part of this PR, new permission `administer Civi<case type category>` has been created for all case type categories available in a system.

## Technical Details
1. In `CRM/Civicase/Service/CaseCategoryPermission.php`, added the new permission.
2. In `config/urls/case_category_url.php`, added `case_type_category` permission check for `civicrm/workflow/a` url.
3. In `xml/Menu/civicase.xml`, updated the permission to access workflows list page.

4. In `ang/workflow/action-links/controllers/workflow-duplicate.controller.js`, changed the Notification message to match the requirements.

5. Also added new unit tests. And in this process, created 2 new services `civicaseCrmLoadForm` and `civicaseCrmUrl`, which encapsulate `CRM.loadForm` and `CRM.url` global JS functions. Reasoning behind creating this, is that we should not use global variables as much as possible, and instead try to encapsulate things in angular scope. This created a lot of issues while writing unit tests too, as spying on global variables created unnecessary results. In future we will replace usage of all global variables.


