### PR TITLE
RSE-1033: Allow filtering by disabled case types

### DIFF
--- a/ang/civicase-base.ang.php
+++ b/ang/civicase-base.ang.php
@@ -93,10 +93,15 @@ function get_base_js_files() {
 function set_case_types_to_js_vars(&$options) {
   $caseTypes = civicrm_api3('CaseType', 'get', [
     'return' => [
-      'id', 'name', 'title', 'description', 'definition', 'case_type_category',
+      'id',
+      'name',
+      'title',
+      'description',
+      'definition',
+      'case_type_category',
+      'is_active',
     ],
     'options' => ['limit' => 0, 'sort' => 'weight'],
-    'is_active' => 1,
   ]);
   foreach ($caseTypes['values'] as &$item) {
     CRM_Utils_Array::remove($item, 'is_forkable', 'is_forked');

--- a/ang/civicase-base/providers/case-type.provider.js
+++ b/ang/civicase-base/providers/case-type.provider.js
@@ -8,6 +8,9 @@
    */
   function CaseTypeServiceProvider () {
     var caseTypes = CRM['civicase-base'].caseTypes;
+    var DEFAULT_GET_ALL_OPTIONS = {
+      includeInactive: false
+    };
 
     this.$get = $get;
     this.getAll = getAll;
@@ -70,10 +73,23 @@
     }
 
     /**
+     * @param {object} options configuration options to use for filtering
+     *   the case types.
      * @returns {object[]} a list of case types.
      */
-    function getAll () {
-      return caseTypes;
+    function getAll (options) {
+      options = _.defaults({}, options, DEFAULT_GET_ALL_OPTIONS);
+
+      return options.includeInactive
+        ? caseTypes
+        : getAllActive();
+    }
+
+    /**
+     * @returns {object[]} all active case types.
+     */
+    function getAllActive () {
+      return _.pick(caseTypes, _.matches({ is_active: '1' }));
     }
 
     /**

--- a/ang/civicase-base/services/case-type-filterer/case-type-filterer.service.js
+++ b/ang/civicase-base/services/case-type-filterer/case-type-filterer.service.js
@@ -35,7 +35,7 @@
      * @returns {object[]} a list of case types.
      */
     function filter (userFilterValues) {
-      var filterValues = _.defaults({}, DEFAULT_FILTER_VALUES, userFilterValues);
+      var filterValues = _.defaults({}, userFilterValues, DEFAULT_FILTER_VALUES);
       var caseTypes = _.values(CaseType.getAll({ includeInactive: true }));
       var listOfFiltersToRun = _.filter(listOfFilters, function (filter) {
         return filter.shouldRun(filterValues);

--- a/ang/civicase-base/services/case-type-filterer/case-type-filterer.service.js
+++ b/ang/civicase-base/services/case-type-filterer/case-type-filterer.service.js
@@ -9,11 +9,16 @@
    * @param {object} BelongsToCategoryCaseTypeFilter case type filter reference.
    * @param {object} CaseType case type service reference.
    * @param {object} HasIdCaseTypeFilter case type filter reference.
+   * @param {object} IsActiveCaseTypeFilter case type filter reference.
    * @param {object} IsIncludedInListOfIdsCaseTypeFilter case type filter reference.
    */
   function CaseTypeFilterer (BelongsToCategoryCaseTypeFilter, CaseType,
-    HasIdCaseTypeFilter, IsIncludedInListOfIdsCaseTypeFilter) {
+    HasIdCaseTypeFilter, IsActiveCaseTypeFilter, IsIncludedInListOfIdsCaseTypeFilter) {
+    var DEFAULT_FILTER_VALUES = {
+      is_active: true
+    };
     var listOfFilters = [
+      IsActiveCaseTypeFilter,
       BelongsToCategoryCaseTypeFilter,
       IsIncludedInListOfIdsCaseTypeFilter,
       HasIdCaseTypeFilter
@@ -26,18 +31,19 @@
      * a list of filters. These filters are selected depending on the parameters
      * sent through `caseTypeFilters`.
      *
-     * @param {object} caseTypeFilters parameters to use for filtering the case types.
+     * @param {object} userFilterValues parameters to use for filtering the case types.
      * @returns {object[]} a list of case types.
      */
-    function filter (caseTypeFilters) {
-      var caseTypes = _.values(CaseType.getAll());
+    function filter (userFilterValues) {
+      var filterValues = _.defaults({}, DEFAULT_FILTER_VALUES, userFilterValues);
+      var caseTypes = _.values(CaseType.getAll({ includeInactive: true }));
       var listOfFiltersToRun = _.filter(listOfFilters, function (filter) {
-        return filter.shouldRun(caseTypeFilters);
+        return filter.shouldRun(filterValues);
       });
 
       return _.filter(caseTypes, function (caseType) {
         return _.every(listOfFiltersToRun, function (filter) {
-          return filter.run(caseType, caseTypeFilters);
+          return filter.run(caseType, filterValues);
         });
       });
     }

--- a/ang/civicase-base/services/case-type-filterer/filters/is-active.service.js
+++ b/ang/civicase-base/services/case-type-filterer/filters/is-active.service.js
@@ -1,0 +1,30 @@
+(function (_, angular) {
+  var module = angular.module('civicase-base');
+
+  module.service('IsActiveCaseTypeFilter', IsActiveCaseTypeFilter);
+
+  /**
+   * IsActiveCaseTypeFilter Case Type Filter service.
+   */
+  function IsActiveCaseTypeFilter () {
+    this.run = run;
+    this.shouldRun = shouldRun;
+
+    /**
+     * @param {object} caseType case type to match.
+     * @param {object} caseTypeFilters list of parameters to use for matching.
+     * @returns {boolean} true when active
+     */
+    function run (caseType, caseTypeFilters) {
+      return caseType.is_active === caseTypeFilters.is_active;
+    }
+
+    /**
+     * @param {object} caseTypeFilters list of parameters to use for matching.
+     * @returns {boolean} true when the `is_active` filter has a value.
+     */
+    function shouldRun (caseTypeFilters) {
+      return typeof caseTypeFilters.is_active !== 'undefined';
+    }
+  }
+})(CRM._, angular);

--- a/ang/civicase-base/services/case-type-filterer/filters/is-active.service.js
+++ b/ang/civicase-base/services/case-type-filterer/filters/is-active.service.js
@@ -5,8 +5,10 @@
 
   /**
    * IsActiveCaseTypeFilter Case Type Filter service.
+   *
+   * @param {Function} isTruthy service to compare truthy values.
    */
-  function IsActiveCaseTypeFilter () {
+  function IsActiveCaseTypeFilter (isTruthy) {
     this.run = run;
     this.shouldRun = shouldRun;
 
@@ -16,7 +18,7 @@
      * @returns {boolean} true when active
      */
     function run (caseType, caseTypeFilters) {
-      return caseType.is_active === caseTypeFilters.is_active;
+      return isTruthy(caseType.is_active) === isTruthy(caseTypeFilters.is_active);
     }
 
     /**

--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -127,7 +127,7 @@
       return CaseTypeFilterer.filter({
         case_type_category: caseFilters['case_type_id.case_type_category'],
         id: caseFilters.case_type_id,
-        is_active: $scope.caseFilter['case_type_id.is_active'] || '1'
+        is_active: caseFilters['case_type_id.is_active'] || '1'
       });
     }
 

--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -126,7 +126,8 @@
     function getFilteredCaseTypes (caseFilters) {
       return CaseTypeFilterer.filter({
         case_type_category: caseFilters['case_type_id.case_type_category'],
-        id: caseFilters.case_type_id
+        id: caseFilters.case_type_id,
+        is_active: $scope.caseFilter['case_type_id.is_active'] || '1'
       });
     }
 

--- a/ang/civicase/case/factories/format-case.factory.js
+++ b/ang/civicase/case/factories/format-case.factory.js
@@ -3,7 +3,7 @@
 
   module.factory('formatCase', function (formatActivity, ContactsCache,
     CaseStatus, CaseType, isTruthy) {
-    var caseTypes = CaseType.getAll();
+    var caseTypes = CaseType.getAll({ includeInactive: true });
     var caseStatuses = CaseStatus.getAll(true);
 
     return function (item) {

--- a/ang/test/civicase-base/providers/case-type.provider.spec.js
+++ b/ang/test/civicase-base/providers/case-type.provider.spec.js
@@ -5,7 +5,7 @@
     let CaseType, CaseTypesData, CaseTypesMockData, CaseTypesMockDataProvider;
 
     afterEach(() => {
-      CaseTypesMockDataProvider.restore();
+      CaseTypesMockDataProvider.reset();
     });
 
     describe('when getting all active case types', () => {

--- a/ang/test/civicase-base/providers/case-type.provider.spec.js
+++ b/ang/test/civicase-base/providers/case-type.provider.spec.js
@@ -2,18 +2,37 @@
 
 ((_) => {
   describe('Case Type', () => {
-    let CaseType, CaseTypesData, CaseTypesMockData;
+    let CaseType, CaseTypesData, CaseTypesMockData, CaseTypesMockDataProvider;
 
-    describe('when getting all case types', () => {
+    afterEach(() => {
+      CaseTypesMockDataProvider.restore();
+    });
+
+    describe('when getting all active case types', () => {
+      let activeCaseTypes, returnedCaseTypes;
+
+      beforeEach(() => initModulesAndServices());
+
+      beforeEach(() => {
+        activeCaseTypes = _.pick(CaseTypesData, (caseType) => caseType.is_active === '1');
+        returnedCaseTypes = CaseType.getAll();
+      });
+
+      it('returns all the active case types', () => {
+        expect(returnedCaseTypes).toEqual(activeCaseTypes);
+      });
+    });
+
+    describe('when getting all case including inactive ones', () => {
       let returnedCaseTypes;
 
       beforeEach(() => initModulesAndServices());
 
       beforeEach(() => {
-        returnedCaseTypes = CaseType.getAll();
+        returnedCaseTypes = CaseType.getAll({ includeInactive: true });
       });
 
-      it('returns all the case types', () => {
+      it('returns all the case types including inactive ones', () => {
         expect(returnedCaseTypes).toEqual(CaseTypesData);
       });
     });
@@ -111,7 +130,14 @@
      * the services required by the spec file.
      */
     function initModulesAndServices () {
-      module('civicase', 'civicase.data');
+      module('civicase', 'civicase.data', (_CaseTypesMockDataProvider_) => {
+        CaseTypesMockDataProvider = _CaseTypesMockDataProvider_;
+
+        CaseTypesMockDataProvider.add({
+          title: 'inactive case type',
+          is_active: '0'
+        });
+      });
 
       inject((_CaseType_, _CaseTypesMockData_) => {
         CaseType = _CaseType_;

--- a/ang/test/civicase-base/services/case-type-filterer/case-type-filterer.service.spec.js
+++ b/ang/test/civicase-base/services/case-type-filterer/case-type-filterer.service.spec.js
@@ -2,16 +2,27 @@
 
 ((_) => {
   describe('CaseTypeFilterer service', () => {
-    let allCaseTypeCategories, allCaseTypes, CaseTypeFilterer, expectedCaseTypes,
-      returnedCaseTypes;
+    let allCaseTypeCategories, allCaseTypes, CaseTypeFilterer,
+      CaseTypesMockDataProvider, expectedCaseTypes, returnedCaseTypes;
 
-    beforeEach(module('civicase-base'));
+    beforeEach(module('civicase-base', 'civicase.data', (_CaseTypesMockDataProvider_) => {
+      CaseTypesMockDataProvider = _CaseTypesMockDataProvider_;
+
+      CaseTypesMockDataProvider.add({
+        title: 'inactive case type',
+        is_active: '0'
+      });
+    }));
 
     beforeEach(inject((_CaseType_, _CaseTypeCategory_, _CaseTypeFilterer_) => {
       allCaseTypeCategories = _CaseTypeCategory_.getAll();
-      allCaseTypes = _CaseType_.getAll();
+      allCaseTypes = _CaseType_.getAll({ includeInactive: true });
       CaseTypeFilterer = _CaseTypeFilterer_;
     }));
+
+    afterEach(() => {
+      CaseTypesMockDataProvider.restore();
+    });
 
     describe('when filtering by case type id', () => {
       beforeEach(() => {
@@ -92,6 +103,57 @@
         });
 
         it('returns a list of case types filtered by multiple parameters', () => {
+          expect(returnedCaseTypes)
+            .toEqual(jasmine.arrayWithExactContents(expectedCaseTypes));
+        });
+      });
+    });
+
+    describe('active and disabled case types', () => {
+      describe('when filtering without specifying the case type active field', () => {
+        beforeEach(() => {
+          expectedCaseTypes = _.filter(allCaseTypes, {
+            is_active: '1'
+          });
+
+          returnedCaseTypes = CaseTypeFilterer.filter({});
+        });
+
+        it('returns all active case types', () => {
+          expect(returnedCaseTypes)
+            .toEqual(jasmine.arrayWithExactContents(expectedCaseTypes));
+        });
+      });
+
+      describe('when filtering for active case types', () => {
+        beforeEach(() => {
+          expectedCaseTypes = _.filter(allCaseTypes, {
+            is_active: '1'
+          });
+
+          returnedCaseTypes = CaseTypeFilterer.filter({
+            is_active: '1'
+          });
+        });
+
+        it('returns all active case types', () => {
+          expect(returnedCaseTypes)
+            .toEqual(jasmine.arrayWithExactContents(expectedCaseTypes));
+        });
+      });
+
+      describe('when filtering for disabled case types', () => {
+        beforeEach(() => {
+          expectedCaseTypes = _.filter(allCaseTypes, {
+            is_active: '0'
+          });
+
+          returnedCaseTypes = CaseTypeFilterer.filter({
+            is_active: '0'
+          });
+        });
+
+        it('returns all active case types', () => {
           expect(returnedCaseTypes)
             .toEqual(jasmine.arrayWithExactContents(expectedCaseTypes));
         });

--- a/ang/test/civicase-base/services/case-type-filterer/case-type-filterer.service.spec.js
+++ b/ang/test/civicase-base/services/case-type-filterer/case-type-filterer.service.spec.js
@@ -21,12 +21,14 @@
     }));
 
     afterEach(() => {
-      CaseTypesMockDataProvider.restore();
+      CaseTypesMockDataProvider.reset();
     });
-
     describe('when filtering by case type id', () => {
       beforeEach(() => {
-        const sampleCaseType = _.sample(allCaseTypes);
+        const sampleCaseType = _.chain(allCaseTypes)
+          .filter({ is_active: '1' })
+          .sample()
+          .value();
 
         expectedCaseTypes = [
           sampleCaseType
@@ -38,14 +40,16 @@
       });
 
       it('returns a list of case types that only includes the requested case type', () => {
-        expect(returnedCaseTypes)
-          .toEqual(jasmine.arrayWithExactContents(expectedCaseTypes));
+        expect(returnedCaseTypes).toEqual(expectedCaseTypes);
       });
     });
 
     describe('when filtering by a list of case type ids', () => {
       beforeEach(() => {
-        expectedCaseTypes = _.sample(allCaseTypes, 2);
+        expectedCaseTypes = _.chain(allCaseTypes)
+          .filter({ is_active: '1' })
+          .sample(2)
+          .value();
         const expectedCaseTypeIds = _.map(expectedCaseTypes, 'id');
 
         returnedCaseTypes = CaseTypeFilterer.filter({
@@ -77,8 +81,7 @@
       });
 
       it('returns a list of case types belonging to the case type category', () => {
-        expect(returnedCaseTypes)
-          .toEqual(jasmine.arrayWithExactContents(expectedCaseTypes));
+        expect(returnedCaseTypes).toEqual(expectedCaseTypes);
       });
     });
 
@@ -103,8 +106,7 @@
         });
 
         it('returns a list of case types filtered by multiple parameters', () => {
-          expect(returnedCaseTypes)
-            .toEqual(jasmine.arrayWithExactContents(expectedCaseTypes));
+          expect(returnedCaseTypes).toEqual(expectedCaseTypes);
         });
       });
     });
@@ -120,8 +122,7 @@
         });
 
         it('returns all active case types', () => {
-          expect(returnedCaseTypes)
-            .toEqual(jasmine.arrayWithExactContents(expectedCaseTypes));
+          expect(returnedCaseTypes).toEqual(expectedCaseTypes);
         });
       });
 
@@ -137,8 +138,7 @@
         });
 
         it('returns all active case types', () => {
-          expect(returnedCaseTypes)
-            .toEqual(jasmine.arrayWithExactContents(expectedCaseTypes));
+          expect(returnedCaseTypes).toEqual(expectedCaseTypes);
         });
       });
 
@@ -153,9 +153,8 @@
           });
         });
 
-        it('returns all active case types', () => {
-          expect(returnedCaseTypes)
-            .toEqual(jasmine.arrayWithExactContents(expectedCaseTypes));
+        it('returns disabled case types only', () => {
+          expect(returnedCaseTypes).toEqual(expectedCaseTypes);
         });
       });
     });

--- a/ang/test/civicase/case/directives/case-overview.directive.spec.js
+++ b/ang/test/civicase/case/directives/case-overview.directive.spec.js
@@ -53,7 +53,8 @@
       beforeEach(() => {
         expectedFilters = {
           case_type_category: 'Cases',
-          id: { IN: ['1', '2'] }
+          id: { IN: ['1', '2'] },
+          is_active: '1'
         };
 
         civicaseCrmApi.and.returnValue($q.resolve([CasesOverviewStats]));

--- a/ang/test/civicase/dashboard/directives/dashboard-tab.directive.spec.js
+++ b/ang/test/civicase/dashboard/directives/dashboard-tab.directive.spec.js
@@ -13,7 +13,7 @@
       });
     }
 
