### PR TITLE
CATL-1900: Redirect After Pdf Download

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/AddScriptToCreatePdfForm.php
+++ b/CRM/Civicase/Hook/BuildForm/AddScriptToCreatePdfForm.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Add script to create pdf form.
+ */
+class CRM_Civicase_Hook_BuildForm_AddScriptToCreatePdfForm {
+
+  /**
+   * Add script to create pdf form.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   * @param string $formName
+   *   Form Name.
+   */
+  public function run(CRM_Core_Form &$form, $formName) {
+    if (!$this->shouldRun($form, $formName)) {
+      return;
+    }
+    CRM_Core_Resources::singleton()->addScriptFile(
+      'uk.co.compucorp.civicase', 'js/create-pdf-form.js');
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   * @param string $formName
+   *   Form class object.
+   *
+   * @return bool
+   *   returns a boolean to determine if hook will run or not.
+   */
+  private function shouldRun(CRM_Core_Form $form, $formName) {
+    return $formName == CRM_Contact_Form_Task_PDF::class && $form->getAction() === CRM_Core_Action::ADD;
+  }
+
+}

--- a/CRM/Civicase/Hook/BuildForm/MakePdfFormSubjectRequired.php
+++ b/CRM/Civicase/Hook/BuildForm/MakePdfFormSubjectRequired.php
@@ -18,7 +18,7 @@ class CRM_Civicase_Hook_BuildForm_MakePdfFormSubjectRequired {
       return;
     }
     if ($form->elementExists('subject')) {
-      $form->addRule('subject', '', 'required');
+      $form->addRule('subject', 'Subject is a required field', 'required');
     }
   }
 

--- a/civicase.php
+++ b/civicase.php
@@ -215,6 +215,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_RemoveExportActionFromReports(),
     new CRM_Civicase_Hook_BuildForm_MakePdfFormSubjectRequired(),
     new CRM_Civicase_Hook_BuildForm_PdfFormButtonsLabelChange(),
