### PR TITLE
Fix deprecated getUrlPath

### DIFF
--- a/ang/civicase.ang.php
+++ b/ang/civicase.ang.php
@@ -26,7 +26,7 @@ $permissionService = new CaseCategoryPermission();
 $caseCategoryPermissions = $permissionService->get($caseCategoryName);
 
 // The following changes are only relevant to the full-page app.
-if (CRM_Utils_System::getUrlPath() == 'civicrm/case/a') {
+if (CRM_Utils_System::currentPath() == 'civicrm/case/a') {
   adds_shoreditch_css();
   CaseCategoryHelper::updateBreadcrumbs($caseCategoryName);
 }


### PR DESCRIPTION
## Overview

Replaces a deprecated use of `getUrlPath` by `currentPath`.

The new function was already used by the extension, a few lines above, so it should not cause any compatibility issues on existing sites.

## Before

CiviCRM logs warnings of deprecated `getUrlPath`.

## After

:sunglasses: 
