### PR TITLE
RSE-1442: Add Bulk Email Activity To All The Selected Cases

### DIFF
--- a/CRM/Civicase/Hook/PostProcess/AttachEmailActivityToAllCases.php
+++ b/CRM/Civicase/Hook/PostProcess/AttachEmailActivityToAllCases.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Add bulk email as an activity to all the selected cases.
+ */
+class CRM_Civicase_Hook_PostProcess_AttachEmailActivityToAllCases {
+
+  /**
+   * Add bulk email as an activity to all the selected cases.
+   *
+   * @param string $formName
+   *   The class name of the submitted form.
+   * @param object $form
+   *   The submitted form instance.
+   */
+  public function run($formName, $form) {
+    if (!$this->shouldRun($formName)) {
+      return;
+    }
+
+    $this->addActivityToAllSelectedCases();
+  }
+
+  /**
+   * Add bulk email as an activity to all the selected cases.
+   */
+  private function addActivityToAllSelectedCases() {
+    try {
+      $firstCaseId = CRM_Utils_Request::retrieve('caseid', 'Integer');
+      $allCaseIds = array_diff(
+        explode(',', CRM_Utils_Request::retrieve('allCaseIds', 'CommaSeparatedIntegers')),
+        [$firstCaseId]
+      );
+      $activity = civicrm_api3('Activity', 'get', [
+        'case_id' => $firstCaseId,
+        'activity_type_id' => 'Email',
+        'source_contact_id' => CRM_Core_Session::getLoggedInContactID(),
+        'options' => [
+          'limit' => 1,
+          'sort' => "id DESC",
+        ],
+        'sequential' => 1,
+        'return' => ['id'],
+      ]);
+    }
+    catch (Throwable $ex) {
+      return;
+    }
+    $activityId = !empty($activity['id']) ? $activity['id'] : NULL;
+    if ($activityId) {
+      foreach ($allCaseIds as $caseId) {
+        $caseActivity = new CRM_Case_DAO_CaseActivity();
+        $caseActivity->case_id = $caseId;
+        $caseActivity->activity_id = $activityId;
+        $caseActivity->save();
+      }
+    }
+  }
+
+  /**
+   * Check whether the hook should run or not.
+   *
+   * @param string $formName
+   *   The name for the current form.
+   *
+   * @return bool
+   *   Whether the hook should run or not.
+   */
+  private function shouldRun($formName) {
+    return $formName === CRM_Contact_Form_Task_Email::class &&
+      !empty(CRM_Utils_Array::value('allCaseIds', $_GET, '0')) &&
+      !empty(CRM_Utils_Array::value('caseid', $_GET, '0'));
+  }
+
+}

--- a/ang/civicase/case/actions/services/email-case-action.service.js
+++ b/ang/civicase/case/actions/services/email-case-action.service.js
@@ -188,12 +188,13 @@
             action: 'add',
             hideDraftButton: 1,
             reset: 1,
-            cid: contactIDs.join(',')
+            cid: contactIDs.join(','),
+            caseid: model.caseIds[0]
           }
         };
 
-        if (model.caseIds.length === 1) {
-          popupPath.query.caseid = model.caseIds[0];
+        if (model.caseIds.length > 1) {
+          popupPath.query.allCaseIds = model.caseIds.join(',');
         }
 
         model.deferObject.resolve(popupPath);

--- a/ang/test/civicase/case/actions/services/email-case-action.service.spec.js
+++ b/ang/test/civicase/case/actions/services/email-case-action.service.spec.js
@@ -141,5 +141,36 @@
         });
       });
     });
+    describe('when clicking on the action with more than one case selected', () => {
+      var modalOpenCall, returnValue;
+
+      beforeEach(function () {
+        caseObj = CasesMockData.get().values[0];
+        var case2Obj = CasesMockData.get().values[1];
+        EmailCaseAction.doAction([caseObj, case2Obj], 'email', jasmine.any(Function))
+          .then(function (result) {
+            returnValue = result;
+          });
+        modalOpenCall = dialogServiceMock.open.calls.mostRecent().args;
+        civicaseCrmApiMock.and.returnValue($q.resolve({ values: RelationshipData.get() }));
+        modalOpenCall[2].selectedCaseRoles = 'client,11,12';
+        modalOpenCall[3].buttons[0].click();
+        $rootScope.$digest();
+      });
+
+      it('adds bulk email activitiy to all the selected cases', () => {
+        expect(returnValue).toEqual({
+          path: 'civicrm/activity/email/add',
+          query: {
+            action: 'add',
+            reset: 1,
+            cid: '170,4,6',
+            hideDraftButton: 1,
+            caseid: '141',
+            allCaseIds: '141,3'
+          }
+        });
+      });
+    });
   });
 })(CRM._, CRM.$);

