### PR TITLE
RSE-1625: Fix disabled cases stats

### DIFF
--- a/api/v3/Case/Getstats.php
+++ b/api/v3/Case/Getstats.php
@@ -111,10 +111,14 @@ function civicrm_api3_case_getstats(array $params) {
  * @return array
  *   An API response containing the filtered case types.
  */
-function _civicrm_api3_case_getstats_get_case_types(array $params, $query) {
+function _civicrm_api3_case_getstats_get_case_types(array $params, CRM_Utils_SQL_Select $query) {
+  $isActiveCaseType = isset($params['case_type_id.is_active'])
+    ? $params['case_type_id.is_active']
+    : '1';
   $caseTypesParams = [
     'options' => ['limit' => 0],
     'return' => 'id',
+    'is_active' => $isActiveCaseType,
   ];
 
   $caseTypes = [];
@@ -138,7 +142,8 @@ function _civicrm_api3_case_getstats_get_case_types(array $params, $query) {
 
   if (empty($caseTypes)) {
     return civicrm_api3('CaseType', 'get', $caseTypesParams);
-  } else {
+  }
+  else {
     return $caseTypes;
   }
 }


### PR DESCRIPTION
## Overview
This PR fixes an issue where disabled cases are not properly represented on the cases dashboard stats.

## Before
![pr](https://user-images.githubusercontent.com/1642119/105786912-530a2f00-5f54-11eb-90ba-c6f2138247ac.gif)

## After
![pr](https://user-images.githubusercontent.com/1642119/105785866-4d134e80-5f52-11eb-90b7-01c214740a29.gif)

## Technical Details

The issue happened because `Case.getstats` doesn't automatically use filters related to case types. They need to be manually added. This is the reason we added the `is_active` parameter to the `$caseTypesParams` filters.

Also, all filters related to case types were moved to a `_civicrm_api3_case_getstats_get_case_types` function to avoid splitting blocks of related code and instead have them in a single function. More refactoring needs to be done on this function, but this is an improvement.


