### PR TITLE
CATL-1876: Optimize query for for handling contact involved filter.

### DIFF
--- a/CRM/Civicase/APIHelpers/CaseDetails.php
+++ b/CRM/Civicase/APIHelpers/CaseDetails.php
@@ -92,6 +92,7 @@ class CRM_Civicase_APIHelpers_CaseDetails {
    *   Contains the data used for filtering.
    */
   public static function handleContactInvolvedFilters(CRM_Utils_SQL_Select $sql, array $params) {
+    self::prepareParamsForFiltering($params, 'contact_involved');
     $hasActivitiesForInvolvedContact = CRM_Utils_Array::value(
       'has_activities_for_involved_contact', $params, NULL);
 

--- a/CRM/Civicase/APIHelpers/CaseDetails.php
+++ b/CRM/Civicase/APIHelpers/CaseDetails.php
@@ -95,28 +95,21 @@ class CRM_Civicase_APIHelpers_CaseDetails {
     $hasActivitiesForInvolvedContact = CRM_Utils_Array::value(
       'has_activities_for_involved_contact', $params, NULL);
 
-    list(
-      'query' => $roleQuery,
-      'where' => $roleWhere
-    ) = self::getRoleQuery([
-      'can_be_client' => TRUE,
-      'all_case_roles_selected' => TRUE,
-      'contact' => $params['contact_involved'],
-    ]);
+    $caseContactFilter = CRM_Core_DAO::createSQLFilter('contact_id', $params['contact_involved']);
+    $relContactFilter = CRM_Core_DAO::createSQLFilter('contact_id_b', $params['contact_involved']);
+    $query = "
+      SELECT case_id FROM civicrm_case_contact WHERE {$caseContactFilter}
+      UNION DISTINCT
+      SELECT case_id FROM civicrm_relationship WHERE is_active = 1 AND {$relContactFilter} AND case_id IS NOT NULL
+    ";
 
     if ($hasActivitiesForInvolvedContact) {
-      $activitiesFilter = self::getRoleActivityFilter($params['contact_involved']);
-
-      $roleWhere .= " OR $activitiesFilter";
+      $query .= " UNION DISTINCT" . self::getCaseInvolvedInByActivityFilter($params['contact_involved']);
     }
 
-    $roleQuery->where($roleWhere);
-
-    $roleSubQueryString = $roleQuery->toSql();
-
     $sql->join('case_involvement', "
-      JOIN ($roleSubQueryString) AS case_involvement
-      ON case_involvement.id = a.id
+      JOIN ($query) AS case_involvement
+      ON case_involvement.case_id = a.id
     ");
   }
 
@@ -205,7 +198,7 @@ class CRM_Civicase_APIHelpers_CaseDetails {
   }
 
   /**
-   * Returns the condition needed for filtering by contact activities.
+   * Returns the condition needed for filtering cases involved in by activity.
    *
    * @param string $contactId
    *   The ID of the activity's contact.
@@ -213,22 +206,17 @@ class CRM_Civicase_APIHelpers_CaseDetails {
    * @return string
    *   The condition that can be used for filtering.
    */
-  private static function getRoleActivityFilter($contactId) {
-    $contactFilter = CRM_Core_DAO::createSQLFilter(
-      'civicrm_activity_contact.contact_id', $contactId);
+  private static function getCaseInvolvedInByActivityFilter($contactId) {
+    $activityContactFilter = CRM_Core_DAO::createSQLFilter('cac.contact_id', $contactId);
 
-    return "civicrm_case.id IN (
-      SELECT DISTINCT(case_id)
-      FROM civicrm_case_activity
-      WHERE activity_id IN (
-        SELECT DISTINCT(civicrm_activity.id)
-        FROM civicrm_activity
-        INNER JOIN civicrm_activity_contact
-        ON civicrm_activity.id = civicrm_activity_contact.activity_id
-        WHERE civicrm_activity.is_deleted = 0
-          AND civicrm_activity.is_current_revision = 1
-          AND civicrm_activity.is_test = 0
-          AND $contactFilter))";
+    return "
+      SELECT DISTINCT case_id
+      FROM civicrm_case_activity ca
+        INNER JOIN civicrm_activity a ON ca.activity_id = a.id
+        INNER JOIN civicrm_activity_contact cac ON a.id = cac.activity_id AND {$activityContactFilter}
+      WHERE a.is_deleted = 0
+        AND a.is_current_revision = 1
+        AND a.is_test = 0";
   }
 
   /**


### PR DESCRIPTION
## Overview
The contact involved filter queries for cases where the passed in contact is a client or has a relationship with the client of a case. If the `Include activities I'm involved in` setting is turned on, it will also include cases where the contact has a linked activity. The functionality works fine but on sites having thousands of records, the subquery to fetch the cases for the involved filter loads very slowly. An investigation was done on this and some recommendations made on how to rewrite this query. This PR implements the recommendations and adds the optimized query.
There might be other query optimizations needed but this PR focuses on optimizing that part of the code for now.

## Before
```sql
SELECT civicrm_case.id
               FROM civicrm_case

                        LEFT JOIN civicrm_case_contact AS case_client
                                  ON case_client.case_id = civicrm_case.id
                                      AND case_client.contact_id IN ("2")


                        LEFT JOIN civicrm_relationship AS case_relationship
                                  ON case_relationship.case_id = civicrm_case.id
                                      AND case_relationship.is_active = 1
                                      AND case_relationship.contact_id_b IN ("2")

               WHERE (case_client.case_id IS NOT NULL OR case_relationship.case_id IS NOT NULL OR civicrm_case.id IN (
                   SELECT DISTINCT(case_id)
                   FROM civicrm_case_activity
                   WHERE activity_id IN (
                       SELECT DISTINCT(civicrm_activity.id)
                       FROM civicrm_activity
                                INNER JOIN civicrm_activity_contact
                                           ON civicrm_activity.id = civicrm_activity_contact.activity_id
                       WHERE civicrm_activity.is_deleted = 0
                         AND civicrm_activity.is_current_revision = 1
                         AND civicrm_activity.is_test = 0
                         AND civicrm_activity_contact.contact_id IN ("2"))))
               GROUP BY civicrm_case.id
```
## After

Basically, what the query above does is to fetch a list of case ids where the contact is a client, or or has a relationship with the client of a case. If the `Include activities I'm involved in` setting is turned on, it will also include cases where the contact has a linked activity. This query is re-written using a UNION and it performs much faster than the original query.
On the site where it was tested, the entire query now runs in about 2 seconds down from the initial 35s (Please see ticket for more details).

New Query

```sql
SELECT case_id FROM civicrm_case_contact WHERE contact_id IN (2)
UNION DISTINCT
SELECT case_id FROM civicrm_relationship WHERE is_active = 1 AND contact_id_b IN (2) AND case_id IS NOT NULL
UNION DISTINCT
SELECT DISTINCT case_id
FROM civicrm_case_activity ca
         INNER JOIN civicrm_activity a ON ca.activity_id = a.id
         INNER JOIN civicrm_activity_contact cac ON a.id = cac.activity_id AND cac.contact_id IN (2)
WHERE a.is_deleted = 0
  AND a.is_current_revision = 1
  AND a.is_test = 0;

```