### PR TITLE
RSE-1438: Disallow space in category name when creating a case type category

### DIFF
--- a/CRM/Civicase/Hook/ValidateForm/SaveCaseTypeCategory.php
+++ b/CRM/Civicase/Hook/ValidateForm/SaveCaseTypeCategory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Class CRM_Civicase_Hook_ValidateForm_SaveCaseTypeCategory.
+ * Validates Case type category.
  */
 class CRM_Civicase_Hook_ValidateForm_SaveCaseTypeCategory {
 
@@ -26,8 +26,8 @@ class CRM_Civicase_Hook_ValidateForm_SaveCaseTypeCategory {
 
     // Validate the label (category name).
     $field_name = 'label';
-    if (!empty($fields[$field_name]) && !preg_match('!^[a-zA-Z0-9 -]+$!', $fields[$field_name])) {
-      $errors[$field_name] = ts('Allowed characters: letters (a-z), numbers, space and hyphen.');
+    if (!empty($fields[$field_name]) && !preg_match('!^[a-zA-Z0-9-]+$!', $fields[$field_name])) {
+      $errors[$field_name] = ts('Allowed characters: letters (a-z), numbers and hyphen.');
     }
   }
 


### PR DESCRIPTION
## Overview
This PR updates the validation rule when creating a case type category to disallow the space character. 

## Before
This validation was not updated

## After
Since we use the case category name to setup some functionalities like custom fields support, Civicrm for example expects the name of the object to be extended not to contain spaces, else the Javascript generated on the Add custom group screen will be broken when trying to select options for the Entity.