-    beforeEach(module('civicase.templates', 'civicase.data', 'civicase', 'crmUtil', function ($provide) {
+    beforeEach(module('civicase.templates', 'civicase', 'crmUtil', function ($provide) {
       $provide.value('civicaseCrmApi', jasmine.createSpy('civicaseCrmApi'));
     }));
 

--- a/ang/test/civicase/dashboard/directives/dashboard-tab.directive.spec.js
+++ b/ang/test/civicase/dashboard/directives/dashboard-tab.directive.spec.js
@@ -13,7 +13,7 @@
       });
     }
 
-    beforeEach(module('civicase.templates', 'civicase', 'crmUtil', function ($provide) {
+    beforeEach(module('civicase.templates', 'civicase.data', 'civicase', 'crmUtil', function ($provide) {
       $provide.value('civicaseCrmApi', jasmine.createSpy('civicaseCrmApi'));
     }));
 

--- a/ang/test/mocks/data/cases-types.data.js
+++ b/ang/test/mocks/data/cases-types.data.js
@@ -196,7 +196,8 @@
       },
       icon: 'icon',
       color: 'color',
-      case_type_category: '1'
+      case_type_category: '1',
+      is_active: '1'
     },
     2: {
       id: '2',
@@ -324,7 +325,8 @@
           }
         ]
       },
