### PR TITLE
CPS-403: Fix Deprecated Case Permission

### DIFF
--- a/CRM/Civicase/Hook/NavigationMenu/AlterForCaseMenu.php
+++ b/CRM/Civicase/Hook/NavigationMenu/AlterForCaseMenu.php
@@ -85,7 +85,7 @@ class CRM_Civicase_Hook_NavigationMenu_AlterForCaseMenu {
         'label' => ts('CiviCase Webforms'),
         'name' => 'CiviCase Webforms',
         'url' => 'civicrm/case/webforms',
-        'permission' => 'access CiviCase',
+        'permission' => 'access all cases and activities',
         'operator' => 'OR',
         'separator' => 1,
         'parentID' => $caseID,


### PR DESCRIPTION
## Overview
Administer -> civicase -> civicase webforms this menu item was only visible for compucorp admin and not any other user. This was due to the fact that a deprecated permission was being used for this menu item. 

## Before
In file `CRM/Civicase/Hook/NavigationMenu/AlterForCaseMenu.php`  the above mentioned menu item was added with a permission of `access CiviCase` which has been deprecated so as a result this menu item was not visible to any user other than the default admin user.
![Screenshot from 2021-01-11 12-12-44](https://user-images.githubusercontent.com/68388745/104154639-34aa1c80-5407-11eb-876a-5f518dfcb6f2.png)

## After
This pr replaces deprecated permission by `access all cases and activities` which fixes the above mentioned issue
![Screenshot from 2021-01-11 12-12-16](https://user-images.githubusercontent.com/68388745/104154702-602d0700-5407-11eb-9ad0-f2f3dfc7a6ab.png)

