### PR TITLE
CATL-1931: Avoid displaying the same contact on different recipient fields

### DIFF
--- a/js/restrict-case-email-contacts.js
+++ b/js/restrict-case-email-contacts.js
@@ -1,6 +1,6 @@
 (function ($, _, caseSettings) {
   var $recipientFields;
-  var caseContacts = JSON.parse(caseSettings.case_contacts);
+  var CASE_CONTACTS = JSON.parse(caseSettings.case_contacts);
 
   // Without the timeout the CC and BCC fields can't be properly replaced
   setTimeout(function init () {
@@ -10,7 +10,8 @@
 
   /**
    * Replaces the "To", "CC", "BCC" dropdowns with new ones that only contain
-   * case contacts.
+   * case contacts. The fields will only display contacts that have not been
+   * selected by other fields.
    *
    * The "To" field values must be stored in a `123::contact@example.com` format,
    * where `123` is the contact's ID. The "CC" and "BCC" field values must contain
@@ -20,31 +21,78 @@
     $recipientFields.each(function () {
       var $field = $(this);
       var isToField = $field.attr('name') === 'to';
-      var caseContactSelect2Options = isToField
-        ? getCaseContactOptions({ idFieldName: 'value' })
-        : getCaseContactOptions({ idFieldName: 'contact_id' });
 
       $field.crmSelect2({
         multiple: true,
-        data: caseContactSelect2Options
+        data: function () {
+          var myContacts = getFieldContactValues($field);
+          var otherContacts = getFieldContactValues($recipientFields.not($field));
+          var availableContacts = getFilteredCaseContacts({
+            include: myContacts,
+            exclude: otherContacts
+          });
+          var caseContactSelect2Options = isToField
+            ? getCaseContactOptions({ caseContacts: availableContacts, idFieldName: 'value' })
+            : getCaseContactOptions({ caseContacts: availableContacts, idFieldName: 'contact_id' });
+
+          return { results: caseContactSelect2Options };
+        }
       });
     });
   }
 
   /**
    * @param {object} options list of options.
+   * @param {object[]} options.caseContacts A list of case contacts to generate
+   *   the options from.
    * @param {string} options.idFieldName The contact's field name to use as the
-   * option's ID.
+   *   option's ID.
    * @returns {object[]} The list of case contacts as expected by the select2
-   * dropdowns.
+   *   dropdowns.
    */
   function getCaseContactOptions (options) {
-    return caseContacts.map(function (caseContact) {
-      return {
-        id: caseContact[options.idFieldName],
-        text: _.template('<%= display_name %> <<%= email %>>')(caseContact)
-      };
+    return _.chain(options.caseContacts)
+      .uniq(function (caseContact) {
+        return caseContact.contact_id;
+      })
+      .map(function (caseContact) {
+        return {
+          id: caseContact[options.idFieldName],
+          text: _.template('<%= display_name %> <<%= email %>>')(caseContact)
+        };
+      })
+      .value();
+  }
+
+  /**
+   * @param {object} filters A list of filters.
+   * @param {string[]} filters.exclude Contact values to exclude from the
+   *   returned objects.
+   * @param {string[]} filters.include Contact values that must be included
+   *   even if they have been marked as excluded.
+   * @returns {object[]} A list of contacts filtered by the given parameters.
+   */
+  function getFilteredCaseContacts (filters) {
+    return _.filter(CASE_CONTACTS, function (caseContact) {
+      var isIncluded = !!_.find(filters.include, function (fieldValue) {
+        return fieldValue === caseContact.value || fieldValue === caseContact.contact_id;
+      });
+      var isExcluded = !!_.find(filters.exclude, function (fieldValue) {
+        return fieldValue === caseContact.value || fieldValue === caseContact.contact_id;
+      });
+
+      return isIncluded || !isExcluded;
     });
+  }
+
+  /**
+   * @param {object} $fields jQuery selector.
+   * @returns {string[]} The contact values as stored on the given fields.
+   */
+  function getFieldContactValues ($fields) {
+    return $fields.map(function () {
+      return $(this).val().split(',');
+    }).toArray();
   }
 
   /**


### PR DESCRIPTION
## Overview
This PR avoids displaying the same contact on different recipient fields when sending a case email.

For more details about the feature please see the original PR:
https://github.com/compucorp/uk.co.compucorp.civicase/pull/623

## Before
![gif](https://user-images.githubusercontent.com/1642119/100169551-24130680-2e9a-11eb-8a76-f6736def1749.gif)

## After
![gif](https://user-images.githubusercontent.com/1642119/100169501-047bde00-2e9a-11eb-9c9e-c13d8a134900.gif)

## Technical Details

We updated the `addNewRecipientDropdowns ` function in the `js/restrict-case-email-contacts.js` file so now the data passed to the Select2 component is now a function. This function checks the values stored in other fields and will only return the appropriate contacts.