### PR TITLE
CATL-1799: Restrict Case Email Contacts

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
+++ b/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
@@ -6,6 +6,13 @@
 class CRM_Civicase_Hook_BuildForm_RestrictCaseEmailContacts {
 
   /**
+   * The current form's instance.
+   *
+   * @var CRM_Core_Form
+   */
+  private $form;
+
+  /**
    * Handles the hook's implementation.
    *
    * @param CRM_Core_Form $form
@@ -16,7 +23,7 @@ class CRM_Civicase_Hook_BuildForm_RestrictCaseEmailContacts {
   public function run(CRM_Core_Form $form, $formName) {
     $this->form = $form;
 
-    if (!$this->shouldRun($form)) {
+    if (!$this->shouldRun()) {
       return;
     }
 

--- a/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
+++ b/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Restricts case emails to case contacts only.
+ */
+class CRM_Civicase_Hook_BuildForm_RestrictCaseEmailContacts {
+
+  /**
+   * Handles the hook's implementation.
+   *
+   * @param CRM_Core_Form $form
+   *   The current form's instance.
+   * @param string $formName
+   *   The name for the current form.
+   */
+  public function run(CRM_Core_Form $form, $formName) {
+    $this->form = $form;
+
+    if (!$this->shouldRun($form)) {
+      return;
+    }
+
+    $this->addListOfCaseContactsToSettings();
+  }
+
+  /**
+   * Determines if the hook should run.
+   *
+   * Only runs for Case Email forms and when the "Restrict Case Email Contacts"
+   * setting is set.
+   *
+   * @return bool
+   *   True when the hook can run.
+   */
+  private function shouldRun() {
+    $isEmailForm = get_class($this->form) === CRM_Contact_Form_Task_Email::class;
+    $isCaseEmail = !empty($this->form->getVar('_caseId'));
+    $shouldRestrictContacts = (bool) Civi::settings()->get('civicaseRestrictCaseEmailContacts');
+
+    return $isEmailForm && $isCaseEmail && $shouldRestrictContacts;
+  }
+
+  /**
+   * Adds the list of contacts for the case to the front-end settings object.
+   *
+   * The list of contacts is exported as a JSON string to avoid CiviCRM from
+   * extending the list instead of replacing it. This would cause problems when
+   * switching cases or updating the contacts for the existing one.
+   */
+  private function addListOfCaseContactsToSettings() {
+    $caseId = $this->form->getVar('_caseId');
+
+    $caseDetailsResponse = civicrm_api3('Case', 'getdetails', [
+      'id' => $caseId,
+      'options' => ['limit' => 1],
+    ]);
+    $caseDetails = CRM_Utils_Array::first($caseDetailsResponse['values']);
+
+    $caseContacts = array_map(function ($caseContact) {
+      return [
+        'role' => $caseContact['role'],
+        'email' => $caseContact['email'],
+        'value' => $caseContact['contact_id'] . '::' . $caseContact['email'],
+        'display_name' => $caseContact['display_name'],
+      ];
+    }, $caseDetails['contacts']);
+
+    CRM_Core_Resources::singleton()
+      ->addSetting([
+        'civicase-base' => [
+          'case_contacts' => json_encode($caseContacts),
+        ],
+      ]);
+  }
+
+}

--- a/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
+++ b/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
@@ -69,6 +69,7 @@ class CRM_Civicase_Hook_BuildForm_RestrictCaseEmailContacts {
         'email' => $caseContact['email'],
         'value' => $caseContact['contact_id'] . '::' . $caseContact['email'],
         'display_name' => $caseContact['display_name'],
+        'contact_id' => $caseContact['contact_id'],
       ];
     }, $caseDetails['contacts']);
 

--- a/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
+++ b/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
@@ -73,6 +73,7 @@ class CRM_Civicase_Hook_BuildForm_RestrictCaseEmailContacts {
     }, $caseDetails['contacts']);
 
     CRM_Core_Resources::singleton()
