### PR TITLE
CPS-414: Fix Mysql8 Reserved Word Issue

### DIFF
--- a/api/v3/Case/Getdetails.php
+++ b/api/v3/Case/Getdetails.php
@@ -217,10 +217,6 @@ function civicrm_api3_case_getdetails(array $params) {
         $case['related_case_ids'] = CRM_Case_BAO_Case::getRelatedCaseIds($case['id']);
       }
     }
-    // Get last update.
-    if (in_array('last_update', $toReturn)) {
-      // todo.
-    }
     if (!empty($params['sequential'])) {
       $result['values'] = array_values($result['values']);
     }

--- a/api/v3/Case/Getdetails.php
+++ b/api/v3/Case/Getdetails.php
@@ -284,7 +284,7 @@ function calculate_activities_for_category($category, array $ids, $statusTypeIds
   $query = "SELECT COUNT(a.id) as count, ca.case_id
   FROM civicrm_activity a, civicrm_case_activity ca
   WHERE ca.activity_id = a.id AND a.is_current_revision = 1 AND a.is_test = 0 AND ca.case_id IN (" . implode(',', $ids) . ")
-  AND a.activity_type_id IN (SELECT value FROM civicrm_option_value WHERE grouping "
+  AND a.activity_type_id IN (SELECT value FROM civicrm_option_value WHERE `grouping` "
   . $categoryCondition . " AND option_group_id = (SELECT id FROM civicrm_option_group WHERE name = 'activity_type'))
   " . $isOverdueCondition . "
   AND is_current_revision = 1


### PR DESCRIPTION
## Overview
One of the query in file `api/v3/Case/Getdetails.php` was using 'grouping' which is a reserved keyword in Mysql8 so this query was resulting in an error. So this pr backticks the 'grouping' word which will allow to run the same query without errors on mysql8. 

## Before
The above issue existed.

## After
This pr modifies the query and uses backticks to make this query compatible with mysql8.

## Technical Details
Query has been modified to this
$query = "SELECT COUNT(a.id) as count, ca.case_id
  FROM civicrm_activity a, civicrm_case_activity ca
  WHERE ca.activity_id = a.id AND a.is_current_revision = 1 AND a.is_test = 0 AND ca.case_id IN (" . implode(',', $ids) . ")
  AND a.activity_type_id IN (SELECT value FROM civicrm_option_value WHERE \`grouping\` "
  . $categoryCondition . " AND option_group_id = (SELECT id FROM civicrm_option_group WHERE name = 'activity_type'))
  " . $isOverdueCondition . "
  AND is_current_revision = 1
  AND is_deleted = 0
  AND a.status_id IN ($statusTypeIds)
  GROUP BY ca.case_id";

See the backticks before and after grouping. 