-      case_type_category: '2'
+      case_type_category: '2',
+      is_active: '1'
     },
     3: {
       id: '3',
@@ -408,7 +410,16 @@
      * @param {object} newCaseTypes a map of case types indexed by their id.
      */
     this.add = function (newCaseTypes) {
-      caseTypesMock = _.assign({}, caseTypesMock, newCaseTypes);
+      var newCaseTypesMock = _.assign({}, caseTypesMock, newCaseTypes);
+
+      CRM['civicase-base'].caseTypes = _.clone(newCaseTypesMock);
+    };
+
+    /**
+     * Restores the mock case types to the default ones. This avoids different
+     * spec files from overriding values to other files.
+     */
+    this.restore = function () {
       CRM['civicase-base'].caseTypes = _.clone(caseTypesMock);
     };
 

--- a/ang/test/mocks/data/cases-types.data.js
+++ b/ang/test/mocks/data/cases-types.data.js
@@ -391,7 +391,8 @@
           }
         ]
       },
-      case_type_category: '1'
+      case_type_category: '1',
+      is_active: '1'
     }
   };
 

--- a/ang/test/mocks/data/cases-types.data.js
+++ b/ang/test/mocks/data/cases-types.data.js
@@ -405,34 +405,32 @@
   })();
 
   module.provider('CaseTypesMockData', function () {
+    this.reset = reset;
+
     /**
      * Merges the given case types to the global case types list.
      *
-     * @param {object} newCaseTypes a map of case types indexed by their id.
+     * @param {object} newCaseType a case type object.
      */
-    this.add = function (newCaseTypes) {
-      var newCaseTypesMock = _.assign({}, caseTypesMock, newCaseTypes);
+    this.add = function (newCaseType) {
+      if (!newCaseType.id) {
+        newCaseType.id = _.uniqueId();
+      }
 
-      CRM['civicase-base'].caseTypes = _.clone(newCaseTypesMock);
-    };
-
-    /**
-     * Restores the mock case types to the default ones. This avoids different
-     * spec files from overriding values to other files.
-     */
-    this.restore = function () {
-      CRM['civicase-base'].caseTypes = _.clone(caseTypesMock);
+      CRM['civicase-base'].caseTypes[newCaseType.id] = newCaseType;
     };
 
     this.$get = () => {
       return {
+        reset: reset,
+
         /**
          * Returns a list of case types
          *
          * @returns {object} a list of case types indexed by id.
          */
         get: function () {
-          return _.clone(caseTypesMock);
+          return _.cloneDeep(CRM['civicase-base'].caseTypes);
         },
         /**
          * Returns a list of case types in array format
@@ -440,18 +438,18 @@
          * @returns {object[]} a list of case types.
          */
         getSequential: function () {
-          var clonesCaseTypesData = _.clone(caseTypesMock);
+          var clonesCaseTypesData = _.cloneDeep(caseTypesMock);
 
           return Object.values(clonesCaseTypesData);
-        },
-
-        /**
-         * Restores the mock data case types after it has been altered.
-         */
-        reset: function () {
-          CRM['civicase-base'].caseTypes = _.clone(caseTypesMock);
         }
       };
     };
+
+    /**
+     * Restores the mock data case types after it has been altered.
+     */
+    function reset () {
+      CRM['civicase-base'].caseTypes = _.cloneDeep(caseTypesMock);
+    }
   });
 }(CRM._));


