### PR TITLE
CPS-397: Release v1.9.7

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/compucorp/uk.co.compucorp.civicase/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2020-11-09</releaseDate>
-  <version>1.9.6</version>
+  <releaseDate>2020-11-26</releaseDate>
+  <version>1.9.7</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.24</ver>


### PR DESCRIPTION
## Release Update - 26th November, 2020
### Improvements
- Case category field is now available on the case type create/edit screen https://github.com/compucorp/uk.co.compucorp.civicase/pull/640
### Bug Fixes
- Fixed issue with the number of case types being limited to 25 on the case creation form https://github.com/compucorp/uk.co.compucorp.civicase/pull/636
- Fixed issue with Add case button on contact actions not pre-filling form values when the case creation form isa webform https://github.com/compucorp/uk.co.compucorp.civicase/pull/638
- Fixed Client role not visible on bulk emails https://github.com/compucorp/uk.co.compucorp.civicase/pull/637
- Fixed issue with Email actions not working properly for a case on manage cases screen https://github.com/compucorp/uk.co.compucorp.civicase/pull/639
- Fixed case activity pivot report issue where multi-value custom fields are not replaced with labels on report display https://github.com/compucorp/uk.co.compucorp.civicase/pull/642