### PR TITLE
RSE-1376: Fix Bug Downloading All Files On Awards

### DIFF
--- a/CRM/Civicase/Page/ActivityFiles.php
+++ b/CRM/Civicase/Page/ActivityFiles.php
@@ -31,7 +31,7 @@ class CRM_Civicase_Page_ActivityFiles {
    * throws a 404 status code.
    */
   private static function getActivityFromRequest() {
-    $activityIds = CRM_Utils_Array::value('activity_ids', $_GET);
+    $activityIds = (array) CRM_Utils_Array::value('activity_ids', $_GET);
     $searchParams = CRM_Utils_Array::value('searchParams', $_GET);
 
     if (!empty($activityIds)) {

--- a/CRM/Civicase/Service/CaseCategoryFromUrl.php
+++ b/CRM/Civicase/Service/CaseCategoryFromUrl.php
@@ -6,6 +6,8 @@ use CRM_Case_BAO_CaseType as CaseType;
 
 /**
  * Class CRM_Civicase_Service_CaseCategoryFromUrl.
+ *
+ * Service for detecting the category name from a Url.
  */
 class CRM_Civicase_Service_CaseCategoryFromUrl {
 
@@ -142,6 +144,10 @@ class CRM_Civicase_Service_CaseCategoryFromUrl {
   private function getCaseCategoryFromActivityIdInUrl($activityIdParamName) {
     $activityId = CRM_Utils_Request::retrieve($activityIdParamName, 'Integer');
 
+    if (!$activityId) {
+      $activityId = $this->getActivityIdFromArrayInUrl($activityIdParamName);
+    }
+
     if ($activityId) {
       $result = civicrm_api3('Activity', 'get', [
         'sequential' => 1,
@@ -157,6 +163,24 @@ class CRM_Civicase_Service_CaseCategoryFromUrl {
 
       return NULL;
     }
+  }
+
+  /**
+   * Return an Activity ID from an array received on the query string.
+   *
+   * @param string $activityIdParamName
+   *   Activity ID param name.
+   *
+   * @return int|null
+   *   The first activity ID found, or null.
+   */
+  private function getActivityIdFromArrayInUrl($activityIdParamName) {
+    $activityIds = CRM_Utils_Array::value($activityIdParamName, $_GET);
+    if ($activityIds) {
+      return array_shift($activityIds);
+    }
+
+    return NULL;
   }
 
   /**

--- a/ang/civicase/activity/card/directives/activity-card-big.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-big.directive.html
@@ -23,7 +23,7 @@
               <li ng-if="activity.attachments.length" role="separator" class="divider"></li>
               <li ng-if="activity.attachments.length">
                 <a class="civicase__activity-attachment__file-name"
-                  ng-href="{{ 'civicrm/case/activity/download-all-files' | civicaseCrmUrl:{ activity_id: activity.id } }}">
+                  ng-href="{{ 'civicrm/case/activity/download-all-files' | civicaseCrmUrl:{ activity_ids: activity.id } }}">
                   <i class="civicase__activity-attachment__file-icon crm-i fa-download"></i> &nbsp;Download all
                 </a>
               </li>

--- a/ang/civicase/activity/card/directives/activity-card-long.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-long.directive.html
@@ -65,7 +65,7 @@
               <li ng-if="activity.attachments.length" role="separator" class="divider"></li>
               <li ng-if="activity.attachments.length">
                 <a class="civicase__activity-attachment__file-name"
-                  ng-href="{{ 'civicrm/case/activity/download-all-files' | civicaseCrmUrl:{ activity_id: activity.id } }}">
+                  ng-href="{{ 'civicrm/case/activity/download-all-files' | civicaseCrmUrl:{ activity_ids: activity.id } }}">
                   <i class="civicase__activity-attachment__file-icon crm-i fa-download"></i> &nbsp;Download all
                 </a>
               </li>

--- a/ang/civicase/activity/card/directives/activity-card-short.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-short.directive.html
@@ -43,7 +43,7 @@
               <li ng-if="activity.attachments.length" role="separator" class="divider"></li>
               <li ng-if="activity.attachments.length">
                 <a class="civicase__activity-attachment__file-name"
-                  ng-href="{{ 'civicrm/case/activity/download-all-files' | civicaseCrmUrl:{ activity_id: activity.id } }}">
+                  ng-href="{{ 'civicrm/case/activity/download-all-files' | civicaseCrmUrl:{ activity_ids: activity.id } }}">
                   <i class="civicase__activity-attachment__file-icon crm-i fa-download"></i> &nbsp;Download all
                 </a>
               </li>

--- a/config/urls/case_category_url.php
+++ b/config/urls/case_category_url.php
@@ -66,6 +66,6 @@ return [
   ],
   'civicrm/case/activity/download-all-files' => [
     'url_type' => CaseCategoryFromUrl::ACTIVITY_TYPE_URL,
-    'param' => 'activity_id',
+    'param' => 'activity_ids',
   ],
 ];


### PR DESCRIPTION
## Overview
This PR solves a problem downloading files attached to an activity. It was reported for Awards, because there was visible a permission error, but it is important to note that also exists for other cases.
In some parts of the frontend, the URL for downloading all files, `civicrm/case/activity/download-all-files`, was receiving the param `activity_id` and in other places was receiving an array named `activity_ids`.
This causes 404 error in some cases, and permission denied in others (in particular, in awards, the permission error did not exist on Cases because of the underlying logic)

## Before
The ticket attachments describe the incorrect behaviour: https://compucorp.atlassian.net/browse/RSE-1376, in all the different cases: Files tab activity, Calendar Activity, and Activity Tab.

## After
After pressing the download files, the download proceeds correctly.
The param name was normalized to `activity_ids`, in plural. This is because the backend code was prepared for handing an array, not a single value. The single value produces an error, even for Cases (not only for awards).
Potentially, the different activities received in the URL could be associated with different category names, but I am assuming that will be always the same. The solution, to my criteria, is good enough, in the sense that solves existing problems and do not create new ones, but we still need be more precise in which we are going to send to the BE in this activity param.

