### PR TITLE
RSE-1345: Fix Delete Activity Bug

### DIFF
--- a/ang/civicase/case/details/file-tab/directives/case-details-file-tab.directive.js
+++ b/ang/civicase/case/details/file-tab/directives/case-details-file-tab.directive.js
@@ -44,6 +44,7 @@
       loadActivities();
 
       $scope.$on('civicase::bulk-actions::bulk-selections', bulkSelectionsListener);
+      $scope.$on('civicase::activity::updated', refresh);
     }());
 
     /**
@@ -88,7 +89,7 @@
      */
     function loadActivities () {
       $scope.isLoading = true;
-
+      $scope.activities = [];
       civicaseCrmApi('Case', 'getfiles', $scope.fileFilterParams)
         .then(function (result) {
           $scope.activities = result.xref


### PR DESCRIPTION
## Overview
When deleting an activity on the files tab the activity list is not refreshed giving an impression that the activity is was not deleted while it got deleted in actual.

## Before
The above bug existed.

## After
Now when an activity is deleted the activity list gets refreshed immediately and the deleted activity is removed from the list.

## Technical Details
Upon deleting an activity an event was fired by the name of 'civicase::activity::updated' but there were no listeners for this event on the files directive. So function for refreshing activities was attached as a listener for the mentioned event.