### PR TITLE
CATL-2031: Use date fields stored inside of relationship object

### DIFF
--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
@@ -259,8 +259,8 @@
       if (!isReplacingClient) {
         promptForContactParams.reassignmentDate = {
           maxDate: moment().format('YYYY-MM-DD'),
-          value: moment().isBefore(moment(role.start_date))
-            ? moment(role.start_date).format('YYYY-MM-DD')
+          value: moment().isBefore(moment(role.relationship.start_date))
+            ? moment(role.relationship.start_date).format('YYYY-MM-DD')
             : moment().format('YYYY-MM-DD')
         };
       }
@@ -301,7 +301,10 @@
             }
           },
           function (contactPromptResult) {
-            if (!isSameOrAfter(contactPromptResult.endDate, contactPromptResult.role.start_date)) {
+            if (!isSameOrAfter(
+              contactPromptResult.endDate,
+              contactPromptResult.role.relationship.start_date
+            )) {
               contactPromptResult.showErrorMessageFor(
                 'endDate',
                 PeoplesTabMessageConstants.RELATIONSHIP_END_DATE_MESSAGE
@@ -743,8 +746,13 @@
           isError = true;
         }
 
-        if (contactPromptResult.reassignmentDate &&
-          !isSameOrAfter(contactPromptResult.reassignmentDate, contactPromptResult.role.start_date)) {
+        if (
+          contactPromptResult.reassignmentDate &&
+          !isSameOrAfter(
+            contactPromptResult.reassignmentDate,
+            contactPromptResult.role.relationship.start_date
+          )
+        ) {
           contactPromptResult.showErrorMessageFor(
             'reassignmentDate',
             PeoplesTabMessageConstants.RELATIONSHIP_REASSIGNMENT_DATE_MESSAGE

--- a/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
+++ b/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
@@ -136,14 +136,12 @@
               description: caseTypeRole.description,
               desc: caseRelation.description,
               display_name: contact.display_name,
-              end_date: caseRelation.end_date,
               email: contact.email,
               is_active: caseRelation.is_active,
               phone: contact.phone,
               relationship_type_id: caseTypeRole.relationship_type_id,
               role: caseTypeRole.role,
               relationship: caseRelation,
-              start_date: caseRelation.start_date,
               previousValues: {
                 end_date: caseRelation.end_date,
                 start_date: caseRelation.start_date

--- a/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
@@ -131,7 +131,7 @@ describe('Case Details People Tab', () => {
             role: roleName,
             id: '101',
             relationship: {
-              start_date: moment().add(5, 'day'),
+              start_date: moment().add(5, 'day')
             }
           });
           selectDialogContact(contact);

--- a/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
@@ -129,8 +129,10 @@ describe('Case Details People Tab', () => {
             display_name: previousContact.display_name,
             relationship_type_id: relationshipTypeId,
             role: roleName,
-            start_date: moment().add(5, 'day'),
-            id: '101'
+            id: '101',
+            relationship: {
+              start_date: moment().add(5, 'day'),
+            }
           });
           selectDialogContact(contact);
           updateDialogModel({
@@ -158,8 +160,10 @@ describe('Case Details People Tab', () => {
             display_name: previousContact.display_name,
             relationship_type_id: relationshipTypeId,
             role: roleName,
-            start_date: moment().add(-1, 'day'),
-            id: '101'
+            id: '101',
+            relationship: {
+              start_date: moment().add(-1, 'day')
+            }
           });
           selectDialogContact(contact);
           updateDialogModel({
@@ -233,7 +237,10 @@ describe('Case Details People Tab', () => {
         var client = CRM._.first($scope.item.client);
         $scope.replaceRoleOrClient({
           relationship_type_id: relationshipTypeId,
-          role: roleName
+          role: roleName,
+          relationship: {
+            start_date: moment().format('YYYY-MM-DD')
+          }
         });
         selectDialogContact(CRM._.assign({}, client, {
           id: client.contact_id
@@ -472,7 +479,9 @@ describe('Case Details People Tab', () => {
             display_name: sampleContact.display_name,
             relationship_type_id: relationshipTypeId,
             role: 'Role',
-            start_date: moment().add(5, 'day')
+            relationship: {
+              start_date: moment().add(5, 'day')
+            }
           });
 
           updateDialogModel({
@@ -498,7 +507,9 @@ describe('Case Details People Tab', () => {
             display_name: sampleContact.display_name,
             relationship_type_id: relationshipTypeId,
             role: 'Role',
-            start_date: moment().add(-5, 'day')
+            relationship: {
+              start_date: moment().add(-5, 'day')
+            }
           });
 
           updateDialogModel({
@@ -535,7 +546,9 @@ describe('Case Details People Tab', () => {
             display_name: sampleContact.display_name,
             relationship_type_id: relationshipTypeId,
             role: 'Role',
-            start_date: moment().add(-5, 'day')
+            relationship: {
+              start_date: moment().add(-5, 'day')
+            }
           });
 
           updateDialogModel({

--- a/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
+++ b/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
@@ -102,13 +102,11 @@
             description: `Case Manager. ${caseTypeRole.name}`,
             desc: caseRelation.description,
             display_name: caseManager.display_name,
-            end_date: caseRelation.end_date,
             email: caseManager.email,
             is_active: caseRelation.is_active,
             phone: caseManager.phone,
             relationship_type_id: caseRelation.relationship_type_id,
             role: caseTypeRole.name,
-            start_date: caseRelation.start_date,
             relationship: jasmine.objectContaining(caseRelation),
             previousValues: {
               end_date: caseRelation.end_date,


### PR DESCRIPTION
## Overview
This PR fixes a bug where roles cannot be reassigned after updating the date for the existing role.

## Before
![pr](https://user-images.githubusercontent.com/1642119/104384722-52ab7600-5508-11eb-8675-75598eee3317.gif)

## After
![pr](https://user-images.githubusercontent.com/1642119/104385021-d9605300-5508-11eb-8122-2a032f109f73.gif)


## Technical Details
The problem is that we changed the model for the start date from `role.start_date` to `role.relationship.start_date` (same for end date) in this PR: https://github.com/compucorp/uk.co.compucorp.civicase/pull/581 but other uses for the start date were not updated. This PR fixes all other references to the date. 