### PR TITLE
CATL-1959: Fix Bug In Fetching Webform Client ID

### DIFF
--- a/CRM/Civicase/Helper/NewCaseWebform.php
+++ b/CRM/Civicase/Helper/NewCaseWebform.php
@@ -5,7 +5,7 @@ use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
 use CRM_Civicase_Service_CaseCategorySetting as CaseCategorySetting;
 
 /**
- * CRM_Civicase_Helper_NewCaseWebform class.
+ * Webform helper class.
  */
 class CRM_Civicase_Helper_NewCaseWebform {
 
@@ -51,7 +51,7 @@ class CRM_Civicase_Helper_NewCaseWebform {
     $client = 0;
 
     if (isset($data['case'][1]['case'][1]['client_id'])) {
-      $clients = $data['case'][1]['case'][1]['client_id'];
+      $clients = (array) $data['case'][1]['case'][1]['client_id'];
       $client = reset($clients);
     }
 


### PR DESCRIPTION
## Overview
On some client sites, where a webform is used for adding a case, when the Add case webform link is clicked the client id in the webform link is not correctly filled thereby leading to some values in the webform not being auto-populated as expected.

## Before
The issue described above exists.

## After
The function for fetching the webform client Id in civicase assumes that the `client_id` would always be an array but it some cases, it is actually an integer as that is what was observed in the client site where this issue was reported thereby returning `null` as the client Id, however checking how the webform_civicrm processes the client_id variable [here](https://github.com/colemanw/webform_civicrm/blob/7.x-5.x/includes/wf_crm_webform_preprocess.inc#L631), the value might not always be an array and is first of all casted into an array. The same approach is used in the `getCaseWebformClientId` function and the variable is casted to an array first. 

This fixes the issue as the `client_id` is now returned when when the original variable is not an array. 
The client_id is now properly appended to the cid variable, [See](https://github.com/compucorp/neu/blob/a34dbc3019607df70d337322ebbfade0bbeb7cb9/sites/all/civicrm_extensions/uk.co.compucorp.civicase/CRM/Civicase/Helper/NewCaseWebform.php#L33).