+    new CRM_Civicase_Hook_BuildForm_AddScriptToCreatePdfForm(),
   ];
 
   foreach ($hooks as $hook) {

--- a/js/create-pdf-form.js
+++ b/js/create-pdf-form.js
@@ -1,0 +1,66 @@
+(function ($) {
+
+  $(document).on('crmLoad', function () {
+
+    function redirectOnFileDownload() {
+      if(isFormValid()) {
+        var caseId = getCaseId();
+        if (caseId) {
+          var urlWithTab = updateQueryStringParameter('tab', 'Activities');
+          document.location = updateQueryStringParameter('caseId', caseId, urlWithTab);
+        } else {
+          if ($('.ui-tabs-anchor[title="Activities"]').length) {
+            $('.ui-tabs-anchor[title="Activities"]').click();
+          }
+        }
+        $('.ui-dialog-titlebar-close').click();
+      }
+    }
+
+    function getCaseId() {
+      var entryUrlElem = $('[name="entryURL"]');
+      var caseId = 0;
+      if (entryUrlElem.length) {
+        var entryUrl = entryUrlElem.val();
+        caseId = getParameterByName('caseid', entryUrl);
+      }
+
+      return caseId;
+    }
+
+    function isFormValid() {
+      return $('.CRM_Contact_Form_Task_PDF').find('.crm-error:not(.valid)').length == 0;
+    }
+
+    function getParameterByName(name, url = window.location.href) {
+      name = name.replace(/[\[\]]/g, '\\$&');
+      var regex = new RegExp('[?&;]' + name + '(=([^&#]*)|&|#|$)'),
+        results = regex.exec(url);
+      if (!results) {
+        return null;
+      }
+      if (!results[2]) {
+        return '';
+      }
+      return decodeURIComponent(results[2].replace(/\+/g, ' '));
+    }
+
+    function updateQueryStringParameter(key, value, uri = window.location.href) {
+      var re = new RegExp("([?&])" + key + "=.*?(&|$)", "i");
+      var separator = uri.indexOf('?') !== -1 ? "&" : "?";
+      if (uri.match(re)) {
+        return uri.replace(re, '$1' + key + "=" + value + '$2');
+      }
+      else {
+        return uri + separator + key + "=" + value;
+      }
+    }
+
+    $('body').off('click', '[data-identifier="buttons[_qf_PDF_upload]"]');
+    $('body').on('click', '[data-identifier="buttons[_qf_PDF_upload]"]', function () {
+      setTimeout(function () {
+        redirectOnFileDownload();
+      }, 200);
+    });
+  });
+})(CRM.$);

--- a/js/create-pdf-form.js
+++ b/js/create-pdf-form.js
@@ -1,9 +1,10 @@
 (function ($) {
-
   $(document).on('crmLoad', function () {
-
-    function redirectOnFileDownload() {
-      if(isFormValid()) {
+    /**
+     * Redirect the user after pdf generation.
+     */
+    function redirectOnFileDownload () {
+      if (isFormValid()) {
         var caseId = getCaseId();
         if (caseId) {
           var urlWithTab = updateQueryStringParameter('tab', 'Activities');
@@ -17,7 +18,12 @@
       }
     }
 
-    function getCaseId() {
+    /**
+     * Returns the case id if available otherwise 0.
+     *
+     * @returns {number} case id.
+     */
+    function getCaseId () {
       var entryUrlElem = $('[name="entryURL"]');
       var caseId = 0;
       if (entryUrlElem.length) {
@@ -28,14 +34,26 @@
       return caseId;
     }
 
-    function isFormValid() {
-      return $('.CRM_Contact_Form_Task_PDF').find('.crm-error:not(.valid)').length == 0;
+    /**
+     * Checks whether the form has errors or not.
+     *
+     * @returns {boolean} form validity.
+     */
+    function isFormValid () {
+      return $('.CRM_Contact_Form_Task_PDF').find('.crm-error:not(.valid)').length === 0;
     }
 
-    function getParameterByName(name, url = window.location.href) {
-      name = name.replace(/[\[\]]/g, '\\$&');
-      var regex = new RegExp('[?&;]' + name + '(=([^&#]*)|&|#|$)'),
-        results = regex.exec(url);
+    /**
+     * Returns parameter value from a query string.
+     *
+     * @param {string} name  name of the parameter.
+     * @param {string} url query string.
+     * @returns {any} parameter value.
+     */
+    function getParameterByName (name, url = window.location.href) {
+      name = name.replace(/[[]]/g, '\\$&');
+      var regex = new RegExp('[?&;]' + name + '(=([^&#]*)|&|#|$)');
+      var results = regex.exec(url);
       if (!results) {
         return null;
       }
@@ -45,14 +63,21 @@
       return decodeURIComponent(results[2].replace(/\+/g, ' '));
     }
 
-    function updateQueryStringParameter(key, value, uri = window.location.href) {
-      var re = new RegExp("([?&])" + key + "=.*?(&|$)", "i");
-      var separator = uri.indexOf('?') !== -1 ? "&" : "?";
+    /**
+     * Add or update a parameter in a url.
+     *
+     * @param {string} key parameter name.
+     * @param {any} value parameter value.
+     * @param {string} uri query string.
+     * @returns {string} updates query string.
+     */
+    function updateQueryStringParameter (key, value, uri = window.location.href) {
+      var re = new RegExp('([?&])' + key + '=.*?(&|$)', 'i');
+      var separator = uri.indexOf('?') !== -1 ? '&' : '?';
       if (uri.match(re)) {
-        return uri.replace(re, '$1' + key + "=" + value + '$2');
-      }
-      else {
-        return uri + separator + key + "=" + value;
+        return uri.replace(re, '$1' + key + '=' + value + '$2');
+      } else {
+        return uri + separator + key + '=' + value;
       }
     }
 


### PR DESCRIPTION
## Overview
This pr adds a redirect for the user after pdf is generated. User is redirected when he clicks on the Create pdf button and not on clicking the preview  button.

## Before
Previously when user generated the pdf the pdf form did not get close and user stayed on the same page.

## After
This pr adds a redirect to the activities page after pdf generation, If the pdf is generated inside a case then the user will be redirected to case activities otherwise to contact activities.

## Technical Details
This pr utilizes buildform hook in `CRM/Civicase/Hook/BuildForm/AddScriptToCreatePdfForm.php` to add new script file to the pdf creation form. This new script checks the user current location while creating the pdf and redirects accordingly.
