### PR TITLE
CPS-366: Fix Custom Group Ordering

### DIFF
--- a/ang/civicase/case/details/summary-tab/directives/case-summary-custom-data.directive.html
+++ b/ang/civicase/case/details/summary-tab/directives/case-summary-custom-data.directive.html
@@ -1,7 +1,7 @@
 <div class="clearfix civicase__summary-tab-tile-container civicase__case-custom-fields__container">
   <civicase-masonry-grid>
     <civicase-masonry-grid-item
-      ng-repeat="(index, customGroup) in customData"
+      ng-repeat="(index, customGroup) in customData | orderBy: 'weight'"
       ng-if="!customGroup.isHidden">
       <div class="panel panel-default civicase__panel-transparent-header">
         <div class="panel-heading">

--- a/ang/civicase/case/factories/get-case-query-params.factory.js
+++ b/ang/civicase/case/factories/get-case-query-params.factory.js
@@ -24,8 +24,9 @@
       var caseListReturnParams = ['case_type_id', 'start_date', 'end_date', 'status_id', 'contacts', 'subject'];
       var customValuesReturnParams = [
         'custom_group.id', 'custom_group.name', 'custom_group.title',
-        'custom_field.name', 'custom_field.label', 'custom_value.display',
-        'custom_group.style'
+        'custom_group.weight', 'custom_group.style',
+        'custom_field.name', 'custom_field.label',
+        'custom_value.display'
       ];
       var relationshipReturnParams = ['id', 'relationship_type_id', 'contact_id_a',
         'contact_id_b', 'description', 'end_date', 'is_active', 'start_date'];

--- a/ang/test/civicase/case/factories/get-case-query-params.factory.spec.js
+++ b/ang/test/civicase/case/factories/get-case-query-params.factory.spec.js
@@ -114,8 +114,9 @@
             entity_type: 'Case',
             return: [
               'custom_group.id', 'custom_group.name', 'custom_group.title',
-              'custom_field.name', 'custom_field.label', 'custom_value.display',
-              'custom_group.style'
+              'custom_group.weight', 'custom_group.style',
+              'custom_field.name', 'custom_field.label',
+              'custom_value.display'
             ]
           },
           // Relationship description field


### PR DESCRIPTION
## Overview
In the Case Details section, the Custom Groups were not displayed in order of their "weight". This PR fixes that.

## Before
![2021-01-20 at 3 18 PM](https://user-images.githubusercontent.com/5058867/105157221-c2d28100-5b32-11eb-8e70-a8ad45cc75d6.png)

![2021-01-20 at 3 18 PM](https://user-images.githubusercontent.com/5058867/105157249-cb2abc00-5b32-11eb-81c8-a24dc8cf8d99.png)

## After
![2021-01-20 at 3 18 PM](https://user-images.githubusercontent.com/5058867/105157167-b51cfb80-5b32-11eb-89b1-7e1659d4b110.png)

![2021-01-20 at 3 17 PM](https://user-images.githubusercontent.com/5058867/105157129-ad5d5700-5b32-11eb-98e2-e279116a0f45.png)

## Technical Details
In `ang/civicase/case/factories/get-case-query-params.factory.js`, added 'custom_group.weight'` so that the weight is fetched in the frontend.

In `ang/civicase/case/details/summary-tab/directives/case-summary-custom-data.directive.html`, added sorting
`ng-repeat="(index, customGroup) in customData | orderBy: 'weight'"`