### PR TITLE
Contact Case Tab: fix Go To Case link

### DIFF
--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.js
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.js
@@ -38,8 +38,8 @@
       var caseTypeCategoryId = caseItem['case_type_id.case_type_category'];
       var caseTypeCategoryName = CaseTypeCategory.getAll()[caseTypeCategoryId].name;
 
-      return '/civicrm/case/a/?case_type_category=' + caseTypeCategoryName +
-        '#/case/list?caseId=' + caseItem.id + '&focus=1&all_statuses=1';
+      return CRM.url('civicrm/case/a/', 'case_type_category=' + caseTypeCategoryName +
+        '#/case/list?caseId=' + caseItem.id + '&focus=1&all_statuses=1');
     }
   }
 })(angular, CRM.$, CRM._);

--- a/ang/test/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.spec.js
+++ b/ang/test/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.spec.js
@@ -24,9 +24,9 @@
           .sample()
           .value();
         mockCase['case_type_id.case_type_category'] = caseTypeCategory.value;
-        expectedUrl = '/civicrm/case/a/' +
+        expectedUrl = CRM.url('/civicrm/case/a/',
           `?case_type_category=${caseTypeCategory.name}` +
-          `#/case/list?caseId=${mockCase.id}&focus=1&all_statuses=1`;
+          `#/case/list?caseId=${mockCase.id}&focus=1&all_statuses=1`);
         returnedUrl = $scope.getCaseDetailsUrl(mockCase);
       });
 


### PR DESCRIPTION
## Overview

When viewing a contact's case tab, the "Go To Case" link is hardcoded. Depending on the CMS configuration, this can lead to odd behaviours.

![civicase-link-2020-10-09_16-35](https://user-images.githubusercontent.com/254741/95629246-8a100f80-0a4d-11eb-8833-866675c2059a.png)

## Before

bad

## After

good

## Technical Details

Fixed with `CRM.url()`.

### Core overrides

n/a

## Comments

:tea: 