### PR TITLE
CATL-1948: Fix missing end dates

### DIFF
--- a/CRM/Civicase/Service/CaseRoleCreationPostProcess.php
+++ b/CRM/Civicase/Service/CaseRoleCreationPostProcess.php
@@ -160,21 +160,13 @@ class CRM_Civicase_Service_CaseRoleCreationPostProcess extends CRM_Civicase_Serv
    *   API request parameters.
    */
   private function setRelationshipsInactive(array $relIds, array $params) {
-    $endDate = empty($params['end_date']) ? new DateTime() : new DateTime($params['end_date']);
-    $today = new DateTime();
-    $isEndDateSameAsToday = $endDate->format('Y-m-d') === $today->format('Y-m-d');
-    $relationshipActiveFields = $isEndDateSameAsToday
-      ? ['is_active' => 0]
-      : ['end_date' => $params['end_date']];
-
     foreach ($relIds as $relId) {
-      civicrm_api3('Relationship', 'create', array_merge(
-        $relationshipActiveFields,
-        [
-          'id' => $relId,
-          'skip_post_processing' => 1,
-        ]
-      ));
+      civicrm_api3('Relationship', 'create', [
+        'id' => $relId,
+        'is_active' => 0,
+        'end_date' => !empty($params['start_date']) ? $params['start_date'] : date('Y-m-d'),
+        'skip_post_processing' => 1,
+      ]);
     }
   }
 

--- a/CRM/Civicase/Service/CaseRoleCreationPostProcess.php
+++ b/CRM/Civicase/Service/CaseRoleCreationPostProcess.php
@@ -45,8 +45,16 @@ class CRM_Civicase_Service_CaseRoleCreationPostProcess extends CRM_Civicase_Serv
     }
 
     if (!empty($existingRelationship)) {
-      $this->setRelationshipsInactive(array_column($existingRelationship, 'id'), $requestParams['params']);
+      $endDate = !empty($requestParams['params']['start_date'])
+        ? $requestParams['params']['start_date']
+        : date('Y-m-d');
+
+      $this->setRelationshipsInactive(
+        array_column($existingRelationship, 'id'),
+        $endDate
+      );
     }
+
     $activitySubject = $this->getActivitySubjectOnCreate($currentRelContactName, $relTypeDetails, $previousRelContactName);
     $this->createCaseActivity($requestParams['params']['case_id'], 'Assign Case Role', $activitySubject);
   }
@@ -152,19 +160,19 @@ class CRM_Civicase_Service_CaseRoleCreationPostProcess extends CRM_Civicase_Serv
   }
 
   /**
-   * Set the relationship Id's inactive and end date to be today.
+   * Set the relationship Id's inactive using the given end date.
    *
    * @param array $relIds
    *   Relationship Ids.
-   * @param array $params
-   *   API request parameters.
+   * @param string $endDate
+   *   End date to use when setting the relationships as innactive.
    */
-  private function setRelationshipsInactive(array $relIds, array $params) {
+  private function setRelationshipsInactive(array $relIds, string $endDate) {
     foreach ($relIds as $relId) {
       civicrm_api3('Relationship', 'create', [
         'id' => $relId,
         'is_active' => 0,
-        'end_date' => !empty($params['start_date']) ? $params['start_date'] : date('Y-m-d'),
+        'end_date' => $endDate,
         'skip_post_processing' => 1,
       ]);
     }

--- a/ang/civicase-base/directives/inline-datepicker.directive.js
+++ b/ang/civicase-base/directives/inline-datepicker.directive.js
@@ -35,6 +35,8 @@
           onChangeMonthYear: removeDatePickerHrefs,
           onClose: handleDatePickerClose
         });
+
+        watchMinMaxDateRangeLimits();
       })();
 
       /**
@@ -109,6 +111,39 @@
         } catch (exception) {
           return false;
         }
+      }
+
+      /**
+       * Updates either the minium or maximum date values for the datepicker.
+       *
+       * @param {string} dateRangeFieldName the name of the range to update.
+       * It should be either "minDate" or "maxDate".
+       */
+      function updateDatepickerRangeLimit (dateRangeFieldName) {
+        var fieldDateValue = attributes[dateRangeFieldName];
+
+        if (!fieldDateValue) {
+          return;
+        }
+
+        var dateObject = moment(fieldDateValue).toDate();
+
+        element.datepicker('option', dateRangeFieldName, dateObject);
+      }
+
+      /**
+       * Watches for changes to the min and max date range values and updates
+       * the inline datepicker so it uses these limits.
+       */
+      function watchMinMaxDateRangeLimits () {
+        attributes.$observe(
+          'minDate',
+          updateDatepickerRangeLimit.bind(this, 'minDate')
+        );
+        attributes.$observe(
+          'maxDate',
+          updateDatepickerRangeLimit.bind(this, 'maxDate')
+        );
       }
     }
   });

