### PR TITLE
CATL-2030: Add date range limits to role inline date pickers

### DIFF
--- a/ang/civicase-base/directives/inline-datepicker.directive.js
+++ b/ang/civicase-base/directives/inline-datepicker.directive.js
@@ -35,6 +35,8 @@
           onChangeMonthYear: removeDatePickerHrefs,
           onClose: handleDatePickerClose
         });
+
+        watchMinMaxDateRangeLimits();
       })();
 
       /**
@@ -109,6 +111,39 @@
         } catch (exception) {
           return false;
         }
+      }
+
+      /**
+       * Updates either the minium or maximum date values for the datepicker.
+       *
+       * @param {string} dateRangeFieldName the name of the range to update.
+       * It should be either "minDate" or "maxDate".
+       */
+      function updateDatepickerRangeLimit (dateRangeFieldName) {
+        var fieldDateValue = attributes[dateRangeFieldName];
+
+        if (!fieldDateValue) {
+          return;
+        }
+
+        var dateObject = moment(fieldDateValue).toDate();
+
+        element.datepicker('option', dateRangeFieldName, dateObject);
+      }
+
+      /**
+       * Watches for changes to the min and max date range values and updates
+       * the inline datepicker so it uses these limits.
+       */
+      function watchMinMaxDateRangeLimits () {
+        attributes.$observe(
+          'minDate',
+          updateDatepickerRangeLimit.bind(this, 'minDate')
+        );
+        attributes.$observe(
+          'maxDate',
+          updateDatepickerRangeLimit.bind(this, 'maxDate')
+        );
       }
     }
   });

--- a/ang/civicase/case/details/people-tab/directives/roles-tab.directive.html
+++ b/ang/civicase/case/details/people-tab/directives/roles-tab.directive.html
@@ -151,9 +151,10 @@
         </td>
         <td class="civicase__people-tab__table-column">
           <input
-            civicase-inline-datepicker
-            civicase-send-to-api-on-change
             class="form-control"
+            civicase-inline-datepicker
+            data-max-date="{{role.relationship.end_date}}"
+            civicase-send-to-api-on-change
             data-api-data="roleDatesUpdater.getApiCallsForStartDate(role, item.id)"
             data-on-api-data-sent="roleDatesUpdater.updatePreviousValue(role, 'start_date')"
             name="role_start_date"
@@ -165,9 +166,10 @@
         </td>
         <td class="civicase__people-tab__table-column">
           <input
-            civicase-inline-datepicker
-            civicase-send-to-api-on-change
             class="form-control"
+            civicase-inline-datepicker
+            data-min-date="{{role.relationship.start_date}}"
+            civicase-send-to-api-on-change
             data-api-data="roleDatesUpdater.getApiCallsForEndDate(role, item.id)"
             data-on-api-data-sent="roleDatesUpdater.updatePreviousValue(role, 'end_date')"
             name="role_end_date"

--- a/ang/test/civicase-base/directives/inline-datepicker.directive.spec.js
+++ b/ang/test/civicase-base/directives/inline-datepicker.directive.spec.js
@@ -164,14 +164,92 @@
       });
     });
 
+    describe('min and max dates', () => {
+      describe('minimum date limit', () => {
+        beforeEach(() => {
+          $scope.date = '1999-06-01';
+          $scope.minDate = '1999-01-01';
+
+          initDirective(`
+            data-min-date="{{minDate}}"
+          `);
+          $scope.$digest();
+        });
+
+        it('sets the minimum date as the provided value', () => {
+          expect($.fn.datepicker).toHaveBeenCalledWith(
+            'option',
+            'minDate',
+            new Date('1999-01-01')
+          );
+        });
+
+        describe('when the minimum date is updated', () => {
+          beforeEach(() => {
+            $scope.minDate = '1999-01-31';
+
+            $scope.$digest();
+          });
+
+          it('updates the minimum date limit', () => {
+            expect($.fn.datepicker).toHaveBeenCalledWith(
+              'option',
+              'minDate',
+              new Date('1999-01-31')
+            );
+          });
+        });
+      });
+
+      describe('maximum date limit', () => {
+        beforeEach(() => {
+          $scope.date = '1999-06-01';
+          $scope.maxDate = '1999-12-31';
+
+          initDirective(`
+            data-max-date="{{maxDate}}"
+          `);
+          $scope.$digest();
+        });
+
+        it('sets the maximum date as the provided value', () => {
+          expect($.fn.datepicker).toHaveBeenCalledWith(
+            'option',
+            'maxDate',
+            new Date('1999-12-31')
+          );
+        });
+
+        describe('when the maximum date is updated', () => {
+          beforeEach(() => {
+            $scope.maxDate = '1999-01-01';
+
+            $scope.$digest();
+          });
+
+          it('updates the minimum date limit', () => {
+            expect($.fn.datepicker).toHaveBeenCalledWith(
+              'option',
+              'maxDate',
+              new Date('1999-01-01')
+            );
+          });
+        });
+      });
+    });
+
     /**
      * Initialises the Inline Datepicker directive on an input element using
      * the global $scope variable.
+     *
+     * @param {string} extraAttributes custom attributes to add to the input
+     *   element alongside the inline datepicker directive.
      */
-    function initDirective () {
+    function initDirective (extraAttributes = '') {
       element = $compile(`
         <input
           civicase-inline-datepicker
+          ${extraAttributes}
           ng-model="date"
           type="text"
         />


### PR DESCRIPTION
## Overview

This PR adds minimum and maximum date limits to the inline date pickers for
case roles.

## Before
![pr](https://user-images.githubusercontent.com/1642119/105700467-45669200-5edf-11eb-8912-83590fd4b306.gif)

## After
![pr](https://user-images.githubusercontent.com/1642119/105700588-734bd680-5edf-11eb-8ff4-adf738bdc228.gif)

## Technical details

The `inline-datepicker.directive.js` directive now adds support for `min-date`
and `max-date` properties. These values are watched in case their values change.

The `roles-tab.directive.html` template was updated so it uses the new inline
datepicker features.
