### PR TITLE
RSE-1295: Override Case Type core screen functionality

### DIFF
--- a/ang/test/workflow/crm/case-type.controller.spec.js
+++ b/ang/test/workflow/crm/case-type.controller.spec.js
@@ -1,0 +1,121 @@
+/* eslint-env jasmine */
+
+(() => {
+  describe('workflow list', () => {
+    let $q, $controller, $rootScope, $scope, $window, CaseTypesMockData,
+      mockGotoFn, mockApiCalls, crmApiMock, crmApiReceievedInCaseTypeCtrl,
+      apiCallsReceievedInCaseTypeCtrl;
+
+    beforeEach(module('workflow', 'civicase.data', ($provide, $controllerProvider) => {
+      crmApiMock = jasmine.createSpy('crmApi');
+      $provide.value('crmApi', crmApiMock);
+
+      mockGotoFn = jasmine.createSpy('goto');
+      $controllerProvider.register('CaseTypeCtrl', function ($scope, crmApi, apiCalls) {
+        $scope.goto = mockGotoFn;
+        crmApiReceievedInCaseTypeCtrl = crmApi;
+        apiCallsReceievedInCaseTypeCtrl = apiCalls;
+      });
+
+      $provide.value('$window', { location: {} });
+
+      mockApiCalls = ['value1', 'value2'];
+    }));
+
+    beforeEach(inject((_$q_, _$controller_, _$rootScope_, _$window_,
+      _CaseTypesMockData_) => {
+      $q = _$q_;
+      $controller = _$controller_;
+      $rootScope = _$rootScope_;
+      $window = _$window_;
+      CaseTypesMockData = _CaseTypesMockData_;
+
+      var apiReturnValue = {
+        id: CaseTypesMockData.getSequential()[1].id,
+        values: [CaseTypesMockData.getSequential()[1]],
+        is_error: '0'
+      };
+      crmApiMock.and.returnValue($q.resolve(apiReturnValue));
+    }));
+
+    describe('basic tests', () => {
+      beforeEach(() => {
+        initController();
+
+        crmApiMock('CaseType', 'create', {});
+        $rootScope.$digest();
+      });
+
+      it('extends case type controller from core', () => {
+        expect(apiCallsReceievedInCaseTypeCtrl).toEqual(mockApiCalls);
+      });
+
+      describe('when clicked on Save button', () => {
+        describe('and case type is being saved', () => {
+          beforeEach(() => {
+            crmApiReceievedInCaseTypeCtrl('CaseType', 'create', {});
+
+            $rootScope.$digest();
+          });
+
+          it('saves the case type succesfully', () => {
+            expect($scope.caseType.id).toBe(CaseTypesMockData.getSequential()[1].id);
+          });
+
+          it('redirects the user the workflow list page', () => {
+            expect($window.location.href).toBe('/civicrm/workflow/a?case_type_category=Prospecting#/list');
+          });
+        });
+
+        describe('and other api calls are made', () => {
+          beforeEach(() => {
+            crmApiReceievedInCaseTypeCtrl('Contact', 'create', {}, 'message');
+
+            $rootScope.$digest();
+          });
+
+          it('calls the backend api in usual manner', () => {
+            expect(crmApiMock).toHaveBeenCalledWith('Contact', 'create', {}, 'message');
+          });
+        });
+      });
+
+      describe('when clicking on cancel button', () => {
+        describe('when creating a new workflow', () => {
+          beforeEach(() => {
+            $scope.caseType = {};
+            $scope.goto();
+          });
+
+          it('redirects to the core case type list screen', () => {
+            expect($window.location.href).toBe('/civicrm/a/#/caseType');
+          });
+        });
+
+        describe('when editing an existing workflow', () => {
+          beforeEach(() => {
+            $scope.caseType = CaseTypesMockData.getSequential()[0];
+            $scope.goto();
+          });
+
+          it('redirects to the core case type list screen', () => {
+            expect($window.location.href).toBe('/civicrm/workflow/a?case_type_category=Cases#/list');
+          });
+        });
+      });
+    });
+
+    /**
+     * Initializes the CivicaseCaseTypeController.
+     */
+    function initController () {
+      $scope = $rootScope.$new();
+      $scope.caseType = CaseTypesMockData.getSequential()[0];
+
+      $controller('CivicaseCaseTypeController', {
+        $scope,
+        apiCalls: mockApiCalls
+      });
+    }
+  });
+})();

