### PR TITLE
CPS-184: Fix Resume Print Merge Draft Issue

### DIFF
--- a/ang/civicase/activity/activity-forms/services/draft-pdf-activity-form.service.js
+++ b/ang/civicase/activity/activity-forms/services/draft-pdf-activity-form.service.js
@@ -29,12 +29,13 @@
      */
     function getActivityFormUrl (activity, optionsWithoutDefaults) {
       var options = _.defaults({}, optionsWithoutDefaults, { action: 'add' });
-      var assigneeContactId = _.first(activity.assignee_contact_id);
+      var contactId = activity.target_contact_id ? _.first(activity.target_contact_id)
+        : _.first(activity.assignee_contact_id);
 
       return getCrmUrl('civicrm/activity/pdf/' + options.action, {
         action: options.action,
         caseid: activity.case_id,
-        cid: assigneeContactId,
+        cid: contactId,
         context: 'standalone',
         draft_id: activity.id,
         id: activity.id,

--- a/ang/test/civicase/activity/activity-forms/services/draft-pdf-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/draft-pdf-activity-form.service.spec.js
@@ -46,12 +46,12 @@
       let activityFormUrlParams, expectedActivityFormUrl;
 
       beforeEach(() => {
-        activity.assignee_contact_id = [_.uniqueId()];
+        activity.target_contact_id = [_.uniqueId()];
 
         activityFormUrlParams = {
           action: 'add',
           caseid: activity.case_id,
-          cid: activity.assignee_contact_id[0],
+          cid: activity.target_contact_id[0],
           context: 'standalone',
           draft_id: activity.id,
           id: activity.id,


### PR DESCRIPTION
## Overview
This pr fixes the empty document issue when user downloads the document from print/merge document popup while resuming draft.

## Before
Previously when user downloaded the document with some content written in it the downloaded file was empty.

## After
The above mentioned issue is fixed and now the downloaded document has the correct content.

## Technical Details
In file `ang/civicase/activity/activity-forms/services/draft-pdf-activity-form.service.js` the contact id parameter was being sent empty while opening the pdf form for resuming the draft. The reason for this was that assignee contact id was being used as contact id and that was empty inside an activity so this pr fixes the issue by using target contact id which refers to the client as the contact id.