### PR TITLE
CPS-391: Fix Issue With Search By Case Roles Not Returning Results

### DIFF
--- a/CRM/Civicase/APIHelpers/CaseDetails.php
+++ b/CRM/Civicase/APIHelpers/CaseDetails.php
@@ -277,7 +277,9 @@ class CRM_Civicase_APIHelpers_CaseDetails {
       'where' => $where
     ) = self::getRoleQuery($params);
 
-    $roleSubQuery->where($where);
+    if ($where) {
+      $roleSubQuery->where($where);
+    }
 
     $roleSubQueryString = $roleSubQuery->toSql();
 

--- a/CRM/Civicase/Api/Wrapper/CaseList.php
+++ b/CRM/Civicase/Api/Wrapper/CaseList.php
@@ -106,7 +106,7 @@ class CRM_Civicase_Api_Wrapper_CaseList implements API_Wrapper {
       }
 
       foreach ($case['contacts'] as $contact) {
-        if ($contact['manager'] == 1) {
+        if (isset($contact['manager']) && $contact['manager'] == 1) {
           $case['manager'] = $contact;
         }
 
@@ -115,7 +115,7 @@ class CRM_Civicase_Api_Wrapper_CaseList implements API_Wrapper {
         }
       }
 
-      $case['next_activity'] = CRM_Utils_Array::value(0, $case['activity_summary']['next']);
+      $case['next_activity'] = isset($case['activity_summary']['next'][0]) ? $case['activity_summary']['next'][0] : NULL;
     }
 
     return $cases;