### PR DESCRIPTION
## Overview
This PR allows civicase to display disable case types and the cases belonging to them.

⚠️ Important: This PR is a rework of https://github.com/compucorp/uk.co.compucorp.civicase/pull/402 work had to be paused for the disabled case types feature and when we could come back to it the implementation had to be slightly changed. More details in the technical details.

## Before & After
Note: the "Show Disabled Awards" filter is not part of this PR and was only added to demonstrate that passing the `is_active` filter works properly.  
### Before
![pr](https://user-images.githubusercontent.com/1642119/103718667-add7e880-4f9d-11eb-8f13-194e4b4c0213.gif)

### After
![pr](https://user-images.githubusercontent.com/1642119/103718365-f5aa4000-4f9c-11eb-9978-562982933afe.gif)

## Technical Details

* All case types are provided to the front end even if they have been disabled. The `is_active` property is also sent to the front end.
* The `CaseType` provider was updated so it returns all active case types when calling it using `CaseType.getAll()`, but returns all case types, including inactive, when calling it using `CaseType.getAll({ includeInactive: true })`. This ensures that all existing calls to this method only return active case types instead of returning all of them.
* The `CaseTypeFilterer` service was updated so it now includes an `IsActive` filter. This is the difference between this and the previous implementation. The previous implementation was based on API Calls, and this one uses the `CaseTypeFilterer` service introduced in https://github.com/compucorp/uk.co.compucorp.civicase/pull/427
* The `formatCase` service was updated so it can format cases belonging to disable case types.
* The `CaseTypesMockData` service has a new `restore` method that should be called when using `add`. This ensures that tests don't keep adding mock case types that may affect later tests.