--- a/civicase.php
+++ b/civicase.php
@@ -430,6 +430,7 @@ function civicase_civicrm_postProcess($formName, &$form) {
     new CRM_Civicase_Hook_PostProcess_CaseCategoryPostProcessor(),
     new CRM_Civicase_Hook_PostProcess_ActivityFormStatusWordReplacement(),
     new CRM_Civicase_Hook_PostProcess_RedirectToCaseDetails(),
+    new CRM_Civicase_Hook_PostProcess_AttachEmailActivityToAllCases(),
   ];
 
   foreach ($hooks as $hook) {
@@ -649,7 +650,9 @@ function civicase_civicrm_summaryActions(&$actions, $contactID) {
  * Implements hook_civicrm_alterAngular().
  */
 function civicase_civicrm_alterAngular(Manager $angular) {
-  if (CRM_Core_Permission::check([['administer CiviCase', 'administer CiviCRM']])) {
+  if (CRM_Core_Permission::check(
+    [['administer CiviCase', 'administer CiviCRM']]
+  )) {
     $angular->add(CRM_Civicase_Hook_alterAngular_AngularChangeSet::getForCaseTypeCategoryField());
   }
 }

--- a/tests/phpunit/CRM/Civicase/Hook/PostProcess/AttachEmailActivityToAllCasesTest.php
+++ b/tests/phpunit/CRM/Civicase/Hook/PostProcess/AttachEmailActivityToAllCasesTest.php
@@ -1,0 +1,114 @@
+<?php
+
+use CRM_Civicase_Hook_PostProcess_AttachEmailActivityToAllCases as AttachEmailActivityToAllCases;
+use CRM_Civicase_Test_Fabricator_Case as CaseFabricator;
+use CRM_Civicase_Test_Fabricator_CaseType as CaseTypeFabricator;
+use CRM_Civicase_Test_Fabricator_Contact as ContactFabricator;
+
+/**
+ * Tests for the CRM_Civicase_Hook_PostProcess_AttachEmailActivityToAllCases.
+ *
+ * @group headless
+ */
+class CRM_Civicase_Hook_PostProcess_AttachEmailActivityToAllCasesTest extends BaseHeadlessTest {
+
+  /**
+   * Test the run method.
+   *
+   * @param int $activityId
+   *   Activity id.
+   * @param int $caseId
+   *   First case id.
+   * @param string $allCaseIds
+   *   All case ids.
+   *
+   * @dataProvider getTestDataForRunMethod
+   */
+  public function testRun($activityId, $caseId, $allCaseIds) {
+    $_GET['caseid'] = $_REQUEST['caseid'] = $caseId;
+    $_GET['allCaseIds'] = $_REQUEST['allCaseIds'] = $allCaseIds;
+    $hook = new AttachEmailActivityToAllCases();
+    $hook->run(CRM_Contact_Form_Task_Email::class, new CRM_Contact_Form_Task_Email());
+    $allCaseIds = array_diff(explode(',', $allCaseIds), [$caseId]);
+    foreach ($allCaseIds as $caseId) {
+      $activity = civicrm_api3('Activity', 'get', [
+        'case_id' => $caseId,
+        'id' => $activityId,
+        'sequential' => 1,
+        'return' => ['id'],
+      ]);
+      $this->assertNotEmpty($activity['id']);
+    }
+  }
+
+  /**
+   * Provides data for run method testing.
+   *
+   * @return array
+   *   List of case and activity id.
+   */
+  public function getTestDataForRunMethod() {
+    $return = [];
+    for ($i = 0; $i < 2; $i++) {
+      $cases = $this->createCases();
+      $activityId = $this->createActivity($cases[0]);
+      $return[] = [
+        $activityId,
+        $cases[0],
+        implode(',', $cases),
+      ];
+    }
+
+    return $return;
+  }
+
+  /**
+   * Provides case ids after creating cases.
+   *
+   * @return array
+   *   List of case ids.
+   */
+  private function createCases() {
+    $cases = [];
+    $creator = ContactFabricator::fabricate();
+    $contact = ContactFabricator::fabricate();
+    $caseType = CaseTypeFabricator::fabricate();
+    for ($i = 0; $i < 2; $i++) {
+      $case = CaseFabricator::fabricate(
+        [
+          'case_type_id' => $caseType['id'],
+          'contact_id' => $contact['id'],
+          'creator_id' => $creator['id'],
+        ]
+      );
+      $cases[] = $case['id'];
+    }
+
+    return $cases;
+  }
+
+  /**
+   * Provides activity id after creating activity.
+   *
+   * @param int $caseId
+   *   Case id.
+   *
+   * @return int
+   *   Activity id.
+   */
+  private function createActivity($caseId) {
+    $creator = ContactFabricator::fabricate();
+    $activity = civicrm_api3('Activity', 'create', [
+      'source_contact_id' => $creator['id'],
+      'activity_type_id' => 3,
+      'activity_date_time' => date('YmdHis'),
+      'subject' => 'Test activity',
+      'details' => '',
+      'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'status_id', 'Completed'),
+      'case_id' => $caseId,
+    ]);
+
+    return $activity['id'];
+  }
+
+}


### PR DESCRIPTION
## Overview
This pr adds the functionality for attaching the bulk email as an activity to all the selected cases. There exists a feature through which a user can send bulk emails to different case roles in multiple cases. This pr attaches this email sending as an activity to all the selected cases.
![Screenshot from 2020-11-30 16-17-31](https://user-images.githubusercontent.com/68388745/100604613-936c7880-3328-11eb-8994-743064993e67.png)

## Before
Previously if user had selected only one case then the activity got recorded successfully against that case but if user selected more than one case then this email sending was not attached to any of the case.

## After
AS described above now the activity is attached to all the selected cases.

## Technical Details
This pr utilizes the post process hook in file `CRM/Civicase/Hook/PostProcess/AttachEmailActivityToAllCases.php` and checks if there are multiple cases that has been selected for bulk emailing then loops over all the selected cases and attaches the activity too each of the selected cases.