### PR TITLE
RSE-1373: Use Category Instance Related Classes In Custom Group Related Hooks

### DIFF
--- a/CRM/Civicase/Helper/CaseManagementCustomGroupPostProcess.php
+++ b/CRM/Civicase/Helper/CaseManagementCustomGroupPostProcess.php
@@ -1,0 +1,9 @@
+<?php
+
+use CRM_Civicase_Helper_InstanceCustomGroupPostProcess as InstanceCustomGroupPostProcess;
+
+/**
+ * Case management custom group helper class.
+ */
+class CRM_Civicase_Helper_CaseManagementCustomGroupPostProcess extends InstanceCustomGroupPostProcess {
+}

--- a/CRM/Civicase/Helper/InstanceCustomGroupPostProcess.php
+++ b/CRM/Civicase/Helper/InstanceCustomGroupPostProcess.php
@@ -28,4 +28,83 @@ abstract class CRM_Civicase_Helper_InstanceCustomGroupPostProcess {
     return array_column($result['values'], 'id');
   }
 
+  /**
+   * Fetches the case type category frr the case type.
+   *
+   * @param int $caseTypeId
+   *   Case Type ID.
+   *
+   * @return array
+   *   Case category details.
+   */
+  public function getCaseCategoryForCaseType($caseTypeId) {
+    $result = civicrm_api3('CaseType', 'getsingle', [
+      'id' => $caseTypeId,
+    ]);
+
+    return $result;
+  }
+
+  /**
+   * Gets the custom groups that the case type is associated with.
+   *
+   * This returns the custom groups extending the `Case` entity and
+   * where the entity column value has teh case type ID or where
+   * the entity column value is NULL.
+   *
+   * @param int $caseTypeId
+   *   Case type Id.
+   *
+   * @return array
+   *   Matched Case type custom groups.
+   */
+  public function getCaseTypeCustomGroups($caseTypeId) {
+    $caseCategory = $this->getCaseCategoryForCaseType($caseTypeId);
+    if (empty($caseCategory['case_type_category'])) {
+      return [];
+    }
+    $caseCategoryId = $caseCategory['case_type_category'];
+    $customGroupsWithoutCurrentCaseType = civicrm_api3('CustomGroup', 'get', [
+      'extends' => 'Case',
+      'extends_entity_column_id' => $caseCategoryId,
+      'extends_entity_column_value' => ['NOT LIKE' => '%' . CRM_Core_DAO::VALUE_SEPARATOR . $caseTypeId . CRM_Core_DAO::VALUE_SEPARATOR . '%'],
+    ]);
+
+    // API above will not fetch results for when
+    // extends_entity_column_value is NULL.
+    $customGroupsWithNullCaseType = civicrm_api3('CustomGroup', 'get', [
+      'extends' => 'Case',
+      'extends_entity_column_id' => $caseCategoryId,
+      'extends_entity_column_value' => ['IS NULL' => 1],
+    ]);
+
+    return array_merge($customGroupsWithoutCurrentCaseType['values'], $customGroupsWithNullCaseType['values']);
+  }
+
+  /**
+   * Gets the custom groups that the case type is associated with.
+   *
+   * This is diffrent from the `getCaseTypeCustomGroups` function in
+   * that it returns custom groups associated with the case type but
+   * the case type category is not the same as the case category
+   * the case type belongs to.
+   *
+   * @param int $caseTypeId
+   *   Case type Id.
+   *
+   * @return array
+   *   Mismatched case type custom groups
+   */
+  public function getCaseTypeCustomGroupsWithCategoryMismatch($caseTypeId) {
+    $caseCategoryId = $this->getCaseCategoryForCaseType($caseTypeId);
+
+    $result = civicrm_api3('CustomGroup', 'get', [
+      'extends' => 'Case',
+      'extends_entity_column_id' => ['NOT IN' => [$caseCategoryId]],
+      'extends_entity_column_value' => ['LIKE' => '%' . CRM_Core_DAO::VALUE_SEPARATOR . $caseTypeId . CRM_Core_DAO::VALUE_SEPARATOR . '%'],
+    ]);
+
+    return $result['values'];
+  }
+
 }

--- a/CRM/Civicase/Helper/InstanceCustomGroupPostProcess.php
+++ b/CRM/Civicase/Helper/InstanceCustomGroupPostProcess.php
@@ -3,7 +3,7 @@
 /**
  * Default instance custom group post process helper class.
  */
