### PR TITLE
CATL-1922: Define minimum and maximum dates for case relationships

### DIFF
--- a/ang/civicase-base/directives/inline-datepicker.directive.js
+++ b/ang/civicase-base/directives/inline-datepicker.directive.js
@@ -32,8 +32,18 @@
         element.datepicker({
           beforeShow: handleDatepickerOpen,
           dateFormat: dateInputFormatValue,
+          maxDate: parseApiDate(attributes.maxDate),
+          minDate: parseApiDate(attributes.minDate),
           onChangeMonthYear: removeDatePickerHrefs,
           onClose: handleDatePickerClose
+        });
+
+        attributes.$observe('maxDate', function () {
+          element.datepicker('option', 'maxDate', parseApiDate(attributes.maxDate));
+        });
+
+        attributes.$observe('minDate', function () {
+          element.datepicker('option', 'minDate', parseApiDate(attributes.minDate));
         });
       })();
 
@@ -65,9 +75,22 @@
         if (modelValue) {
           return $.datepicker.formatDate(
             dateInputFormatValue,
-            $.datepicker.parseDate(API_DATE_FORMAT, modelValue)
+            parseApiDate(modelValue)
           );
         }
+      }
+
+      /**
+       * @param {string} date The date formatted as a string as provided by
+       *   the API.
+       * @returns {Date} a Date instance corresponding to the given date.
+       */
+      function parseApiDate (date) {
+        if (!date) {
+          return null;
+        }
+
+        return $.datepicker.parseDate(API_DATE_FORMAT, date);
       }
 
       /**
@@ -103,7 +126,7 @@
         }
 
         try {
-          $.datepicker.parseDate(API_DATE_FORMAT, modelValue);
+          parseApiDate(modelValue);
 
           return true;
         } catch (exception) {

--- a/ang/civicase/case/details/people-tab/directives/roles-tab.directive.html
+++ b/ang/civicase/case/details/people-tab/directives/roles-tab.directive.html
@@ -155,6 +155,7 @@
             civicase-send-to-api-on-change
             class="form-control"
             data-api-data="roleDatesUpdater.getApiCallsForStartDate(role, item.id)"
+            data-max-date="{{role.relationship.end_date}}"
             data-on-api-data-sent="roleDatesUpdater.updatePreviousValue(role, 'start_date')"
             name="role_start_date"
             ng-disabled="roleForm.role_start_date.isSaving"
@@ -169,6 +170,7 @@
             civicase-send-to-api-on-change
             class="form-control"
             data-api-data="roleDatesUpdater.getApiCallsForEndDate(role, item.id)"
+            data-min-date="{{role.relationship.start_date}}"
             data-on-api-data-sent="roleDatesUpdater.updatePreviousValue(role, 'end_date')"
             name="role_end_date"
             ng-disabled="roleForm.role_end_date.isSaving"


### PR DESCRIPTION
## Overview
This PR limits the start and end date for case relationships. Start dates can't be set after the relationship end date, and the end date can't be set before the start date.

## Before
![gif](https://user-images.githubusercontent.com/1642119/100284280-588fcc80-2f45-11eb-9deb-a42d5ab45132.gif)

## After
![gif](https://user-images.githubusercontent.com/1642119/100284111-0b135f80-2f45-11eb-814d-3040db4f0a68.gif)

## Technical Details
We added two new attributes to the directive: `data-min-date` and `data-max-date`. These attributes are passed to the `datepicker` function, but we parse them before we do so. The format for these dates must be in `year-month-day` format. We parse them to `Date`.

These values are also updated if the attribute changes. We use `attributes.$observe` for this purpose. We don't use the directive's `scope` attribute to pass the `maxDate` and `minDate` attributes because this directive is shared with the `ng-model` and other directives and we can't use `scope` in such scenarios.