--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
@@ -259,8 +259,8 @@
       if (!isReplacingClient) {
         promptForContactParams.reassignmentDate = {
           maxDate: moment().format('YYYY-MM-DD'),
-          value: moment().isBefore(moment(role.start_date))
-            ? moment(role.start_date).format('YYYY-MM-DD')
+          value: moment().isBefore(moment(role.relationship.start_date))
+            ? moment(role.relationship.start_date).format('YYYY-MM-DD')
             : moment().format('YYYY-MM-DD')
         };
       }
@@ -301,7 +301,10 @@
             }
           },
           function (contactPromptResult) {
-            if (!isSameOrAfter(contactPromptResult.endDate, contactPromptResult.role.start_date)) {
+            if (!isSameOrAfter(
+              contactPromptResult.endDate,
+              contactPromptResult.role.relationship.start_date
+            )) {
               contactPromptResult.showErrorMessageFor(
                 'endDate',
                 PeoplesTabMessageConstants.RELATIONSHIP_END_DATE_MESSAGE
@@ -743,8 +746,13 @@
           isError = true;
         }
 
-        if (contactPromptResult.reassignmentDate &&
-          !isSameOrAfter(contactPromptResult.reassignmentDate, contactPromptResult.role.start_date)) {
+        if (
+          contactPromptResult.reassignmentDate &&
+          !isSameOrAfter(
+            contactPromptResult.reassignmentDate,
+            contactPromptResult.role.relationship.start_date
+          )
+        ) {
           contactPromptResult.showErrorMessageFor(
             'reassignmentDate',
             PeoplesTabMessageConstants.RELATIONSHIP_REASSIGNMENT_DATE_MESSAGE

--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
@@ -782,17 +782,15 @@
      * @returns {Array} API call
      */
     function unassignRoleCall (role, endDate) {
-      var isEndDateSameAsToday = moment().isSame(endDate, 'day');
-      var unassignRelationshipApiCall = isEndDateSameAsToday
-        ? { is_active: 0 }
-        : { end_date: endDate };
-
       return ['Relationship', 'get', {
         relationship_type_id: role.relationship_type_id,
         contact_id_b: role.contact_id,
         case_id: item.id,
         is_active: 1,
-        'api.Relationship.create': unassignRelationshipApiCall
+        'api.Relationship.create': {
+          end_date: endDate,
+          is_active: 0
+        }
       }];
     }
 

--- a/ang/civicase/case/details/people-tab/directives/roles-tab.directive.html
+++ b/ang/civicase/case/details/people-tab/directives/roles-tab.directive.html
@@ -151,9 +151,10 @@
         </td>
         <td class="civicase__people-tab__table-column">
           <input
-            civicase-inline-datepicker
-            civicase-send-to-api-on-change
             class="form-control"
+            civicase-inline-datepicker
+            data-max-date="{{role.relationship.end_date}}"
+            civicase-send-to-api-on-change
             data-api-data="roleDatesUpdater.getApiCallsForStartDate(role, item.id)"
             data-on-api-data-sent="roleDatesUpdater.updatePreviousValue(role, 'start_date')"
             name="role_start_date"
@@ -165,9 +166,10 @@
         </td>
         <td class="civicase__people-tab__table-column">
           <input
-            civicase-inline-datepicker
-            civicase-send-to-api-on-change
             class="form-control"
+            civicase-inline-datepicker
+            data-min-date="{{role.relationship.start_date}}"
+            civicase-send-to-api-on-change
             data-api-data="roleDatesUpdater.getApiCallsForEndDate(role, item.id)"
             data-on-api-data-sent="roleDatesUpdater.updatePreviousValue(role, 'end_date')"
             name="role_end_date"

--- a/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
+++ b/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
@@ -136,14 +136,12 @@
               description: caseTypeRole.description,
               desc: caseRelation.description,
               display_name: contact.display_name,
-              end_date: caseRelation.end_date,
               email: contact.email,
               is_active: caseRelation.is_active,
               phone: contact.phone,
               relationship_type_id: caseTypeRole.relationship_type_id,
               role: caseTypeRole.role,
               relationship: caseRelation,
-              start_date: caseRelation.start_date,
               previousValues: {
                 end_date: caseRelation.end_date,
                 start_date: caseRelation.start_date

--- a/ang/test/civicase-base/directives/inline-datepicker.directive.spec.js
+++ b/ang/test/civicase-base/directives/inline-datepicker.directive.spec.js
@@ -164,14 +164,92 @@
       });
     });
 
+    describe('min and max dates', () => {
+      describe('minimum date limit', () => {
+        beforeEach(() => {
+          $scope.date = '1999-06-01';
+          $scope.minDate = '1999-01-01';
+
+          initDirective(`
+            data-min-date="{{minDate}}"
+          `);
+          $scope.$digest();
+        });
+
+        it('sets the minimum date as the provided value', () => {
+          expect($.fn.datepicker).toHaveBeenCalledWith(
+            'option',
+            'minDate',
+            new Date('1999-01-01')
+          );
+        });
+
+        describe('when the minimum date is updated', () => {
+          beforeEach(() => {
+            $scope.minDate = '1999-01-31';
+
+            $scope.$digest();
+          });
+
+          it('updates the minimum date limit', () => {
+            expect($.fn.datepicker).toHaveBeenCalledWith(
+              'option',
+              'minDate',
+              new Date('1999-01-31')
+            );
+          });
+        });
+      });
+
+      describe('maximum date limit', () => {
+        beforeEach(() => {
+          $scope.date = '1999-06-01';
+          $scope.maxDate = '1999-12-31';
+
+          initDirective(`
+            data-max-date="{{maxDate}}"
+          `);
+          $scope.$digest();
+        });
+
+        it('sets the maximum date as the provided value', () => {
+          expect($.fn.datepicker).toHaveBeenCalledWith(
+            'option',
+            'maxDate',
+            new Date('1999-12-31')
+          );
+        });
+
+        describe('when the maximum date is updated', () => {
+          beforeEach(() => {
+            $scope.maxDate = '1999-01-01';
+
+            $scope.$digest();
+          });
+
+          it('updates the minimum date limit', () => {
+            expect($.fn.datepicker).toHaveBeenCalledWith(
+              'option',
+              'maxDate',
+              new Date('1999-01-01')
+            );
+          });
+        });
+      });
+    });
+
     /**
      * Initialises the Inline Datepicker directive on an input element using
      * the global $scope variable.
+     *
+     * @param {string} extraAttributes custom attributes to add to the input
+     *   element alongside the inline datepicker directive.
      */
-    function initDirective () {
+    function initDirective (extraAttributes = '') {
       element = $compile(`
         <input
           civicase-inline-datepicker
+          ${extraAttributes}
           ng-model="date"
           type="text"
         />

--- a/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
@@ -129,8 +129,10 @@ describe('Case Details People Tab', () => {
             display_name: previousContact.display_name,
             relationship_type_id: relationshipTypeId,
             role: roleName,
-            start_date: moment().add(5, 'day'),
-            id: '101'
+            id: '101',
+            relationship: {
+              start_date: moment().add(5, 'day')
+            }
           });
           selectDialogContact(contact);
           updateDialogModel({
@@ -158,8 +160,10 @@ describe('Case Details People Tab', () => {
             display_name: previousContact.display_name,
             relationship_type_id: relationshipTypeId,
             role: roleName,
-            start_date: moment().add(-1, 'day'),
-            id: '101'
+            id: '101',
+            relationship: {
+              start_date: moment().add(-1, 'day')
+            }
           });
           selectDialogContact(contact);
           updateDialogModel({
@@ -233,7 +237,10 @@ describe('Case Details People Tab', () => {
         var client = CRM._.first($scope.item.client);
         $scope.replaceRoleOrClient({
           relationship_type_id: relationshipTypeId,
-          role: roleName
+          role: roleName,
+          relationship: {
+            start_date: moment().format('YYYY-MM-DD')
+          }
         });
         selectDialogContact(CRM._.assign({}, client, {
           id: client.contact_id
@@ -472,7 +479,9 @@ describe('Case Details People Tab', () => {
             display_name: sampleContact.display_name,
             relationship_type_id: relationshipTypeId,
             role: 'Role',
-            start_date: moment().add(5, 'day')
+            relationship: {
+              start_date: moment().add(5, 'day')
+            }
           });
 
           updateDialogModel({
@@ -498,7 +507,9 @@ describe('Case Details People Tab', () => {
             display_name: sampleContact.display_name,
             relationship_type_id: relationshipTypeId,
             role: 'Role',
-            start_date: moment().add(-5, 'day')
+            relationship: {
+              start_date: moment().add(-5, 'day')
+            }
           });
 
           updateDialogModel({
@@ -535,7 +546,9 @@ describe('Case Details People Tab', () => {
             display_name: sampleContact.display_name,
             relationship_type_id: relationshipTypeId,
             role: 'Role',
-            start_date: moment().add(-5, 'day')
+            relationship: {
+              start_date: moment().add(-5, 'day')
+            }
           });
 
           updateDialogModel({

--- a/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
@@ -517,6 +517,7 @@ describe('Case Details People Tab', () => {
               case_id: $scope.item.id,
               is_active: 1,
               'api.Relationship.create': {
+                end_date: moment().format('YYYY-MM-DD'),
                 is_active: 0
               }
             }]

--- a/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
@@ -524,6 +524,44 @@ describe('Case Details People Tab', () => {
           ]));
         });
       });
+
+      describe('when reassining to a past date', () => {
+        beforeEach(() => {
+          sampleContact = CRM._.sample(ContactsData.values);
+          relationshipTypeId = CRM._.uniqueId();
+
+          $scope.unassignRole({
+            contact_id: sampleContact.contact_id,
+            display_name: sampleContact.display_name,
+            relationship_type_id: relationshipTypeId,
+            role: 'Role',
+            start_date: moment().add(-5, 'day')
+          });
+
+          updateDialogModel({
+            description: roleDescription,
+            endDate: { value: moment().add(-3, 'day').format('YYYY-MM-DD') }
+          });
+          submitDialog();
+
+          $rootScope.$digest();
+        });
+
+        it('marks the current role relationship as finished using the end date of the new relationship start date', () => {
+          expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
+            ['Relationship', 'get', {
+              relationship_type_id: relationshipTypeId,
+              contact_id_b: sampleContact.contact_id,
+              case_id: $scope.item.id,
+              is_active: 1,
+              'api.Relationship.create': {
+                end_date: moment().add(-3, 'day').format('YYYY-MM-DD'),
+                is_active: 0
+              }
+            }]
+          ]));
+        });
+      });
     });
   });
 

--- a/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
+++ b/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
@@ -102,13 +102,11 @@
             description: `Case Manager. ${caseTypeRole.name}`,
             desc: caseRelation.description,
             display_name: caseManager.display_name,
-            end_date: caseRelation.end_date,
             email: caseManager.email,
             is_active: caseRelation.is_active,
             phone: caseManager.phone,
             relationship_type_id: caseRelation.relationship_type_id,
             role: caseTypeRole.name,
-            start_date: caseRelation.start_date,
             relationship: jasmine.objectContaining(caseRelation),
             previousValues: {
               end_date: caseRelation.end_date,

--- a/tests/phpunit/CRM/Civicase/Service/CaseRoleCreationPostProcessTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseRoleCreationPostProcessTest.php
@@ -363,6 +363,9 @@ class CRM_Civicase_Service_CaseRoleCreationPostProcessTest extends BaseHeadlessT
     $this->assertEquals($expectedActivitySubject, $activity['values'][0]['subject']);
   }
 
+  /**
+   * Test reassigning case role with no start date.
+   */
   public function testRoleReassignment() {
     $caseType = CaseTypeFabricator::fabricate();
     $client = ContactFabricator::fabricate();
@@ -405,6 +408,9 @@ class CRM_Civicase_Service_CaseRoleCreationPostProcessTest extends BaseHeadlessT
     $this->assertEquals('1', $currentManagerRelationshipDetails['is_active'], 'current manager is active');
   }
 
+  /**
+   * Test reassign case role with start and end date.
+   */
   public function testRoleReassignmentWithStartDate() {
     $caseType = CaseTypeFabricator::fabricate();
     $client = ContactFabricator::fabricate();


### PR DESCRIPTION
## Overview
This PR fixes an issue where reassigning or removing a case role would not add the end date for the past case role.

## Before
![pr](https://user-images.githubusercontent.com/1642119/102289515-44703700-3f15-11eb-8e6a-8ab2c6379354.gif)

## After
![pr](https://user-images.githubusercontent.com/1642119/102289381-e4799080-3f14-11eb-8519-52edc7308781.gif)

## Technical Details

The issue was introduced by this PR: https://github.com/compucorp/uk.co.compucorp.civicase/pull/626. The assumption was that the https://github.com/civicrm/civicrm-core/pull/18844 core PR was going to fill the end date when passing `is_active: 0`. This assumption not only was wrong, but this core PR won't be accepted so we need to remove this implementation.

## Related PRs

* CATL-2031: Use date fields stored inside of relationship object #677
* CATL-2030: Add date range limits to role inline date pickers #685