### PR TITLE
BASW-638: Pivot Report Bug Fix

### DIFF
--- a/CRM/Civicase/Form/Report/BaseExtendedReport.php
+++ b/CRM/Civicase/Form/Report/BaseExtendedReport.php
@@ -1014,15 +1014,15 @@ abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_
    * Use the options for the field to map the display value.
    *
    * @param string $value
-   *    Value of the field.
+   *   Value of the field.
    * @param array $row
-   *    Row display values.
+   *   Row display values.
    * @param string $selectedField
-   *    Selected field.
+   *   Selected field.
    * @param string $criteriaFieldName [optional]
-   *    Criteria field name.
+   *   Criteria field name.
    * @param array $specs
-   *    Specifications of the column.
+   *   Specifications of the column.
    *
    * @return string
    */

--- a/CRM/Civicase/Form/Report/BaseExtendedReport.php
+++ b/CRM/Civicase/Form/Report/BaseExtendedReport.php
@@ -1014,10 +1014,15 @@ abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_
    * Use the options for the field to map the display value.
    *
    * @param string $value
+   *    Value of the field.
    * @param array $row
+   *    Row display values.
    * @param string $selectedField
+   *    Selected field.
    * @param string $criteriaFieldName [optional]
+   *    Criteria field name.
    * @param array $specs
+   *    Specifications of the column.
    *
    * @return string
    */

--- a/CRM/Civicase/Form/Report/BaseExtendedReport.php
+++ b/CRM/Civicase/Form/Report/BaseExtendedReport.php
@@ -1009,6 +1009,38 @@ abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_
   }
 
   /**
+   * Use the options for the field to map the display value.
+   *
+   * @param string $value
+   * @param array $row
+   * @param string $selectedField
+   * @param string $criteriaFieldName [optional]
+   * @param array $specs
+   *
+   * @return string
+   */
+  public function alterFromOptions($value, &$row, $selectedField, $criteriaFieldName, $specs) {
+    if ($specs['data_type'] == 'ContactReference') {
+      if (!empty($row[$selectedField])) {
+        return CRM_Contact_BAO_Contact::displayName($row[$selectedField]);
+      }
+      return NULL;
+    }
+    $value = trim($value, CRM_Core_DAO::VALUE_SEPARATOR);
+    $options = $this->getCustomFieldOptions($specs);
+    if (strpos($value, CRM_Core_DAO::VALUE_SEPARATOR) === false) {
+      return CRM_Utils_Array::value($value, $options, $value);
+    } else {
+      $values = explode(CRM_Core_DAO::VALUE_SEPARATOR, $value);
+      $labels = [];
+      foreach ($values as $val) {
+        $labels[] = CRM_Utils_Array::value($val, $options, $val);
+      }
+      return implode(' | ', $labels);
+    }
+  }
+
+  /**
    * Adjusts row total.
    *
    * Since we have introduced other data aggregate functions like COUNT UNIQUE,

--- a/CRM/Civicase/Form/Report/BaseExtendedReport.php
+++ b/CRM/Civicase/Form/Report/BaseExtendedReport.php
@@ -310,7 +310,8 @@ abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_
       'dbAlias' => $prefix . $field['table_key'] . '.' . $field['column_name'],
       'alias' => $prefix . $field['table_name'] . '_' . 'custom_' . $field['id'],
     ]);
-    $field['is_aggregate_columns'] = in_array($field['html_type'], ['Select', 'Radio']);
+    $field['is_aggregate_columns'] =
+      in_array($field['html_type'], ['Select', 'Radio']);
 
     if (!empty($field['option_group_id'])) {
       if (in_array($field['html_type'], [

--- a/CRM/Civicase/Form/Report/BaseExtendedReport.php
+++ b/CRM/Civicase/Form/Report/BaseExtendedReport.php
@@ -617,7 +617,8 @@ abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_
     $value = $optionValue;
     $operator = '=';
 
-    if (!empty($spec['htmlType']) && in_array($spec['htmlType'], ['CheckBox', 'MultiSelect'])) {
+    if (!empty($spec['htmlType']) &&
+      in_array($spec['htmlType'], ['CheckBox', 'MultiSelect'])) {
       $value = "%" . CRM_Core_DAO::VALUE_SEPARATOR . $optionValue . CRM_Core_DAO::VALUE_SEPARATOR . "%";
       $operator = 'LIKE';
     }

--- a/CRM/Civicase/Form/Report/BaseExtendedReport.php
+++ b/CRM/Civicase/Form/Report/BaseExtendedReport.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Class CRM_Civicase_Form_Report_BaseExtendedReport.
+ * Base class for case reports.
  */
 abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_Form_Report_ExtendedReport {
 

--- a/CRM/Civicase/Form/Report/BaseExtendedReport.php
+++ b/CRM/Civicase/Form/Report/BaseExtendedReport.php
@@ -1019,14 +1019,15 @@ abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_
    *   Row display values.
    * @param string $selectedField
    *   Selected field.
-   * @param string $criteriaFieldName [optional]
+   * @param string $criteriaFieldName
    *   Criteria field name.
    * @param array $specs
    *   Specifications of the column.
    *
    * @return string
+   *   Label of the option ids.
    */
-  public function alterFromOptions($value, &$row, $selectedField, $criteriaFieldName, $specs) {
+  public function alterFromOptions($value, array &$row, $selectedField, $criteriaFieldName, array $specs) {
     if ($specs['data_type'] == 'ContactReference') {
       if (!empty($row[$selectedField])) {
         return CRM_Contact_BAO_Contact::displayName($row[$selectedField]);
@@ -1035,9 +1036,10 @@ abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_
     }
     $value = trim($value, CRM_Core_DAO::VALUE_SEPARATOR);
     $options = $this->getCustomFieldOptions($specs);
-    if (strpos($value, CRM_Core_DAO::VALUE_SEPARATOR) === false) {
+    if (strpos($value, CRM_Core_DAO::VALUE_SEPARATOR) === FALSE) {
       return CRM_Utils_Array::value($value, $options, $value);
-    } else {
+    }
+    else {
       $values = explode(CRM_Core_DAO::VALUE_SEPARATOR, $value);
       $labels = [];
       foreach ($values as $val) {


### PR DESCRIPTION
## Overview
This pr fixes the issue with display of custom fields and form fields with select multiple enabled in case reports. When the fields that have multiple values were loaded in report the column displayed the ids mixed with some weird characters, This pr fixes the issue for all the custom fields and form fields with select multiple enabled and displays multiple label separated by a | character.

## Before
Multiple values for theme were shown incorrectly
![Screenshot from 2020-11-24 20-02-00](https://user-images.githubusercontent.com/68388745/100111484-f4f79780-2e8f-11eb-8f3f-9a5a2e9e3388.png)

## After
All the values are displayed correctly
![Screenshot from 2020-11-24 20-03-55](https://user-images.githubusercontent.com/68388745/100111731-37b96f80-2e90-11eb-9eb1-8051f53d4505.png)

## Technical Details
The alterFromOptions function in class CRM_Civicase_Form_Report_BaseExtendedReport is responsible for changing option ids with option labels. Previously it only cater for single values now it has been modified to work with mulitple options as well.
