### PR TITLE
CATL-1961: Fix Contact Details On Webform Not Being Pre-filled With Add Case Button on Actions Menu 

### DIFF
--- a/CRM/Civicase/Helper/NewCaseWebform.php
+++ b/CRM/Civicase/Helper/NewCaseWebform.php
@@ -26,14 +26,32 @@ class CRM_Civicase_Helper_NewCaseWebform {
       $options['caseCategoryWebformSettings'][$caseTypeCategoryNameLowerCase]['newCaseWebformClient'] = 'cid';
       $options['caseCategoryWebformSettings'][$caseTypeCategoryNameLowerCase]['newCaseWebformUrl'] = $newCaseWebformUrl;
       if ($newCaseWebformUrl) {
-        $path = explode('/', $newCaseWebformUrl);
-        $webformId = array_pop($path);
-        $clientId = self::getCaseWebformClientId($webformId);
+        $clientId = self::getClientIdFromWebformUrl($newCaseWebformUrl);
         if ($clientId) {
           $options['caseCategoryWebformSettings'][$caseTypeCategoryNameLowerCase]['newCaseWebformClient'] = 'cid' . $clientId;
         }
       }
     }
+  }
+
+  /**
+   * Gets the case client id from webform URL.
+   *
+   * @param string $webformUrl
+   *   Webform URL.
+   *
+   * @return int|null
+   *   client ID.
+   */
+  public static function getClientIdFromWebformUrl($webformUrl) {
+    $path = explode('/', $webformUrl);
+    $webformId = array_pop($path);
+
+    if (!$webformId) {
+      return NULL;
+    }
+
+    return self::getCaseWebformClientId($webformId);
   }
 
   /**


### PR DESCRIPTION
## Overview
When the Add case creation form is overriden via the civicase settings to instead redirect to a webform, using the Add case button on the actions menu for a contact redirects to the webform correctly but the contact details that should be autofilled on the webform is not autofilled because the contact ID and webform cid parameter is not passed in the URL.
This PR fixes the issue.

## Before
- The issue described above exists.

![image-20201109-152644](https://user-images.githubusercontent.com/6951813/99395197-5e9c0280-28e0-11eb-9e8f-6eb5b8f8a230.png)


## After
The `CaseTypeCategoryWebFormRedirect` PreProcess hook is responsible for redirecting the Case form to the equivalent webform URL for the case category. This hook is modified to take the form contact ID into consideration and pass it along with the webform cid parameter as URL arguments when redirecting to the webform. 

![image-20201109-152716](https://user-images.githubusercontent.com/6951813/99395229-6b205b00-28e0-11eb-8aea-6db3e92ea985.png)


