### PR TITLE
CPS-417: Fix Bug With Recent Communication Block

### DIFF
--- a/ang/civicase/activity/factories/view-in-popup.factory.js
+++ b/ang/civicase/activity/factories/view-in-popup.factory.js
@@ -1,9 +1,9 @@
 (function (angular, $, _, CRM) {
   var module = angular.module('civicase');
 
-  module.factory('viewInPopup', function (ActivityForms, ActivityType) {
+  module.factory('viewInPopup', function (ActivityForms) {
     /**
-     * View given activity in a popup
+     * View activity in a popup
      *
      * @param {object} $event event
      * @param {*} activity activity to be viewed

--- a/ang/civicase/activity/factories/view-in-popup.factory.js
+++ b/ang/civicase/activity/factories/view-in-popup.factory.js
@@ -11,8 +11,9 @@
      */
     function viewInPopup ($event, activity) {
       var isClickingAButton = $event && $($event.target).is('a, a *, input, button, button *');
+      var isEmailTypeActivity = activity.type.toLowerCase() === 'email';
       var activityForm = ActivityForms.getActivityFormService(activity, {
-        action: 'update'
+        action: isEmailTypeActivity ? 'view' : 'update'
       });
 
       if (!activityForm || isClickingAButton) {

--- a/ang/test/civicase/activity/factories/view-in-popup.factory.spec.js
+++ b/ang/test/civicase/activity/factories/view-in-popup.factory.spec.js
@@ -1,0 +1,84 @@
+/* eslint-env jasmine */
+
+(function (_, $) {
+  describe('viewInPopup', function () {
+    var viewInPopup, mockGetActivityFormService, mockGetActivityFormUrl;
+
+    beforeEach(module('civicase', 'civicase.data', function ($provide) {
+      mockGetActivityFormService = jasmine.createSpy('getActivityFormService');
+      mockGetActivityFormUrl = jasmine.createSpy('getActivityFormUrl');
+      mockGetActivityFormUrl.and.returnValue('mock GetActivityFormUrl return value');
+
+      mockGetActivityFormService.and.returnValue({
+        getActivityFormUrl: mockGetActivityFormUrl
+      });
+
+      $provide.value('ActivityForms', { getActivityFormService: mockGetActivityFormService });
+    }));
+
+    beforeEach(inject(function (_viewInPopup_) {
+      viewInPopup = _viewInPopup_;
+    }));
+
+    describe('when clicking a button', function () {
+      var activity;
+
+      beforeEach(function () {
+        var event = $.Event('click');
+        event.target = document.createElement('a');
+
+        activity = { type: 'email' };
+        viewInPopup(event, activity);
+      });
+
+      it('does not show the activity in a popup', function () {
+        expect(mockGetActivityFormUrl).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when not clicking a button', () => {
+      var loadFormBefore, activity, returnValue, event;
+
+      beforeEach(() => {
+        loadFormBefore = CRM.loadForm;
+        CRM.loadForm = jasmine.createSpy();
+        CRM.loadForm.and.returnValue('loadForm');
+
+        event = $.Event('click');
+        event.target = document.createElement('span');
+      });
+
+      afterEach(function () {
+        CRM.loadForm = loadFormBefore;
+      });
+
+      describe('and the activity is email type', function () {
+        beforeEach(function () {
+          activity = { type: 'Email' };
+          returnValue = viewInPopup(event, activity);
+        });
+
+        it('shows the activity in a popup in view mode', function () {
+          expect(mockGetActivityFormService).toHaveBeenCalledWith(activity, { action: 'view' });
+          expect(mockGetActivityFormUrl).toHaveBeenCalledWith(activity);
+          expect(CRM.loadForm).toHaveBeenCalledWith('mock GetActivityFormUrl return value');
+          expect(returnValue).toBe('loadForm');
+        });
+      });
+
+      describe('and the activity is not email type', function () {
+        beforeEach(function () {
+          activity = { type: 'Meeting' };
+          returnValue = viewInPopup(event, activity);
+        });
+
+        it('shows the activity in a popup in update mode', function () {
+          expect(mockGetActivityFormService).toHaveBeenCalledWith(activity, { action: 'update' });
+          expect(mockGetActivityFormUrl).toHaveBeenCalledWith(activity);
+          expect(CRM.loadForm).toHaveBeenCalledWith('mock GetActivityFormUrl return value');
+          expect(returnValue).toBe('loadForm');
+        });
+      });
+    });
+  });
+})(CRM._, CRM.$);


### PR DESCRIPTION
## Overview
This pr fixes the issue with email activity in recent communication block on case summary page. When user clicked on an email activity in recent communication an error was shown to the user.

## Before
Previously when user clicked on an email activity in recent communication a request was sent to civicrm to edit the activity but civicrm does not allow editing of an email activity so an error was thrown as shown below.
![image-20201208-163955](https://user-images.githubusercontent.com/68388745/103196301-c09b4f00-4905-11eb-8818-380c251dc635.png)

## After
This pr changes the request from edit to view for email activities in recent communication so now when user clicks on an email activity a view of the activity is opened up in a popup.
![Peek 2020-12-28 12-27](https://user-images.githubusercontent.com/68388745/103197796-8d0df400-4908-11eb-8803-fec243f3442c.gif)

## Technical Details
`ang/civicase/activity/factories/view-in-popup.factory.js` file is responsible for providing services for either view or update of an activity. This pr introduces a check in `viewInPopup` function which checks if the type of an activity is email then fetch view service otherwise update service.