### PR TITLE
CATL-1863: Add case email contacts to front-end settings

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
+++ b/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
@@ -6,6 +6,13 @@
 class CRM_Civicase_Hook_BuildForm_RestrictCaseEmailContacts {
 
   /**
+   * The current form's instance.
+   *
+   * @var CRM_Core_Form
+   */
+  private $form;
+
+  /**
    * Handles the hook's implementation.
    *
    * @param CRM_Core_Form $form
@@ -16,7 +23,7 @@ class CRM_Civicase_Hook_BuildForm_RestrictCaseEmailContacts {
   public function run(CRM_Core_Form $form, $formName) {
     $this->form = $form;
 
-    if (!$this->shouldRun($form)) {
+    if (!$this->shouldRun()) {
       return;
     }
 

--- a/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
+++ b/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Restricts case emails to case contacts only.
+ */
+class CRM_Civicase_Hook_BuildForm_RestrictCaseEmailContacts {
+
+  /**
+   * Handles the hook's implementation.
+   *
+   * @param CRM_Core_Form $form
+   *   The current form's instance.
+   * @param string $formName
+   *   The name for the current form.
+   */
+  public function run(CRM_Core_Form $form, $formName) {
+    $this->form = $form;
+
+    if (!$this->shouldRun($form)) {
+      return;
+    }
+
+    $this->addListOfCaseContactsToSettings();
+  }
+
+  /**
+   * Determines if the hook should run.
+   *
+   * Only runs for Case Email forms and when the "Restrict Case Email Contacts"
+   * setting is set.
+   *
+   * @return bool
+   *   True when the hook can run.
+   */
+  private function shouldRun() {
+    $isEmailForm = get_class($this->form) === CRM_Contact_Form_Task_Email::class;
+    $isCaseEmail = !empty($this->form->getVar('_caseId'));
+    $shouldRestrictContacts = (bool) Civi::settings()->get('civicaseRestrictCaseEmailContacts');
+
+    return $isEmailForm && $isCaseEmail && $shouldRestrictContacts;
+  }
+
+  /**
+   * Adds the list of contacts for the case to the front-end settings object.
+   *
+   * The list of contacts is exported as a JSON string to avoid CiviCRM from
+   * extending the list instead of replacing it. This would cause problems when
+   * switching cases or updating the contacts for the existing one.
+   */
+  private function addListOfCaseContactsToSettings() {
+    $caseId = $this->form->getVar('_caseId');
+
+    $caseDetailsResponse = civicrm_api3('Case', 'getdetails', [
+      'id' => $caseId,
+      'options' => ['limit' => 1],
+    ]);
+    $caseDetails = CRM_Utils_Array::first($caseDetailsResponse['values']);
+
+    $caseContacts = array_map(function ($caseContact) {
+      return [
+        'role' => $caseContact['role'],
+        'email' => $caseContact['email'],
+        'value' => $caseContact['contact_id'] . '::' . $caseContact['email'],
+        'display_name' => $caseContact['display_name'],
+      ];
+    }, $caseDetails['contacts']);
+
+    CRM_Core_Resources::singleton()
+      ->addSetting([
+        'civicase-base' => [
+          'case_contacts' => json_encode($caseContacts),
+        ],
+      ]);
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -213,6 +213,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_DisplayAllCustomGroupsInCaseForm(),
     new CRM_Civicase_Hook_BuildForm_LinkToCaseSearchByCaseId(),
     new CRM_Civicase_Hook_BuildForm_RemoveExportActionFromReports(),
+    new CRM_Civicase_Hook_BuildForm_RestrictCaseEmailContacts(),
   ];
 
   foreach ($hooks as $hook) {

--- a/js/civicase-settings-form.js
+++ b/js/civicase-settings-form.js
@@ -1,11 +1,13 @@
-(function ($) {
+(function ($, crmHelp) {
   $(document).on('crmLoad', function () {
     var $radioButtonsThatToggleVisibility = $('[data-toggles-visibility-for]');
     var $multiCaseClient = $('#civicaseAllowMultipleClients');
     var $singleCaseRoleParent = $('.crm-mail-form-block-civicaseSingleCaseRolePerType');
     var $singleCaseRole = $('#civicaseSingleCaseRolePerType_civicaseSingleCaseRolePerType');
+    var $helpTextIcons = $('#crm-main-content-wrapper .helpicon');
 
     (function init () {
+      displayHelpTextMessagesOnClick();
       toggleVisibilityOnRadioButtonChange();
       toggleVisibilityForSingleCaseRole();
 
@@ -14,6 +16,37 @@
         $multiCaseClient.change(toggleVisibilityForSingleCaseRole);
       }
     })();
+
+    /**
+     * Handles the display of help text messages associated with setting fields.
+     *
+     * Fixes an issue in core where help texts are not properly displayed.
+     */
+    function displayHelpTextMessagesOnClick () {
+      $helpTextIcons.each((index, helpTextIconReference) => {
+        var $helpTextIcon = $(helpTextIconReference);
+        var $field = $helpTextIcon.siblings('[data-help-text]');
+        var helpText = $field.attr('data-help-text');
+        var fieldName = $field.attr('name');
+
+        $helpTextIcon.removeAttr('onclick');
+        $helpTextIcon.on('click', displayHelpTextMessage);
+
+        /**
+         * Displays the text message for the field.
+         *
+         * @param {object} event DOM Event.
+         */
+        function displayHelpTextMessage (event) {
+          event.preventDefault();
+
+          crmHelp(helpText, {
+            id: fieldName + '-id',
+            file: 'CRM/Admin/Form/Setting/Case'
+          });
+        }
+      });
+    }
 
     /**
      * Toggles the visibility of civicase settings fields based on radio button values.
@@ -64,4 +97,4 @@
       }
     }
   });
-})(CRM.$);
+})(CRM.$, CRM.help);

--- a/settings/CiviCase.setting.php
+++ b/settings/CiviCase.setting.php
@@ -2,6 +2,13 @@
 
 /**
  * @file
+ * Civicase Settings.
+ */
+
+use CRM_Civicase_ExtensionUtil as E;
+
+/**
+ * @file
  * CiviCase Setting file.
  */
 
@@ -18,10 +25,10 @@ $setting = [
     'default' => FALSE,
     'html_type' => 'radio',
     'add' => '4.7',
-    'title' => 'Allow cases to be locked',
+    'title' => E::ts('Allow cases to be locked'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'This will allow cases to be locked for certain contacts.',
+    'description' => E::ts('This will allow cases to be locked for certain contacts.'),
     'help_text' => '',
   ],
   'civicaseShowComingSoonCaseSummaryBlock' => [
@@ -33,10 +40,10 @@ $setting = [
     'default' => TRUE,
     'html_type' => 'radio',
     'add' => '4.7',
-    'title' => 'Show "Coming Soon" section on Case Summary',
+    'title' => E::ts('Show "Coming Soon" section on Case Summary'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'This configuration controls the visibility of the coming soon section on the case summary screen which has Next Milestone, Next Activity and the Case Calendar.',
+    'description' => E::ts('This configuration controls the visibility of the coming soon section on the case summary screen which has Next Milestone, Next Activity and the Case Calendar.'),
   ],
   'civicaseAllowLinkedCasesTab' => [
     'group_name' => 'CiviCRM Preferences',
@@ -47,10 +54,10 @@ $setting = [
     'default' => FALSE,
     'html_type' => 'radio',
     'add' => '4.7',
-    'title' => 'Allow linked cases tab',
+    'title' => E::ts('Allow linked cases tab'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'This will allow linked cases to be viewed on a separate tab.',
+    'description' => E::ts('This will allow linked cases to be viewed on a separate tab.'),
     'help_text' => '',
   ],
   'civicaseShowWebformsListSeparately' => [
@@ -66,10 +73,10 @@ $setting = [
     ],
     'html_type' => 'radio',
     'add' => '4.7',
-    'title' => 'Show Webforms list in a separate dropdown',
+    'title' => E::ts('Show Webforms list in a separate dropdown'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'This will show the webforms list in a separate dropdown.',
+    'description' => E::ts('This will show the webforms list in a separate dropdown.'),
     'help_text' => '',
   ],
   'civicaseWebformsDropdownButtonLabel' => [
@@ -86,10 +93,10 @@ $setting = [
     'html_type' => 'text',
     'default' => 'Webforms',
     'add' => '4.7',
-    'title' => 'Label for the Webforms dropdown button',
+    'title' => E::ts('Label for the Webforms dropdown button'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'Label for the Webforms dropdown button',
+    'description' => E::ts('Label for the Webforms dropdown button'),
     'help_text' => '',
   ],
   'showFullContactNameOnActivityFeed' => [
@@ -101,10 +108,10 @@ $setting = [
     'default' => TRUE,
     'html_type' => 'radio',
     'add' => '4.7',
-    'title' => 'Show full name on Case activity feed',
+    'title' => E::ts('Show full name on Case activity feed'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'This configuration determines whether or not the full name of the activity creator is displayed in the case activity feed.',
+    'description' => E::ts('This configuration determines whether or not the full name of the activity creator is displayed in the case activity feed.'),
     'help_text' => '',
   ],
   'includeActivitiesForInvolvedContact' => [
@@ -116,10 +123,10 @@ $setting = [
     'default' => FALSE,
     'html_type' => 'radio',
     'add' => '4.7',
-    'title' => "Include activities I'm involved in",
+    'title' => E::ts("Include activities I'm involved in"),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => "Cases I'm involved in filter will include 'activities created by me' and 'activities assigned to me'.",
+    'description' => E::ts("Cases I'm involved in filter will include 'activities created by me' and 'activities assigned to me'."),
     'help_text' => '',
   ],
   'civicaseSingleCaseRolePerType' => [
@@ -134,10 +141,10 @@ $setting = [
     ],
     'html_type' => 'checkbox',
     'add' => '4.7',
-    'title' => ts('One active case role'),
+    'title' => E::ts('One active case role'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => ts('This setting will only allow one active instance of each case role for all case types.'),
+    'description' => E::ts('This setting will only allow one active instance of each case role for all case types.'),
     'help_text' => '',
   ],
   'civicaseRestrictCaseEmailContacts' => [
@@ -149,13 +156,13 @@ $setting = [
     'default' => FALSE,
     'html_type' => 'radio',
     'add' => '4.7',
-    'title' => 'Restrict email recipients to contacts involved with the case',
+    'title' => E::ts('Restrict email recipients to contacts involved with the case'),
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => '',
     'help_text' => TRUE,
     'html_attributes' => [
-      'data-help-text' => 'When this setting is enabled users will only be able to add existing contacts who are either the case clients or people currently involved with the case as recipients of new emails.',
+      'data-help-text' => E::ts('When this setting is enabled users will only be able to add existing contacts who are either the case clients or people currently involved with the case as recipients of new emails.'),
     ],
   ],
 ];

--- a/settings/CiviCase.setting.php
+++ b/settings/CiviCase.setting.php
@@ -140,6 +140,24 @@ $setting = [
     'description' => ts('This setting will only allow one active instance of each case role for all case types.'),
     'help_text' => '',
   ],
+  'civicaseRestrictCaseEmailContacts' => [
+    'group_name' => 'CiviCRM Preferences',
+    'group' => 'core',
+    'name' => 'civicaseRestrictCaseEmailContacts',
+    'type' => 'Boolean',
+    'quick_form_type' => 'YesNo',
+    'default' => FALSE,
+    'html_type' => 'radio',
+    'add' => '4.7',
+    'title' => 'Restrict email recipients to contacts involved with the case',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => '',
+    'help_text' => TRUE,
+    'html_attributes' => [
+      'data-help-text' => 'When this setting is enabled users will only be able to add existing contacts who are either the case clients or people currently involved with the case as recipients of new emails.',
+    ],
+  ],
 ];
 
 $caseSetting = new CRM_Civicase_Service_CaseCategorySetting();


### PR DESCRIPTION
## Overview
This PR adds the following changes:

* A new "Restrict email recipients to contacts involved with the case" setting.
* The list of case contacts is added to the front-end settings object when opening a case email form.

## How it looks

### New Setting
![gif](https://user-images.githubusercontent.com/1642119/96941726-323bc480-14a1-11eb-9150-38c379a44723.gif)

### Configuration object
![Screen Shot 2020-10-22 at 7 56 55 PM](https://user-images.githubusercontent.com/1642119/96941684-12a49c00-14a1-11eb-8d4d-2fa3a13553ee.png)

## Technical Details

The new setting was added to the `settings/CiviCase.setting.php` file in the regular way except for the help text. There seems to be an issue in CiviCRM with settings pages and help texts as explained by their documentation (https://docs.civicrm.org/dev/en/latest/framework/setting/ see `help_text`). The help text is not exposed to the front-end and the `CRM.help` service displays an empty message. To fix this we pass the help text through an HTML parameter and added javascript code in `js/civicase-settings-form.js` to make sure the help text is properly displayed.

The `settings/CiviCase.setting.php` file was also updated to support Transifex translations.

A new `CRM_Civicase_Hook_BuildForm_RestrictCaseEmailContacts` hook was introduced to run when viewing a case email form and when the newly introduced setting is set to "yes". The list of contacts is taken from the "contacts" property of the case details response. The structure that is returned to the front-end follows a similar structure as the ones for the current recipient fields. For example, the value used is `1::admin@example.com` where `1` is the ID of the contact, and the rest is the contact's email. This pattern is expected by the email form when selecting recipients.

Finally, the setting is exposed to the front-end as a string instead of an object because CiviCRM would try to extend the existing object instead of replacing it. This can be an issue when switching to different cases or when the case contacts have been updated. By sending a string we ensure that the value will be appropriate. 