### PR TITLE
RSE-1565: Fix logic for showing Milestone Activities

### DIFF
--- a/ang/civicase/dashboard/directives/dashboard-tab.directive.js
+++ b/ang/civicase/dashboard/directives/dashboard-tab.directive.js
@@ -93,7 +93,7 @@
         cardRefresh: activityCardRefreshActivities
       },
       handlers: {
-        range: _.curry(rangeHandler)('activity_date_time')('YYYY-MM-DD HH:mm:ss')(false),
+        range: _.curry(rangeHandler)('activity_date_time')('YYYY-MM-DD HH:mm:ss'),
         results: _.curry(resultsHandler)(formatActivity)('case_id.contacts')
       }
     };
@@ -112,7 +112,7 @@
         cardRefresh: activityCardRefreshMilestones
       },
       handlers: {
-        range: _.curry(rangeHandler)('activity_date_time')('YYYY-MM-DD HH:mm:ss')(true),
+        range: _.curry(rangeHandler)('activity_date_time')('YYYY-MM-DD HH:mm:ss'),
         results: _.curry(resultsHandler)(formatActivity)('case_id.contacts')
       }
     };
@@ -130,7 +130,7 @@
         params: getQueryParams('cases')
       },
       handlers: {
-        range: _.curry(rangeHandler)('start_date')('YYYY-MM-DD')(false),
+        range: _.curry(rangeHandler)('start_date')('YYYY-MM-DD'),
         results: _.curry(resultsHandler)(formatCase)('contacts')
       }
     };
@@ -309,14 +309,12 @@
      * @param {string} property the property where the information about the
      *   date is stored
      * @param {string} format the date format
-     * @param {boolean} useNowAsStart whether the starting point should be the
-     *   current datetime
      * @param {string} selectedRange the currently selected period range
      * @param {object} queryParams params
      */
-    function rangeHandler (property, format, useNowAsStart, selectedRange, queryParams) {
+    function rangeHandler (property, format, selectedRange, queryParams) {
       var now = moment();
-      var start = (useNowAsStart ? now : now.startOf(selectedRange)).format(format);
+      var start = now.startOf(selectedRange).format(format);
       var end = now.endOf(selectedRange).format(format);
 
       queryParams[property] = { BETWEEN: [start, end] };

--- a/ang/test/civicase/dashboard/directives/dashboard-tab.directive.spec.js
+++ b/ang/test/civicase/dashboard/directives/dashboard-tab.directive.spec.js
@@ -466,7 +466,7 @@
               it('filters by `activity_date_time` between today and end of the current week', function () {
                 expect($scope.newMilestonesPanel.query.params.activity_date_time).toBeDefined();
                 expect($scope.newMilestonesPanel.query.params.activity_date_time).toEqual({
-                  BETWEEN: getStartEndOfRange('week', 'YYYY-MM-DD HH:mm:ss', true)
+                  BETWEEN: getStartEndOfRange('week', 'YYYY-MM-DD HH:mm:ss')
                 });
               });
             });
@@ -479,7 +479,7 @@
               it('filters by `activity_date_time` between today and end of the current month', function () {
                 expect($scope.newMilestonesPanel.query.params.activity_date_time).toBeDefined();
                 expect($scope.newMilestonesPanel.query.params.activity_date_time).toEqual({
-                  BETWEEN: getStartEndOfRange('month', 'YYYY-MM-DD HH:mm:ss', true)
+                  BETWEEN: getStartEndOfRange('month', 'YYYY-MM-DD HH:mm:ss')
                 });
               });
             });
@@ -911,12 +911,11 @@
      *
      * @param {string} range range
      * @param {string} format format
-     * @param {string} useNowAsStart use now as start
      * @returns {Array} stand and end date
      */
-    function getStartEndOfRange (range, format, useNowAsStart) {
+    function getStartEndOfRange (range, format) {
       var now = moment();
-      var start = (useNowAsStart ? now : now.startOf(range)).format(format);
+      var start = now.startOf(range).format(format);
       var end = now.endOf(range).format(format);
 
       return [start, end];

--- a/api/v3/Activity/Getcontactactivitiescount.php
+++ b/api/v3/Activity/Getcontactactivitiescount.php
@@ -1,12 +1,40 @@
 <?php
 
 /**
+ * @file
+ * Activity.getcontactactivitiescount file.
+ */
+
+/**
+ * Defines the fields for the "getcontactactivitiescount" action api.
+ *
+ * The case id, contact id, and return fields are set to be required.
+ *
+ * @param array $params
+ *   Parameters.
+ */
+function _civicrm_api3_activity_getcontactactivitiescount_spec(array &$params) {
+  _civicrm_api3_activity_get_spec($params);
+
+  $params['contact_id']['api.required'] = TRUE;
+  $params['return'] = [
+    'api.required' => TRUE,
+    'api.default' => "assignee_contact_id",
+    'name' => 'return',
+    'title' => 'Return fields',
+    'description' => 'The "assignee_contact_id" field is required for this action.',
+  ];
+}
+
+/**
  * Returns the activity count for the given contact.
  *
- * @see civicrm_api3_activity_getcontactactivities
  * @param array $params
+ *   Parameters.
+ *
+ * @see civicrm_api3_activity_getcontactactivities
  */
-function civicrm_api3_activity_getcontactactivitiescount($params) {
+function civicrm_api3_activity_getcontactactivitiescount(array $params) {
   $contactActivitySelector = new CRM_Civicase_Activity_ContactActivitiesSelector();
 
   return $contactActivitySelector->getActivitiesForContactCount($params);


### PR DESCRIPTION
## Overview
In the Case(or any other Instance) Dashboard, the milestone activities were not shown. This PR fixes that.

## Before
![2021-01-19 at 3 08 PM](https://user-images.githubusercontent.com/5058867/105016011-2643ac80-5a68-11eb-9818-fab7904de070.png)

## After
![2021-01-19 at 3 07 PM](https://user-images.githubusercontent.com/5058867/105015964-1af08100-5a68-11eb-977a-3c2937cf3817.png)

## Technical Details
This is caused by https://github.com/compucorp/uk.co.compucorp.civicase/pull/551/files#diff-e944ee6f08041bf15a7bf9bd1680b6a516d69c0973b4f9e59f0d53f099a2db0cR536, when we first introduced a `modified_date` filter. But internally the issue with Date filter was always present.

In `ang/civicase/dashboard/directives/dashboard-tab.directive.js`, only for `Milestone` block, the start time was added as the Current Date and Time of the system. But for other blocks, the Start time of the Week(or the selected date filter) is considered. And because of this, all the activities, before the current time, was not shown. 
Tried to go back in Git history, but could not find any reason of this specific logic for Milestone block. So now applying the same logic for all blocks in Dashboard.

## Fixed `Activity.getcontactactivitiescount` API
This api did not return correct values when `contact_id: "user_contact_id"` was sent. Because when sending `contact_id=user_contact_id`, the value was not getting converted to the original contact values. Hence added `_civicrm_api3_activity_getcontactactivitiescount_spec` function which takes care of this.
