### PR TITLE
CPS-390: Remove Limit restrictions And Fetch Only Active Case Types

### DIFF
--- a/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
+++ b/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
@@ -4,7 +4,7 @@ use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 use CRM_Civicase_Service_CaseCategorySetting as CaseCategorySetting;
 
 /**
- * CRM_Civicase_Hook_Helper_CaseTypeCategory class.
+ * Case type category helper class.
  */
 class CRM_Civicase_Hook_Helper_CaseTypeCategory {
 
@@ -46,7 +46,9 @@ class CRM_Civicase_Hook_Helper_CaseTypeCategory {
     try {
       $result = civicrm_api3('CaseType', 'get', [
         'return' => ['id'],
+        'is_active' => 1,
         'case_type_category' => $caseCategoryName,
+        'options' => ['limit' => 0],
       ]);
 
       if ($result['count'] == 0) {
@@ -54,7 +56,8 @@ class CRM_Civicase_Hook_Helper_CaseTypeCategory {
       }
 
       return array_column($result['values'], 'id');
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
     }
 
   }


### PR DESCRIPTION
## Overview
When creating a case for a case type category, the case type dropdown lists the case types belonging to the relevant case category. The function for fetching these case types will currently return `25` case types by default (i.e the default limit for civicrm api calls), this is not an issue for sites that don't have much case types but for sites that have a lot of case types, this will result in unexpected behaviour as not all case types will be present in the dropdown. 

## Before
The issue described above exists.


## After
The `getCaseTypesForCategory` function is modified to return only active case types and also to return all case types for the concerned case category.


**Affected screen**
![image-20201110-135109](https://user-images.githubusercontent.com/6951813/98794583-7fa8b300-2409-11eb-8629-d38a942d00c2.png)
