### PR TITLE
RSE-1528: Create Email did not work for Application Management instance

### DIFF
--- a/ang/civicase/case/details/directives/case-details.directive.js
+++ b/ang/civicase/case/details/directives/case-details.directive.js
@@ -141,7 +141,9 @@
         caseid: $scope.item.id,
         atype: '3',
         reset: 1,
-        cid: CasesUtils.getAllCaseClientContactIds($scope.item.contacts).join(',')
+        cid: $scope.item.client.map(function (client) {
+          return client.contact_id;
+        }).join(',')
       };
 
       CRM

--- a/ang/civicase/case/services/cases-utils.service.js
+++ b/ang/civicase/case/services/cases-utils.service.js
@@ -18,24 +18,6 @@
     };
 
     /**
-     * Get all case clients ids for a case contacts list
-     *
-     * @param {Array} contacts contacts of a case
-     *
-     * @returns {Array} contact contacts of all client ids
-     */
-    this.getAllCaseClientContactIds = function (contacts) {
-      return _.chain(contacts)
-        .filter(function (contact) {
-          return contact.role === ts('Client');
-        })
-        .map(function (client) {
-          return client.contact_id;
-        })
-        .value();
-    };
-
-    /**
      * Get all the contacts of the given case
      *
      * @param {object} caseObj - case object to be processed

--- a/ang/test/civicase/case/details/directives/case-details.directive.spec.js
+++ b/ang/test/civicase/case/details/directives/case-details.directive.spec.js
@@ -405,7 +405,7 @@
 
   describe('civicaseCaseDetailsController', function () {
     let $controller, $provide, $rootScope, $route, $scope, apiResponses,
-      CasesData, CasesUtils, civicaseCrmApiMock, controller, DetailsCaseTab,
+      CasesData, civicaseCrmApiMock, controller, DetailsCaseTab,
       loadFormBefore;
 
     beforeEach(module('civicase', 'civicase.data', function (_$provide_) {
@@ -417,12 +417,11 @@
     }));
 
     beforeEach(inject(function (_$controller_, $q, _$rootScope_, _$route_,
-      _CasesData_, _CasesUtils_, _DetailsCaseTab_) {
+      _CasesData_, _DetailsCaseTab_) {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       $route = _$route_;
       CasesData = _CasesData_;
-      CasesUtils = _CasesUtils_;
       DetailsCaseTab = _DetailsCaseTab_;
       apiResponses = {
         'Contact.get': { values: [] }
@@ -667,7 +666,7 @@
           caseid: $scope.item.id,
           atype: '3',
           reset: 1,
-          cid: CasesUtils.getAllCaseClientContactIds($scope.item.contacts).join(',')
+          cid: '170'
         });
       });
 

--- a/ang/test/civicase/case/services/cases-utils.service.spec.js
+++ b/ang/test/civicase/case/services/cases-utils.service.spec.js
@@ -40,41 +40,5 @@
         expect(contactsFetched).toEqual(expectedContacts);
       });
     });
-
-    describe('getAllCaseClientContactIds()', () => {
-      let cases;
-
-      beforeEach(() => {
-        cases = CasesData.get().values[0];
-      });
-
-      it('fetches all client contact ids of the case', () => {
-        expect(CasesUtils.getAllCaseClientContactIds(cases.contacts)).toEqual(['170']);
-      });
-
-      describe('when the client word has been translated to a different one', () => {
-        beforeEach(() => {
-          cases.contacts = cases.contacts
-            .map((contact) => ({
-              ...contact,
-              role: contact.role === 'Client'
-                ? 'Member'
-                : contact.role
-            }));
-
-          mockTs.and.callFake((string) => {
-            if (string === 'Client') {
-              return 'Member';
-            }
-
-            return string;
-          });
-        });
-
-        it('returns clients even when their roles have been translated', () => {
-          expect(CasesUtils.getAllCaseClientContactIds(cases.contacts)).toEqual(['170']);
-        });
-      });
-    });
   });
 })(CRM._);


### PR DESCRIPTION
## Overview
"Create Email" Activity did not work for "Application Management" instance, and there was console errors.

## Before
![before](https://user-images.githubusercontent.com/5058867/99767877-d3ae4880-2b29-11eb-98da-d4f3852101d5.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/99767835-bda08800-2b29-11eb-989e-0144ff3842de.gif)

## Technical Details
In `ang/civicase/case/details/directives/case-details.directive.js`, `CasesUtils.getAllCaseClientContactIds` function was called to fetch client IDs for a case. But the `CasesUtils.getAllCaseClientContactIds` function relies on a string called `Client` to be present in the `caseObject.contacts` array. Now due to word replacement, this word gets translated to Member(for NEU), or Applicant(for Awards), so the logic did not work in all cases.

Now this `CasesUtils.getAllCaseClientContactIds` function has been removed, instead in `ang/civicase/case/details/directives/case-details.directive.js`, the client ids are fetched from the `caseObject.client` array.