--- a/CRM/Civicase/Api/Wrapper/CaseList.php
+++ b/CRM/Civicase/Api/Wrapper/CaseList.php
@@ -15,58 +15,58 @@ class CRM_Civicase_Api_Wrapper_CaseList implements API_Wrapper {
    *   Allowed headers.
    */
   public function getAllowedHeaders() {
-    return array(
-      'values' => array(
-        array(
+    return [
+      'values' => [
+        [
           'name' => 'next_activity',
           'label' => ts('Next Activity'),
           'sort' => 'next_activity',
           'display_type' => 'activity_card',
-        ),
-        array(
+        ],
+        [
           'name' => 'subject',
           'label' => ts('Subject'),
           'sort' => 'subject',
           'display_type' => 'default',
-        ),
-        array(
+        ],
+        [
           'name' => 'status',
           'label' => ts('Status'),
           'sort' => 'status_id.label',
           'display_type' => 'status_badge',
-        ),
-        array(
+        ],
+        [
           'name' => 'case_type',
           'label' => ts('Type'),
           'sort' => 'case_type_id.title',
           'display_type' => 'default',
-        ),
-        array(
+        ],
+        [
           'name' => 'manager',
           'label' => ts('Case Manager'),
           'sort' => 'case_manager.sort_name',
           'display_type' => 'contact_reference',
-        ),
-        array(
+        ],
+        [
           'name' => 'start_date',
           'label' => ts('Start Date'),
           'sort' => 'start_date',
           'display_type' => 'date',
-        ),
-        array(
+        ],
+        [
           'name' => 'modified_date',
           'label' => ts('Last Updated'),
           'sort' => 'modified_date',
           'display_type' => 'date',
-        ),
-        array(
+        ],
+        [
           'name' => 'myRole',
           'label' => ts('My Role'),
           'sort' => 'my_role.label_b_a',
           'display_type' => 'multiple_values',
-        ),
-      ),
-    );
+        ],
+      ],
+    ];
   }
 
   /**
@@ -81,24 +81,24 @@ class CRM_Civicase_Api_Wrapper_CaseList implements API_Wrapper {
   public function getCaseList(array $params) {
     $loggedContactID = CRM_Core_Session::singleton()->getLoggedInContactID();
 
-    $defaultAPIReturnedColumns = array(
+    $defaultAPIReturnedColumns = [
       'subject', 'case_type_id', 'status_id', 'is_deleted', 'start_date',
       'modified_date', 'contacts', 'activity_summary', 'category_count',
       'tag_id.name', 'tag_id.color', 'tag_id.description',
-    );
+    ];
     $params['return'] = (isset($params['return']) ? array_merge($defaultAPIReturnedColumns, $params['return']) : $defaultAPIReturnedColumns);
     $cases = civicrm_api3('Case', 'getdetails', $params);
 
     foreach ($cases['values'] as &$case) {
-      $caseLockedContacts = civicrm_api3('CaseContactLock', 'get', array(
+      $caseLockedContacts = civicrm_api3('CaseContactLock', 'get', [
         'case_id' => $case['id'],
         'contact_id' => $loggedContactID,
-      ));
+      ]);
 
       // If case is locked for current user, activities should not be sent in
       // response.
       if ($caseLockedContacts['count'] > 0) {
-        $case['activity_summary'] = array();
+        $case['activity_summary'] = [];
         $case['lock'] = 1;
       }
       else {

--- a/tests/phpunit/api/v3/Case/GetcaselistTest.php
+++ b/tests/phpunit/api/v3/Case/GetcaselistTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use CRM_Civicase_Test_Fabricator_Contact as ContactFabricator;
+use CRM_Civicase_Test_Fabricator_RelationshipType as RelationshipTypeFabricator;
+use CRM_Civicase_Test_Fabricator_Relationship as RelationshipFabricator;
+use CRM_Civicase_Test_Fabricator_CaseType as CaseTypeFabricator;
+use CRM_Civicase_Test_Fabricator_Case as CaseFabricator;
+
+/**
+ * Runs tests for api_v3_Case_Getcaselist api class.
+ *
+ * @group headless
+ */
+class api_v3_Case_GetcaselistTest extends BaseHeadlessTest {
+
+  use CRM_Civicase_Helpers_SessionTrait;
+
+  /**
+   * Holds logged in contact/case creator id.
+   *
+   * @var int
+   */
+  private $creator;
+
+  /**
+   * Setup data before tests run.
+   */
+  public function setUp() {
+    $contact = ContactFabricator::fabricate();
+    $this->registerCurrentLoggedInContactInSession($contact['id']);
+    $this->creator = $contact['id'];
+  }
+
+  /**
+   * Test fetch cases filtered by relationship type and contact.
+   */
+  public function testFilterByRelationshipTypeAndRelatedContact() {
+    $contact = ContactFabricator::fabricate();
+    $client = ContactFabricator::fabricate();
+    $caseType = CaseTypeFabricator::fabricate();
+
+    $caseA = CaseFabricator::fabricate(
+      [
+        'case_type_id' => $caseType['id'],
+        'contact_id' => $client['id'],
+        'creator_id' => $this->creator,
+      ]
+    );
+
+    $caseB = CaseFabricator::fabricate(
+      [
+        'case_type_id' => $caseType['id'],
+        'contact_id' => $client['id'],
+        'creator_id' => $this->creator,
+      ]
+    );
+
+    $relationshipTypeParams = [
+      'name_a_b' => 'Manager is',
+      'name_b_a' => 'Manager',
+    ];
+    $relationshipType = RelationshipTypeFabricator::fabricate($relationshipTypeParams);
+    $params = [
+      'contact_id_b' => $contact['id'],
+      'contact_id_a' => $client['id'],
+      'relationship_type_id' => $relationshipType['id'],
+      'case_id' => $caseA['id'],
+    ];
+
+    RelationshipFabricator::fabricate($params);
+
+    $caseDetailsParams = [
+      'has_role' =>
+        [
+          'contact' => ['IN' => [$contact['id']]],
+          'can_be_client' => FALSE,
+          'all_case_roles_selected' => FALSE,
+          'role_type' => ['IN' => [$relationshipType['id']]],
+        ],
+    ];
+
+    $result = civicrm_api3('Case', 'getcaselist', $caseDetailsParams);
+    // Only Case A is expected to be returned because that is the only case a
+    // relationship type manager was defined for with contact.
+    $this->assertEquals($caseA['id'], $result['id']);
+  }
+
+}


### PR DESCRIPTION
## Overview
When searching for cases where a contact has a particular case role, No results are returned. There is actually a db syntax error when performing this search. 

## Before
The issue described above exists.
![CaseRoleBefore](https://user-images.githubusercontent.com/6951813/101346551-0033c580-3889-11eb-8287-ec348847deec.gif)


## After
The `$where` variable here is set empty and is returned empty at the end of the function if `$canBeAClient` is false which is the case here because the contact search is for a user with a particular role and not for a client.
This causes an issue [here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/APIHelpers/CaseDetails.php#L280) as a query condition is formed for a WHERE clause with an empty string which triggers an error when the query is ran
```sql
    AND case_relationship.relationship_type_id IN ("66")
WHERE () //Syntax error is thrown here
GROUP BY civicrm_case.id
) AS case_roles
      ON case_roles.id = a.id
```
The fix is to check if the where condition is empty or not before including it in the query condition.

![CaseRole](https://user-images.githubusercontent.com/6951813/101346618-1c376700-3889-11eb-9e61-d9cbd27659d0.gif)
