### PR TITLE
RSE-1543: Expose Case Category Field On Case Type Create/Edit Screen

### DIFF
--- a/CRM/Civicase/Hook/alterAngular/AngularChangeSet.php
+++ b/CRM/Civicase/Hook/alterAngular/AngularChangeSet.php
@@ -1,0 +1,30 @@
+<?php
+
+use CRM_Civicase_ExtensionUtil as ExtensionUtil;
+use Civi\Angular\ChangeSet;
+
+/**
+ * Angular ChangeSet Helper Class.
+ */
+class CRM_Civicase_Hook_alterAngular_AngularChangeSet {
+
+  /**
+   * Returns ChangeSet for the case type category field.
+   *
+   * This ChangeSet is needed for the core Case Type create/Edit screen.
+   *
+   * @return \Civi\Angular\ChangeSet
+   *   Angular ChangeSet.
+   */
+  public static function getForCaseTypeCategoryField() {
+    $path = CRM_Core_Resources::singleton()
+      ->getPath(ExtensionUtil::LONG_NAME, 'templates/CRM/Civicase/ChangeSet/CaseTypeCategory.html');
+    $caseTypeCategoryContent = file_get_contents($path);
+
+    return ChangeSet::create('case-type-category')
+      ->alterHtml('~/crmCaseType/caseTypeDetails.html', function (phpQueryObject $doc) use ($caseTypeCategoryContent) {
+        $doc->find("div[crm-ui-field*=name: 'caseTypeDetailForm.caseTypeName']")->after($caseTypeCategoryContent);
+      });
+  }
+
+}

--- a/CRM/Civicase/Hook/alterAngular/AngularChangeSet.php
+++ b/CRM/Civicase/Hook/alterAngular/AngularChangeSet.php
@@ -23,7 +23,15 @@ class CRM_Civicase_Hook_alterAngular_AngularChangeSet {
 
     return ChangeSet::create('case-type-category')
       ->alterHtml('~/crmCaseType/caseTypeDetails.html', function (phpQueryObject $doc) use ($caseTypeCategoryContent) {
-        $doc->find("div[crm-ui-field*=name: 'caseTypeDetailForm.caseTypeName']")->after($caseTypeCategoryContent);
+        $element = $doc->find("div[crm-ui-field*=name: 'caseTypeDetailForm.caseTypeName']");
+        if ($element->length) {
+          $element->after($caseTypeCategoryContent);
+        }
+        else {
+          $doc->find("[ng-form='caseTypeDetailForm']")->prepend(
+            '<p class="error">The case type name selector is invalid, The Instance field will not be available</p>'
+          );
+        }
       });
   }
 

--- a/civicase.php
+++ b/civicase.php
@@ -6,6 +6,7 @@
  */
 
 use Civi\Angular\AngularLoader;
+use Civi\Angular\Manager;
 
 require_once 'civicase.civix.php';
 
@@ -641,6 +642,15 @@ function civicase_civicrm_summaryActions(&$actions, $contactID) {
 
   foreach ($hooks as $hook) {
     $hook->run($actions, $contactID);
+  }
+}
+
+/**
+ * Implements hook_civicrm_alterAngular().
+ */
+function civicase_civicrm_alterAngular(Manager $angular) {
+  if (CRM_Core_Permission::check([['administer CiviCase', 'administer CiviCRM']])) {
+    $angular->add(CRM_Civicase_Hook_alterAngular_AngularChangeSet::getForCaseTypeCategoryField());
   }
 }
 

--- a/templates/CRM/Civicase/ChangeSet/CaseTypeCategory.html
+++ b/templates/CRM/Civicase/ChangeSet/CaseTypeCategory.html
@@ -1,0 +1,21 @@
+<div crm-ui-field="{name: 'caseTypeDetailForm.caseTypeCategory', title: ts('Instance')}">
+  <input
+    name="caseTypeCategory"
+    crm-ui-id="caseType.case_type_category"
+    ng-model="caseType.case_type_category"
+    crm-entityref="{
+      entity: 'OptionValue',
+      api: {
+        params: {option_group_id: 'case_type_categories'}
+      },
+      select: {allowClear: true, multiple: false, placeholder: ts('Select Instance')},
+    }"
+    class="big crm-form-text"
+  />
+  <a
+    href="/civicrm/admin/options/case_type_categories?reset=1"
+    class="crm-option-edit-link medium-popup crm-hover-button"
+    target="_blank" >
+    <i aria-hidden="true" title="Edit Instance" class="crm-i fa-wrench"></i>
+  </a>
+</div>


### PR DESCRIPTION
## Overview
This PR exposes the Case Type Category field on the Case Type create/edit screen. The field is exposed with the name `Instance`. 

## Before
This Case Type Category field is not part of the create/edit screen.

## After

The Case Type Category field is now part of the create/edit screen with the field name `Instance`. Only users with the `Administer CiviCRM` or `Administer CiviCase` permission can view this field. 


![CaseTypeExpose](https://user-images.githubusercontent.com/6951813/99804526-6dcabc80-2b3b-11eb-8d1b-689baa6eea43.gif)

## Technical Details
- A new Angular ChangeSet was created for the case category field and injected into the core `~/crmCaseType/caseTypeDetails.html` angular template via the `civicrm_alterAngular` hook.

```php
  if (CRM_Core_Permission::check([['administer CiviCase', 'administer CiviCRM']])) {
    $angular->add(CRM_Civicase_Hook_alterAngular_AngularChangeSet::getForCaseTypeCategoryField());
  }
```

## Update
If the `$doc->find("div[crm-ui-field*=name: 'caseTypeDetailForm.caseTypeName']")` selector is for some reason not available, we target the form selector instead and display an error message that the case type name selector is not valid. This seems much better than throwing an exception as that renders the whole Case type form unusable.
<img width="1280" alt="Cases_1  CaseLatest 2020-11-20 15-22-52" src="https://user-images.githubusercontent.com/6951813/99810994-d4a0a380-2b44-11eb-9541-3ad3fdf7f13b.png">


