### PR TITLE
CATL-1981: Fix case linking

### DIFF
--- a/ang/civicase/case/details/linked-cases-tab/directives/case-details-linked-cases-tab.directive.js
+++ b/ang/civicase/case/details/linked-cases-tab/directives/case-details-linked-cases-tab.directive.js
@@ -28,11 +28,12 @@
      * The case details are refreshed after linking the cases.
      */
     function linkCase () {
-      var linkCaseForm = LinkCasesCaseAction.doAction([$scope.item]);
-
-      loadCrmForm(getCrmUrl(linkCaseForm.path, linkCaseForm.query))
-        .on('crmFormSuccess crmPopupFormSuccess', function () {
-          $scope.refresh();
+      LinkCasesCaseAction.doAction([$scope.item])
+        .then(function (linkCaseForm) {
+          loadCrmForm(getCrmUrl(linkCaseForm.path, linkCaseForm.query))
+            .on('crmFormSuccess crmPopupFormSuccess', function () {
+              $scope.refresh();
+            });
         });
     }
   }

--- a/ang/test/civicase/case/details/linked-cases-tab/directives/case-details-linked-cases-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/linked-cases-tab/directives/case-details-linked-cases-tab.directive.spec.js
@@ -3,39 +3,42 @@
 (($, _, getCrmUrl) => {
   describe('linked cases tab', () => {
     let $controller, $scope, LinkCasesCaseAction;
-    const mockLinkedCaseFormurl = {
-      path: '/linked-case-form',
-      query: 'linked-case-query'
-    };
 
     beforeEach(module('civicase'));
 
-    beforeEach(inject((_$controller_, _$rootScope_) => {
+    beforeEach(inject((_$controller_, _$rootScope_, _LinkCasesCaseAction_) => {
       $controller = _$controller_;
       $scope = _$rootScope_.$new();
+      LinkCasesCaseAction = _LinkCasesCaseAction_;
     }));
 
     beforeEach(() => {
-      LinkCasesCaseAction = jasmine.createSpyObj('LinkCasesCaseAction', ['doAction']);
       $scope.refresh = jasmine.createSpy('refresh');
-      $scope.item = { id: _.uniqueId() };
+      $scope.item = {
+        id: _.uniqueId(),
+        client: [
+          { contact_id: _.uniqueId() }
+        ]
+      };
 
-      LinkCasesCaseAction.doAction.and.returnValue(mockLinkedCaseFormurl);
-      initController({
-        $scope,
-        LinkCasesCaseAction
-      });
+      initController({ $scope });
     });
 
     describe('when linking the current case to a different one', () => {
       let $mockForm, expecteFormUrl;
 
-      beforeEach(() => {
+      beforeEach((done) => {
         $mockForm = $('<div></div>');
-        expecteFormUrl = getCrmUrl(mockLinkedCaseFormurl.path, mockLinkedCaseFormurl.query);
 
         CRM.loadForm.and.returnValue($mockForm);
         $scope.linkCase();
+
+        LinkCasesCaseAction.doAction([$scope.item])
+          .then(function (linkCaseForm) {
+            expecteFormUrl = getCrmUrl(linkCaseForm.path, linkCaseForm.query);
+            done();
+          });
+        $scope.$digest();
       });
 
       it('opens the link case form', () => {


### PR DESCRIPTION
## Overview
This PR fixes a regression issue related to case linking. 


## Before

![gif](https://user-images.githubusercontent.com/1642119/100402230-25773700-3032-11eb-965b-538e6695070e.gif)

## After
![gif](https://user-images.githubusercontent.com/1642119/100402181-011b5a80-3032-11eb-948f-37fcaba864b9.gif)


## Technical Details

The https://github.com/compucorp/uk.co.compucorp.civicase/commit/f89b7c8331833acd4f156f2ecfcfa83e4ad5dd01 commit changed the `LinkCasesCaseAction`'s `doAction` return value from an object to a promise that resolves to an object. This works for case actions, but we were also using this service directly in the `civicaseCaseDetailsLinkedCasesTab` directive and this usage was not updated. This issue was not caught by tests because we were mocking the `LinkCasesCaseAction` in this directive.

To fix the issue we have updated `civicaseCaseDetailsLinkedCasesTab` so it uses the `LinkCasesCaseAction` service's return value as a promise that needs to be resolved.

For testing, we are not mocking the service anymore, but using it directly. If the implementation changes, we'll notice the change by running the tests.
