### PR TITLE
CATL-1823: Make subject field required in create pdf form

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/MakePdfFormSubjectRequired.php
+++ b/CRM/Civicase/Hook/BuildForm/MakePdfFormSubjectRequired.php
@@ -3,7 +3,7 @@
 /**
  * Makes the subject field required in the create PDF form.
  */
-class CRM_Civicase_Hook_BuildForm_PdfFormSubjectRequired {
+class CRM_Civicase_Hook_BuildForm_MakePdfFormSubjectRequired {
 
   /**
    * Makes the subject field required in the create PDF form.

--- a/CRM/Civicase/Hook/BuildForm/PdfFormSubjectRequired.php
+++ b/CRM/Civicase/Hook/BuildForm/PdfFormSubjectRequired.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Makes the subject field required in the create PDF form.
+ */
+class CRM_Civicase_Hook_BuildForm_PdfFormSubjectRequired {
+
+  /**
+   * Makes the subject field required in the create PDF form.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   * @param string $formName
+   *   Form Name.
+   */
+  public function run(CRM_Core_Form &$form, $formName) {
+    if (!$this->shouldRun($formName)) {
+      return;
+    }
+    if ($form->elementExists('subject')) {
+      $form->addRule('subject', '', 'required');
+    }
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * @param string $formName
+   *   Form class object.
+   *
+   * @return bool
+   *   returns a boolean to determine if hook will run or not.
+   */
+  private function shouldRun($formName) {
+    return $formName == CRM_Contact_Form_Task_PDF::class;
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -213,6 +213,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_DisplayAllCustomGroupsInCaseForm(),
     new CRM_Civicase_Hook_BuildForm_LinkToCaseSearchByCaseId(),
     new CRM_Civicase_Hook_BuildForm_RemoveExportActionFromReports(),
+    new CRM_Civicase_Hook_BuildForm_PdfFormSubjectRequired(),
   ];
 
   foreach ($hooks as $hook) {

--- a/civicase.php
+++ b/civicase.php
@@ -213,7 +213,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_DisplayAllCustomGroupsInCaseForm(),
     new CRM_Civicase_Hook_BuildForm_LinkToCaseSearchByCaseId(),
     new CRM_Civicase_Hook_BuildForm_RemoveExportActionFromReports(),
-    new CRM_Civicase_Hook_BuildForm_PdfFormSubjectRequired(),
+    new CRM_Civicase_Hook_BuildForm_MakePdfFormSubjectRequired(),
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview
This pr makes the subject field required in the pdf create form.

## Before
Previously it was possible to fill and submit the form and create the pdf without filling the subject field.

## After
This pr stop user from submitting the pdf creation form with subject field being empty.
![121133940_592170158222650_7278002493728553904_n](https://user-images.githubusercontent.com/68388745/95760619-ae295600-0cc4-11eb-87d9-5804c778ca4a.png)


## Technical Details
Build form hook is used to check if there is a subject field in the pdf create form and if there is then this makes that field required