### PR TITLE
CPS-409: Add tests for CategoryFromUrl class

### DIFF
--- a/CRM/Civicase/Service/CaseCategoryFromUrl.php
+++ b/CRM/Civicase/Service/CaseCategoryFromUrl.php
@@ -96,7 +96,7 @@ class CRM_Civicase_Service_CaseCategoryFromUrl {
    *   Category URL.
    */
   private function getCaseCategoryFromUrl($caseTypeCategoryParam) {
-    $caseCategory = $this->getRequestResponse($caseTypeCategoryParam, 'String');
+    $caseCategory = CRM_Utils_Request::retrieve($caseTypeCategoryParam, 'String');
     if ($caseCategory) {
       if (is_numeric($caseCategory)) {
         $caseTypeCategories = CaseType::buildOptions($caseTypeCategoryParam, 'validate');
@@ -120,7 +120,7 @@ class CRM_Civicase_Service_CaseCategoryFromUrl {
    *   Parameter value.
    */
   private function getParamValueFromEntryUrl($param) {
-    $entryURL = $this->getRequestResponse('entryURL', 'String');
+    $entryURL = CRM_Utils_Request::retrieve('entryURL', 'String');
 
     $urlParams = parse_url(htmlspecialchars_decode($entryURL), PHP_URL_QUERY);
     parse_str($urlParams, $urlParams);
@@ -142,7 +142,7 @@ class CRM_Civicase_Service_CaseCategoryFromUrl {
    *   Case category name.
    */
   private function getCaseCategoryFromActivityIdInUrl($activityIdParamName) {
-    $activityId = $this->getRequestResponse($activityIdParamName, 'Integer');
+    $activityId = CRM_Utils_Request::retrieve($activityIdParamName, 'Integer');
 
     if ($activityId) {
       $result = civicrm_api3('Activity', 'get', [
@@ -173,7 +173,7 @@ class CRM_Civicase_Service_CaseCategoryFromUrl {
    *   Case category name.
    */
   private function getCaseCategoryNameFromCaseIdInUrl($caseIdParamName) {
-    $caseId = $this->getRequestResponse($caseIdParamName, 'Integer');
+    $caseId = CRM_Utils_Request::retrieve($caseIdParamName, 'Integer');
 
     if (!$caseId) {
       $caseId = $this->getParamValueFromEntryUrl($caseIdParamName);
@@ -192,8 +192,8 @@ class CRM_Civicase_Service_CaseCategoryFromUrl {
    *   Case category name.
    */
   private function getCaseCategoryForAjaxRequest($caseTypeCategoryParam) {
-    $entity = $this->getRequestResponse('entity', 'String');
-    $json = $this->getRequestResponse('json', 'String');
+    $entity = CRM_Utils_Request::retrieve('entity', 'String');
+    $json = CRM_Utils_Request::retrieve('json', 'String');
     $json = $json ? json_decode($json, TRUE) : [];
 
     if ($entity && strtolower($entity) == 'case') {
@@ -248,13 +248,6 @@ class CRM_Civicase_Service_CaseCategoryFromUrl {
     }
 
     return CaseCategoryHelper::getCaseCategoryNameFromOptionValue($caseTypeCategory);
-  }
-
-  /**
-   * Get information from the Request.
-   */
-  public function getRequestResponse($name, $type) {
-    return CRM_Utils_Request::retrieve($name, $type);
   }
 
 }

--- a/CRM/Civicase/Service/CaseCategoryFromUrl.php
+++ b/CRM/Civicase/Service/CaseCategoryFromUrl.php
@@ -6,6 +6,8 @@ use CRM_Case_BAO_CaseType as CaseType;
 
 /**
  * Class CRM_Civicase_Service_CaseCategoryFromUrl.
+ *
+ * Service for detecting the category name from a Url.
  */
 class CRM_Civicase_Service_CaseCategoryFromUrl {
 
@@ -94,7 +96,7 @@ class CRM_Civicase_Service_CaseCategoryFromUrl {
    *   Category URL.
    */
   private function getCaseCategoryFromUrl($caseTypeCategoryParam) {
-    $caseCategory = CRM_Utils_Request::retrieve($caseTypeCategoryParam, 'String');
+    $caseCategory = $this->getRequestResponse($caseTypeCategoryParam, 'String');
     if ($caseCategory) {
       if (is_numeric($caseCategory)) {
         $caseTypeCategories = CaseType::buildOptions($caseTypeCategoryParam, 'validate');
@@ -118,7 +120,7 @@ class CRM_Civicase_Service_CaseCategoryFromUrl {
    *   Parameter value.
    */
   private function getParamValueFromEntryUrl($param) {
-    $entryURL = CRM_Utils_Request::retrieve('entryURL', 'String');
+    $entryURL = $this->getRequestResponse('entryURL', 'String');
 
     $urlParams = parse_url(htmlspecialchars_decode($entryURL), PHP_URL_QUERY);
     parse_str($urlParams, $urlParams);
@@ -140,7 +142,7 @@ class CRM_Civicase_Service_CaseCategoryFromUrl {
    *   Case category name.
    */
   private function getCaseCategoryFromActivityIdInUrl($activityIdParamName) {
-    $activityId = CRM_Utils_Request::retrieve($activityIdParamName, 'Integer');
+    $activityId = $this->getRequestResponse($activityIdParamName, 'Integer');
 
     if ($activityId) {
       $result = civicrm_api3('Activity', 'get', [
@@ -157,6 +159,8 @@ class CRM_Civicase_Service_CaseCategoryFromUrl {
 
       return NULL;
     }
+
+    return NULL;
   }
 
   /**
@@ -169,7 +173,7 @@ class CRM_Civicase_Service_CaseCategoryFromUrl {
    *   Case category name.
    */
   private function getCaseCategoryNameFromCaseIdInUrl($caseIdParamName) {
-    $caseId = CRM_Utils_Request::retrieve($caseIdParamName, 'Integer');
+    $caseId = $this->getRequestResponse($caseIdParamName, 'Integer');
 
     if (!$caseId) {
       $caseId = $this->getParamValueFromEntryUrl($caseIdParamName);
@@ -188,8 +192,8 @@ class CRM_Civicase_Service_CaseCategoryFromUrl {
    *   Case category name.
    */
   private function getCaseCategoryForAjaxRequest($caseTypeCategoryParam) {
-    $entity = CRM_Utils_Request::retrieve('entity', 'String');
-    $json = CRM_Utils_Request::retrieve('json', 'String');
+    $entity = $this->getRequestResponse('entity', 'String');
+    $json = $this->getRequestResponse('json', 'String');
     $json = $json ? json_decode($json, TRUE) : [];
 
     if ($entity && strtolower($entity) == 'case') {
@@ -200,8 +204,8 @@ class CRM_Civicase_Service_CaseCategoryFromUrl {
     }
 
     if (strtolower($entity) == 'api3') {
-      foreach ($json as $entity) {
-        [$entityName, $action, $params] = $entity;
+      foreach ($json as $entityParam) {
+        [$entityName, $action, $params] = $entityParam;
 
         if (strtolower($entityName) == 'case') {
           $this->isCaseEntity = TRUE;
@@ -211,6 +215,8 @@ class CRM_Civicase_Service_CaseCategoryFromUrl {
         }
       }
     }
+
+    return NULL;
   }
 
   /**
@@ -242,6 +248,13 @@ class CRM_Civicase_Service_CaseCategoryFromUrl {
     }
 
     return CaseCategoryHelper::getCaseCategoryNameFromOptionValue($caseTypeCategory);
+  }
+
+  /**
+   * Get information from the Request.
+   */
+  public function getRequestResponse($name, $type) {
+    return CRM_Utils_Request::retrieve($name, $type);
   }
 
 }

--- a/tests/phpunit/CRM/Civicase/Service/CaseCategoryFromUrlTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseCategoryFromUrlTest.php
@@ -22,10 +22,11 @@ class CRM_Civicase_Service_CaseCategoryFromUrlTest extends BaseHeadlessTest {
    */
   public function testGetCategoryNameFromCaseIdInRequestBody() {
     $case = $this->createCase();
-    $categoryFromUrlServiceMock = $this->mockRequestResponse([$case['id']]);
     $requestedUrl = $this->getUrlByType(CategoryFromUrlService::CASE_TYPE_URL);
+    $param = $this->getParamByUrl($requestedUrl);
+    $_GET[$param] = $_REQUEST[$param] = $case['id'];
 
-    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+    $categoryName = (new CategoryFromUrlService())->get($requestedUrl);
 
     $this->assertEquals(
       $this->getCaseTypeCategoryNameByCaseTypeId($case['case_type_id']),
@@ -44,12 +45,11 @@ class CRM_Civicase_Service_CaseCategoryFromUrlTest extends BaseHeadlessTest {
 
     $requestedUrl = $this->getUrlByType(CategoryFromUrlService::CASE_TYPE_URL);
     $requestedUrlWithQueryString = $this->getUrlWithQueryString($requestedUrl, $case['id']);
+    $param = $this->getParamByUrl($requestedUrl);
+    $_GET[$param] = $_REQUEST[$param] = NULL;
+    $_GET['entryURL'] = $_REQUEST['entryURL'] = $requestedUrlWithQueryString;
 
-    $categoryFromUrlServiceMock = $this->mockRequestResponse(
-      [NULL, $requestedUrlWithQueryString]
-    );
-
-    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+    $categoryName = (new CategoryFromUrlService())->get($requestedUrl);
 
     $this->assertEquals(
       $this->getCaseTypeCategoryNameByCaseTypeId($case['case_type_id']),
@@ -65,10 +65,11 @@ class CRM_Civicase_Service_CaseCategoryFromUrlTest extends BaseHeadlessTest {
    */
   public function testGetCategoryNameFromRequestBodyContainingTheCategoryName() {
     $category = CaseCategoryFabricator::fabricate();
-    $categoryFromUrlServiceMock = $this->mockRequestResponse([$category['name']]);
     $requestedUrl = $this->getUrlByType(CategoryFromUrlService::CASE_CATEGORY_TYPE_URL);
+    $param = $this->getParamByUrl($requestedUrl);
+    $_GET[$param] = $_REQUEST[$param] = $category['name'];
 
-    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+    $categoryName = (new CategoryFromUrlService())->get($requestedUrl);
 
     $this->assertEquals($category['name'], $categoryName);
   }
@@ -76,15 +77,16 @@ class CRM_Civicase_Service_CaseCategoryFromUrlTest extends BaseHeadlessTest {
   /**
    * Test get category name from category Id in request.
    *
-   * Test the detection of the category name, when it is received the category
-   * Id on the request body.
+   * Test the detection of the category name, when it is received from the
+   * category Id on the request body.
    */
   public function testGetCategoryNameFromRequestBodyContainingTheCategoryId() {
     $category = CaseCategoryFabricator::fabricate();
-    $categoryFromUrlServiceMock = $this->mockRequestResponse([$category['value']]);
     $requestedUrl = $this->getUrlByType(CategoryFromUrlService::CASE_CATEGORY_TYPE_URL);
+    $param = $this->getParamByUrl($requestedUrl);
+    $_GET[$param] = $_REQUEST[$param] = $category['value'];
 
-    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+    $categoryName = (new CategoryFromUrlService())->get($requestedUrl);
 
     $this->assertEquals($category['name'], $categoryName);
   }
@@ -99,13 +101,10 @@ class CRM_Civicase_Service_CaseCategoryFromUrlTest extends BaseHeadlessTest {
     $category = CaseCategoryFabricator::fabricate();
 
     $requestedUrl = $this->getUrlByType(CategoryFromUrlService::CASE_CATEGORY_TYPE_URL);
-    $requestedUrlWithQueryString = $this->getUrlWithQueryString($requestedUrl, $category['name']);
+    $param = $this->getParamByUrl($requestedUrl);
+    $_GET[$param] = $_REQUEST[$param] = $category['name'];
 
-    $categoryFromUrlServiceMock = $this->mockRequestResponse(
-      [NULL, $requestedUrlWithQueryString]
-    );
-
-    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+    $categoryName = (new CategoryFromUrlService())->get($requestedUrl);
 
     $this->assertEquals($category['name'], $categoryName);
   }
@@ -119,10 +118,11 @@ class CRM_Civicase_Service_CaseCategoryFromUrlTest extends BaseHeadlessTest {
   public function testGetCategoryNameFromActivityIdInRequestBody() {
     $case = $this->createCase();
     $activity = $this->createActivityForCaseId($case['id']);
-    $categoryFromUrlServiceMock = $this->mockRequestResponse([$activity['id']]);
     $requestedUrl = $this->getUrlByType(CategoryFromUrlService::ACTIVITY_TYPE_URL);
+    $param = $this->getParamByUrl($requestedUrl);
+    $_GET[$param] = $_REQUEST[$param] = $activity['id'];
 
-    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+    $categoryName = (new CategoryFromUrlService())->get($requestedUrl);
 
     $this->assertEquals(
       $this->getCaseTypeCategoryNameByCaseTypeId($case['case_type_id']),
@@ -137,10 +137,11 @@ class CRM_Civicase_Service_CaseCategoryFromUrlTest extends BaseHeadlessTest {
    * when it is received an invalid activity Id on the request body.
    */
   public function testGetCategoryNameFromInvalidActivityIdInRequestBody() {
-    $categoryFromUrlServiceMock = $this->mockRequestResponse([rand()]);
     $requestedUrl = $this->getUrlByType(CategoryFromUrlService::ACTIVITY_TYPE_URL);
+    $param = $this->getParamByUrl($requestedUrl);
+    $_GET[$param] = $_REQUEST[$param] = rand();
 
-    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+    $categoryName = (new CategoryFromUrlService())->get($requestedUrl);
 
     $this->assertNull($categoryName);
   }
@@ -148,21 +149,17 @@ class CRM_Civicase_Service_CaseCategoryFromUrlTest extends BaseHeadlessTest {
   /**
    * Test get category name from category Id in case entity ajax request.
    *
-   * Test the detection of the category name, when it is received the category
-   * Id on an ajax request, related to case entity URL.
+   * Test the detection of the category name, when it is received from the
+   * category Id on an ajax request, related to case entity URL.
    */
   public function testGetCategoryNameFromAjaxRequestOfCaseEntityContainingTheCategoryId() {
     $category = CaseCategoryFabricator::fabricate();
     $requestedUrl = $this->getUrlByType(CategoryFromUrlService::AJAX_TYPE_URL);
     $param = $this->getParamByUrl($requestedUrl);
-    $categoryFromUrlServiceMock = $this->mockRequestResponse(
-      [
-        'case',
-        json_encode([$param => $category['value']]),
-      ]
-    );
+    $_GET['entity'] = $_REQUEST['entity'] = 'case';
+    $_GET['json'] = $_REQUEST['json'] = json_encode([$param => $category['value']]);
 
-    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+    $categoryName = (new CategoryFromUrlService())->get($requestedUrl);
 
     $this->assertEquals($category['name'], $categoryName);
   }
@@ -170,8 +167,8 @@ class CRM_Civicase_Service_CaseCategoryFromUrlTest extends BaseHeadlessTest {
   /**
    * Test get category name from case entity ajax request.
    *
-   * Test the detection of the category name, when it is received that category
-   * name on an ajax request, related to case entity URL.
+   * Test the detection of the category name, when it is received from that
+   * category name on an ajax request, related to case entity URL.
    */
   public function testGetCategoryNameFromAjaxRequestOfCaseEntityContainingTheCategoryName() {
     $category = CaseCategoryFabricator::fabricate();
@@ -179,14 +176,10 @@ class CRM_Civicase_Service_CaseCategoryFromUrlTest extends BaseHeadlessTest {
     $requestedUrl = $this->getUrlByType(CategoryFromUrlService::AJAX_TYPE_URL);
     $param = $this->getParamByUrl($requestedUrl);
 
-    $categoryFromUrlServiceMock = $this->mockRequestResponse(
-      [
-        'case',
-        json_encode([$param => $category['name']]),
-      ]
-    );
+    $_GET['entity'] = $_REQUEST['entity'] = 'case';
+    $_GET['json'] = $_REQUEST['json'] = json_encode([$param => $category['name']]);
 
-    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+    $categoryName = (new CategoryFromUrlService())->get($requestedUrl);
 
     $this->assertEquals($category['name'], $categoryName);
   }
@@ -194,8 +187,8 @@ class CRM_Civicase_Service_CaseCategoryFromUrlTest extends BaseHeadlessTest {
   /**
    * Test get category name from category Id in api3 ajax request.
    *
-   * Test the detection of the category name, when it is received the category
-   * Id on an ajax request, related to an api3 URL.
+   * Test the detection of the category name, when it is received from the
+   * category Id on an ajax request, related to an api3 URL.
    */
   public function testGetCategoryNameFromAjaxRequestOfApi3ContainingTheCategoryId() {
     $category = CaseCategoryFabricator::fabricate();
@@ -203,18 +196,14 @@ class CRM_Civicase_Service_CaseCategoryFromUrlTest extends BaseHeadlessTest {
     $requestedUrl = $this->getUrlByType(CategoryFromUrlService::AJAX_TYPE_URL);
     $param = $this->getParamByUrl($requestedUrl);
 
-    $categoryFromUrlServiceMock = $this->mockRequestResponse(
+    $_GET['entity'] = $_REQUEST['entity'] = 'api3';
+    $_GET['json'] = $_REQUEST['json'] = json_encode(
       [
-        'api3',
-        json_encode(
-          [
-            ['case', '', [$param => $category['value']]],
-          ]
-        ),
+        ['case', '', [$param => $category['value']]],
       ]
     );
 
-    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+    $categoryName = (new CategoryFromUrlService())->get($requestedUrl);
 
     $this->assertEquals($category['name'], $categoryName);
   }
@@ -222,52 +211,24 @@ class CRM_Civicase_Service_CaseCategoryFromUrlTest extends BaseHeadlessTest {
   /**
    * Test get category name from api3 ajax request.
    *
-   * Test the detection of the category name, when it is received that category
-   * name on an ajax request, related to an api3 URL.
+   * Test the detection of the category name, when it is received from that
+   * category name on an ajax request, related to an api3 URL.
    */
   public function testGetCategoryNameFromAjaxRequestOfApi3ContainingTheCategoryName() {
     $category = CaseCategoryFabricator::fabricate();
     $requestedUrl = $this->getUrlByType(CategoryFromUrlService::AJAX_TYPE_URL);
     $param = $this->getParamByUrl($requestedUrl);
 
-    $categoryFromUrlServiceMock = $this->mockRequestResponse(
+    $_GET['entity'] = $_REQUEST['entity'] = 'api3';
+    $_GET['json'] = $_REQUEST['json'] = json_encode(
       [
-        'api3',
-        json_encode(
-          [
-            ['case', '', [$param => $category['name']]],
-          ]
-        ),
+        ['case', '', [$param => $category['name']]],
       ]
     );
 
-    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+    $categoryName = (new CategoryFromUrlService())->get($requestedUrl);
 
     $this->assertEquals($category['name'], $categoryName);
-  }
-
-  /**
-   * Mock method getRequestResponse from the tested class.
-   *
-   * This method interacts with a static method from another class
-   * (CRM_Utils_Request), then we mock the results for doing appropriate tests.
-   *
-   * @param array $responses
-   *   Response/s that the mocked method will return.
-   *
-   * @return CRM_Civicase_Service_CaseCategoryFromUrl|PHPUnit_Framework_MockObject_MockObject
-   *   Mocked instance of CategoryFromUrlService.
-   */
-  private function mockRequestResponse(array $responses) {
-    $categoryFromUrlServiceMock = $this->getMockBuilder(CategoryFromUrlService::class)
-      ->setMethods(['getRequestResponse'])
-      ->getMock();
-    $categoryFromUrlServiceMock
-      ->expects($this->exactly(count($responses)))
-      ->method('getRequestResponse')
-      ->willReturnOnConsecutiveCalls(...$responses);
-
-    return $categoryFromUrlServiceMock;
   }
 
   /**
@@ -320,7 +281,7 @@ class CRM_Civicase_Service_CaseCategoryFromUrlTest extends BaseHeadlessTest {
    */
   private function getUrlWithQueryString(string $requestedUrl, $valueForParam) {
     $param = $this->getParamByUrl($requestedUrl);
-    $requestedUrl = (parse_url($requestedUrl, PHP_URL_QUERY) ? '&' : '?');
+    $requestedUrl .= (parse_url($requestedUrl, PHP_URL_QUERY) ? '&' : '?');
     $requestedUrl .= $param . '=' . $valueForParam;
 
     return $requestedUrl;

--- a/tests/phpunit/CRM/Civicase/Service/CaseCategoryFromUrlTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseCategoryFromUrlTest.php
@@ -1,0 +1,398 @@
+<?php
+
+use CRM_Civicase_Service_CaseCategoryFromUrl as CategoryFromUrlService;
+use CRM_Civicase_ExtensionUtil as ExtensionUtil;
+use CRM_Civicase_Test_Fabricator_Contact as ContactFabricator;
+use CRM_Civicase_Test_Fabricator_CaseType as CaseTypeFabricator;
+use CRM_Civicase_Test_Fabricator_Case as CaseFabricator;
+use CRM_Civicase_Test_Fabricator_CaseCategory as CaseCategoryFabricator;
+
+/**
+ * Test class for the CRM_Civicase_Service_CaseCategoryFromUrl.
+ *
+ * @group headless
+ */
+class CRM_Civicase_Service_CaseCategoryFromUrlTest extends BaseHeadlessTest {
+
+  /**
+   * Test get category name from case id in request.
+   *
+   * Test the detection of the category name, when it is received a case Id
+   * on the request body.
+   */
+  public function testGetCategoryNameFromCaseIdInRequestBody() {
+    $case = $this->createCase();
+    $categoryFromUrlServiceMock = $this->mockRequestResponse([$case['id']]);
+    $requestedUrl = $this->getUrlByType(CategoryFromUrlService::CASE_TYPE_URL);
+
+    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+
+    $this->assertEquals(
+      $this->getCaseTypeCategoryNameByCaseTypeId($case['case_type_id']),
+      $categoryName
+    );
+  }
+
+  /**
+   * Test get category name from case id in query string.
+   *
+   * Test the detection of the category name, when it is received a case id
+   * on the query string of the URL.
+   */
+  public function testGetCategoryNameFromCaseIdInUrlQueryString() {
+    $case = $this->createCase();
+
+    $requestedUrl = $this->getUrlByType(CategoryFromUrlService::CASE_TYPE_URL);
+    $requestedUrlWithQueryString = $this->getUrlWithQueryString($requestedUrl, $case['id']);
+
+    $categoryFromUrlServiceMock = $this->mockRequestResponse(
+      [NULL, $requestedUrlWithQueryString]
+    );
+
+    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+
+    $this->assertEquals(
+      $this->getCaseTypeCategoryNameByCaseTypeId($case['case_type_id']),
+      $categoryName
+    );
+  }
+
+  /**
+   * Test get category name from request.
+   *
+   * Test the detection of the category name, when it is received that name
+   * on the request body.
+   */
+  public function testGetCategoryNameFromRequestBodyContainingTheCategoryName() {
+    $category = CaseCategoryFabricator::fabricate();
+    $categoryFromUrlServiceMock = $this->mockRequestResponse([$category['name']]);
+    $requestedUrl = $this->getUrlByType(CategoryFromUrlService::CASE_CATEGORY_TYPE_URL);
+
+    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+
+    $this->assertEquals($category['name'], $categoryName);
+  }
+
+  /**
+   * Test get category name from category Id in request.
+   *
+   * Test the detection of the category name, when it is received the category
+   * Id on the request body.
+   */
+  public function testGetCategoryNameFromRequestBodyContainingTheCategoryId() {
+    $category = CaseCategoryFabricator::fabricate();
+    $categoryFromUrlServiceMock = $this->mockRequestResponse([$category['value']]);
+    $requestedUrl = $this->getUrlByType(CategoryFromUrlService::CASE_CATEGORY_TYPE_URL);
+
+    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+
+    $this->assertEquals($category['name'], $categoryName);
+  }
+
+  /**
+   * Test get category name from query string.
+   *
+   * Test the detection of the category name, when it is received that name
+   * on the query string of the URL.
+   */
+  public function testGetCategoryNameFromUrlQueryStringContainingTheCategoryName() {
+    $category = CaseCategoryFabricator::fabricate();
+
+    $requestedUrl = $this->getUrlByType(CategoryFromUrlService::CASE_CATEGORY_TYPE_URL);
+    $requestedUrlWithQueryString = $this->getUrlWithQueryString($requestedUrl, $category['name']);
+
+    $categoryFromUrlServiceMock = $this->mockRequestResponse(
+      [NULL, $requestedUrlWithQueryString]
+    );
+
+    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+
+    $this->assertEquals($category['name'], $categoryName);
+  }
+
+  /**
+   * Test get category name from activity Id in request.
+   *
+   * Test the detection of the category name, when it is received an activity
+   * Id on the request body.
+   */
+  public function testGetCategoryNameFromActivityIdInRequestBody() {
+    $case = $this->createCase();
+    $activity = $this->createActivityForCaseId($case['id']);
+    $categoryFromUrlServiceMock = $this->mockRequestResponse([$activity['id']]);
+    $requestedUrl = $this->getUrlByType(CategoryFromUrlService::ACTIVITY_TYPE_URL);
+
+    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+
+    $this->assertEquals(
+      $this->getCaseTypeCategoryNameByCaseTypeId($case['case_type_id']),
+      $categoryName
+    );
+  }
+
+  /**
+   * Test get category name from invalid activity Id in request.
+   *
+   * Test that NULL is return from the detection of the category name,
+   * when it is received an invalid activity Id on the request body.
+   */
+  public function testGetCategoryNameFromInvalidActivityIdInRequestBody() {
+    $categoryFromUrlServiceMock = $this->mockRequestResponse([rand()]);
+    $requestedUrl = $this->getUrlByType(CategoryFromUrlService::ACTIVITY_TYPE_URL);
+
+    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+
+    $this->assertNull($categoryName);
+  }
+
+  /**
+   * Test get category name from category Id in case entity ajax request.
+   *
+   * Test the detection of the category name, when it is received the category
+   * Id on an ajax request, related to case entity URL.
+   */
+  public function testGetCategoryNameFromAjaxRequestOfCaseEntityContainingTheCategoryId() {
+    $category = CaseCategoryFabricator::fabricate();
+    $requestedUrl = $this->getUrlByType(CategoryFromUrlService::AJAX_TYPE_URL);
+    $param = $this->getParamByUrl($requestedUrl);
+    $categoryFromUrlServiceMock = $this->mockRequestResponse(
+      [
+        'case',
+        json_encode([$param => $category['value']]),
+      ]
+    );
+
+    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+
+    $this->assertEquals($category['name'], $categoryName);
+  }
+
+  /**
+   * Test get category name from case entity ajax request.
+   *
+   * Test the detection of the category name, when it is received that category
+   * name on an ajax request, related to case entity URL.
+   */
+  public function testGetCategoryNameFromAjaxRequestOfCaseEntityContainingTheCategoryName() {
+    $category = CaseCategoryFabricator::fabricate();
+
+    $requestedUrl = $this->getUrlByType(CategoryFromUrlService::AJAX_TYPE_URL);
+    $param = $this->getParamByUrl($requestedUrl);
+
+    $categoryFromUrlServiceMock = $this->mockRequestResponse(
+      [
+        'case',
+        json_encode([$param => $category['name']]),
+      ]
+    );
+
+    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+
+    $this->assertEquals($category['name'], $categoryName);
+  }
+
+  /**
+   * Test get category name from category Id in api3 ajax request.
+   *
+   * Test the detection of the category name, when it is received the category
+   * Id on an ajax request, related to an api3 URL.
+   */
+  public function testGetCategoryNameFromAjaxRequestOfApi3ContainingTheCategoryId() {
+    $category = CaseCategoryFabricator::fabricate();
+
+    $requestedUrl = $this->getUrlByType(CategoryFromUrlService::AJAX_TYPE_URL);
+    $param = $this->getParamByUrl($requestedUrl);
+
+    $categoryFromUrlServiceMock = $this->mockRequestResponse(
+      [
+        'api3',
+        json_encode(
+          [
+            ['case', '', [$param => $category['value']]],
+          ]
+        ),
+      ]
+    );
+
+    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+
+    $this->assertEquals($category['name'], $categoryName);
+  }
+
+  /**
+   * Test get category name from api3 ajax request.
+   *
+   * Test the detection of the category name, when it is received that category
+   * name on an ajax request, related to an api3 URL.
+   */
+  public function testGetCategoryNameFromAjaxRequestOfApi3ContainingTheCategoryName() {
+    $category = CaseCategoryFabricator::fabricate();
+    $requestedUrl = $this->getUrlByType(CategoryFromUrlService::AJAX_TYPE_URL);
+    $param = $this->getParamByUrl($requestedUrl);
+
+    $categoryFromUrlServiceMock = $this->mockRequestResponse(
+      [
+        'api3',
+        json_encode(
+          [
+            ['case', '', [$param => $category['name']]],
+          ]
+        ),
+      ]
+    );
+
+    $categoryName = $categoryFromUrlServiceMock->get($requestedUrl);
+
+    $this->assertEquals($category['name'], $categoryName);
+  }
+
+  /**
+   * Mock method getRequestResponse from the tested class.
+   *
+   * This method interacts with a static method from another class
+   * (CRM_Utils_Request), then we mock the results for doing appropriate tests.
+   *
+   * @param array $responses
+   *   Response/s that the mocked method will return.
+   *
+   * @return CRM_Civicase_Service_CaseCategoryFromUrl|PHPUnit_Framework_MockObject_MockObject
+   *   Mocked instance of CategoryFromUrlService.
+   */
+  private function mockRequestResponse(array $responses) {
+    $categoryFromUrlServiceMock = $this->getMockBuilder(CategoryFromUrlService::class)
+      ->setMethods(['getRequestResponse'])
+      ->getMock();
+    $categoryFromUrlServiceMock
+      ->expects($this->exactly(count($responses)))
+      ->method('getRequestResponse')
+      ->willReturnOnConsecutiveCalls(...$responses);
+
+    return $categoryFromUrlServiceMock;
+  }
+
+  /**
+   * Returns the URL's array configurations.
+   *
+   * @return array
+   *   The URLs config array.
+   */
+  private function getUrlsConfig() {
+    $configFile = CRM_Core_Resources::singleton()
+      ->getPath(ExtensionUtil::LONG_NAME, 'config/urls/case_category_url.php');
+
+    return include $configFile;
+  }
+
+  /**
+   * Find a Url of the type specified.
+   *
+   * @param string $urlType
+   *   Type of URL that the test service can handle.
+   *
+   * @return string|null
+   *   Example URL for testing the service response.
+   */
+  private function getUrlByType(string $urlType) {
+    $configs = $this->getUrlsConfig();
+
+    foreach ($configs as $url => $config) {
+      if ($config['url_type'] == $urlType) {
+        return $url;
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Generate the full Url, with the appropriate query string.
+   *
+   * The value for the param is given as an argument, while the name of the
+   * param is determined by a conf. file, and returned in getParamByUrl method.
+   *
+   * @param string $requestedUrl
+   *   Url to add the query string value.
+   * @param string|int $valueForParam
+   *   Value to be added for the param.
+   *
+   * @return string
+   *   Url with the query string appended.
+   */
+  private function getUrlWithQueryString(string $requestedUrl, $valueForParam) {
+    $param = $this->getParamByUrl($requestedUrl);
+    $requestedUrl = (parse_url($requestedUrl, PHP_URL_QUERY) ? '&' : '?');
+    $requestedUrl .= $param . '=' . $valueForParam;
+
+    return $requestedUrl;
+  }
+
+  /**
+   * Return the param name associated with the Url received.
+   *
+   * @param string $url
+   *   Url that can be handled by the service.
+   *
+   * @return string
+   *   Name of the param that contains the information on the Url.
+   */
+  private function getParamByUrl(string $url) {
+    $configs = $this->getUrlsConfig();
+
+    return $configs[$url]['param'];
+  }
+
+  /**
+   * Create a case.
+   *
+   * @return mixed
+   *   Case details.
+   */
+  private function createCase() {
+    $caseType = CaseTypeFabricator::fabricate();
+    $contact = ContactFabricator::fabricate();
+
+    return CaseFabricator::fabricate(
+      [
+        'case_type_id' => $caseType['id'],
+        'contact_id' => $contact['id'],
+        'creator_id' => $contact['id'],
+      ]
+    );
+  }
+
+  /**
+   * Find the category name associated with the case type specified.
+   *
+   * @param int $caseTypeId
+   *   Id of the case type.
+   *
+   * @return string
+   *   The category name.
+   */
+  private function getCaseTypeCategoryNameByCaseTypeId($caseTypeId) {
+    return civicrm_api3('CaseType', 'getsingle', [
+      'id' => $caseTypeId,
+      'return' => ['case_type_category.name'],
+    ])['case_type_category.name'];
+  }
+
+  /**
+   * Creates an activity related to the case specified.
+   *
+   * @param int $caseId
+   *   Id of the case.
+   *
+   * @return array
+   *   Activity details.
+   */
+  private function createActivityForCaseId($caseId) {
+    $contact = ContactFabricator::fabricate();
+
+    return civicrm_api3('Activity', 'create', [
+      'case_id' => $caseId,
+      'source_contact_id' => $contact['id'],
+      'activity_type_id' => 'Assign Case Role',
+    ]);
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR adds unit tests for the functionality provided by the service `CaseCategoryFromUrl`, that is, basically, to detect the category name from a given Url / Request.
At this moment there are 4 types of URLs that can be used in the class: 
- Url containing information about a Case.
- Url containing information about an Activity.
- Url containing information about a Category.
- Url requested by an Ajax call.

## Before
There were no tests for this Service.

## After
We added tests for all the different cases in which the service can detect a category name. 

## Technical Details
This service interacts with a static method of `CRM_Utils_Request` class, that therefore can't be mocked.
For removing this limitation, the usual path is to create appropriate interfaces and wrap the static method, but for this particular case that would have been overkill, from my point of view.
For solving the problem I isolate the interaction with the service in one public method, that later I mock:
```php
  public function getRequestResponse($name, $type) {
    return CRM_Utils_Request::retrieve($name, $type);
  }
```

## Comments
Some small bugs on the service were fixed.
The tested class takes the task of creating appropriate instances with helper methods. I was tempted to move these methods to fabricators (the existent for `Case` or a new one for `Activity`) but it seems that will not be really useful in future.
In case of need, I will do a refactor later.
