### PR TITLE
RSE-1516: Add Client Role To Roles List While Sending Bulk Email

### DIFF
--- a/ang/civicase/case/actions/services/email-case-action.service.js
+++ b/ang/civicase/case/actions/services/email-case-action.service.js
@@ -54,7 +54,7 @@
      * @returns {Promise} promise resolves to list of contact ids
      */
     function getContactsForCaseIds (caseRoleIds, model) {
-      var isClientRoleSelected = caseRoleIds.indexOf('client') !== -1;
+      var isClientRoleSelected = _.includes(caseRoleIds, 'client');
       var contactIDs = [];
 
       if (isClientRoleSelected) {

--- a/ang/test/civicase/case/actions/services/email-case-action.service.spec.js
+++ b/ang/test/civicase/case/actions/services/email-case-action.service.spec.js
@@ -42,11 +42,13 @@
           });
         expectedModelObject = {
           caseRoles: [
+            { name: 'Client', id: 'client', text: 'Client' },
             { name: 'Homeless Services Coordinator', id: '11', text: 'Homeless Services Coordinator' },
             { name: 'Health Services Coordinator', id: '12', text: 'Health Services Coordinator' },
             { name: 'Benefits Specialist', id: '14', text: 'Benefits Specialist' },
             { name: 'Senior Services Coordinator', id: '16', text: 'Senior Services Coordinator' }
           ],
+          caseClientIDs: ['170'],
           selectedCaseRoles: '',
           caseIds: [caseObj.id],
           deferObject: jasmine.any(Object)
@@ -77,7 +79,7 @@
         describe('and there are roles present for the selected relationships', () => {
           beforeEach(() => {
             civicaseCrmApiMock.and.returnValue($q.resolve({ values: RelationshipData.get() }));
-            modalOpenCall[2].selectedCaseRoles = '11,12';
+            modalOpenCall[2].selectedCaseRoles = 'client,11,12';
             modalOpenCall[3].buttons[0].click();
 
             $rootScope.$digest();
@@ -96,7 +98,7 @@
           it('returns the path to open the send email popup and hides the draft button', () => {
             expect(returnValue).toEqual({
               path: 'civicrm/activity/email/add',
-              query: { action: 'add', reset: 1, cid: '4,6', hideDraftButton: 1, caseid: '141' }
+              query: { action: 'add', reset: 1, cid: '170,4,6', hideDraftButton: 1, caseid: '141' }
             });
           });
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3538,14 +3538,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3560,20 +3558,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3690,8 +3685,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3703,7 +3697,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3718,7 +3711,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3726,14 +3718,12 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3752,7 +3742,6 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -3814,8 +3803,7 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -3843,8 +3831,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3856,7 +3843,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3970,7 +3956,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3538,12 +3538,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3558,17 +3560,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3685,7 +3690,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3697,6 +3703,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3711,6 +3718,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3718,12 +3726,14 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3742,6 +3752,7 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -3803,7 +3814,8 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -3831,7 +3843,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3843,6 +3856,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3956,6 +3970,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
## Overview
Previously in the "Email - Send Now" popup, "client" role was not shown as an option. This PR adds that feature, so that email can be sent to clients too.

## Before
![2020-11-18 at 3 36 PM](https://user-images.githubusercontent.com/5058867/99516104-d1c27900-29b3-11eb-9533-23b4d25805f1.png)


## After
![2020-11-18 at 3 35 PM](https://user-images.githubusercontent.com/5058867/99516055-c2433000-29b3-11eb-9184-32d088cc57b6.png)

## Technical Details
In `ang/civicase/case/actions/services/email-case-action.service.js` modified the `getContactsForCaseIds` function to fetch client ids, if Client role is selected.