### PR TITLE
RSE-1570: Fix case actions

### DIFF
--- a/ang/civicase-base/providers/case-type.provider.js
+++ b/ang/civicase-base/providers/case-type.provider.js
@@ -54,6 +54,7 @@
           .map('definition')
           .map('caseRoles')
           .flatten()
+          .compact() // removes undefined values
           .uniq('name') // removes same role present in different case types
           .map(function (caseRole) {
             var relationshipType = RelationshipType.getByName(caseRole.name);

--- a/ang/civicase/case/list/directives/case-list-table.directive.js
+++ b/ang/civicase/case/list/directives/case-list-table.directive.js
@@ -331,7 +331,8 @@
         return: [
           'subject', 'case_type_id', 'status_id', 'is_deleted', 'start_date',
           'modified_date', 'contacts', 'activity_summary', 'category_count',
-          'tag_id.name', 'tag_id.color', 'tag_id.description'
+          'tag_id.name', 'tag_id.color', 'tag_id.description',
+          'case_type_id.case_type_category'
         ],
         options: {
           sort: sort.field + ' ' + sort.dir,

--- a/ang/test/civicase-base/providers/case-type.provider.spec.js
+++ b/ang/test/civicase-base/providers/case-type.provider.spec.js
@@ -2,17 +2,12 @@
 
 ((_) => {
   describe('Case Type', () => {
-    let CaseType, CaseTypesData;
-
-    beforeEach(module('civicase', 'civicase.data'));
-
-    beforeEach(inject((_CaseType_, _CaseTypesMockData_) => {
-      CaseType = _CaseType_;
-      CaseTypesData = _CaseTypesMockData_.get();
-    }));
+    let CaseType, CaseTypesData, CaseTypesMockDataProvider;
 
     describe('when getting all case types', () => {
       let returnedCaseTypes;
+
+      beforeEach(() => initModulesAndServices());
 
       beforeEach(() => {
         returnedCaseTypes = CaseType.getAll();
@@ -25,6 +20,8 @@
 
     describe('when getting the titles for case types using their name', () => {
       let returnedTitles;
+
+      beforeEach(() => initModulesAndServices());
 
       beforeEach(() => {
         returnedTitles = CaseType.getTitlesForNames([
@@ -44,6 +41,8 @@
     describe('when getting a case type by id', () => {
       let expectedCaseType, returnedCaseType;
 
+      beforeEach(() => initModulesAndServices());
+
       beforeEach(() => {
         const caseTypeId = _.chain(CaseTypesData).keys().sample().value();
         expectedCaseType = CaseTypesData[caseTypeId];
@@ -55,23 +54,70 @@
       });
     });
 
-    describe('when getting all roles for the given case type category id', () => {
+    describe('case roles', () => {
       let expectedResult, returnedResult;
 
       beforeEach(() => {
-        const casesCategoryId = '1';
         expectedResult = [
           { name: 'Homeless Services Coordinator', id: '11' },
           { name: 'Health Services Coordinator', id: '12' },
           { name: 'Benefits Specialist', id: '14' },
           { name: 'Senior Services Coordinator', id: '16' }
         ];
-        returnedResult = CaseType.getAllRolesByCategoryID(casesCategoryId);
       });
 
-      it('returns all the unique case roles', () => {
-        expect(returnedResult).toEqual(expectedResult);
+      describe('when getting all roles for the given case type category id', () => {
+        beforeEach(() => initModulesAndServices());
+
+        beforeEach(() => {
+          const casesCategoryId = '1';
+          returnedResult = CaseType.getAllRolesByCategoryID(casesCategoryId);
+        });
+
+        it('returns all the unique case roles', () => {
+          expect(returnedResult).toEqual(expectedResult);
+        });
       });
-    });
+
+      describe('when there is a case type with no definition', () => {
+        beforeEach(() => {
+          CRM['civicase-base'].caseTypes = {
+            4: {
+              id: '4',
+              name: 'case_with_no_definition',
+              title: 'Case With No Definition',
+              description: '',
+              definition: [],
+              case_type_category: '1'
+            }
+          };
+          initModulesAndServices();
+        });
+
+        afterEach(() => {
+          CaseTypesMockData.reset();
+        });
+
+        it('does not throw an error when trying to get the case roles', () => {
+          expect(() => {
+            CaseType.getAllRolesByCategoryID('1');
+          }).not.toThrow();
+        });
+      });
+    })
+
+    /**
+     * Initialises the civicase and mock data modules. Will also hoist
+     * the services required by the spec file.
+     */
+    function initModulesAndServices() {
+      module('civicase', 'civicase.data');
+
+      inject((_CaseType_, _CaseTypesMockData_) => {
+        CaseType = _CaseType_;
+        CaseTypesMockData = _CaseTypesMockData_;
+        CaseTypesData = CaseTypesMockData.get();
+      });
+    }
   });
 })(CRM._);

--- a/ang/test/civicase-base/providers/case-type.provider.spec.js
+++ b/ang/test/civicase-base/providers/case-type.provider.spec.js
@@ -2,7 +2,7 @@
 
 ((_) => {
   describe('Case Type', () => {
-    let CaseType, CaseTypesData, CaseTypesMockDataProvider;
+    let CaseType, CaseTypesData, CaseTypesMockData;
 
     describe('when getting all case types', () => {
       let returnedCaseTypes;
@@ -104,13 +104,13 @@
           }).not.toThrow();
         });
       });
-    })
+    });
 
     /**
      * Initialises the civicase and mock data modules. Will also hoist
      * the services required by the spec file.
      */
-    function initModulesAndServices() {
+    function initModulesAndServices () {
       module('civicase', 'civicase.data');
 
       inject((_CaseType_, _CaseTypesMockData_) => {

--- a/ang/test/civicase/case/list/directives/case-list-table.directive.spec.js
+++ b/ang/test/civicase/case/list/directives/case-list-table.directive.spec.js
@@ -162,7 +162,8 @@
             return: [
               'subject', 'case_type_id', 'status_id', 'is_deleted', 'start_date',
               'modified_date', 'contacts', 'activity_summary', 'category_count',
-              'tag_id.name', 'tag_id.color', 'tag_id.description'
+              'tag_id.name', 'tag_id.color', 'tag_id.description',
+              'case_type_id.case_type_category'
             ],
             options: jasmine.any(Object),
             'case_type_id.is_active': 1,

--- a/ang/test/mocks/data/cases-types.data.js
+++ b/ang/test/mocks/data/cases-types.data.js
@@ -393,7 +393,13 @@
     }
   };
 
-  CRM['civicase-base'].caseTypes = _.clone(caseTypesMock);
+  (function init () {
+    CRM['civicase-base'].caseTypes = _.extend(
+      {},
+      CRM['civicase-base'].caseTypes,
+      _.clone(caseTypesMock)
+    );
+  })();
 
   module.provider('CaseTypesMockData', function () {
     /**
@@ -425,6 +431,13 @@
           var clonesCaseTypesData = _.clone(caseTypesMock);
 
           return Object.values(clonesCaseTypesData);
+        },
+
+        /**
+         * Restores the mock data case types after it has been altered.
+         */
+        reset: function () {
+          CRM['civicase-base'].caseTypes = _.clone(caseTypesMock);
         }
       };
     };


### PR DESCRIPTION
## Overview

This PR fixes some issues found for case actions:

* Convert Prospect actions were breaking because the case category parameter was not being included in the cases passed to the action.
* Email case roles were breaking when there were case types without a definition.

## Before

![pr-before-after](https://user-images.githubusercontent.com/1642119/101446134-0a8da800-38f9-11eb-9218-98fb5fe11ada.gif)

## After

![pr-before-after](https://user-images.githubusercontent.com/1642119/101446267-56405180-38f9-11eb-958b-4affc75143dc.gif)

## Technical Details

The convert to prospect action was failing because it required the `case_type_id.case_type_category` property to be included in the case object. This action was working in other areas such as the contact's cases tab because the property is included there. This action was only breaking in the manage cases page so we updated the `case-list-table.directive.js` directive so it requests the parameter required by the action.

In terms of the email action, the issue happens when there are some case types without a definition object. This breaks the action because it tries to get the case role name out of an undefined property. To fix it, we remove all undefined results.