--- a/ang/workflow.ang.php
+++ b/ang/workflow.ang.php
@@ -24,6 +24,7 @@ function get_workflow_js_files() {
 
 $requires = [
   'crmUi',
+  'crmCaseType',
   'ngRoute',
   'dialogService',
   'civicase-base',

--- a/ang/workflow/crm/case-type.controller.js
+++ b/ang/workflow/crm/case-type.controller.js
@@ -1,0 +1,97 @@
+(function ($, _, angular) {
+  var module = angular.module('workflow');
+
+  module.controller('CivicaseCaseTypeController', CivicaseCaseTypeController);
+
+  /**
+   * @param {object} $q angular queue service
+   * @param {Function} $controller controller service
+   * @param {object} $scope controller's scope object
+   * @param {Function} crmApi service to access civicrm api
+   * @param {Array} apiCalls api calls
+   * @param {object} $window browsers window object
+   * @param {object} CaseTypeCategory case type category service
+   */
+  function CivicaseCaseTypeController ($q, $controller, $scope, crmApi, apiCalls, $window, CaseTypeCategory) {
+    (function init () {
+      initParentController();
+    })();
+
+    $scope.goto = goto;
+
+    /**
+     * Creates a fake crmApi service, which is then feeded to `CaseTypeCtrl` in
+     * CiviCRM core's "modules/contrib/civicrm/ang/crmCaseType.js" file
+     *
+     * This is done, because we need to override the $scope.save function of
+     * the `CaseTypeCtrl` and redirect to a different url.
+     *
+     * This function applies a custom save logic when `CaseType.create` api is
+     * called, otherwise it calls the original `crmApi` service itself.
+     *
+     * @param {string} entity entity name
+     * @param {string} action action name
+     * @param {object} params paramters
+     * @param {string} message message
+     * @returns {Promise} promise
+     */
+    function fakeCrmApi (entity, action, params, message) {
+      if (entity === 'CaseType' && action === 'create') {
+        saveCaseType();
+
+        return $q.defer().promise;
+      } else {
+        return crmApi(entity, action, params, message);
+      }
+    }
+
+    /**
+     * Overrides the $rootScope.goto function from civicrm core
+     */
+    function goto () {
+      if ($scope.caseType.id) {
+        $window.location.href = getUrlToManageWorkflowPage($scope.caseType.case_type_category);
+      } else {
+        $window.location.href = '/civicrm/a/#/caseType';
+      }
+    }
+
+    /**
+     * Initialise the CaseTypeCtrl controller
+     */
+    function initParentController () {
+      $controller('CaseTypeCtrl', {
+        $scope: $scope,
+        crmApi: fakeCrmApi,
+        apiCalls: apiCalls
+      });
+    }
+
+    /**
+     * Saves the case type
+     * The logic is similar to the save function of `CaseTypeCtrl` in
+     * CiviCRM core's "modules/contrib/civicrm/ang/crmCaseType.js" file.
+     * Only the redirection url is different.
+     */
+    function saveCaseType () {
+      var result = crmApi('CaseType', 'create', $scope.caseType, true);
+
+      result.then(function (data) {
+        if (data.is_error === 0 || data.is_error === '0') {
+          $scope.caseType.id = data.id;
+          $window.location.href = getUrlToManageWorkflowPage(Object.values(data.values)[0].case_type_category);
+        }
+      });
+    }
+
+    /**
+     * @param {string} caseTypeCategoryId case type category id
+     * @returns {string} url
+     */
+    function getUrlToManageWorkflowPage (caseTypeCategoryId) {
+      var caseTypeCategoryName = CaseTypeCategory.findById(caseTypeCategoryId).name;
+
+      return '/civicrm/workflow/a?case_type_category=' + caseTypeCategoryName + '#/list';
+    }
+  }
+})(CRM.$, CRM._, angular);

--- a/ang/workflow/crm/override-case-type.config.js
+++ b/ang/workflow/crm/override-case-type.config.js
@@ -1,0 +1,14 @@
+(function (angular) {
+  var module = angular.module('workflow');
+
+  module.config(function ($provide) {
+    $provide.decorator('$route', function ($delegate) {
+      // Changing the controller of the following route to override the core
+      // functionality
+      var caseTypeEditRoute = $delegate.routes['/caseType/:id'];
+      caseTypeEditRoute.controller = 'CivicaseCaseTypeController';
+
+      return $delegate;
+    });
+  });
+})(angular);

--- a/templates/CRM/Civicase/ChangeSet/CaseTypeCategory.html
+++ b/templates/CRM/Civicase/ChangeSet/CaseTypeCategory.html
@@ -1,6 +1,7 @@
-<div crm-ui-field="{name: 'caseTypeDetailForm.caseTypeCategory', title: ts('Instance')}">
+<div crm-ui-field="{name: 'caseTypeDetailForm.caseTypeCategory', title: ts('Instance'), required: true}">
   <input
     name="caseTypeCategory"
+    required="true"
     crm-ui-id="caseType.case_type_category"
     ng-model="caseType.case_type_category"
     crm-entityref="{


### PR DESCRIPTION
## Overview
When clicked on the Save or Cancel button, in the New/Edit Case Type screen, the browser redirects to the Core Case Type List screen. This has been changed to redirect to the New Manage Workflow screen for each Case Type Category. But while creating a new Case Type, if Cancel is pressed, the old functionality still remains, as the Case Type Category cannot be determined at this stage.

## Before/After
No UI Changes.

## Technical Details
1. In `ang/workflow.ang.php`, core module `crmCaseType` is added as a dependency, so that the functionality can be overridden.

2. In `ang/workflow/crm/override-case-type.config.js`, the core route `/caseType/:id` has been edited, to assign a new controller `CivicaseCaseTypeController`.

3. A new controller `CivicaseCaseTypeController` has been created. This controller extends the core `CaseTypeCtrl` controller. But it overrides 2 things
   - It overrides the `goto` function to implement new redirect url for the `Cancel` button.
   - It feeds the `CaseTypeCtrl` with a fake `crmApi` function. 
       - When trying to create a CaseType, this function applies a new redirect url.
       - If not, it calls the original `crmApi`.

## Update
Also made the "Instance" field mandatory.

### Before
![2021-01-27 at 12 42 PM](https://user-images.githubusercontent.com/5058867/105956028-2ca3db00-609d-11eb-90f1-bdfea5b236a4.png)

### After
![2021-01-27 at 12 42 PM](https://user-images.githubusercontent.com/5058867/105955959-1433c080-609d-11eb-9954-1b9aa2632c6c.png)
