### PR TITLE
RSE-1455: Refactor Duplicate Workflow functionality

### DIFF
--- a/CRM/Workflow/Hook/addDependentAngularModules.php
+++ b/CRM/Workflow/Hook/addDependentAngularModules.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Creates a hook to add modules dependent on Workflow.
+ */
+class CRM_Workflow_Hook_addDependentAngularModules {
+
+  /**
+   * This hook allows other extensions add modules dependent on Workflow.
+   *
+   * @param array $dependentModules
+   *   Modules dependent on Workflow.
+   *
+   * @return array
+   *   Array of dependent modules.
+   */
+  public static function invoke(array $dependentModules) {
+    CRM_Utils_Hook::singleton()->invoke(['dependentModules'],
+      $dependentModules,
+      CRM_Utils_Hook::$_nullObject,
+      CRM_Utils_Hook::$_nullObject,
+      CRM_Utils_Hook::$_nullObject,
+      CRM_Utils_Hook::$_nullObject,
+      CRM_Utils_Hook::$_nullObject,
+      'addWorkflowDependentAngularModules'
+    );
+
+    return $dependentModules;
+  }
+
+}

--- a/ang/civicase-base/providers/case-type-category.provider.js
+++ b/ang/civicase-base/providers/case-type-category.provider.js
@@ -22,7 +22,7 @@
     this.$get = $get;
     this.findByName = findByName;
     this.findAllByInstance = findAllByInstance;
-    this.getInstance = getInstance;
+    this.getCaseTypeCategoryInstance = getCaseTypeCategoryInstance;
     this.getAll = getAll;
     this.isInstance = isInstance;
 
@@ -37,7 +37,7 @@
         findById: findById,
         findByName: findByName,
         findAllByInstance: findAllByInstance,
-        getInstance: getInstance,
+        getCaseTypeCategoryInstance: getCaseTypeCategoryInstance,
         getCategoriesWithAccessToActivity: getCategoriesWithAccessToActivity,
         isInstance: isInstance
       };
@@ -90,7 +90,7 @@
      * @param {string} caseTypeCategoryValue case type category value
      * @returns {boolean} if the sent case type category is part of the sent instance
      */
-    function getInstance (caseTypeCategoryValue) {
+    function getCaseTypeCategoryInstance (caseTypeCategoryValue) {
       var instanceID = _.find(caseCategoryInstanceMapping, function (instanceMap) {
         return instanceMap.category_id === caseTypeCategoryValue;
       }).instance_id;

--- a/ang/civicase-base/providers/case-type-category.provider.js
+++ b/ang/civicase-base/providers/case-type-category.provider.js
@@ -22,6 +22,7 @@
     this.$get = $get;
     this.findByName = findByName;
     this.findAllByInstance = findAllByInstance;
+    this.getInstance = getInstance;
     this.getAll = getAll;
     this.isInstance = isInstance;
 
@@ -36,6 +37,7 @@
         findById: findById,
         findByName: findByName,
         findAllByInstance: findAllByInstance,
+        getInstance: getInstance,
         getCategoriesWithAccessToActivity: getCategoriesWithAccessToActivity,
         isInstance: isInstance
       };
@@ -80,6 +82,22 @@
       }).value;
 
       return caseTypeCategory.instance_id === instanceID;
