### PR TITLE
CPS-359: Fix case client issues

### DIFF
--- a/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
+++ b/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
@@ -180,7 +180,7 @@
             end_date: null,
             email: contact.email,
             phone: contact.phone,
-            role: contact.role,
+            role: ts('Client'),
             start_date: null
           };
         });

--- a/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
+++ b/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
@@ -169,7 +169,7 @@
      */
     function getClientRoles () {
       return _.filter(caseContacts, {
-        role: ts('Client')
+        role: 'Client'
       })
         .map(function (contact) {
           return {

--- a/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
+++ b/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
@@ -73,7 +73,7 @@
             end_date: null,
             email: caseClient.email,
             phone: caseClient.phone,
-            role: 'Client',
+            role: ts('Client'),
             start_date: null
           }));
         });
@@ -246,7 +246,7 @@
 
         it('only contains the roles for that type', () => {
           expect(peopleTabRoles.list).toEqual([jasmine.objectContaining({
-            role: 'Client'
+            role: ts('Client')
           })]);
         });
       });
@@ -281,7 +281,7 @@
         it('only contains the roles that match the given letter', () => {
           expect(peopleTabRoles.list).toEqual([jasmine.objectContaining({
             display_name: caseClient.display_name,
-            role: 'Client'
+            role: ts('Client')
           })]);
         });
       });

--- a/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
+++ b/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
@@ -285,6 +285,17 @@
           })]);
         });
       });
+
+      describe('when filtering by a non-existent role', () => {
+        beforeEach(() => {
+          peopleTabRoles.updateRolesList();
+          peopleTabRoles.filterRoles('', 'Applicant');
+        });
+
+        it('does not return any roles', () => {
+          expect(peopleTabRoles.list).toEqual([]);
+        });
+      });
     });
 
     describe('pagination', () => {


### PR DESCRIPTION
## Overview
This PR fixes an issue where client roles would not be visible 

## Before
![Screen Shot 2020-10-13 at 10 03 55 AM](https://user-images.githubusercontent.com/1642119/95871261-74476680-0d3b-11eb-8a57-1a40837cd394.png)


## After
![Screen Shot 2020-10-13 at 10 03 36 AM](https://user-images.githubusercontent.com/1642119/95871278-79a4b100-0d3b-11eb-8c1c-c801028379c4.png)


## Technical Details

The issue happened because we were filtering the case clients in the list of case contacts using the ts function as follows: `{ role: ts('Client') }`. The problem is that the role is always set to `Client`, even if the particular case category displays this as `Applicant` or `Prospect`, etc.

This was a regression introduced by https://github.com/compucorp/uk.co.compucorp.civicase/pull/574

To fix the issue we simply removed the `ts` function when filtering.

There was also an issue with the translation of the word `Client` for certain case categories, such as award. The problem is that the object we were using to display the client's data didn't have the role translated. To fix this issue we translated the word `Client` directly. This is fine since we know this role is specific for clients.