### PR TITLE
CATL-1864: Replace recipient dropdowns with case contacts dropdowns

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
+++ b/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
@@ -69,6 +69,7 @@ class CRM_Civicase_Hook_BuildForm_RestrictCaseEmailContacts {
         'email' => $caseContact['email'],
         'value' => $caseContact['contact_id'] . '::' . $caseContact['email'],
         'display_name' => $caseContact['display_name'],
+        'contact_id' => $caseContact['contact_id'],
       ];
     }, $caseDetails['contacts']);
 

--- a/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
+++ b/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
@@ -73,6 +73,7 @@ class CRM_Civicase_Hook_BuildForm_RestrictCaseEmailContacts {
     }, $caseDetails['contacts']);
 
     CRM_Core_Resources::singleton()
+      ->addScriptFile('uk.co.compucorp.civicase', 'js/restrict-case-email-contacts.js')
       ->addSetting([
         'civicase-base' => [
           'case_contacts' => json_encode($caseContacts),

--- a/js/restrict-case-email-contacts.js
+++ b/js/restrict-case-email-contacts.js
@@ -11,24 +11,37 @@
   /**
    * Replaces the "To", "CC", "BCC" dropdowns with new ones that only contain
    * case contacts.
+   *
+   * The "To" field values must be stored in a `123::contact@example.com` format,
+   * where `123` is the contact's ID. The "CC" and "BCC" field values must contain
+   * the contact ID only.
    */
   function addNewRecipientDropdowns () {
-    var caseContactSelect2Options = getCaseContactSelect2Options();
+    $recipientFields.each(function () {
+      var $field = $(this);
+      var isToField = $field.attr('name') === 'to';
+      var caseContactSelect2Options = isToField
+        ? getCaseContactOptions({ idFieldName: 'value' })
+        : getCaseContactOptions({ idFieldName: 'contact_id' });
 
-    $recipientFields.crmSelect2({
-      multiple: true,
-      data: caseContactSelect2Options
+      $field.crmSelect2({
+        multiple: true,
+        data: caseContactSelect2Options
+      });
     });
   }
 
   /**
+   * @param {object} options list of options.
+   * @param {string} options.idFieldName The contact's field name to use as the
+   * option's ID.
    * @returns {object[]} The list of case contacts as expected by the select2
    * dropdowns.
    */
-  function getCaseContactSelect2Options () {
+  function getCaseContactOptions (options) {
     return caseContacts.map(function (caseContact) {
       return {
-        id: caseContact.value,
+        id: caseContact[options.idFieldName],
         text: _.template('<%= display_name %> <<%= email %>>')(caseContact)
       };
     });

--- a/js/restrict-case-email-contacts.js
+++ b/js/restrict-case-email-contacts.js
@@ -1,0 +1,48 @@
+(function ($, _, caseSettings) {
+  var $recipientFields;
+  var caseContacts = JSON.parse(caseSettings.case_contacts);
+
+  // Without the timeout the CC and BCC fields can't be properly replaced
+  setTimeout(function init () {
+    initSelectors();
+    addNewRecipientDropdowns();
+  });
+
+  /**
+   * Replaces the "To", "CC", "BCC" dropdowns with new ones that only contain
+   * case contacts.
+   */
+  function addNewRecipientDropdowns () {
+    var caseContactSelect2Options = getCaseContactSelect2Options();
+
+    $recipientFields.crmSelect2({
+      multiple: true,
+      data: caseContactSelect2Options
+    });
+  }
+
+  /**
+   * @returns {object[]} The list of case contacts as expected by the select2
+   * dropdowns.
+   */
+  function getCaseContactSelect2Options () {
+    return caseContacts.map(function (caseContact) {
+      return {
+        id: caseContact.value,
+        text: _.template('<%= display_name %> <<%= email %>>')(caseContact)
+      };
+    });
+  }
+
+  /**
+   * Populates the Recipient form rows selectors.
+   */
+  function initSelectors () {
+    var recipientFieldRowsSelectors = [
+      '.crm-contactEmail-form-block-recipient input[name]',
+      '.crm-contactEmail-form-block-cc_id input[name]',
+      '.crm-contactEmail-form-block-bcc_id input[name]'
+    ];
+    $recipientFields = $(recipientFieldRowsSelectors.join(','));
+  }
+})(CRM.$, CRM._, CRM['civicase-base']);


### PR DESCRIPTION
## Overview

This PR replaces the recipient dropdowns in the case email forms by using new dropdowns that can only select case contacts.

## Before
![gif](https://user-images.githubusercontent.com/1642119/97356636-eefd9f00-186e-11eb-8999-9177f9f30be7.gif)

## After
![gif](https://user-images.githubusercontent.com/1642119/97359252-d8594700-1872-11eb-948c-26de5efc09d3.gif)

## Technical Details

We took the list of contacts generated in https://github.com/compucorp/uk.co.compucorp.civicase/pull/618 and used them to replace the existing recipient dropdowns. The only note is that the `To` field expects values to be in a `123::contact@example.com` and the `CC` and `BCC` expect the contact IDs only.