### PR TITLE
CATL-1917: Limit relationship remove/reassign end date to today

### DIFF
--- a/CRM/Civicase/Service/CaseRoleCreationPostProcess.php
+++ b/CRM/Civicase/Service/CaseRoleCreationPostProcess.php
@@ -160,13 +160,21 @@ class CRM_Civicase_Service_CaseRoleCreationPostProcess extends CRM_Civicase_Serv
    *   API request parameters.
    */
   private function setRelationshipsInactive(array $relIds, array $params) {
+    $endDate = empty($params['end_date']) ? new DateTime() : new DateTime($params['end_date']);
+    $today = new DateTime();
+    $isEndDateSameAsToday = $endDate->format('Y-m-d') === $today->format('Y-m-d');
+    $relationshipActiveFields = $isEndDateSameAsToday
+      ? ['is_active' => 0]
+      : ['end_date' => $params['end_date']];
+
     foreach ($relIds as $relId) {
-      civicrm_api3('Relationship', 'create', [
-        'id' => $relId,
-        'is_active' => 0,
-        'end_date' => !empty($params['start_date']) ? $params['start_date'] : date('Y-m-d'),
-        'skip_post_processing' => 1,
-      ]);
+      civicrm_api3('Relationship', 'create', array_merge(
+        $relationshipActiveFields,
+        [
+          'id' => $relId,
+          'skip_post_processing' => 1,
+        ]
+      ));
     }
   }
 

--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
@@ -258,7 +258,7 @@
 
       if (!isReplacingClient) {
         promptForContactParams.reassignmentDate = {
-          minDate: role.start_date,
+          maxDate: moment().format('YYYY-MM-DD'),
           value: moment().isBefore(moment(role.start_date))
             ? moment(role.start_date).format('YYYY-MM-DD')
             : moment().format('YYYY-MM-DD')
@@ -296,7 +296,7 @@
             hideContactField: true,
             role: role,
             endDate: {
-              minDate: role.start_date,
+              maxDate: moment().format('YYYY-MM-DD'),
               value: moment().format('YYYY-MM-DD')
             }
           },
@@ -652,12 +652,12 @@
         endDate: {
           value: options.endDate.value,
           show: !!options.endDate.value,
-          minDate: options.endDate.minDate
+          maxDate: moment().format('YYYY-MM-DD')
         },
         reassignmentDate: {
           value: options.reassignmentDate.value,
           show: !!options.reassignmentDate.value,
-          minDate: options.reassignmentDate.minDate
+          maxDate: options.reassignmentDate.maxDate
         }
       };
 
@@ -782,12 +782,17 @@
      * @returns {Array} API call
      */
     function unassignRoleCall (role, endDate) {
+      var isEndDateSameAsToday = moment().isSame(endDate, 'day');
+      var unassignRelationshipApiCall = isEndDateSameAsToday
+        ? { is_active: 0 }
+        : { end_date: endDate };
+
       return ['Relationship', 'get', {
         relationship_type_id: role.relationship_type_id,
         contact_id_b: role.contact_id,
         case_id: item.id,
         is_active: 1,
-        'api.Relationship.create': { is_active: 0, end_date: endDate }
+        'api.Relationship.create': unassignRelationshipApiCall
       }];
     }
 

--- a/ang/civicase/case/details/people-tab/directives/contact-prompt-dialog.html
+++ b/ang/civicase/case/details/people-tab/directives/contact-prompt-dialog.html
@@ -11,6 +11,7 @@
           placeholder="Start Date"
           crm-ui-datepicker="{
             time: false,
+            maxDate: model.endDate.value,
             beforeShow: model.removeDatePickerHrefs,
             onChangeMonthYear: model.removeDatePickerHrefs
           }" />
@@ -34,7 +35,7 @@
           placeholder="End Date"
           crm-ui-datepicker="{
             time: false,
-            minDate: model.endDate.minDate,
+            maxDate: model.endDate.maxDate,
             beforeShow: model.removeDatePickerHrefs,
             onChangeMonthYear: model.removeDatePickerHrefs
           }" />
@@ -64,7 +65,7 @@
           ng-change="model.errorMessage.reassignmentDate = null"
           crm-ui-datepicker="{
             time: false,
-            minDate: model.reassignmentDate.minDate,
+            maxDate: model.reassignmentDate.maxDate,
             beforeShow: model.removeDatePickerHrefs,
             onChangeMonthYear: model.removeDatePickerHrefs
           }" />

--- a/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
@@ -364,7 +364,7 @@ describe('Case Details People Tab', () => {
             reassignmentDate: {
               value: undefined,
               show: false,
-              minDate: undefined
+              maxDate: undefined
             }
           }),
           jasmine.any(Object)
@@ -509,7 +509,7 @@ describe('Case Details People Tab', () => {
           $rootScope.$digest();
         });
 
-        it('marks the current role relationship as finished', () => {
+        it('marks the current role relationship as finished using the active field', () => {
           expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
             ['Relationship', 'get', {
               relationship_type_id: relationshipTypeId,
@@ -517,7 +517,7 @@ describe('Case Details People Tab', () => {
               case_id: $scope.item.id,
               is_active: 1,
               'api.Relationship.create': {
-                is_active: 0, end_date: getDialogModel().endDate.value
+                is_active: 0
               }
             }]
           ]));


### PR DESCRIPTION
## Overview
This PR changes the way relationships are removed or reassigned. Previously we would only allow the current or future dates, but this was changed to the current or past dates.

This change is made to be in alignment with the https://github.com/civicrm/civicrm-core/pull/18844 core PR that handles the active status of the relationship depending on the start and end dates provided.

## Before & After
These screen grabs have been taken from the NEU site where https://github.com/civicrm/civicrm-core/pull/18844 has been merged and the issue is more apparent. This has been tested in Compuclient sites without the aformentioned change and it works the same as before, but dates are limited.

### NEU

#### Before
![gif](https://user-images.githubusercontent.com/1642119/97596255-e9bd6300-19da-11eb-930f-c09630090ecd.gif)

#### After
![gif](https://user-images.githubusercontent.com/1642119/97595788-6ac82a80-19da-11eb-8bc0-192fa8d26d3a.gif)


### Compuclient

![gif](https://user-images.githubusercontent.com/1642119/97595309-f4c3c380-19d9-11eb-9a52-29e6d5a5f2ca.gif)


## Technical Details

We added logic to the BE and FE so when the end date is the same as today we send `is_active: 0` instead of the end date. This is because the relationship is still active if the end date is the same as the current date according to https://github.com/civicrm/civicrm-core/pull/18844