### PR TITLE
RSE-1380: Add "Manage Workflows" Menu

### DIFF
--- a/CRM/Civicase/Service/CaseCategoryInstance.php
+++ b/CRM/Civicase/Service/CaseCategoryInstance.php
@@ -1,11 +1,12 @@
 <?php
 
 use CRM_Civicase_BAO_CaseCategoryInstance as CaseCategoryInstance;
+use CRM_Civicase_Helper_CaseCategory as CaseCategory;
 
 /**
  * Case Instance class.
  */
-class CRM_Civicase_Service_CaseInstance {
+class CRM_Civicase_Service_CaseCategoryInstance {
 
   /**
    * Get case categories instances.
@@ -13,7 +14,7 @@ class CRM_Civicase_Service_CaseInstance {
    * @param string $instanceName
    *   Instance ID.
    */
-  public static function getCaseCategoryInstances($instanceName = NULL) {
+  public function getCaseCategoryInstances($instanceName = NULL) {
     $caseCategoryInstances = [];
     $caseCategoryInstance = new CaseCategoryInstance();
 
@@ -42,13 +43,10 @@ class CRM_Civicase_Service_CaseInstance {
    * Assigns `case_management` instance to the existing case type categories
    * which does not have instance assigned.
    */
-  public static function assignInstanceForExistingCaseCategories() {
-    $caseTypeCategories = civicrm_api3('OptionValue', 'get', [
-      'sequential' => 1,
-      'option_group_id' => 'case_type_categories',
-    ])['values'];
+  public function assignInstanceForExistingCaseCategories() {
+    $caseTypeCategories = CaseCategory::getCaseCategories();
 
-    $instances = CRM_Civicase_Service_CaseInstance::getCaseCategoryInstances();
+    $instances = $this->getCaseCategoryInstances();
 
     foreach ($caseTypeCategories as $caseTypeCategory) {
       $instanceRecord = NULL;
@@ -67,7 +65,7 @@ class CRM_Civicase_Service_CaseInstance {
           'name' => 'case_management',
         ])['values'][0]['value'];
 
-        CRM_Civicase_Service_CaseInstance::createInstanceTypeFor(
+        $this->createInstanceTypeFor(
           $caseTypeCategory['value'],
           $instanceId
         );
@@ -83,7 +81,7 @@ class CRM_Civicase_Service_CaseInstance {
    * @param mixed $instanceId
    *   Instance ID.
    */
-  public static function createInstanceTypeFor($categoryValue, $instanceId) {
+  public function createInstanceTypeFor($categoryValue, $instanceId) {
     $caseCategoryInstance = new CaseCategoryInstance();
     $caseCategoryInstance->instance_id = $instanceId;
     $caseCategoryInstance->category_id = $categoryValue;

--- a/CRM/Civicase/Service/CaseCategoryMenu.php
+++ b/CRM/Civicase/Service/CaseCategoryMenu.php
@@ -270,7 +270,7 @@ class CRM_Civicase_Service_CaseCategoryMenu {
     $permissions = $caseCategoryPermission->get($caseTypeCategoryName);
 
     $ifMenuExist = count(civicrm_api3('Navigation', 'get', [
-      'name' => 'manage_' . $caseTypeCategory['name'] . '_workflows',
+      'name' => 'manage_' . $caseTypeCategoryName . '_workflows',
     ])['values']) > 0;
 
     if (!$ifMenuExist) {
@@ -278,7 +278,7 @@ class CRM_Civicase_Service_CaseCategoryMenu {
         'parent_id' => $parentId,
         'url' => '/civicrm/workflow/a?case_type_category=' . $caseTypeCategoryName . '#/list',
         'label' => $menuLabel,
-        'name' => 'manage_' . $caseTypeCategory['name'] . '_workflows',
+        'name' => 'manage_' . $caseTypeCategoryName . '_workflows',
         'is_active' => TRUE,
         'permission' => "{$permissions['ADMINISTER_CASE_CATEGORY']['name']}, administer CiviCRM",
         'permission_operator' => 'OR',

--- a/CRM/Civicase/Service/CaseCategoryMenu.php
+++ b/CRM/Civicase/Service/CaseCategoryMenu.php
@@ -97,6 +97,14 @@ class CRM_Civicase_Service_CaseCategoryMenu {
         'url' => 'civicrm/case/a/?case_type_category=' . $caseTypeCategoryName . '#/case/list?cf={"case_type_category":"' . $caseTypeCategoryName . '"}',
         'permission' => "{$permissions['ACCESS_MY_CASE_CATEGORY_AND_ACTIVITIES']['name']},{$permissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name']}",
         'permission_operator' => 'OR',
+        'has_separator' => 1,
+      ],
+      [
+        'label' => ts("Manage Workflows"),
+        'name' => "manage_{$caseTypeCategoryName}_workflows",
+        'url' => 'civicrm/workflow/a?case_type_category=' . $caseTypeCategoryName . '#/list',
+        'permission' => "{$permissions['ADMINISTER_CASE_CATEGORY']['name']}, administer CiviCRM",
+        'permission_operator' => 'OR',
       ],
     ];
 

--- a/CRM/Civicase/Service/CaseInstance.php
+++ b/CRM/Civicase/Service/CaseInstance.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Case Instance class.
+ */
+class CRM_Civicase_Service_CaseInstance {
+
+  /**
+   * Assigns instance to case type categories without an instance.
+   *
+   * Assigns `case_management` instance to the existing case type categories
+   * which does not have instance assigned.
+   */
+  public static function assignInstanceForExistingCaseCategories() {
+    $caseTypeCategories = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'option_group_id' => 'case_type_categories',
+    ])['values'];
+
+    $instances = civicrm_api3('CaseCategoryInstance', 'get', [
+      'sequential' => 1,
+    ])['values'];
+
+    foreach ($caseTypeCategories as $caseTypeCategory) {
+      $instanceRecord = NULL;
+
+      foreach ($instances as $instance) {
+        if ($instance['category_id'] == $caseTypeCategory['value']) {
+          $instanceRecord = $instance;
+          break;
+        }
+      }
+
+      if (!$instanceRecord) {
+        civicrm_api3('CaseCategoryInstance', 'create', [
+          'category_id' => $caseTypeCategory['value'],
+          'instance_id' => 'case_management',
+        ]);
+      }
+    }
+  }
+
+}

--- a/CRM/Civicase/Service/CaseInstance.php
+++ b/CRM/Civicase/Service/CaseInstance.php
@@ -1,9 +1,40 @@
 <?php
 
+use CRM_Civicase_BAO_CaseCategoryInstance as CaseCategoryInstance;
+
 /**
  * Case Instance class.
  */
 class CRM_Civicase_Service_CaseInstance {
+
+  /**
+   * Get case categories instances.
+   *
+   * @param string $instanceName
+   *   Instance ID.
+   */
+  public static function getCaseCategoryInstances($instanceName = NULL) {
+    $caseCategoryInstances = [];
+    $caseCategoryInstance = new CaseCategoryInstance();
+
+    if ($instanceName) {
+      $instanceId = civicrm_api3('OptionValue', 'get', [
+        'sequential' => 1,
+        'option_group_id' => 'case_category_instance_type',
+        'name' => $instanceName,
+      ])['values'][0]['value'];
+
+      $caseCategoryInstance->instance_id = $instanceId;
+    }
+
+    $caseCategoryInstance->find();
+
+    while ($caseCategoryInstance->fetch()) {
+      $caseCategoryInstances[$caseCategoryInstance->id] = clone $caseCategoryInstance;
+    }
+
+    return $caseCategoryInstances;
+  }
 
   /**
    * Assigns instance to case type categories without an instance.
@@ -17,27 +48,47 @@ class CRM_Civicase_Service_CaseInstance {
       'option_group_id' => 'case_type_categories',
     ])['values'];
 
-    $instances = civicrm_api3('CaseCategoryInstance', 'get', [
-      'sequential' => 1,
-    ])['values'];
+    $instances = CRM_Civicase_Service_CaseInstance::getCaseCategoryInstances();
 
     foreach ($caseTypeCategories as $caseTypeCategory) {
       $instanceRecord = NULL;
 
       foreach ($instances as $instance) {
-        if ($instance['category_id'] == $caseTypeCategory['value']) {
+        if ($instance->category_id == $caseTypeCategory['value']) {
           $instanceRecord = $instance;
           break;
         }
       }
 
       if (!$instanceRecord) {
-        civicrm_api3('CaseCategoryInstance', 'create', [
-          'category_id' => $caseTypeCategory['value'],
-          'instance_id' => 'case_management',
-        ]);
+        $instanceId = civicrm_api3('OptionValue', 'get', [
+          'sequential' => 1,
+          'option_group_id' => 'case_category_instance_type',
+          'name' => 'case_management',
+        ])['values'][0]['value'];
+
+        CRM_Civicase_Service_CaseInstance::createInstanceTypeFor(
+          $caseTypeCategory['value'],
+          $instanceId
+        );
       }
     }
+  }
+
+  /**
+   * Creates instance for the given case type category.
+   *
+   * @param mixed $categoryValue
+   *   Case category value.
+   * @param mixed $instanceId
+   *   Instance ID.
+   */
+  public static function createInstanceTypeFor($categoryValue, $instanceId) {
+    $caseCategoryInstance = new CaseCategoryInstance();
+    $caseCategoryInstance->instance_id = $instanceId;
+    $caseCategoryInstance->category_id = $categoryValue;
+
+    $caseCategoryInstance->save();
   }
 
 }

--- a/CRM/Civicase/Setup/AddManageWorkflowMenu.php
+++ b/CRM/Civicase/Setup/AddManageWorkflowMenu.php
@@ -1,0 +1,19 @@
+<?php
+
+use CRM_Civicase_Service_CaseCategoryMenu as CaseCategoryMenu;
+use CRM_Civicase_Service_CaseInstance as CaseInstance;
+
+/**
+ * Adds the Manage Workflow Menu item for existing Case types.
+ */
+class CRM_Civicase_Setup_AddManageWorkflowMenu {
+
+  /**
+   * Updates the Manage Cases Menu URLs.
+   */
+  public function apply() {
+    CaseInstance::assignInstanceForExistingCaseCategories();
+    CaseCategoryMenu::createManageWorkflowMenuForExistingCaseCategories('case_management', FALSE);
+  }
+
+}

--- a/CRM/Civicase/Setup/AddManageWorkflowMenu.php
+++ b/CRM/Civicase/Setup/AddManageWorkflowMenu.php
@@ -1,7 +1,6 @@
 <?php
 
 use CRM_Civicase_Service_CaseCategoryMenu as CaseCategoryMenu;
-use CRM_Civicase_Service_CaseInstance as CaseInstance;
 
 /**
  * Adds the Manage Workflow Menu item for existing Case types.
@@ -12,8 +11,9 @@ class CRM_Civicase_Setup_AddManageWorkflowMenu {
    * Updates the Manage Cases Menu URLs.
    */
   public function apply() {
-    CaseInstance::assignInstanceForExistingCaseCategories();
-    CaseCategoryMenu::createManageWorkflowMenuForExistingCaseCategories('case_management', FALSE);
+    $caseCategoryMenuObj = new CaseCategoryMenu();
+
+    $caseCategoryMenuObj->createManageWorkflowMenu('case_management', FALSE);
   }
 
 }

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -78,7 +78,6 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
       new CreateSafeFileExtensionOptionValue(),
       new ProcessCaseCategoryForCustomGroupSupport(),
       new AddChangeCaseRoleDateActivityTypes(),
-      new AddManageWorkflowMenu(),
     ];
     foreach ($steps as $step) {
       $step->apply();
@@ -396,6 +395,9 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     $this->swapCaseMenuItems();
 
     $this->toggleNav('Manage Cases', TRUE);
+
+    $workflowMenu = new AddManageWorkflowMenu();
+    $workflowMenu->apply();
   }
 
   /**

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -10,6 +10,7 @@ use CRM_Civicase_Uninstall_RemoveCustomGroupSupportForCaseCategory as RemoveCust
 use CRM_Civicase_Setup_ProcessCaseCategoryForCustomGroupSupport as ProcessCaseCategoryForCustomGroupSupport;
 use CRM_Civicase_Setup_CaseCategoryInstanceSupport as CaseCategoryInstanceSupport;
 use CRM_Civicase_Setup_AddChangeCaseRoleDateActivityTypes as AddChangeCaseRoleDateActivityTypes;
+use CRM_Civicase_Setup_AddManageWorkflowMenu as AddManageWorkflowMenu;
 
 /**
  * Collection of upgrade steps.
@@ -77,6 +78,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
       new CreateSafeFileExtensionOptionValue(),
       new ProcessCaseCategoryForCustomGroupSupport(),
       new AddChangeCaseRoleDateActivityTypes(),
+      new AddManageWorkflowMenu(),
     ];
     foreach ($steps as $step) {
       $step->apply();

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -245,7 +245,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
    * Fixes original id of followup activities to point to the original activity
    * and not a revision.
    *
-   * TODO: This is a WIP (untested) and not yet called from anywhere.
+   * @todo This is a WIP (untested) and not yet called from anywhere.
    * When it's ready we can change its name to upgrade_000X and call it from
    * the installer.
    */
@@ -255,7 +255,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
       WHERE a.parent_id = b.id
       AND b.original_id IS NOT NULL';
     CRM_Core_DAO::executeQuery($sql);
-    // TODO: before we uncomment the below, need to migrate this history
+    // @todo before we uncomment the below, need to migrate this history
     // to advanced logging table.
     // CRM_Core_DAO::executeQuery('DELETE FROM civicrm_activity WHERE
     // original_id IS NOT NULL');.

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -11,6 +11,7 @@ use CRM_Civicase_Setup_ProcessCaseCategoryForCustomGroupSupport as ProcessCaseCa
 use CRM_Civicase_Setup_CaseCategoryInstanceSupport as CaseCategoryInstanceSupport;
 use CRM_Civicase_Setup_AddChangeCaseRoleDateActivityTypes as AddChangeCaseRoleDateActivityTypes;
 use CRM_Civicase_Setup_AddManageWorkflowMenu as AddManageWorkflowMenu;
+use CRM_Civicase_Service_CaseCategoryInstance as CaseCategoryInstance;
 
 /**
  * Collection of upgrade steps.
@@ -395,6 +396,9 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     $this->swapCaseMenuItems();
 
     $this->toggleNav('Manage Cases', TRUE);
+
+    $instanceObj = new CaseCategoryInstance();
+    $instanceObj->assignInstanceForExistingCaseCategories();
 
     $workflowMenu = new AddManageWorkflowMenu();
     $workflowMenu->apply();

--- a/CRM/Civicase/Upgrader/Steps/Step0014.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0014.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_Civicase_Setup_AddManageWorkflowMenu as AddManageWorkflowMenu;
+use CRM_Civicase_Service_CaseCategoryInstance as CaseCategoryInstance;
 
 /**
  * Assigns instance to case type categories without an instance.
@@ -17,6 +18,9 @@ class CRM_Civicase_Upgrader_Steps_Step0014 {
    *   Return value in boolean.
    */
   public function apply() {
+    $instanceObj = new CaseCategoryInstance();
+    $instanceObj->assignInstanceForExistingCaseCategories();
+
     $step = new AddManageWorkflowMenu();
     $step->apply();
 

--- a/CRM/Civicase/Upgrader/Steps/Step0014.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0014.php
@@ -1,0 +1,26 @@
+<?php
+
+use CRM_Civicase_Setup_AddManageWorkflowMenu as AddManageWorkflowMenu;
+
+/**
+ * Assigns instance to case type categories without an instance.
+ *
+ * Also creates Manage Workflow menu for existing 'case management' type
+ * categories.
+ */
+class CRM_Civicase_Upgrader_Steps_Step0014 {
+
+  /**
+   * Runs the upgrader changes.
+   *
+   * @return bool
+   *   Return value in boolean.
+   */
+  public function apply() {
+    $step = new AddManageWorkflowMenu();
+    $step->apply();
+
+    return TRUE;
+  }
+
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3517,8 +3517,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3539,14 +3538,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3561,20 +3558,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3691,8 +3685,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3704,7 +3697,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3719,7 +3711,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3727,14 +3718,12 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3753,7 +3742,6 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -3815,8 +3803,7 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -3844,8 +3831,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3857,7 +3843,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3935,8 +3920,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3972,7 +3956,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3992,7 +3975,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4036,14 +4018,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },


### PR DESCRIPTION
## Overview
As part of this PR, the Manage Workflows menu has been created for `case_management` case type categories.

## Before
Menu Items were not present.

## After
Menu Items are created. 

## Technical Details
1. In `CRM/Civicase/Service/CaseCategoryMenu.php`, added "Manage Workflows" menu item for newly created sites.
Also added `createManageWorkflowMenuForExistingCaseCategories ` function, which creates Manage Workflow menu for existing case type categories of the system.

2. Added `CRM_Civicase_Service_CaseInstance` service class, which includes `assignInstanceForExistingCaseCategories` function. This function assigns all existing Case Type categories to the `case_management` instance.

3. Added a new upgrader which uses `CRM_Civicase_Setup_AddManageWorkflowMenu ` class to execute both of the above steps.