+      ->addScriptFile('uk.co.compucorp.civicase', 'js/restrict-case-email-contacts.js')
       ->addSetting([
         'civicase-base' => [
           'case_contacts' => json_encode($caseContacts),

--- a/civicase.php
+++ b/civicase.php
@@ -213,6 +213,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_DisplayAllCustomGroupsInCaseForm(),
     new CRM_Civicase_Hook_BuildForm_LinkToCaseSearchByCaseId(),
     new CRM_Civicase_Hook_BuildForm_RemoveExportActionFromReports(),
+    new CRM_Civicase_Hook_BuildForm_RestrictCaseEmailContacts(),
   ];
 
   foreach ($hooks as $hook) {

--- a/js/civicase-settings-form.js
+++ b/js/civicase-settings-form.js
@@ -1,11 +1,13 @@
-(function ($) {
+(function ($, crmHelp) {
   $(document).on('crmLoad', function () {
     var $radioButtonsThatToggleVisibility = $('[data-toggles-visibility-for]');
     var $multiCaseClient = $('#civicaseAllowMultipleClients');
     var $singleCaseRoleParent = $('.crm-mail-form-block-civicaseSingleCaseRolePerType');
     var $singleCaseRole = $('#civicaseSingleCaseRolePerType_civicaseSingleCaseRolePerType');
+    var $helpTextIcons = $('#crm-main-content-wrapper .helpicon');
 
     (function init () {
+      displayHelpTextMessagesOnClick();
       toggleVisibilityOnRadioButtonChange();
       toggleVisibilityForSingleCaseRole();
 
@@ -14,6 +16,37 @@
         $multiCaseClient.change(toggleVisibilityForSingleCaseRole);
       }
     })();
+
+    /**
+     * Handles the display of help text messages associated with setting fields.
+     *
+     * Fixes an issue in core where help texts are not properly displayed.
+     */
+    function displayHelpTextMessagesOnClick () {
+      $helpTextIcons.each((index, helpTextIconReference) => {
+        var $helpTextIcon = $(helpTextIconReference);
+        var $field = $helpTextIcon.siblings('[data-help-text]');
+        var helpText = $field.attr('data-help-text');
+        var fieldName = $field.attr('name');
+
+        $helpTextIcon.removeAttr('onclick');
+        $helpTextIcon.on('click', displayHelpTextMessage);
+
+        /**
+         * Displays the text message for the field.
+         *
+         * @param {object} event DOM Event.
+         */
+        function displayHelpTextMessage (event) {
+          event.preventDefault();
+
+          crmHelp(helpText, {
+            id: fieldName + '-id',
+            file: 'CRM/Admin/Form/Setting/Case'
+          });
+        }
+      });
+    }
 
     /**
      * Toggles the visibility of civicase settings fields based on radio button values.
@@ -64,4 +97,4 @@
       }
     }
   });
-})(CRM.$);
+})(CRM.$, CRM.help);

--- a/js/restrict-case-email-contacts.js
+++ b/js/restrict-case-email-contacts.js
@@ -11,24 +11,37 @@
   /**
    * Replaces the "To", "CC", "BCC" dropdowns with new ones that only contain
    * case contacts.
+   *
+   * The "To" field values must be stored in a `123::contact@example.com` format,
+   * where `123` is the contact's ID. The "CC" and "BCC" field values must contain
+   * the contact ID only.
    */
   function addNewRecipientDropdowns () {
-    var caseContactSelect2Options = getCaseContactSelect2Options();
+    $recipientFields.each(function () {
+      var $field = $(this);
+      var isToField = $field.attr('name') === 'to';
+      var caseContactSelect2Options = isToField
+        ? getCaseContactOptions({ idFieldName: 'value' })
+        : getCaseContactOptions({ idFieldName: 'contact_id' });
 
-    $recipientFields.crmSelect2({
-      multiple: true,
-      data: caseContactSelect2Options
+      $field.crmSelect2({
+        multiple: true,
+        data: caseContactSelect2Options
+      });
     });
   }
 
   /**
+   * @param {object} options list of options.
+   * @param {string} options.idFieldName The contact's field name to use as the
+   * option's ID.
    * @returns {object[]} The list of case contacts as expected by the select2
    * dropdowns.
    */
-  function getCaseContactSelect2Options () {
+  function getCaseContactOptions (options) {
     return caseContacts.map(function (caseContact) {
       return {
-        id: caseContact.value,
+        id: caseContact[options.idFieldName],
         text: _.template('<%= display_name %> <<%= email %>>')(caseContact)
       };
     });

--- a/js/restrict-case-email-contacts.js
+++ b/js/restrict-case-email-contacts.js
@@ -1,0 +1,48 @@
+(function ($, _, caseSettings) {
+  var $recipientFields;
+  var caseContacts = JSON.parse(caseSettings.case_contacts);
+
+  // Without the timeout the CC and BCC fields can't be properly replaced
+  setTimeout(function init () {
+    initSelectors();
+    addNewRecipientDropdowns();
+  });
+
+  /**
+   * Replaces the "To", "CC", "BCC" dropdowns with new ones that only contain
+   * case contacts.
+   */
+  function addNewRecipientDropdowns () {
+    var caseContactSelect2Options = getCaseContactSelect2Options();
+
+    $recipientFields.crmSelect2({
+      multiple: true,
+      data: caseContactSelect2Options
+    });
+  }
+
+  /**
+   * @returns {object[]} The list of case contacts as expected by the select2
+   * dropdowns.
+   */
+  function getCaseContactSelect2Options () {
+    return caseContacts.map(function (caseContact) {
+      return {
+        id: caseContact.value,
+        text: _.template('<%= display_name %> <<%= email %>>')(caseContact)
+      };
+    });
+  }
+
+  /**
+   * Populates the Recipient form rows selectors.
+   */
+  function initSelectors () {
+    var recipientFieldRowsSelectors = [
+      '.crm-contactEmail-form-block-recipient input[name]',
+      '.crm-contactEmail-form-block-cc_id input[name]',
+      '.crm-contactEmail-form-block-bcc_id input[name]'
+    ];
+    $recipientFields = $(recipientFieldRowsSelectors.join(','));
+  }
+})(CRM.$, CRM._, CRM['civicase-base']);

--- a/settings/CiviCase.setting.php
+++ b/settings/CiviCase.setting.php
@@ -2,6 +2,13 @@
 
 /**
  * @file
+ * Civicase Settings.
+ */
+
+use CRM_Civicase_ExtensionUtil as E;
+
+/**
+ * @file
  * CiviCase Setting file.
  */
 
@@ -18,10 +25,10 @@ $setting = [
     'default' => FALSE,
     'html_type' => 'radio',
     'add' => '4.7',
-    'title' => 'Allow cases to be locked',
+    'title' => E::ts('Allow cases to be locked'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'This will allow cases to be locked for certain contacts.',
+    'description' => E::ts('This will allow cases to be locked for certain contacts.'),
     'help_text' => '',
   ],
   'civicaseShowComingSoonCaseSummaryBlock' => [
@@ -33,10 +40,10 @@ $setting = [
     'default' => TRUE,
     'html_type' => 'radio',
     'add' => '4.7',
-    'title' => 'Show "Coming Soon" section on Case Summary',
+    'title' => E::ts('Show "Coming Soon" section on Case Summary'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'This configuration controls the visibility of the coming soon section on the case summary screen which has Next Milestone, Next Activity and the Case Calendar.',
+    'description' => E::ts('This configuration controls the visibility of the coming soon section on the case summary screen which has Next Milestone, Next Activity and the Case Calendar.'),
   ],
   'civicaseAllowLinkedCasesTab' => [
     'group_name' => 'CiviCRM Preferences',
@@ -47,10 +54,10 @@ $setting = [
     'default' => FALSE,
     'html_type' => 'radio',
     'add' => '4.7',
-    'title' => 'Allow linked cases tab',
+    'title' => E::ts('Allow linked cases tab'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'This will allow linked cases to be viewed on a separate tab.',
+    'description' => E::ts('This will allow linked cases to be viewed on a separate tab.'),
     'help_text' => '',
   ],
   'civicaseShowWebformsListSeparately' => [
@@ -66,10 +73,10 @@ $setting = [
     ],
     'html_type' => 'radio',
     'add' => '4.7',
-    'title' => 'Show Webforms list in a separate dropdown',
+    'title' => E::ts('Show Webforms list in a separate dropdown'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'This will show the webforms list in a separate dropdown.',
+    'description' => E::ts('This will show the webforms list in a separate dropdown.'),
     'help_text' => '',
   ],
   'civicaseWebformsDropdownButtonLabel' => [
@@ -86,10 +93,10 @@ $setting = [
     'html_type' => 'text',
     'default' => 'Webforms',
     'add' => '4.7',
-    'title' => 'Label for the Webforms dropdown button',
+    'title' => E::ts('Label for the Webforms dropdown button'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'Label for the Webforms dropdown button',
+    'description' => E::ts('Label for the Webforms dropdown button'),
     'help_text' => '',
   ],
   'showFullContactNameOnActivityFeed' => [
@@ -101,10 +108,10 @@ $setting = [
     'default' => TRUE,
     'html_type' => 'radio',
     'add' => '4.7',
-    'title' => 'Show full name on Case activity feed',
+    'title' => E::ts('Show full name on Case activity feed'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => 'This configuration determines whether or not the full name of the activity creator is displayed in the case activity feed.',
+    'description' => E::ts('This configuration determines whether or not the full name of the activity creator is displayed in the case activity feed.'),
     'help_text' => '',
   ],
   'includeActivitiesForInvolvedContact' => [
@@ -116,10 +123,10 @@ $setting = [
     'default' => FALSE,
     'html_type' => 'radio',
     'add' => '4.7',
-    'title' => "Include activities I'm involved in",
+    'title' => E::ts("Include activities I'm involved in"),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => "Cases I'm involved in filter will include 'activities created by me' and 'activities assigned to me'.",
+    'description' => E::ts("Cases I'm involved in filter will include 'activities created by me' and 'activities assigned to me'."),
     'help_text' => '',
   ],
   'civicaseSingleCaseRolePerType' => [
@@ -134,10 +141,10 @@ $setting = [
     ],
     'html_type' => 'checkbox',
     'add' => '4.7',
-    'title' => ts('One active case role'),
+    'title' => E::ts('One active case role'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => ts('This setting will only allow one active instance of each case role for all case types.'),
+    'description' => E::ts('This setting will only allow one active instance of each case role for all case types.'),
     'help_text' => '',
   ],
   'civicaseRestrictCaseEmailContacts' => [
@@ -149,13 +156,13 @@ $setting = [
     'default' => FALSE,
     'html_type' => 'radio',
     'add' => '4.7',
-    'title' => 'Restrict email recipients to contacts involved with the case',
+    'title' => E::ts('Restrict email recipients to contacts involved with the case'),
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => '',
     'help_text' => TRUE,
     'html_attributes' => [
-      'data-help-text' => 'When this setting is enabled users will only be able to add existing contacts who are either the case clients or people currently involved with the case as recipients of new emails.',
+      'data-help-text' => E::ts('When this setting is enabled users will only be able to add existing contacts who are either the case clients or people currently involved with the case as recipients of new emails.'),
     ],
   ],
 ];

--- a/settings/CiviCase.setting.php
+++ b/settings/CiviCase.setting.php
@@ -140,6 +140,24 @@ $setting = [
     'description' => ts('This setting will only allow one active instance of each case role for all case types.'),
     'help_text' => '',
   ],
+  'civicaseRestrictCaseEmailContacts' => [
+    'group_name' => 'CiviCRM Preferences',
+    'group' => 'core',
+    'name' => 'civicaseRestrictCaseEmailContacts',
+    'type' => 'Boolean',
+    'quick_form_type' => 'YesNo',
+    'default' => FALSE,
+    'html_type' => 'radio',
+    'add' => '4.7',
+    'title' => 'Restrict email recipients to contacts involved with the case',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => '',
+    'help_text' => TRUE,
+    'html_attributes' => [
+      'data-help-text' => 'When this setting is enabled users will only be able to add existing contacts who are either the case clients or people currently involved with the case as recipients of new emails.',
+    ],
+  ],
 ];
 
 $caseSetting = new CRM_Civicase_Service_CaseCategorySetting();


### PR DESCRIPTION
## Overview

This PR has all the changes needed to restrict case email recipients to case contacts only. The included changes are:

* CATL-1863: Add case email contacts to front-end settings #618
* CATL-1864: Replace recipient dropdowns with case contacts dropdowns #623