### PR TITLE
CPS-384: Fix PDF Download activity deletion

### DIFF
--- a/civicase.php
+++ b/civicase.php
@@ -443,8 +443,20 @@ function civicase_civicrm_postProcess($formName, &$form) {
   if (in_array($formName, $specialForms)) {
     $urlParams = parse_url(htmlspecialchars_decode($form->controller->_entryURL), PHP_URL_QUERY);
     parse_str($urlParams, $urlParams);
-    if (!empty($urlParams['draft_id'])) {
-      civicrm_api3('Activity', 'delete', ['id' => $urlParams['draft_id']]);
+
+    $ifDownloadDocumentButtonClicked = array_key_exists('_qf_PDF_upload', $form->getVar('_submitValues')['buttons']);
+
+    if ($ifDownloadDocumentButtonClicked && !empty($urlParams['draft_id'])) {
+      $completedActivityStatusId = civicrm_api3('OptionValue', 'get', [
+        'sequential' => 1,
+        'option_group_id' => "activity_status",
+        'name' => "Completed",
+      ])['values'][0]['value'];
+
+      civicrm_api3('Activity', 'create', [
+        'id' => $urlParams['draft_id'],
+        'status_id' => $completedActivityStatusId,
+      ]);
     }
   }
 }

--- a/civicase.php
+++ b/civicase.php
@@ -447,15 +447,9 @@ function civicase_civicrm_postProcess($formName, &$form) {
     $ifDownloadDocumentButtonClicked = array_key_exists('_qf_PDF_upload', $form->getVar('_submitValues')['buttons']);
 
     if ($ifDownloadDocumentButtonClicked && !empty($urlParams['draft_id'])) {
-      $completedActivityStatusId = civicrm_api3('OptionValue', 'get', [
-        'sequential' => 1,
-        'option_group_id' => "activity_status",
-        'name' => "Completed",
-      ])['values'][0]['value'];
-
       civicrm_api3('Activity', 'create', [
         'id' => $urlParams['draft_id'],
-        'status_id' => $completedActivityStatusId,
+        'status_id' => 'Completed',
       ]);
     }
   }


### PR DESCRIPTION
## Overview
Fixed the following issues, about PDF Download activity.
1. When "Download Document" was pressed, it deleted the activity instead of moving it to `Completed` state.
2. When `Preview` was pressed, it also deleted the activity, but nothing should have happened to the activity.

## Before
Issues were not fixed.

## After
Issues are fixed.

## Technical Details
In `civicase.php` postpocess hook,
1. Added code to check if the clicked button is "Download Document".
2. If true, instead of deleting the activity, updating its status to `Completed`.