+    }
+
+    /**
+     * Get instance object for the sent case type category value
+     *
+     * @param {string} caseTypeCategoryValue case type category value
+     * @returns {boolean} if the sent case type category is part of the sent instance
+     */
+    function getInstance (caseTypeCategoryValue) {
+      var instanceID = _.find(caseCategoryInstanceMapping, function (instanceMap) {
+        return instanceMap.category_id === caseTypeCategoryValue;
+      }).instance_id;
+
+      return _.find(caseCategoryInstanceType, function (instance) {
+        return instance.value === instanceID;
+      });
     }
 
     /**

--- a/ang/test/civicase-base/providers/case-type-category.provider.spec.js
+++ b/ang/test/civicase-base/providers/case-type-category.provider.spec.js
@@ -131,7 +131,7 @@
       });
 
       it('returns the instance of the case type category', () => {
-        expect(CaseTypeCategory.getInstance('1')).toEqual(expectedResult);
+        expect(CaseTypeCategory.getCaseTypeCategoryInstance('1')).toEqual(expectedResult);
       });
     });
 

--- a/ang/test/civicase-base/providers/case-type-category.provider.spec.js
+++ b/ang/test/civicase-base/providers/case-type-category.provider.spec.js
@@ -1,11 +1,11 @@
 /* eslint-env jasmine */
 ((_, angular) => {
   describe('CaseTypeCategory Provider', () => {
-    let CaseTypeCategory;
+    let CaseTypeCategory, CaseCategoryInstanceTypeData;
 
     describe('when all case type categories are requested', () => {
       beforeEach(() => {
-        module('civicase-base');
+        module('civicase-base', 'civicase.data');
         injectDependencies();
       });
 
@@ -18,7 +18,7 @@
       var expectedResult;
 
       beforeEach(() => {
-        module('civicase-base');
+        module('civicase-base', 'civicase.data');
         injectDependencies();
 
         expectedResult = _.find(CRM['civicase-base'].caseTypeCategories, function (caseTypeCategory) {
@@ -35,7 +35,7 @@
       var expectedResult;
 
       beforeEach(() => {
-        module('civicase-base');
+        module('civicase-base', 'civicase.data');
         injectDependencies();
 
         expectedResult = _.find(CRM['civicase-base'].caseTypeCategories, function (caseTypeCategory) {
@@ -54,7 +54,7 @@
       beforeEach(() => {
         CRM['civicase-base'].caseTypeCategoriesWhereUserCanAccessActivities = ['awards'];
 
-        module('civicase-base');
+        module('civicase-base', 'civicase.data');
         injectDependencies();
 
         expectedResults = [_.find(CRM['civicase-base'].caseTypeCategories, function (caseTypeCategory) {
@@ -69,7 +69,7 @@
 
     describe('when checking if a case type category is part of sent instance type', () => {
       beforeEach(() => {
-        module('civicase-base');
+        module('civicase-base', 'civicase.data');
         injectDependencies();
       });
 
@@ -82,7 +82,7 @@
       var expectedResult;
 
       beforeEach(() => {
-        module('civicase-base');
+        module('civicase-base', 'civicase.data');
         injectDependencies();
 
         expectedResult = {
@@ -102,7 +102,7 @@
       var expectedResult;
 
       beforeEach(() => {
-        module('civicase-base');
+        module('civicase-base', 'civicase.data');
         injectDependencies();
 
         expectedResult = [{
@@ -118,12 +118,30 @@
       });
     });
 
+    describe('when searching for instance of a case type category', () => {
+      var expectedResult;
+
+      beforeEach(() => {
+        module('civicase-base', 'civicase.data');
+        injectDependencies();
+
+        expectedResult = _.find(CaseCategoryInstanceTypeData.get(), function (instance) {
+          return instance.name === 'case_management';
+        });
+      });
+
+      it('returns the instance of the case type category', () => {
+        expect(CaseTypeCategory.getInstance('1')).toEqual(expectedResult);
+      });
+    });
+
     /**
      * Injects and hoists the dependencies needed by this spec.
      */
     function injectDependencies () {
-      inject((_CaseTypeCategory_) => {
+      inject((_CaseTypeCategory_, _CaseCategoryInstanceTypeData_) => {
         CaseTypeCategory = _CaseTypeCategory_;
+        CaseCategoryInstanceTypeData = _CaseCategoryInstanceTypeData_;
       });
     }
   });

--- a/ang/test/workflow/action-links/controllers/workflow-duplicate.controller.spec.js
+++ b/ang/test/workflow/action-links/controllers/workflow-duplicate.controller.spec.js
@@ -3,30 +3,31 @@
 ((_) => {
   describe('workflow duplicate controller', () => {
     let $controller, $rootScope, $q, $scope, dialogService, CaseTypesMockData,
-      civicaseCrmApiMock, crmStatus;
+      crmStatus, DuplicateWorkflowCasemanagement;
 
     beforeEach(module('workflow', 'civicase.data', ($provide) => {
-      civicaseCrmApiMock = jasmine.createSpy('civicaseCrmApi');
-
-      $provide.value('civicaseCrmApi', civicaseCrmApiMock);
       $provide.value('dialogService',
         jasmine.createSpyObj('dialogService', ['open', 'close'])
       );
     }));
 
     beforeEach(inject((_$q_, _$controller_, _$rootScope_, _CaseTypesMockData_,
-      _dialogService_, _crmStatus_) => {
+      _dialogService_, _crmStatus_, _DuplicateWorkflowCasemanagement_) => {
       $q = _$q_;
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       dialogService = _dialogService_;
       CaseTypesMockData = _CaseTypesMockData_;
       crmStatus = _crmStatus_;
+      DuplicateWorkflowCasemanagement = _DuplicateWorkflowCasemanagement_;
 
       dialogService.dialogs = {};
-      civicaseCrmApiMock.and.returnValue($q.resolve({
+
+      spyOn(DuplicateWorkflowCasemanagement, 'create');
+      DuplicateWorkflowCasemanagement.create.and.returnValue($q.resolve({
         values: CaseTypesMockData.getSequential()
       }));
+
       spyOn($rootScope, '$broadcast').and.callThrough();
     }));
 
@@ -51,7 +52,6 @@
           $scope.clickHandler(workflow);
 
           expectedWorkflowObject = _.clone(workflow);
-          expectedWorkflowObject.id = null;
           expectedWorkflowObject.title = '';
           expectedWorkflowObject.name = '';
 
@@ -92,8 +92,7 @@
               expectedApiParam = _.extend(_.clone(workflow), {
                 title: 'New Workflow',
                 name: 'new_workflow',
-                sequential: true,
-                id: null
+                sequential: true
               });
             });
 
@@ -102,8 +101,8 @@
             });
 
             it('duplicates the workflow', () => {
-              expect(civicaseCrmApiMock)
-                .toHaveBeenCalledWith('CaseType', 'create', expectedApiParam);
+              expect(DuplicateWorkflowCasemanagement.create)
+                .toHaveBeenCalledWith(expectedApiParam);
             });
 
             it('shows saving notification while save is in progress', () => {
@@ -136,7 +135,7 @@
 
           describe('when there is error while saving', () => {
             beforeEach(() => {
-              civicaseCrmApiMock.and.returnValue($q.reject({
+              DuplicateWorkflowCasemanagement.create.and.returnValue($q.reject({
                 error_code: 'already exists'
               }));
               saveButtonClickFunction();
@@ -161,7 +160,7 @@
           });
 
           it('does not call the api to save the workflow', () => {
-            expect(civicaseCrmApiMock).not.toHaveBeenCalled();
+            expect(DuplicateWorkflowCasemanagement.create).not.toHaveBeenCalled();
           });
         });
       });

--- a/ang/test/workflow/services/ang/workflow/services/duplicate-workflow-case-management.service.spec.js
+++ b/ang/test/workflow/services/ang/workflow/services/duplicate-workflow-case-management.service.spec.js
@@ -25,7 +25,7 @@
 
       it('creates a duplicate workflow', () => {
         expect(civicaseCrmApiMock).toHaveBeenCalledWith([
-          ['CaseType', 'create', _.extend(workflow, { id: null })]
+          ['CaseType', 'create', _.extend({}, workflow, { id: null })]
         ]);
       });
     });

--- a/ang/test/workflow/services/ang/workflow/services/duplicate-workflow-case-management.service.spec.js
+++ b/ang/test/workflow/services/ang/workflow/services/duplicate-workflow-case-management.service.spec.js
@@ -1,0 +1,33 @@
+/* eslint-env jasmine */
+
+((_) => {
+  describe('duplicate case management workflow', () => {
+    let civicaseCrmApiMock, CaseTypesMockData, DuplicateWorkflowCasemanagement;
+
+    beforeEach(module('workflow', 'civicase.data', ($provide) => {
+      civicaseCrmApiMock = jasmine.createSpy('civicaseCrmApi');
+
+      $provide.value('civicaseCrmApi', civicaseCrmApiMock);
+    }));
+
+    beforeEach(inject((_DuplicateWorkflowCasemanagement_, _CaseTypesMockData_) => {
+      DuplicateWorkflowCasemanagement = _DuplicateWorkflowCasemanagement_;
+      CaseTypesMockData = _CaseTypesMockData_;
+    }));
+
+    describe('when duplicating a workflow', () => {
+      var workflow;
+
+      beforeEach(() => {
+        workflow = CaseTypesMockData.getSequential(0);
+        DuplicateWorkflowCasemanagement.create(workflow);
+      });
+
+      it('creates a duplicate workflow', () => {
+        expect(civicaseCrmApiMock).toHaveBeenCalledWith([
+          ['CaseType', 'create', _.extend(workflow, { id: null })]
+        ]);
+      });
+    });
+  });
+})(CRM._);

--- a/ang/workflow.ang.php
+++ b/ang/workflow.ang.php
@@ -22,18 +22,22 @@ function get_workflow_js_files() {
   ], GlobRecursive::get(dirname(__FILE__) . '/workflow/*.js'));
 }
 
+$requires = [
+  'crmUi',
+  'ngRoute',
+  'dialogService',
+  'civicase-base',
+];
+
+$requires = CRM_Workflow_Hook_addDependentAngularModules::invoke($requires);
+
 return [
   'css' => [
     'css/*.css',
   ],
   'js' => get_workflow_js_files(),
   'settings' => $options,
-  'requires' => [
-    'crmUi',
-    'ngRoute',
-    'dialogService',
-    'civicase-base',
-  ],
+  'requires' => $requires,
   'partials' => [
     'ang/workflow',
   ],

--- a/ang/workflow/action-links/controllers/workflow-duplicate.controller.js
+++ b/ang/workflow/action-links/controllers/workflow-duplicate.controller.js
@@ -7,12 +7,13 @@
    * @param {object} $scope scope object
    * @param {object} $rootScope root scope object
    * @param {object} $q angular's queue service
+   * @param {object} $injector angular's injector service
    * @param {object} dialogService service to open dialog box
    * @param {object} crmStatus civicrm status service
-   * @param {object} civicaseCrmApi service to use civicrm api
+   * @param {object} CaseTypeCategory case type category service
    */
-  function WorkflowDuplicateController ($scope, $rootScope, $q, dialogService, crmStatus,
-    civicaseCrmApi) {
+  function WorkflowDuplicateController ($scope, $rootScope, $q, $injector,
+    dialogService, crmStatus, CaseTypeCategory) {
     $scope.submitInProgress = false;
     $scope.clickHandler = clickHandler;
 
@@ -26,7 +27,6 @@
         workflow: _.clone(workflow)
       };
 
-      model.workflow.id = null;
       model.workflow.title = '';
       model.workflow.name = '';
 
@@ -85,9 +85,17 @@
           $rootScope.$broadcast('workflow::list::refresh');
         })
         .catch(function (error) {
-          var errorMessage = error.error_code === 'already exists'
-            ? ts('This title is already in use. Please choose another')
-            : error.error_message;
+          var errorMessage;
+
+          _.each(error, function (errorObj) {
+            if (errorObj.error_code === 'already exists') {
+              errorMessage = ts('This title is already in use. Please choose another');
+
+              return false;
+            } else {
+              errorMessage = errorObj.error_message;
+            }
+          });
 
           return $q.reject({
             error_message: errorMessage
@@ -113,9 +121,35 @@
       workflow.name = generateWorkflowName(workflow.title);
       workflow.sequential = true;
 
-      return civicaseCrmApi('CaseType', 'create', workflow).then(function (workflowData) {
-        return workflowData.values[0];
-      });
+      var instanceName = CaseTypeCategory.getInstance(workflow.case_type_category).name;
+
+      var service = getServiceToDuplicate(instanceName);
+
+      if (service) {
+        return service.create(_.clone(workflow));
+      }
+    }
+
+    /**
+     * @param {string} instanceName name of the instance
+     * @returns {object/null} service
+     */
+    function getServiceToDuplicate (instanceName) {
+      try {
+        return $injector.get(
+          'DuplicateWorkflow' + capitalizeFirstLetterAndRemoveUnderScore(instanceName)
+        );
+      } catch (e) {
+        return null;
+      }
+    }
+
+    /**
+     * @param {string} string string to capitalize
+     * @returns {string} capitalized string
+     */
+    function capitalizeFirstLetterAndRemoveUnderScore (string) {
+      return (string.charAt(0).toUpperCase() + string.slice(1)).replace('_', '');
     }
 
     /**

--- a/ang/workflow/action-links/controllers/workflow-duplicate.controller.js
+++ b/ang/workflow/action-links/controllers/workflow-duplicate.controller.js
@@ -121,26 +121,32 @@
       workflow.name = generateWorkflowName(workflow.title);
       workflow.sequential = true;
 
-      var instanceName = CaseTypeCategory.getInstance(workflow.case_type_category).name;
+      var instanceName = CaseTypeCategory.getCaseTypeCategoryInstance(workflow.case_type_category).name;
 
       var service = getServiceToDuplicate(instanceName);
 
-      if (service) {
-        return service.create(_.clone(workflow));
-      }
+      return service.create(_.clone(workflow));
     }
 
     /**
+     * Searches for a angularJS service for the current case type category
+     * instance, if not found, returns the service for case management service
+     * as default.
+     *
      * @param {string} instanceName name of the instance
      * @returns {object/null} service
      */
     function getServiceToDuplicate (instanceName) {
+      var CASE_MANAGEMENT_INSTACE_NAME = 'case_management';
+
       try {
         return $injector.get(
           'DuplicateWorkflow' + capitalizeFirstLetterAndRemoveUnderScore(instanceName)
         );
       } catch (e) {
-        return null;
+        return $injector.get(
+          'DuplicateWorkflow' + capitalizeFirstLetterAndRemoveUnderScore(CASE_MANAGEMENT_INSTACE_NAME)
+        );
       }
     }
 

--- a/ang/workflow/services/duplicate-workflow-case-management.service.js
+++ b/ang/workflow/services/duplicate-workflow-case-management.service.js
@@ -1,0 +1,24 @@
+(function (_, angular) {
+  var module = angular.module('workflow');
+
+  module.service('DuplicateWorkflowCasemanagement', DuplicateWorkflow);
+
+  /**
+   * Duplicate Case management workflows service
+   *
+   * @param {Function} civicaseCrmApi civicrm api service
+   */
+  function DuplicateWorkflow (civicaseCrmApi) {
+    this.create = create;
+
+    /**
+     * @param {object} workflow workflow object
+     * @returns {Array} api call parameters
+     */
+    function create (workflow) {
+      return civicaseCrmApi([
+        ['CaseType', 'create', _.extend(workflow, { id: null })]
+      ]);
+    }
+  }
+})(CRM._, angular);

--- a/ang/workflow/services/duplicate-workflow-case-management.service.js
+++ b/ang/workflow/services/duplicate-workflow-case-management.service.js
@@ -17,7 +17,7 @@
      */
     function create (workflow) {
       return civicaseCrmApi([
-        ['CaseType', 'create', _.extend(workflow, { id: null })]
+        ['CaseType', 'create', _.extend({}, workflow, { id: null })]
       ]);
     }
   }


### PR DESCRIPTION
## Overview
Refactor Duplicate Workflow functionality to support overriding from other extentions.

## Before/After
No visual change has happened.

## Technical Details
1. In `ang/workflow/action-links/controllers/workflow-duplicate.controller.js`, changed the logic to look for a service with the name of `DuplicateWorkflow<case-category-instance-name>`. This service should have a function called `create`, which should have the logic to duplicate workflows of that instance.
Here underscores are removed, and the first letter is capitalised from the <case-category-instance-name>.
So for `case_management`, the service name would be `DuplicateWorkflowCasemanagement`.

2. Added a way to add dependent angularjs modules of `workflow`. So created `CRM_Workflow_Hook_addDependentAngularModules` class. Which is going to be used by other extentions.