### PR TITLE
CPS-347: Release v1.9.2

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/compucorp/uk.co.compucorp.civicase/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2020-09-28</releaseDate>
-  <version>1.9.1</version>
+  <releaseDate>2020-10-09</releaseDate>
+  <version>1.9.2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.24</ver>


### PR DESCRIPTION
## Release Update - 09th October, 2020

**New Features**
* Add a new permission to restrict the export of reports and case information. [CATL-1585](https://github.com/compucorp/uk.co.compucorp.civicase/pull/584).


**Enhancements**
* End date is visible for a case role in peoples tab while adding/updating case roles. [CATL-1591](https://github.com/compucorp/uk.co.compucorp.civicase/pull/575).
* Introduce an inline date picker for case role start and end date while adding/updating case roles. [CATL-1592](https://github.com/compucorp/uk.co.compucorp.civicase/pull/585).
* Past case roles are visible in peoples tab. [CATL-1593](https://github.com/compucorp/uk.co.compucorp.civicase/pull/574).
* Add New tokens for current user while creating pdf and emails. [CATL-1785](https://github.com/compucorp/uk.co.compucorp.civicase/pull/590)


**Bug Fixes**
* Fix clear filter buttons issue on redirect in manage cases page. [CATL-1675](https://github.com/compucorp/uk.co.compucorp.civicase/pull/586).


**Developer Updates**
* Add a flag to determine if custom fields are not present. [RSE-1296](https://github.com/compucorp/uk.co.compucorp.civicase/pull/592).
* Add unit test badge to Readme.md file. [RSE-1288](https://github.com/compucorp/uk.co.compucorp.civicase/pull/591)