### PR TITLE
RSE-1600: Support for instance specific Action Items

### DIFF
--- a/ang/civicase-base/providers/workflow-list-action-items.provider.js
+++ b/ang/civicase-base/providers/workflow-list-action-items.provider.js
@@ -36,5 +36,6 @@
 /**
  * @typedef {object} ActionItemConfig
  * @property {string} templateUrl
+ * @property {boolean} onlyVisibleForInstance
  * @property {number} weight
  */

--- a/ang/test/workflow/directives/workflow-list.directive.spec.js
+++ b/ang/test/workflow/directives/workflow-list.directive.spec.js
@@ -21,6 +21,12 @@
       }
     ];
 
+    const applicantManagementActionItem = {
+      templateUrl: '~/test-action.html',
+      onlyVisibleForInstance: 'applicant_management',
+      weight: 1
+    };
+
     describe('basic tests', () => {
       beforeEach(() => {
         injectModulesAndDependencies();
@@ -47,8 +53,18 @@
           expect($scope.workflows).toEqual(CaseTypesMockData.getSequential());
         });
 
-        it('displays the action items dropdown', () => {
-          expect($scope.actionItems).toEqual(WorkflowListActionItems);
+        describe('action items', () => {
+          var expectedActionItems;
+
+          beforeEach(() => {
+            expectedActionItems = _.filter(WorkflowListActionItems, function (actionItem) {
+              return actionItem.onlyVisibleForInstance !== 'applicant_management';
+            });
+          });
+
+          it('displays the action items only meant for current instance', () => {
+            expect($scope.actionItems).toEqual(expectedActionItems);
+          });
         });
 
         it('displays the columns', () => {
@@ -109,8 +125,9 @@
      */
     function initSpyModule () {
       angular.module('civicase.spy', ['civicase-base'])
-        .config((WorkflowListFiltersProvider) => {
+        .config((WorkflowListFiltersProvider, WorkflowListActionItemsProvider) => {
           WorkflowListFiltersProvider.addItems(testFilters);
+          WorkflowListActionItemsProvider.addItems([applicantManagementActionItem]);
         });
     }
 

--- a/ang/workflow/directives/workflow-list.directive.js
+++ b/ang/workflow/directives/workflow-list.directive.js
@@ -30,7 +30,7 @@
     $scope.ts = ts;
     $scope.isLoading = false;
     $scope.workflows = [];
-    $scope.actionItems = WorkflowListActionItems;
+    $scope.actionItems = filterArrayForCurrentInstance(WorkflowListActionItems);
     $scope.tableColumns = filterArrayForCurrentInstance(WorkflowListColumns);
     $scope.filters = filterArrayForCurrentInstance(WorkflowListFilters);
     $scope.selectedFilters = {};


### PR DESCRIPTION
## Overview
As part of this PR, support for instance specific Action Items in Workflow List is added.
This PR is related to https://github.com/compucorp/uk.co.compucorp.civiawards/pull/167

## Before/After
There are no UI changes for Edit Workflow page(for Case Management instance).

## Technical Details
In `ang/workflow/directives/workflow-list.directive.js`, a check is added to only show instance specific Action Items.