### PR TITLE
RSE-1627: Update disabled cases filter label

### DIFF
--- a/ang/civicase/case/search/directives/search.directive.html
+++ b/ang/civicase/case/search/directives/search.directive.html
@@ -105,7 +105,7 @@
         ng-if="checkPerm('administer CiviCase') && isEnabled('case_type_id.is_active')"
         ng-model="filters['case_type_id.is_active']"
       >
-        {{ts('Show Cases from disabled Case Types')}}
+        {{ts('Only Show Disabled Cases')}}
       </div>
       <div ng-if="isEnabled('start_date')" class="civicase__case-filter-form-elements">
         <label>{{ ts('Case Start Date') }}</label>


### PR DESCRIPTION
## Overview
This PR updates the label for the new filter for disabled cases.

The reason for changing the label is that this makes it more explicit to the user that **only** disabled cases will be displayed instead of both enabled and disabled cases.

This PR is related to https://github.com/compucorp/uk.co.compucorp.civiawards/pull/178

## Before

<img width="1343" alt="Screen Shot 2021-01-25 at 11 13 43 AM" src="https://user-images.githubusercontent.com/1642119/105796119-82289c80-5f64-11eb-931a-84d3eb1a0c3a.png">

## After
<img width="959" alt="Screen Shot 2021-01-25 at 11 19 26 PM" src="https://user-images.githubusercontent.com/1642119/105796125-8654ba00-5f64-11eb-9213-340ad41ed0e7.png">


## Technical Details

The `ang/civicase/case/search/directives/search.directive.html` template was updated. No other changes to the code were needed.
