### PR TITLE
CPS-386: Release v1.9.5

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/compucorp/uk.co.compucorp.civicase/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2020-10-28</releaseDate>
-  <version>1.9.4</version>
+  <releaseDate>2020-11-05</releaseDate>
+  <version>1.9.5</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.24</ver>


### PR DESCRIPTION
## Release Update - 05th November, 2020

**Improvements**

* Restricted case email recipients to case contacts only. https://github.com/compucorp/uk.co.compucorp.civicase/pull/627

**Bug Fixes**

* Fixed PDF Download activity deletion when "Download Document" was pressed. https://github.com/compucorp/uk.co.compucorp.civicase/pull/629
* Refactored duplicate Awards functionality. https://github.com/compucorp/uk.co.compucorp.civicase/pull/620
* Limit relationship remove/reassign end date to today. https://github.com/compucorp/uk.co.compucorp.civicase/pull/626
* Limit Adv. Search By Accessible Case Categories Only When Case Filters Are Present. https://github.com/compucorp/uk.co.compucorp.civicase/pull/630