### PR TITLE
CATL-2016: Fix Issue while resuming draft

### DIFF
--- a/CRM/Civicase/Hook/ValidateForm/SaveActivityDraft.php
+++ b/CRM/Civicase/Hook/ValidateForm/SaveActivityDraft.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Class CRM_Civicase_Hook_ValidateForm_SaveActivityDraft.
+ * Save activity draft.
  */
 class CRM_Civicase_Hook_ValidateForm_SaveActivityDraft {
 
@@ -82,6 +82,9 @@ class CRM_Civicase_Hook_ValidateForm_SaveActivityDraft {
     if ($formName == $this->specialForms['email']) {
       $params['target_contact_id'] = explode(',', CRM_Utils_Array::value('to', $fields));
       $params['target_contact_id'] = array_map('intval', $params['target_contact_id']);
+    }
+    elseif ($formName == $this->specialForms['pdf'] && !empty($form->_contactIds)) {
+      $params['target_contact_id'] = $form->_contactIds;
     }
 
     civicrm_api3('Activity', 'create', $params + $fields);

--- a/ang/civicase/activity/activity-forms/services/draft-email-activity-form.service.js
+++ b/ang/civicase/activity/activity-forms/services/draft-email-activity-form.service.js
@@ -29,11 +29,11 @@
      */
     function getActivityFormUrl (activity, optionsWithoutDefaults) {
       var options = _.defaults({}, optionsWithoutDefaults, { action: 'add' });
-      var sourceContactId = _.first(activity.source_contact_id);
+      var targetContactId = _.first(activity.target_contact_id);
       var draftFormParameters = {
         action: options.action,
         atype: activity.activity_type_id,
-        cid: sourceContactId,
+        cid: targetContactId,
         draft_id: activity.id,
         id: activity.id,
         reset: '1'

--- a/ang/civicase/activity/activity-forms/services/draft-pdf-activity-form.service.js
+++ b/ang/civicase/activity/activity-forms/services/draft-pdf-activity-form.service.js
@@ -29,12 +29,12 @@
      */
     function getActivityFormUrl (activity, optionsWithoutDefaults) {
       var options = _.defaults({}, optionsWithoutDefaults, { action: 'add' });
-      var assigneeContactId = _.first(activity.assignee_contact_id);
+      var targetContactId = _.first(activity.target_contact_id);
 
       return getCrmUrl('civicrm/activity/pdf/' + options.action, {
         action: options.action,
         caseid: activity.case_id,
-        cid: assigneeContactId,
+        cid: targetContactId,
         context: 'standalone',
         draft_id: activity.id,
         id: activity.id,

--- a/ang/test/civicase/activity/activity-forms/services/draft-email-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/draft-email-activity-form.service.spec.js
@@ -47,13 +47,13 @@
       let expectedActivityFormUrlParams;
 
       beforeEach(() => {
-        activity.assignee_contact_id = [_.uniqueId()];
+        activity.target_contact_id = [_.uniqueId()];
 
         expectedActivityFormUrlParams = {
           action: 'add',
           atype: activity.activity_type_id,
           caseid: activity.case_id,
-          cid: activity.source_contact_id[0],
+          cid: activity.target_contact_id[0],
           draft_id: activity.id,
           id: activity.id,
           reset: '1'

--- a/ang/test/civicase/activity/activity-forms/services/draft-pdf-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/draft-pdf-activity-form.service.spec.js
@@ -46,12 +46,12 @@
       let activityFormUrlParams, expectedActivityFormUrl;
 
       beforeEach(() => {
-        activity.assignee_contact_id = [_.uniqueId()];
+        activity.target_contact_id = [_.uniqueId()];
 
         activityFormUrlParams = {
           action: 'add',
           caseid: activity.case_id,
-          cid: activity.assignee_contact_id[0],
+          cid: activity.target_contact_id[0],
           context: 'standalone',
           draft_id: activity.id,
           id: activity.id,


### PR DESCRIPTION
## Overview
This issue fixes the wrong client id issue while opening the email/pdf form when user resumes the saved draft.

## Before
Previously the contact id of the activity creator was being sent as client contact id to the email or pdf form which resulted in multiple errors.
![image-20201211-122754](https://user-images.githubusercontent.com/68388745/102883622-1ee1b100-4472-11eb-8d6d-7e8eada5f3c6.png)

## After
The client id is sent to the email or pdf form
![Peek 2020-12-22 16-27](https://user-images.githubusercontent.com/68388745/102883956-a0394380-4472-11eb-9d6d-602446e1ff49.gif)


## Technical Details
`getActivityFormUrl` function in `ang/civicase/activity/activity-forms/services/draft-pdf-activity-form.service.js` and `ang/civicase/activity/activity-forms/services/draft-email-activity-form.service.js` was responsible for creating the link and parameter for pdf and email forms while resuming draft. Both of these function were sending assignee or source id which refers to creator of activity instead of target id which refers to client id. This pr fixes this issue