-abstract class CRM_Civicase_Helper_InstanceCustomGroupPostProcess {
+class CRM_Civicase_Helper_InstanceCustomGroupPostProcess {
 
   /**
    * Returns case type ID's for a case category.
@@ -25,7 +25,7 @@ abstract class CRM_Civicase_Helper_InstanceCustomGroupPostProcess {
   }
 
   /**
-   * Fetches the case type category frr the case type.
+   * Fetches the case type category for the case type.
    *
    * @param int $caseTypeId
    *   Case Type ID.

--- a/CRM/Civicase/Helper/InstanceCustomGroupPostProcess.php
+++ b/CRM/Civicase/Helper/InstanceCustomGroupPostProcess.php
@@ -1,7 +1,5 @@
 <?php
 
-use CRM_Core_BAO_CustomGroup as CustomGroup;
-
 /**
  * Default instance custom group post process helper class.
  */
@@ -10,15 +8,13 @@ abstract class CRM_Civicase_Helper_InstanceCustomGroupPostProcess {
   /**
    * Returns case type ID's for a case category.
    *
-   * @param CRM_Core_BAO_CustomGroup $customGroup
-   *   Custom Group Object.
    * @param int $caseTypeCategoryId
    *   Case Type Category ID.
    *
    * @return array
    *   Case Type Ids.
    */
-  public function getCaseTypeIdsForCaseCategory(CustomGroup $customGroup, $caseTypeCategoryId) {
+  public function getCaseTypeIdsForCaseCategory($caseTypeCategoryId) {
     $result = civicrm_api3('CaseType', 'get', [
       'sequential' => 1,
       'return' => ['id'],

--- a/CRM/Civicase/Helper/InstanceCustomGroupPostProcess.php
+++ b/CRM/Civicase/Helper/InstanceCustomGroupPostProcess.php
@@ -107,4 +107,29 @@ abstract class CRM_Civicase_Helper_InstanceCustomGroupPostProcess {
     return $result['values'];
   }
 
+  /**
+   * Returns values from cg_extend_object option group.
+   *
+   * @return array
+   *   CG extends values.
+   */
+  public function getCgExtendValues() {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'option_group_id' => "cg_extend_objects",
+    ]);
+
+    return array_column($result['values'], 'label', 'value');
+  }
+
+  /**
+   * Returns the available case type categories.
+   *
+   * @return array
+   *   Case type categories.
+   */
+  public function getCaseTypeCategories() {
+    return CRM_Case_BAO_CaseType::buildOptions('case_type_category', 'validate');
+  }
+
 }

--- a/CRM/Civicase/Helper/InstanceCustomGroupPostProcess.php
+++ b/CRM/Civicase/Helper/InstanceCustomGroupPostProcess.php
@@ -1,0 +1,31 @@
+<?php
+
+use CRM_Core_BAO_CustomGroup as CustomGroup;
+
+/**
+ * Default instance custom group post process helper class.
+ */
+abstract class CRM_Civicase_Helper_InstanceCustomGroupPostProcess {
+
+  /**
+   * Returns case type ID's for a case category.
+   *
+   * @param CRM_Core_BAO_CustomGroup $customGroup
+   *   Custom Group Object.
+   * @param int $caseTypeCategoryId
+   *   Case Type Category ID.
+   *
+   * @return array
+   *   Case Type Ids.
+   */
+  public function getCaseTypeIdsForCaseCategory(CustomGroup $customGroup, $caseTypeCategoryId) {
+    $result = civicrm_api3('CaseType', 'get', [
+      'sequential' => 1,
+      'return' => ['id'],
+      'case_type_category' => $caseTypeCategoryId,
+    ]);
+
+    return array_column($result['values'], 'id');
+  }
+
+}

--- a/CRM/Civicase/Hook/PageRun/CaseCategoryCustomGroupListing.php
+++ b/CRM/Civicase/Hook/PageRun/CaseCategoryCustomGroupListing.php
@@ -1,9 +1,18 @@
 <?php
 
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+
 /**
- * Class CRM_Civicase_Hook_PageRun_CaseCategoryCustomGroupListing.
+ * Handles the custom group listing page display for case categories.
  */
 class CRM_Civicase_Hook_PageRun_CaseCategoryCustomGroupListing {
+
+  /**
+   * Stores display formatter objects.
+   *
+   * @var CRM_Civicase_Service_BaseCustomGroupDisplayFormatter[]
+   */
+  private $displayFormatters;
 
   /**
    * Add resources (CSS and JS)for this Page.
@@ -16,22 +25,21 @@ class CRM_Civicase_Hook_PageRun_CaseCategoryCustomGroupListing {
       return;
     }
 
-    $this->setCorrectLabelForCaseCategory($page);
+    $this->processDisplay($page);
   }
 
   /**
-   * Sets the correct label for custom group category on listing page.
+   * Processes the custom group page display based on instance formatter.
    *
    * @param object $page
    *   Page Object.
    */
-  private function setCorrectLabelForCaseCategory(&$page) {
+  private function processDisplay(&$page) {
     $rows = $page->get_template_vars('rows');
-    $caseTypeCategories = (CRM_Case_BAO_CaseType::buildOptions('case_type_category', 'validate'));
-    $cgExtendValues = $this->getCgExtendValues();
     foreach ($rows as &$row) {
       if ($row['extends'] == 'Case' && !empty($row['extends_entity_column_id'])) {
-        $row['extends_display'] = $cgExtendValues[$caseTypeCategories[$row['extends_entity_column_id']]];
+        $displayFormatter = $this->getInstanceDisplayFormatter($row['extends_entity_column_id']);
+        $displayFormatter->processDisplay($row);
       }
     }
 
@@ -39,18 +47,22 @@ class CRM_Civicase_Hook_PageRun_CaseCategoryCustomGroupListing {
   }
 
   /**
-   * Returns values from cg_extend_object option group.
+   * Returns the display formatter object for the category instance.
    *
-   * @return array
-   *   CG extends values.
+   * @param int $caseCategoryValue
+   *   Case category Value.
+   *
+   * @return CRM_Civicase_Service_BaseCustomGroupDisplayFormatter
+   *   Category instance display formatter.
    */
-  private function getCgExtendValues() {
-    $result = civicrm_api3('OptionValue', 'get', [
-      'sequential' => 1,
-      'option_group_id' => "cg_extend_objects",
-    ]);
+  private function getInstanceDisplayFormatter($caseCategoryValue) {
+    if (empty($this->displayFormatters[$caseCategoryValue])) {
+      $caseCategoryInstance = CaseCategoryHelper::getInstanceObject($caseCategoryValue);
+      $displayFormatter = $caseCategoryInstance->getCustomGroupDisplayFormatter();
+      $this->displayFormatters[$caseCategoryValue] = $displayFormatter;
+    }
 
-    return array_column($result['values'], 'label', 'value');
+    return $this->displayFormatters[$caseCategoryValue];
   }
 
   /**

--- a/CRM/Civicase/Hook/Post/CaseCategoryCustomGroupSaver.php
+++ b/CRM/Civicase/Hook/Post/CaseCategoryCustomGroupSaver.php
@@ -1,7 +1,9 @@
 <?php
 
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+
 /**
- * Class CRM_Civicase_Hook_Post_CaseCategoryCustomGroupSaver.
+ * Handles case category custom group post processing.
  */
 class CRM_Civicase_Hook_Post_CaseCategoryCustomGroupSaver {
 
@@ -22,54 +24,15 @@ class CRM_Civicase_Hook_Post_CaseCategoryCustomGroupSaver {
       return;
     }
 
-    $this->saveCustomGroupForCaseCategory($objectRef);
-  }
-
-  /**
-   * Saves case type category custom groups.
-   *
-   * This function allows saving the Custom groups that extends a Case category
-   * entity to extend the Case entity and to save the ID of the case category
-   * in the `extends_entity_column_id` of the `custom_group` table and
-   * also to store all case types for the Case category in the
-   * `extends_entity_column_value` column.
-   *
-   * @param object $objectRef
-   *   Object reference.
-   */
-  private function saveCustomGroupForCaseCategory(&$objectRef) {
     $caseTypeCategories = array_flip(CRM_Case_BAO_CaseType::buildOptions('case_type_category', 'validate'));
     if (empty($caseTypeCategories[$objectRef->extends])) {
       return;
     }
 
-    $caseTypeIds = $this->getCaseTypeIdsForCaseCategory($caseTypeCategories[$objectRef->extends]);
-    $ids = CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR, $caseTypeIds) . CRM_Core_DAO::VALUE_SEPARATOR;
-    $objectRef->extends_entity_column_id = $caseTypeCategories[$objectRef->extends];
-    if (!empty($ids)) {
-      $objectRef->extends_entity_column_value = $ids;
-    }
-    $objectRef->extends = 'Case';
-    $objectRef->save();
-  }
-
-  /**
-   * Returns case type ID's for a case category.
-   *
-   * @param int $caseTypeCategoryId
-   *   Case Type Category ID.
-   *
-   * @return array
-   *   Case Type Ids.
-   */
-  private function getCaseTypeIdsForCaseCategory($caseTypeCategoryId) {
-    $result = civicrm_api3('CaseType', 'get', [
-      'sequential' => 1,
-      'return' => ['id'],
-      'case_type_category' => $caseTypeCategoryId,
-    ]);
-
-    return array_column($result['values'], 'id');
+    $caseCategoryValue = $caseTypeCategories[$objectRef->extends];
+    $caseCategoryInstance = CaseCategoryHelper::getInstanceObject($caseCategoryValue);
+    $customGroupPostProcessor = $caseCategoryInstance->getCustomGroupPostProcessor();
+    $customGroupPostProcessor->saveCustomGroupForCaseCategory($objectRef, $caseCategoryInstance->getPostProcessHelper());
   }
 
   /**

--- a/CRM/Civicase/Hook/Post/CaseCategoryCustomGroupSaver.php
+++ b/CRM/Civicase/Hook/Post/CaseCategoryCustomGroupSaver.php
@@ -24,7 +24,9 @@ class CRM_Civicase_Hook_Post_CaseCategoryCustomGroupSaver {
       return;
     }
 
-    $caseTypeCategories = array_flip(CRM_Case_BAO_CaseType::buildOptions('case_type_category', 'validate'));
+    $caseTypeCategories = CRM_Civicase_Helper_CaseCategory::getCaseCategories();
+    $caseTypeCategories = array_column($caseTypeCategories, 'value', 'name');
+
     if (empty($caseTypeCategories[$objectRef->extends])) {
       return;
     }

--- a/CRM/Civicase/Hook/Post/CaseCategoryCustomGroupSaver.php
+++ b/CRM/Civicase/Hook/Post/CaseCategoryCustomGroupSaver.php
@@ -32,7 +32,7 @@ class CRM_Civicase_Hook_Post_CaseCategoryCustomGroupSaver {
     $caseCategoryValue = $caseTypeCategories[$objectRef->extends];
     $caseCategoryInstance = CaseCategoryHelper::getInstanceObject($caseCategoryValue);
     $customGroupPostProcessor = $caseCategoryInstance->getCustomGroupPostProcessor();
-    $customGroupPostProcessor->saveCustomGroupForCaseCategory($objectRef, $caseCategoryInstance->getPostProcessHelper());
+    $customGroupPostProcessor->saveCustomGroupForCaseCategory($objectRef);
   }
 
   /**

--- a/CRM/Civicase/Hook/Post/UpdateCaseTypeListForCaseCategoryCustomGroup.php
+++ b/CRM/Civicase/Hook/Post/UpdateCaseTypeListForCaseCategoryCustomGroup.php
@@ -32,11 +32,11 @@ class CRM_Civicase_Hook_Post_UpdateCaseTypeListForCaseCategoryCustomGroup {
     $caseTypePostProcessor = $caseCategoryInstance->getCaseTypePostProcessor();
 
     if ($op === 'create') {
-      $caseTypePostProcessor->processCaseTypeCustomGroupsOnCreate($objectId, $caseCategoryInstance->getPostProcessHelper());
+      $caseTypePostProcessor->processCaseTypeCustomGroupsOnCreate($objectId);
     }
 
     if ($op === 'edit') {
-      $caseTypePostProcessor->processCaseTypeCustomGroupsOnUpdate($objectId, $caseCategoryInstance->getPostProcessHelper());
+      $caseTypePostProcessor->processCaseTypeCustomGroupsOnUpdate($objectId);
     }
   }
 

--- a/CRM/Civicase/Hook/Post/UpdateCaseTypeListForCaseCategoryCustomGroup.php
+++ b/CRM/Civicase/Hook/Post/UpdateCaseTypeListForCaseCategoryCustomGroup.php
@@ -1,7 +1,9 @@
 <?php
 
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+
 /**
- * Class CCRM_Civicase_Hook_Post_UpdateCaseTypeListForCaseCategoryCustomGroup.
+ * Handles custom group related logic when case type is created/edited.
  */
 class CRM_Civicase_Hook_Post_UpdateCaseTypeListForCaseCategoryCustomGroup {
 
@@ -23,14 +25,18 @@ class CRM_Civicase_Hook_Post_UpdateCaseTypeListForCaseCategoryCustomGroup {
     }
 
     $caseTypeDetails = $this->getCaseTypeDetails($objectId);
+    $caseCategoryInstance = CaseCategoryHelper::getInstanceObject($caseTypeDetails['case_type_category']);
+    if (empty($caseCategoryInstance)) {
+      return;
+    }
+    $caseTypePostProcessor = $caseCategoryInstance->getCaseTypePostProcessor();
 
     if ($op === 'create') {
-      $this->addCaseTypeToCaseCategoryCustomGroupList($caseTypeDetails['case_type_category'], $objectId);
+      $caseTypePostProcessor->processCaseTypeCustomGroupsOnCreate($objectId, $caseCategoryInstance->getPostProcessHelper());
     }
 
     if ($op === 'edit') {
-      $this->removeCaseTypeFromNonRelatedCaseCategoryCustomGroupList($caseTypeDetails['case_type_category'], $objectId);
-      $this->addCaseTypeToCaseCategoryCustomGroupList($caseTypeDetails['case_type_category'], $objectId);
+      $caseTypePostProcessor->processCaseTypeCustomGroupsOnUpdate($objectId, $caseCategoryInstance->getPostProcessHelper());
     }
   }
 
@@ -49,88 +55,6 @@ class CRM_Civicase_Hook_Post_UpdateCaseTypeListForCaseCategoryCustomGroup {
     ]);
 
     return $result;
-  }
-
-  /**
-   * Adds a case type to the the Case Category CustomGroup list.
-   *
-   * @param int $caseCategoryId
-   *   Case category Id.
-   * @param int $caseTypeId
-   *   Case type Id.
-   */
-  private function addCaseTypeToCaseCategoryCustomGroupList($caseCategoryId, $caseTypeId) {
-    $customGroupsWithoutCurrentCaseType = civicrm_api3('CustomGroup', 'get', [
-      'extends' => 'Case',
-      'extends_entity_column_id' => $caseCategoryId,
-      'extends_entity_column_value' => ['NOT LIKE' => '%' . CRM_Core_DAO::VALUE_SEPARATOR . $caseTypeId . CRM_Core_DAO::VALUE_SEPARATOR . '%'],
-    ]);
-
-    // API above will not fetch results for when
-    // extends_entity_column_value is NULL.
-    $customGroupsWithNullCaseType = civicrm_api3('CustomGroup', 'get', [
-      'extends' => 'Case',
-      'extends_entity_column_id' => $caseCategoryId,
-      'extends_entity_column_value' => ['IS NULL' => 1],
-    ]);
-
-    $affectedCustomGroups = array_merge($customGroupsWithoutCurrentCaseType['values'], $customGroupsWithNullCaseType['values']);
-    if (count($affectedCustomGroups) == 0) {
-      return;
-    }
-
-    foreach ($affectedCustomGroups as $cusGroup) {
-      $extendColValue = !empty($cusGroup['extends_entity_column_value']) ? $cusGroup['extends_entity_column_value'] : [];
-      $entityColumnValues = array_merge($extendColValue, [$caseTypeId]);
-      $this->updateCustomGroup($cusGroup['id'], $entityColumnValues);
-    }
-  }
-
-  /**
-   * Removes a case type from list for non related Case Category CustomGroup.
-   *
-   * @param int $caseCategoryId
-   *   Case category Id.
-   * @param int $caseTypeId
-   *   Case type Id.
-   */
-  private function removeCaseTypeFromNonRelatedCaseCategoryCustomGroupList($caseCategoryId, $caseTypeId) {
-    $result = civicrm_api3('CustomGroup', 'get', [
-      'extends' => 'Case',
-      'extends_entity_column_id' => ['NOT IN' => [$caseCategoryId]],
-      'extends_entity_column_value' => ['LIKE' => '%' . CRM_Core_DAO::VALUE_SEPARATOR . $caseTypeId . CRM_Core_DAO::VALUE_SEPARATOR . '%'],
-    ]);
-
-    if ($result['count'] == 0) {
-      return;
-    }
-
-    foreach ($result['values'] as $cusGroup) {
-      $entityColumnValues = array_diff($cusGroup['extends_entity_column_value'], [$caseTypeId]);
-      $entityColumnValues = $entityColumnValues ? $entityColumnValues : NULL;
-      $this->updateCustomGroup($cusGroup['id'], $entityColumnValues);
-    }
-  }
-
-  /**
-   * Updates a custom group.
-   *
-   * We are using the custom group object here rather than the API because if
-   * this is updated via the API the `extends_entity_column_id` field will be
-   * set to NULL and this is needed to keep track of custom groups extending
-   * case categories.
-   *
-   * @param int $id
-   *   Custom group Id.
-   * @param array|null $entityColumnValues
-   *   Entity custom values for custom group.
-   */
-  private function updateCustomGroup($id, $entityColumnValues) {
-    $cusGroup = new CRM_Core_BAO_CustomGroup();
-    $cusGroup->id = $id;
-    $entityColValue = is_null($entityColumnValues) ? 'null' : CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR, $entityColumnValues) . CRM_Core_DAO::VALUE_SEPARATOR;
-    $cusGroup->extends_entity_column_value = $entityColValue;
-    $cusGroup->save();
   }
 
   /**

--- a/CRM/Civicase/Service/BaseCaseTypePostProcessor.php
+++ b/CRM/Civicase/Service/BaseCaseTypePostProcessor.php
@@ -1,0 +1,39 @@
+<?php
+
+use CRM_Civicase_Helper_InstanceCustomGroupPostProcess as InstanceCustomGroupPostProcess;
+
+/**
+ * The base class for case category case type processor classes.
+ */
+abstract class CRM_Civicase_Service_BaseCaseTypePostProcessor {
+
+  /**
+   * This function updates the custom groups for the case type on create.
+   *
+   * The case type when created need to be added to the custom group
+   * extending the Case entity for the case category of the case type.
+   *
+   * @param int $caseTypeId
+   *   Custom group object.
+   * @param \CRM_Civicase_Helper_InstanceCustomGroupPostProcess $postProcessHelper
+   *   Custom group instance helper.
+   */
+  abstract public function processCaseTypeCustomGroupsOnCreate($caseTypeId, InstanceCustomGroupPostProcess $postProcessHelper);
+
+  /**
+   * This function updates the custom groups for the case type on update.
+   *
+   * The case type when created need to be added to the custom group extending
+   * the Case entity for the case category of the case type and also needs to be
+   * removed from custom groups extending the Case entity for case category that
+   * is not same as the case type (For the case when the case category of case
+   * type is updated to another).
+   *
+   * @param int $caseTypeId
+   *   Custom group object.
+   * @param \CRM_Civicase_Helper_InstanceCustomGroupPostProcess $postProcessHelper
+   *   Custom group instance helper.
+   */
+  abstract public function processCaseTypeCustomGroupsOnUpdate($caseTypeId, InstanceCustomGroupPostProcess $postProcessHelper);
+
+}

--- a/CRM/Civicase/Service/BaseCaseTypePostProcessor.php
+++ b/CRM/Civicase/Service/BaseCaseTypePostProcessor.php
@@ -1,7 +1,5 @@
 <?php
 
-use CRM_Civicase_Helper_InstanceCustomGroupPostProcess as InstanceCustomGroupPostProcess;
-
 /**
  * The base class for case category case type processor classes.
  */
@@ -14,11 +12,9 @@ abstract class CRM_Civicase_Service_BaseCaseTypePostProcessor {
    * extending the Case entity for the case category of the case type.
    *
    * @param int $caseTypeId
-   *   Custom group object.
-   * @param \CRM_Civicase_Helper_InstanceCustomGroupPostProcess $postProcessHelper
-   *   Custom group instance helper.
+   *   Custom group object..
    */
-  abstract public function processCaseTypeCustomGroupsOnCreate($caseTypeId, InstanceCustomGroupPostProcess $postProcessHelper);
+  abstract public function processCaseTypeCustomGroupsOnCreate($caseTypeId);
 
   /**
    * This function updates the custom groups for the case type on update.
@@ -31,9 +27,7 @@ abstract class CRM_Civicase_Service_BaseCaseTypePostProcessor {
    *
    * @param int $caseTypeId
    *   Custom group object.
-   * @param \CRM_Civicase_Helper_InstanceCustomGroupPostProcess $postProcessHelper
-   *   Custom group instance helper.
    */
-  abstract public function processCaseTypeCustomGroupsOnUpdate($caseTypeId, InstanceCustomGroupPostProcess $postProcessHelper);
+  abstract public function processCaseTypeCustomGroupsOnUpdate($caseTypeId);
 
 }

--- a/CRM/Civicase/Service/BaseCustomGroupDisplayFormatter.php
+++ b/CRM/Civicase/Service/BaseCustomGroupDisplayFormatter.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * The base class for case category custom group display formatting.
+ */
+abstract class CRM_Civicase_Service_BaseCustomGroupDisplayFormatter {
+
+  /**
+   * Process the category display on the custom group listing page.
+   *
+   * Some case category instance requires to format the custom group
+   * display on the listing page differently hence the need for this
+   * function. This function will modify the custom group page object
+   * and modify the rows/fields display as necessary.
+   *
+   * @param array $row
+   *   One of the rows of the custom group listing page.
+   */
+  abstract public function processDisplay(array &$row);
+
+}

--- a/CRM/Civicase/Service/BaseCustomGroupPostProcessor.php
+++ b/CRM/Civicase/Service/BaseCustomGroupPostProcessor.php
@@ -1,7 +1,6 @@
 <?php
 
 use CRM_Core_BAO_CustomGroup as CustomGroup;
-use CRM_Civicase_Helper_InstanceCustomGroupPostProcess as InstanceCustomGroupPostProcess;
 
 /**
  * The base class for case category custom group processor classes.
@@ -13,9 +12,7 @@ abstract class CRM_Civicase_Service_BaseCustomGroupPostProcessor {
    *
    * @param \CRM_Core_BAO_CustomGroup $customGroup
    *   Custom group object.
-   * @param \CRM_Civicase_Helper_InstanceCustomGroupPostProcess $postProcessHelper
-   *   Custom group instance helper.
    */
-  abstract public function saveCustomGroupForCaseCategory(CustomGroup $customGroup, InstanceCustomGroupPostProcess $postProcessHelper);
+  abstract public function saveCustomGroupForCaseCategory(CustomGroup $customGroup);
 
 }

--- a/CRM/Civicase/Service/BaseCustomGroupPostProcessor.php
+++ b/CRM/Civicase/Service/BaseCustomGroupPostProcessor.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_Core_BAO_CustomGroup as CustomGroup;
+use CRM_Core_DAO_CustomGroup as CustomGroup;
 
 /**
  * The base class for case category custom group processor classes.
@@ -10,7 +10,7 @@ abstract class CRM_Civicase_Service_BaseCustomGroupPostProcessor {
   /**
    * Handles the saving of a custom group related to a case type category.
    *
-   * @param \CRM_Core_BAO_CustomGroup $customGroup
+   * @param \CRM_Core_DAO_CustomGroup $customGroup
    *   Custom group object.
    */
   abstract public function saveCustomGroupForCaseCategory(CustomGroup $customGroup);

--- a/CRM/Civicase/Service/BaseCustomGroupPostProcessor.php
+++ b/CRM/Civicase/Service/BaseCustomGroupPostProcessor.php
@@ -1,0 +1,21 @@
+<?php
+
+use CRM_Core_BAO_CustomGroup as CustomGroup;
+use CRM_Civicase_Helper_InstanceCustomGroupPostProcess as InstanceCustomGroupPostProcess;
+
+/**
+ * The base class for case category custom group processor classes.
+ */
+abstract class CRM_Civicase_Service_BaseCustomGroupPostProcessor {
+
+  /**
+   * Handles the saving of a custom group related to a case type category.
+   *
+   * @param \CRM_Core_BAO_CustomGroup $customGroup
+   *   Custom group object.
+   * @param \CRM_Civicase_Helper_InstanceCustomGroupPostProcess $postProcessHelper
+   *   Custom group instance helper.
+   */
+  abstract public function saveCustomGroupForCaseCategory(CustomGroup $customGroup, InstanceCustomGroupPostProcess $postProcessHelper);
+
+}

--- a/CRM/Civicase/Service/CaseCategoryInstanceUtils.php
+++ b/CRM/Civicase/Service/CaseCategoryInstanceUtils.php
@@ -26,6 +26,40 @@ abstract class CRM_Civicase_Service_CaseCategoryInstanceUtils {
   abstract public function getMenuObject();
 
   /**
+   * Returns the custom group post processor for the category instance.
+   *
+   * This processor will be responsible for the events that happen after a
+   * custom group set extending a case category is saved or updated.
+   *
+   * @return CRM_Civicase_Service_BaseCustomGroupPostProcessor
+   *   Custom group Post processor class.
+   */
+  abstract public function getCustomGroupPostProcessor();
+
+  /**
+   * Returns the case type processor for the category instance.
+   *
+   * This processor will be responsible for the events that happen after a
+   * case type belonging to a particular case category is saved or updated.
+   *
+   * @return CRM_Civicase_Service_BaseCaseTypePostProcessor
+   *   Case type post processor class.
+   */
+  abstract public function getCaseTypePostProcessor();
+
+  /**
+   * Returns the custom group display formatter for the category instance.
+   *
+   * This processor will be responsible for the rows display for the
+   * custom group set for the category instance on the custom group
+   * listing page.
+   *
+   * @return CRM_Civicase_Service_BaseCustomGroupDisplayFormatter
+   *   Custom group display formatter class.
+   */
+  abstract public function getCustomGroupDisplayFormatter();
+
+  /**
    * CRM_Civicase_Service_CaseCategoryInstanceUtils constructor.
    *
    * @param int|null $caseCategoryInstanceKey

--- a/CRM/Civicase/Service/CaseManagementCaseTypePostProcessor.php
+++ b/CRM/Civicase/Service/CaseManagementCaseTypePostProcessor.php
@@ -1,0 +1,78 @@
+<?php
+
+use CRM_Civicase_Service_BaseCaseTypePostProcessor as BaseCaseTypePostProcessor;
+use CRM_Civicase_Helper_InstanceCustomGroupPostProcess as InstanceCustomGroupPostProcess;
+
+/**
+ * Handles the custom field related post processing for a case type.
+ *
+ * This class is specific for the Case management instance and handles the
+ * post processing as related to custom field set associated with a case type
+ * when the case type is created/updated.
+ */
+class CRM_Civicase_Service_CaseManagementCaseTypePostProcessor extends BaseCaseTypePostProcessor {
+
+  /**
+   * Handles case type post processing on create.
+   *
+   * @param int $caseTypeId
+   *   Case Type ID.
+   * @param \CRM_Civicase_Helper_InstanceCustomGroupPostProcess $postProcessHelper
+   *   Post process helper class.
+   */
+  public function processCaseTypeCustomGroupsOnCreate($caseTypeId, InstanceCustomGroupPostProcess $postProcessHelper) {
+    $customGroups = $postProcessHelper->getCaseTypeCustomGroups($caseTypeId);
+    if (empty($customGroups)) {
+      return;
+    }
+    foreach ($customGroups as $cusGroup) {
+      $extendColValue = !empty($cusGroup['extends_entity_column_value']) ? $cusGroup['extends_entity_column_value'] : [];
+      $entityColumnValues = array_merge($extendColValue, [$caseTypeId]);
+      $this->updateCustomGroup($cusGroup['id'], $entityColumnValues);
+    }
+  }
+
+  /**
+   * Handles case type post processing on update.
+   *
+   * @param int $caseTypeId
+   *   Case type Id.
+   * @param \CRM_Civicase_Helper_InstanceCustomGroupPostProcess $postProcessHelper
+   *   Post process helper class.
+   */
+  public function processCaseTypeCustomGroupsOnUpdate($caseTypeId, InstanceCustomGroupPostProcess $postProcessHelper) {
+    $mismatchCustomGroups = $postProcessHelper->getCaseTypeCustomGroupsWithCategoryMismatch($caseTypeId);
+    if (empty($mismatchCustomGroups)) {
+      return;
+    }
+    foreach ($mismatchCustomGroups as $cusGroup) {
+      $entityColumnValues = array_diff($cusGroup['extends_entity_column_value'], [$caseTypeId]);
+      $entityColumnValues = $entityColumnValues ? $entityColumnValues : NULL;
+      $this->updateCustomGroup($cusGroup['id'], $entityColumnValues);
+    }
+
+    $this->processCaseTypeCustomGroupsOnCreate($caseTypeId, $postProcessHelper);
+  }
+
+  /**
+   * Updates a custom group.
+   *
+   * We are using the custom group object here rather than the API because if
+   * this is updated via the API the `extends_entity_column_id` field will be
+   * set to NULL and this is needed to keep track of custom groups extending
+   * case categories.
+   *
+   * @param int $id
+   *   Custom group Id.
+   * @param array|null $entityColumnValues
+   *   Entity custom values for custom group.
+   */
+  private function updateCustomGroup($id, $entityColumnValues) {
+    $cusGroup = new CRM_Core_BAO_CustomGroup();
+    $cusGroup->id = $id;
+    $entityColValue = is_null($entityColumnValues) ? 'null' : CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR, $entityColumnValues) . CRM_Core_DAO::VALUE_SEPARATOR;
+    $cusGroup->extends_entity_column_value = $entityColValue;
+    $cusGroup->save();
+  }
+
+}

--- a/CRM/Civicase/Service/CaseManagementCaseTypePostProcessor.php
+++ b/CRM/Civicase/Service/CaseManagementCaseTypePostProcessor.php
@@ -1,7 +1,7 @@
 <?php
 
 use CRM_Civicase_Service_BaseCaseTypePostProcessor as BaseCaseTypePostProcessor;
-use CRM_Civicase_Helper_InstanceCustomGroupPostProcess as InstanceCustomGroupPostProcess;
+use CRM_Civicase_Helper_CaseManagementCustomGroupPostProcess as CaseManagementCustomGroupPostProcess;
 
 /**
  * Handles the custom field related post processing for a case type.
@@ -13,15 +13,30 @@ use CRM_Civicase_Helper_InstanceCustomGroupPostProcess as InstanceCustomGroupPos
 class CRM_Civicase_Service_CaseManagementCaseTypePostProcessor extends BaseCaseTypePostProcessor {
 
   /**
+   * Stores the CaseManagement Post process helper.
+   *
+   * @var \CRM_Civicase_Helper_CaseManagementCustomGroupPostProcess
+   */
+  private $postProcessHelper;
+
+  /**
+   * Constructor function.
+   *
+   * @param \CRM_Civicase_Helper_CaseManagementCustomGroupPostProcess $postProcessHelper
+   *   Post process helper class.
+   */
+  public function __construct(CaseManagementCustomGroupPostProcess $postProcessHelper) {
+    $this->postProcessHelper = $postProcessHelper;
+  }
+
+  /**
    * Handles case type post processing on create.
    *
    * @param int $caseTypeId
    *   Case Type ID.
-   * @param \CRM_Civicase_Helper_InstanceCustomGroupPostProcess $postProcessHelper
-   *   Post process helper class.
    */
-  public function processCaseTypeCustomGroupsOnCreate($caseTypeId, InstanceCustomGroupPostProcess $postProcessHelper) {
-    $customGroups = $postProcessHelper->getCaseTypeCustomGroups($caseTypeId);
+  public function processCaseTypeCustomGroupsOnCreate($caseTypeId) {
+    $customGroups = $this->postProcessHelper->getCaseTypeCustomGroups($caseTypeId);
     if (empty($customGroups)) {
       return;
     }
@@ -37,11 +52,9 @@ class CRM_Civicase_Service_CaseManagementCaseTypePostProcessor extends BaseCaseT
    *
    * @param int $caseTypeId
    *   Case type Id.
-   * @param \CRM_Civicase_Helper_InstanceCustomGroupPostProcess $postProcessHelper
-   *   Post process helper class.
    */
-  public function processCaseTypeCustomGroupsOnUpdate($caseTypeId, InstanceCustomGroupPostProcess $postProcessHelper) {
-    $mismatchCustomGroups = $postProcessHelper->getCaseTypeCustomGroupsWithCategoryMismatch($caseTypeId);
+  public function processCaseTypeCustomGroupsOnUpdate($caseTypeId) {
+    $mismatchCustomGroups = $this->postProcessHelper->getCaseTypeCustomGroupsWithCategoryMismatch($caseTypeId);
     if (empty($mismatchCustomGroups)) {
       return;
     }
@@ -51,7 +64,7 @@ class CRM_Civicase_Service_CaseManagementCaseTypePostProcessor extends BaseCaseT
       $this->updateCustomGroup($cusGroup['id'], $entityColumnValues);
     }
 
-    $this->processCaseTypeCustomGroupsOnCreate($caseTypeId, $postProcessHelper);
+    $this->processCaseTypeCustomGroupsOnCreate($caseTypeId);
   }
 
   /**

--- a/CRM/Civicase/Service/CaseManagementCustomGroupDisplayFormatter.php
+++ b/CRM/Civicase/Service/CaseManagementCustomGroupDisplayFormatter.php
@@ -1,0 +1,54 @@
+<?php
+
+use CRM_Civicase_Service_BaseCustomGroupDisplayFormatter as BaseCustomGroupDisplayFormatter;
+use CRM_Civicase_Helper_CaseManagementCustomGroupPostProcess as CaseManagementCustomGroupPostProcess;
+
+/**
+ * Case Management Instance Custom Group page formatter.
+ */
+class CRM_Civicase_Service_CaseManagementCustomGroupDisplayFormatter extends BaseCustomGroupDisplayFormatter {
+
+  /**
+   * Stores the CaseManagement Post process helper.
+   *
+   * @var \CRM_Civicase_Helper_CaseManagementCustomGroupPostProcess
+   */
+  private $postProcessHelper;
+
+  /**
+   * Stores case type categories.
+   *
+   * @var array
+   */
+  private $caseTypeCategories;
+
+  /**
+   * Stores option values for  `cg_extends` option group.
+   *
+   * @var array
+   */
+  private $cgExtendValues;
+
+  /**
+   * Constructor function.
+   *
+   * @param \CRM_Civicase_Helper_CaseManagementCustomGroupPostProcess $postProcessHelper
+   *   Post process helper class.
+   */
+  public function __construct(CaseManagementCustomGroupPostProcess $postProcessHelper) {
+    $this->postProcessHelper = $postProcessHelper;
+    $this->caseTypeCategories = $postProcessHelper->getCaseTypeCategories();
+    $this->cgExtendValues = $postProcessHelper->getCgExtendValues();
+  }
+
+  /**
+   * Sets the correct label for custom group category on listing page.
+   *
+   * @param array $row
+   *   One of the rows of the custom group listing page.
+   */
+  public function processDisplay(array &$row) {
+    $row['extends_display'] = $this->cgExtendValues[$this->caseTypeCategories[$row['extends_entity_column_id']]];
+  }
+
+}

--- a/CRM/Civicase/Service/CaseManagementCustomGroupPostProcessor.php
+++ b/CRM/Civicase/Service/CaseManagementCustomGroupPostProcessor.php
@@ -1,7 +1,7 @@
 <?php
 
 use CRM_Core_BAO_CustomGroup as CustomGroup;
-use CRM_Civicase_Helper_InstanceCustomGroupPostProcess as InstanceCustomGroupPostProcess;
+use CRM_Civicase_Helper_CaseManagementCustomGroupPostProcess as CaseManagementCustomGroupPostProcess;
 
 /**
  * Case management custom group post processor class.
@@ -10,6 +10,24 @@ use CRM_Civicase_Helper_InstanceCustomGroupPostProcess as InstanceCustomGroupPos
  * is saved.
  */
 class CRM_Civicase_Service_CaseManagementCustomGroupPostProcessor extends CRM_Civicase_Service_BaseCustomGroupPostProcessor {
+
+  /**
+   * Stores the CaseManagement Post process helper.
+   *
+   * @var \CRM_Civicase_Helper_CaseManagementCustomGroupPostProcess
+   *   Post process helper class.
+   */
+  private $postProcessHelper;
+
+  /**
+   * Constructor function.
+   *
+   * @param \CRM_Civicase_Helper_CaseManagementCustomGroupPostProcess $postProcessHelper
+   *   Post process helper class.
+   */
+  public function __construct(CaseManagementCustomGroupPostProcess $postProcessHelper) {
+    $this->postProcessHelper = $postProcessHelper;
+  }
 
   /**
    * Saves case type category custom groups.
@@ -23,10 +41,8 @@ class CRM_Civicase_Service_CaseManagementCustomGroupPostProcessor extends CRM_Ci
    *
    * @param \CRM_Core_BAO_CustomGroup $customGroup
    *   Custom Group Object.
-   * @param \CRM_Civicase_Helper_InstanceCustomGroupPostProcess $postProcessHelper
-   *   Post process helper class.
    */
-  public function saveCustomGroupForCaseCategory(CustomGroup $customGroup, InstanceCustomGroupPostProcess $postProcessHelper) {
+  public function saveCustomGroupForCaseCategory(CustomGroup $customGroup) {
     $caseTypeCategories = CRM_Civicase_Helper_CaseCategory::getCaseCategories();
     $caseTypeCategories = array_column($caseTypeCategories, 'value', 'name');
 
@@ -34,7 +50,7 @@ class CRM_Civicase_Service_CaseManagementCustomGroupPostProcessor extends CRM_Ci
       return;
     }
 
-    $caseTypeIds = $postProcessHelper->getCaseTypeIdsForCaseCategory($customGroup, $caseTypeCategories[$customGroup->extends]);
+    $caseTypeIds = $this->postProcessHelper->getCaseTypeIdsForCaseCategory($customGroup, $caseTypeCategories[$customGroup->extends]);
     $ids = 'null';
     if (!empty($caseTypeIds)) {
       $ids = CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR, $caseTypeIds) . CRM_Core_DAO::VALUE_SEPARATOR;

--- a/CRM/Civicase/Service/CaseManagementCustomGroupPostProcessor.php
+++ b/CRM/Civicase/Service/CaseManagementCustomGroupPostProcessor.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_Core_BAO_CustomGroup as CustomGroup;
+use CRM_Core_DAO_CustomGroup as CustomGroup;
 use CRM_Civicase_Helper_CaseManagementCustomGroupPostProcess as CaseManagementCustomGroupPostProcess;
 
 /**
@@ -39,7 +39,7 @@ class CRM_Civicase_Service_CaseManagementCustomGroupPostProcessor extends CRM_Ci
    * all case types for the Case category in the `extends_entity_column_value`
    * column.
    *
-   * @param \CRM_Core_BAO_CustomGroup $customGroup
+   * @param \CRM_Core_DAO_CustomGroup $customGroup
    *   Custom Group Object.
    */
   public function saveCustomGroupForCaseCategory(CustomGroup $customGroup) {
@@ -50,7 +50,7 @@ class CRM_Civicase_Service_CaseManagementCustomGroupPostProcessor extends CRM_Ci
       return;
     }
 
-    $caseTypeIds = $this->postProcessHelper->getCaseTypeIdsForCaseCategory($customGroup, $caseTypeCategories[$customGroup->extends]);
+    $caseTypeIds = $this->postProcessHelper->getCaseTypeIdsForCaseCategory($caseTypeCategories[$customGroup->extends]);
     $ids = 'null';
     if (!empty($caseTypeIds)) {
       $ids = CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR, $caseTypeIds) . CRM_Core_DAO::VALUE_SEPARATOR;

--- a/CRM/Civicase/Service/CaseManagementCustomGroupPostProcessor.php
+++ b/CRM/Civicase/Service/CaseManagementCustomGroupPostProcessor.php
@@ -1,0 +1,49 @@
+<?php
+
+use CRM_Core_BAO_CustomGroup as CustomGroup;
+use CRM_Civicase_Helper_InstanceCustomGroupPostProcess as InstanceCustomGroupPostProcess;
+
+/**
+ * Case management custom group post processor class.
+ *
+ * Handles events after a custom group extending a case category entity
+ * is saved.
+ */
+class CRM_Civicase_Service_CaseManagementCustomGroupPostProcessor extends CRM_Civicase_Service_BaseCustomGroupPostProcessor {
+
+  /**
+   * Saves case type category custom groups.
+   *
+   * This function allows saving the Custom groups that extends a Case category
+   * (that belongs to the Case Management Instance) entity to extend the Case
+   * entity and to save the ID of the case category in the
+   * `extends_entity_column_id` of the `custom_group` table and also to store
+   * all case types for the Case category in the `extends_entity_column_value`
+   * column.
+   *
+   * @param \CRM_Core_BAO_CustomGroup $customGroup
+   *   Custom Group Object.
+   * @param \CRM_Civicase_Helper_InstanceCustomGroupPostProcess $postProcessHelper
+   *   Post process helper class.
+   */
+  public function saveCustomGroupForCaseCategory(CustomGroup $customGroup, InstanceCustomGroupPostProcess $postProcessHelper) {
+    $caseTypeCategories = CRM_Civicase_Helper_CaseCategory::getCaseCategories();
+    $caseTypeCategories = array_column($caseTypeCategories, 'value', 'name');
+
+    if (empty($caseTypeCategories[$customGroup->extends])) {
+      return;
+    }
+
+    $caseTypeIds = $postProcessHelper->getCaseTypeIdsForCaseCategory($customGroup, $caseTypeCategories[$customGroup->extends]);
+    $ids = 'null';
+    if (!empty($caseTypeIds)) {
+      $ids = CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR, $caseTypeIds) . CRM_Core_DAO::VALUE_SEPARATOR;
+    }
+
+    $customGroup->extends_entity_column_value = $ids;
+    $customGroup->extends_entity_column_id = $caseTypeCategories[$customGroup->extends];
+    $customGroup->extends = 'Case';
+    $customGroup->save();
+  }
+
+}

--- a/CRM/Civicase/Service/CaseManagementUtils.php
+++ b/CRM/Civicase/Service/CaseManagementUtils.php
@@ -3,6 +3,7 @@
 use CRM_Civicase_Service_CaseCategoryMenu as CaseCategoryMenu;
 use CRM_Civicase_Service_CaseManagementCustomGroupPostProcessor as CaseManagementCustomGroupPostProcessor;
 use CRM_Civicase_Helper_CaseManagementCustomGroupPostProcess as CaseManagementCustomGroupPostProcessHelper;
+use CRM_Civicase_Service_CaseManagementCaseTypePostProcessor as CaseManagementCaseTypePostProcessor;
 
 /**
  * CaseManagementUtils class for case instance type.
@@ -23,7 +24,7 @@ class CRM_Civicase_Service_CaseManagementUtils extends CRM_Civicase_Service_Case
    * {@inheritDoc}
    */
   public function getCaseTypePostProcessor() {
-    // TODO: Implement getCaseTypePostProcessor() method.
+    return new CaseManagementCaseTypePostProcessor();
   }
 
   /**

--- a/CRM/Civicase/Service/CaseManagementUtils.php
+++ b/CRM/Civicase/Service/CaseManagementUtils.php
@@ -24,7 +24,7 @@ class CRM_Civicase_Service_CaseManagementUtils extends CRM_Civicase_Service_Case
    * {@inheritDoc}
    */
   public function getCaseTypePostProcessor() {
-    return new CaseManagementCaseTypePostProcessor();
+    return new CaseManagementCaseTypePostProcessor(new CaseManagementCustomGroupPostProcessHelper());
   }
 
   /**
@@ -38,14 +38,7 @@ class CRM_Civicase_Service_CaseManagementUtils extends CRM_Civicase_Service_Case
    * {@inheritDoc}
    */
   public function getCustomGroupPostProcessor() {
-    return new CaseManagementCustomGroupPostProcessor();
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  public function getPostProcessHelper() {
-    return new CaseManagementCustomGroupPostProcessHelper();
+    return new CaseManagementCustomGroupPostProcessor(new CaseManagementCustomGroupPostProcessHelper());
   }
 
 }

--- a/CRM/Civicase/Service/CaseManagementUtils.php
+++ b/CRM/Civicase/Service/CaseManagementUtils.php
@@ -1,6 +1,8 @@
 <?php
 
 use CRM_Civicase_Service_CaseCategoryMenu as CaseCategoryMenu;
+use CRM_Civicase_Service_CaseManagementCustomGroupPostProcessor as CaseManagementCustomGroupPostProcessor;
+use CRM_Civicase_Helper_CaseManagementCustomGroupPostProcess as CaseManagementCustomGroupPostProcessHelper;
 
 /**
  * CaseManagementUtils class for case instance type.
@@ -15,6 +17,34 @@ class CRM_Civicase_Service_CaseManagementUtils extends CRM_Civicase_Service_Case
    */
   public function getMenuObject() {
     return new CaseCategoryMenu();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getCaseTypePostProcessor() {
+    // TODO: Implement getCaseTypePostProcessor() method.
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getCustomGroupDisplayFormatter() {
+    // TODO: Implement getCustomGroupDisplayFormatter() method.
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getCustomGroupPostProcessor() {
+    return new CaseManagementCustomGroupPostProcessor();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getPostProcessHelper() {
+    return new CaseManagementCustomGroupPostProcessHelper();
   }
 
 }

--- a/CRM/Civicase/Service/CaseManagementUtils.php
+++ b/CRM/Civicase/Service/CaseManagementUtils.php
@@ -4,6 +4,7 @@ use CRM_Civicase_Service_CaseCategoryMenu as CaseCategoryMenu;
 use CRM_Civicase_Service_CaseManagementCustomGroupPostProcessor as CaseManagementCustomGroupPostProcessor;
 use CRM_Civicase_Helper_CaseManagementCustomGroupPostProcess as CaseManagementCustomGroupPostProcessHelper;
 use CRM_Civicase_Service_CaseManagementCaseTypePostProcessor as CaseManagementCaseTypePostProcessor;
+use CRM_Civicase_Service_CaseManagementCustomGroupDisplayFormatter as CaseManagementCustomGroupDisplayFormatter;
 
 /**
  * CaseManagementUtils class for case instance type.
@@ -31,7 +32,7 @@ class CRM_Civicase_Service_CaseManagementUtils extends CRM_Civicase_Service_Case
    * {@inheritDoc}
    */
   public function getCustomGroupDisplayFormatter() {
-    // TODO: Implement getCustomGroupDisplayFormatter() method.
+    return new CaseManagementCustomGroupDisplayFormatter(new CaseManagementCustomGroupPostProcessHelper());
   }
 
   /**

--- a/tests/phpunit/CRM/Civicase/Hook/PageRun/CaseCategoryCustomGroupListingTest.php
+++ b/tests/phpunit/CRM/Civicase/Hook/PageRun/CaseCategoryCustomGroupListingTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use CRM_Custom_Page_Group as CustomGroupPage;
+use CRM_Civicase_Hook_PageRun_CaseCategoryCustomGroupListing as CaseCategoryCustomGroupListing;
+use CRM_Civicase_Setup_ProcessCaseCategoryForCustomGroupSupport as CaseCategoryForCustomGroupSupport;
+
+/**
+ * Contains tests for the CaseCategoryCustomGroupListing class.
+ *
+ * @group headless
+ */
+class CRM_Civicase_Hook_PageRun_CaseCategoryCustomGroupListingTest extends BaseHeadlessTest {
+
+  /**
+   * Test the CaseCategoryCustomGroupListing run method.
+   */
+  public function testRun() {
+    $rows = [
+      [
+        'extends_entity_column_id' => 1,
+        'extends' => 'Case',
+      ],
+    ];
+    $page = $this->getCustomGroupPageObject($rows);
+
+    $customGroupListing = new CaseCategoryCustomGroupListing();
+    $customGroupListing->run($page);
+
+    // Modify rows to suite expected result.
+    $rows[0]['extends_display'] = CaseCategoryForCustomGroupSupport::CASE_CATEGORY_LABEL;
+    $this->assertEquals($rows, $page->get_template_vars('rows'));
+  }
+
+  /**
+   * Returns the custom group page object.
+   *
+   * @param array $rows
+   *   Page rows.
+   *
+   * @return \CRM_Custom_Page_Group
+   *   Page object.
+   */
+  private function getCustomGroupPageObject(array $rows) {
+    $customGroupPage = new CustomGroupPage();
+    $customGroupPage->assign('rows', $rows);
+
+    return $customGroupPage;
+  }
+
+}

--- a/tests/phpunit/CRM/Civicase/Hook/Post/CaseCategoryCustomGroupSaverTest.php
+++ b/tests/phpunit/CRM/Civicase/Hook/Post/CaseCategoryCustomGroupSaverTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use CRM_Core_BAO_CustomGroup as CustomGroup;
+use CRM_Civicase_Hook_Post_CaseCategoryCustomGroupSaver as CaseCategoryCustomGroupSaver;
+
+/**
+ * Test class for CaseCategoryCustomGroupSaverTest.
+ *
+ * @group headless
+ */
+class CRM_Civicase_Hook_Post_CaseCategoryCustomGroupSaverTest extends BaseHeadlessTest {
+
+  /**
+   * Test the run method.
+   *
+   * The purpose of this test is to ensure that the customGroupPostProcessor
+   * instance class is being triggered for only when the object name is
+   * `CustomGroup` for the create and edit operations.
+   *
+   * @param string $objectName
+   *   Object name.
+   * @param string $op
+   *   Operation being performed (create|edit).
+   * @param mixed $expectedExtendsId
+   *   Custom group extends Id.
+   *
+   * @dataProvider getDataForRun
+   */
+  public function testRun($objectName, $op, $expectedExtendsId) {
+    $objectId = 1;
+    $objectRef = $this->getCustomGroupObject();
+    $caseCategoryCustomGroupSaver = new CaseCategoryCustomGroupSaver();
+    $caseCategoryCustomGroupSaver->run($op, $objectName, $objectId, $objectRef);
+    $this->assertEquals($expectedExtendsId, $objectRef->extends_entity_column_id);
+  }
+
+  /**
+   * Provides sample data for testRun test.
+   *
+   * @return array
+   *   An array of sample data.
+   */
+  public function getDataForRun() {
+    return [
+      [
+        'CustomGroup',
+        'create',
+        // This is the case category value for the case category type.
+        1,
+      ],
+      [
+        'CustomGroup',
+        'edit',
+        // This is the case category value for the case category type.
+        1,
+      ],
+      [
+        'CaseType',
+        'edit',
+        '',
+      ],
+      [
+        'CaseType',
+        'create',
+        '',
+      ],
+    ];
+  }
+
+  /**
+   * Returns a custom group object.
+   *
+   * @return CRM_Core_BAO_CustomGroup
+   *   Custom group object.
+   */
+  private function getCustomGroupObject() {
+    $customGroup = new CustomGroup();
+    $customGroup->extends = 'Cases';
+    $customGroup->title = 'Group' . uniqid();
+
+    return $customGroup;
+  }
+
+}

--- a/tests/phpunit/CRM/Civicase/Service/CaseManagementCaseTypePostProcessorTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseManagementCaseTypePostProcessorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_Civicase_Helper_InstanceCustomGroupPostProcess as CaseManagementPostProcessHelper;
+use CRM_Civicase_Helper_CaseManagementCustomGroupPostProcess as CaseManagementPostProcessHelper;
 use CRM_Civicase_Service_CaseManagementCaseTypePostProcessor as CaseManagementCaseTypePostProcessor;
 
 /**
@@ -26,8 +26,8 @@ class CRM_Civicase_Service_CaseManagementCaseTypePostProcessorTest extends BaseH
     $customGroup = $this->createCustomGroup($entityColumnValues);
     $customGroupId = $customGroup[0]['id'];
     $caseManagementHelper = $this->getCaseManagementHelperMock($customGroup, []);
-    $caseManagementProcessor = new CaseManagementCaseTypePostProcessor();
-    $caseManagementProcessor->processCaseTypeCustomGroupsOnCreate($caseTypeId, $caseManagementHelper);
+    $caseManagementProcessor = new CaseManagementCaseTypePostProcessor($caseManagementHelper);
+    $caseManagementProcessor->processCaseTypeCustomGroupsOnCreate($caseTypeId);
     $expectedCustomGroup = civicrm_api3('CustomGroup', 'getsingle', ['id' => $customGroupId]);
 
     $this->assertEquals($expectedCustomGroup['extends_entity_column_value'], $expectedEntityColumnValues);
@@ -60,8 +60,8 @@ class CRM_Civicase_Service_CaseManagementCaseTypePostProcessorTest extends BaseH
     $customGroupId = $customGroup[0]['id'];
     $mismatchCustomGroupId = $mismatchCustomGroup[0]['id'];
     $caseManagementHelper = $this->getCaseManagementHelperMock($customGroup, $mismatchCustomGroup);
-    $caseManagementProcessor = new CaseManagementCaseTypePostProcessor();
-    $caseManagementProcessor->processCaseTypeCustomGroupsOnUpdate($caseTypeId, $caseManagementHelper);
+    $caseManagementProcessor = new CaseManagementCaseTypePostProcessor($caseManagementHelper);
+    $caseManagementProcessor->processCaseTypeCustomGroupsOnUpdate($caseTypeId);
     $expectedCustomGroup = civicrm_api3('CustomGroup', 'getsingle', ['id' => $customGroupId]);
     $expectedMismatchCustomGroup = civicrm_api3('CustomGroup', 'getsingle', ['id' => $mismatchCustomGroupId]);
 
@@ -138,7 +138,7 @@ class CRM_Civicase_Service_CaseManagementCaseTypePostProcessorTest extends BaseH
           'getCaseTypeCustomGroups',
           'getCaseTypeCustomGroupsWithCategoryMismatch',
           'getCaseCategoryForCaseType',
-        ],
+        ]
       )
       ->getMock();
     $caseManagementHelper->method('getCaseTypeCustomGroups')->willReturn($customGroupReturn);

--- a/tests/phpunit/CRM/Civicase/Service/CaseManagementCaseTypePostProcessorTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseManagementCaseTypePostProcessorTest.php
@@ -1,0 +1,151 @@
+<?php
+
+use CRM_Civicase_Helper_InstanceCustomGroupPostProcess as CaseManagementPostProcessHelper;
+use CRM_Civicase_Service_CaseManagementCaseTypePostProcessor as CaseManagementCaseTypePostProcessor;
+
+/**
+ * Runs tests on CaseManagementCustomGroupPostProcessor methods.
+ *
+ * @group headless
+ */
+class CRM_Civicase_Service_CaseManagementCaseTypePostProcessorTest extends BaseHeadlessTest {
+
+  /**
+   * Test process case type custom group on case type create.
+   *
+   * @param int $caseTypeId
+   *   Case type Id.
+   * @param mixed $entityColumnValues
+   *   Custom group entity column values.
+   * @param mixed $expectedEntityColumnValues
+   *   Expected entity column values for matched custom groups.
+   *
+   * @dataProvider getDataForTestProcessCaseTypeCustomGroupsOnCreate
+   */
+  public function testProcessCaseTypeCustomGroupsOnCreate($caseTypeId, $entityColumnValues, $expectedEntityColumnValues) {
+    $customGroup = $this->createCustomGroup($entityColumnValues);
+    $customGroupId = $customGroup[0]['id'];
+    $caseManagementHelper = $this->getCaseManagementHelperMock($customGroup, []);
+    $caseManagementProcessor = new CaseManagementCaseTypePostProcessor();
+    $caseManagementProcessor->processCaseTypeCustomGroupsOnCreate($caseTypeId, $caseManagementHelper);
+    $expectedCustomGroup = civicrm_api3('CustomGroup', 'getsingle', ['id' => $customGroupId]);
+
+    $this->assertEquals($expectedCustomGroup['extends_entity_column_value'], $expectedEntityColumnValues);
+  }
+
+  /**
+   * Test process case type custom group on case type update.
+   *
+   * @param int $caseTypeId
+   *   Case type Id.
+   * @param mixed $entityColumnValues
+   *   Custom group entity column values.
+   * @param mixed $mismatchEntityColumnValues
+   *   Entity column values for mismatched custom groups.
+   * @param mixed $expectedEntityColumnValues
+   *   Expected entity column values for matched custom groups.
+   * @param mixed $correctedMismatchValues
+   *   Expected/corrected entity column values for mismatched custom groups.
+   *
+   * @dataProvider getDataForTestProcessCaseTypeCustomGroupsOnUpdate
+   */
+  public function testProcessCaseTypeCustomGroupsOnUpdate(
+    $caseTypeId,
+    $entityColumnValues,
+    $mismatchEntityColumnValues,
+    $expectedEntityColumnValues,
+    $correctedMismatchValues) {
+    $customGroup = $this->createCustomGroup($entityColumnValues);
+    $mismatchCustomGroup = $this->createCustomGroup($mismatchEntityColumnValues);
+    $customGroupId = $customGroup[0]['id'];
+    $mismatchCustomGroupId = $mismatchCustomGroup[0]['id'];
+    $caseManagementHelper = $this->getCaseManagementHelperMock($customGroup, $mismatchCustomGroup);
+    $caseManagementProcessor = new CaseManagementCaseTypePostProcessor();
+    $caseManagementProcessor->processCaseTypeCustomGroupsOnUpdate($caseTypeId, $caseManagementHelper);
+    $expectedCustomGroup = civicrm_api3('CustomGroup', 'getsingle', ['id' => $customGroupId]);
+    $expectedMismatchCustomGroup = civicrm_api3('CustomGroup', 'getsingle', ['id' => $mismatchCustomGroupId]);
+
+    $this->assertEquals($expectedCustomGroup['extends_entity_column_value'], $expectedEntityColumnValues);
+    $this->assertEquals($expectedMismatchCustomGroup['extends_entity_column_value'], $correctedMismatchValues);
+  }
+
+  /**
+   * Data set for TestProcessCaseTypeCustomGroupsOnCreate.
+   *
+   * @return array
+   *   Data set.
+   */
+  public function getDataForTestProcessCaseTypeCustomGroupsOnCreate() {
+    return [
+      [5, [1, 2, 3], [1, 2, 3, 5]],
+      [4, [1], [1, 4]],
+      [5, NULL, [5]],
+    ];
+  }
+
+  /**
+   * Data set for TestProcessCaseTypeCustomGroupsOnUpdate.
+   *
+   * @return array
+   *   Data set.
+   */
+  public function getDataForTestProcessCaseTypeCustomGroupsOnUpdate() {
+    return [
+      [5, [1, 2, 3], [4, 5, 6], [1, 2, 3, 5], [4, 6]],
+      [8, [1, 2, 3], [4, 5, 8], [1, 2, 3, 8], [4, 5]],
+      [2, NULL, [4, 5, 2], [2], [4, 5]],
+    ];
+  }
+
+  /**
+   * Creates a custom group object and returns value as array.
+   *
+   * @param array|null $entityColumnValues
+   *   Entity custom values for custom group.
+   */
+  private function createCustomGroup($entityColumnValues) {
+    $cusGroup = new CRM_Core_BAO_CustomGroup();
+    $cusGroup->title = 'Group' . uniqid();
+    $cusGroup->extends = 'Case';
+    $entityColValue = is_null($entityColumnValues) ? 'null' : CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR, $entityColumnValues) . CRM_Core_DAO::VALUE_SEPARATOR;
+    $cusGroup->extends_entity_column_value = $entityColValue;
+    $cusGroup->save();
+
+    return [
+      [
+        'id' => $cusGroup->id,
+        'extends_entity_column_value' => $entityColumnValues,
+      ],
+    ];
+  }
+
+  /**
+   * Returns a mock object for CaseManagementHelper.
+   *
+   * @param mixed $customGroupReturn
+   *   What to return for the getCaseTypeCustomGroups' method.
+   * @param mixed $customGroupMismatchReturn
+   *   What to return for the
+   *   getCaseTypeCustomGroupsWithCategoryMismatch method.
+   *
+   * @return \PHPUnit_Framework_MockObject_MockObject
+   *   CaseManagementHelper mock object.
+   */
+  private function getCaseManagementHelperMock($customGroupReturn, $customGroupMismatchReturn) {
+    $caseManagementHelper = $this->getMockBuilder(CaseManagementPostProcessHelper::class)
+      ->setMethods(
+        [
+          'getCaseTypeCustomGroups',
+          'getCaseTypeCustomGroupsWithCategoryMismatch',
+          'getCaseCategoryForCaseType',
+        ],
+      )
+      ->getMock();
+    $caseManagementHelper->method('getCaseTypeCustomGroups')->willReturn($customGroupReturn);
+    $caseManagementHelper->method('getCaseCategoryForCaseType')->willReturn(1);
+    $caseManagementHelper->method('getCaseTypeCustomGroupsWithCategoryMismatch')->willReturn($customGroupMismatchReturn);
+
+    return $caseManagementHelper;
+  }
+
+}

--- a/tests/phpunit/CRM/Civicase/Service/CaseManagementCustomGroupDisplayFormatterTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseManagementCustomGroupDisplayFormatterTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use CRM_Civicase_Helper_CaseManagementCustomGroupPostProcess as CaseManagementPostProcessHelper;
+use CRM_Civicase_Service_CaseManagementCustomGroupDisplayFormatter as CaseManagementCustomGroupDisplayFormatter;
+use CRM_Civicase_Setup_ProcessCaseCategoryForCustomGroupSupport as CaseCategoryForCustomGroupSupport;
+
+/**
+ * Runs tests for CaseManagementCustomGroupDisplayFormatterTest.
+ *
+ * @group headless
+ */
+class CRM_Civicase_Service_CaseManagementCustomGroupDisplayFormatterTest extends BaseHeadlessTest {
+
+  /**
+   * Test process display function.
+   */
+  public function testProcessDisplay() {
+    $caseCategories = [1 => 'Cases'];
+    $expectedDisplay = CaseCategoryForCustomGroupSupport::CASE_CATEGORY_LABEL;
+    $cgExtends = ['Cases' => $expectedDisplay];
+    $caseManagementHelper = $this->getCaseManagementHelperMock($caseCategories, $cgExtends);
+    $row['extends_entity_column_id'] = 1;
+    $displayFormatter = new CaseManagementCustomGroupDisplayFormatter($caseManagementHelper);
+    $displayFormatter->processDisplay($row);
+    $this->assertEquals($expectedDisplay, $row['extends_display']);
+  }
+
+  /**
+   * Returns a mock object for CaseManagementHelper.
+   *
+   * @param mixed $caseCategoryReturn
+   *   What to return for the `getCaseTypeCategories` method.
+   * @param mixed $cgExtendReturn
+   *   What to return for the `getCgExtendValues` method.
+   *
+   * @return \PHPUnit_Framework_MockObject_MockObject
+   *   CaseManagementHelper mock object.
+   */
+  private function getCaseManagementHelperMock($caseCategoryReturn, $cgExtendReturn) {
+    $caseManagementHelper = $this->getMockBuilder(CaseManagementPostProcessHelper::class)
+      ->setMethods(
+        [
+          'getCaseTypeCategories',
+          'getCgExtendValues',
+        ]
+      )
+      ->getMock();
+    $caseManagementHelper->method('getCaseTypeCategories')->willReturn($caseCategoryReturn);
+    $caseManagementHelper->method('getCgExtendValues')->willReturn($cgExtendReturn);
+
+    return $caseManagementHelper;
+  }
+
+}

--- a/tests/phpunit/CRM/Civicase/Service/CaseManagementCustomGroupPostProcessorTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseManagementCustomGroupPostProcessorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_Civicase_Helper_InstanceCustomGroupPostProcess as CaseManagementPostProcessHelper;
+use CRM_Civicase_Helper_CaseManagementCustomGroupPostProcess as CaseManagementPostProcessHelper;
 use CRM_Core_BAO_CustomGroup as CustomGroup;
 use CRM_Civicase_Service_CaseManagementCustomGroupPostProcessor as CaseManagementCustomGroupPostProcessor;
 
@@ -26,8 +26,8 @@ class CRM_Civicase_Service_CaseManagementCustomGroupPostProcessorTest extends Ba
   public function testSaveCustomGroupForCaseCategory($expectedExtendsId, $expectedExtendsValue, $caseTypes) {
     $customGroup = $this->getCustomGroupObject();
     $caseManagementHelper = $this->getCaseManagementHelperMock($caseTypes);
-    $caseManagementProcessor = new CaseManagementCustomGroupPostProcessor();
-    $caseManagementProcessor->saveCustomGroupForCaseCategory($customGroup, $caseManagementHelper);
+    $caseManagementProcessor = new CaseManagementCustomGroupPostProcessor($caseManagementHelper);
+    $caseManagementProcessor->saveCustomGroupForCaseCategory($customGroup);
     $this->assertEquals($expectedExtendsId, $customGroup->extends_entity_column_id);
     $this->assertEquals($expectedExtendsValue, $customGroup->extends_entity_column_value, $expectedExtendsValue);
   }

--- a/tests/phpunit/CRM/Civicase/Service/CaseManagementCustomGroupPostProcessorTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseManagementCustomGroupPostProcessorTest.php
@@ -18,12 +18,12 @@ class CRM_Civicase_Service_CaseManagementCustomGroupPostProcessorTest extends Ba
    *   Expected Extends Id.
    * @param string $expectedExtendsValue
    *   Expected extends value.
-   * @param array $caseTypes
+   * @param mixed $caseTypes
    *   Case types for the cases category.
    *
    * @dataProvider getDataForCaseManagementCustomGroup
    */
-  public function testSaveCustomGroupForCaseCategory($expectedExtendsId, $expectedExtendsValue, array $caseTypes) {
+  public function testSaveCustomGroupForCaseCategory($expectedExtendsId, $expectedExtendsValue, $caseTypes) {
     $customGroup = $this->getCustomGroupObject();
     $caseManagementHelper = $this->getCaseManagementHelperMock($caseTypes);
     $caseManagementProcessor = new CaseManagementCustomGroupPostProcessor();

--- a/tests/phpunit/CRM/Civicase/Service/CaseManagementCustomGroupPostProcessorTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseManagementCustomGroupPostProcessorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use CRM_Civicase_Helper_InstanceCustomGroupPostProcess as CaseManagementPostProcessHelper;
+use CRM_Core_BAO_CustomGroup as CustomGroup;
+use CRM_Civicase_Service_CaseManagementCustomGroupPostProcessor as CaseManagementCustomGroupPostProcessor;
+
+/**
+ * Runs tests on CaseManagementCustomGroupPostProcessor methods.
+ *
+ * @group headless
+ */
+class CRM_Civicase_Service_CaseManagementCustomGroupPostProcessorTest extends BaseHeadlessTest {
+
+  /**
+   * Test for the SaveCustomGroupForCaseCategory method.
+   *
+   * @param int $expectedExtendsId
+   *   Expected Extends Id.
+   * @param string $expectedExtendsValue
+   *   Expected extends value.
+   * @param array $caseTypes
+   *   Case types for the cases category.
+   *
+   * @dataProvider getDataForCaseManagementCustomGroup
+   */
+  public function testSaveCustomGroupForCaseCategory($expectedExtendsId, $expectedExtendsValue, array $caseTypes) {
+    $customGroup = $this->getCustomGroupObject();
+    $caseManagementHelper = $this->getCaseManagementHelperMock($caseTypes);
+    $caseManagementProcessor = new CaseManagementCustomGroupPostProcessor();
+    $caseManagementProcessor->saveCustomGroupForCaseCategory($customGroup, $caseManagementHelper);
+    $this->assertEquals($expectedExtendsId, $customGroup->extends_entity_column_id);
+    $this->assertEquals($expectedExtendsValue, $customGroup->extends_entity_column_value, $expectedExtendsValue);
+  }
+
+  /**
+   * Returns a mock object for CaseManagementHelper.
+   *
+   * @param mixed $toReturn
+   *   What to return for the getCaseTypeIdsForCaseCategory method.
+   *
+   * @return \PHPUnit_Framework_MockObject_MockObject
+   *   CaseManagementHelper mock object.
+   */
+  private function getCaseManagementHelperMock($toReturn) {
+    $caseManagementHelper = $this->getMockBuilder(CaseManagementPostProcessHelper::class)
+      ->setMethods(['getCaseTypeIdsForCaseCategory'])
+      ->getMock();
+    $caseManagementHelper->method('getCaseTypeIdsForCaseCategory')->willReturn($toReturn);
+
+    return $caseManagementHelper;
+  }
+
+  /**
+   * Returns a custom group object.
+   *
+   * @return CRM_Core_BAO_CustomGroup
+   *   Custom group object.
+   */
+  private function getCustomGroupObject() {
+    $customGroup = new CustomGroup();
+    $customGroup->extends = 'Cases';
+    $customGroup->title = 'Group' . uniqid();
+
+    return $customGroup;
+  }
+
+  /**
+   * Provides sample data for the SaveCustomGroupForCaseCategory test.
+   *
+   * @return array
+   *   An array of sample data.
+   */
+  public function getDataForCaseManagementCustomGroup() {
+    return [
+      [
+        // This is the case category value for the case category type.
+        1,
+        CRM_Core_DAO::VALUE_SEPARATOR .
+        implode(CRM_Core_DAO::VALUE_SEPARATOR, [1, 2, 3]) .
+        CRM_Core_DAO::VALUE_SEPARATOR,
+        [1, 2, 3],
+      ],
+      [
+        1,
+        'null',
+        NULL,
+      ],
+      [
+        1,
+        CRM_Core_DAO::VALUE_SEPARATOR . implode(CRM_Core_DAO::VALUE_SEPARATOR, [4]) . CRM_Core_DAO::VALUE_SEPARATOR,
+        [4],
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
## Overview
Previously we have business logic in some hook classes for modifying the custom group listing page, performing some actions when a custom group is saved or updated or when a case type is created/updated. 
This was working fine but now that we have introduced category instances, what to modify on the listing page for a custom group might be diffrent for the case management and applicant management instances which is why this PR decouples this logic into specific instance related classes so that each category instance can have it's own logic encapsulated within it's related class.

## Before
The hook classes for modifying the custom group listing page, performing some actions when a custom group is saved or updated or when a case type is created/updated runs based on a general business logic for all case category instances.

## After
There was not much change in business logic in this PR. It is more of decoupling and adding unit tests for existing logic. 
Now The hook classes for modifying the custom group listing page, performing some actions when a custom group is saved or updated or when a case type is created/updated runs based on the case category instance of the related entity being created/updated.

## Technical Details
The classes below now first of all check the case category instance class applicable to the entity being updated and use that class for it's operation.
- CRM_Civicase_Hook_Post_CaseCategoryCustomGroupSaver
- CRM_Civicase_Hook_Post_UpdateCaseTypeListForCaseCategoryCustomGroup
- CRM_Civicase_Hook_PageRun_CaseCategoryCustomGroupListing

A couple of new classes were added for this purpose:
- CRM_Civicase_Service_BaseCaseTypePostProcessor
- CRM_Civicase_Service_BaseCustomGroupDisplayFormatter
- CRM_Civicase_Service_BaseCustomGroupPostProcessor

Applicant management, Case management and any other case category instance will extend these classes in order to provide it's own logic for modifying the custom group listing page, performing some actions when a custom group is saved or updated or when a case type is created/updated.

The `CRM_Civicase_Service_CaseCategoryInstanceUtils` was updated to include new methods that return objects of these classes to perform the operations needed.
