### PR TITLE
CATL-1387: Add Contact Reference Fields To Column Header

### DIFF
--- a/CRM/Civicase/Form/Report/BaseExtendedReport.php
+++ b/CRM/Civicase/Form/Report/BaseExtendedReport.php
@@ -47,6 +47,15 @@ abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_
    */
   protected $dateGroupingOptions = ['month' => 'Month', 'year' => 'Year'];
 
+
+  /**
+   * Aggregate column html types.
+   *
+   * @var array
+   */
+  private $aggregateColumnHtmlTypes =
+    ['Select', 'Radio', 'Autocomplete-Select', 'CheckBox'];
+
   /**
    * CRM_Civicase_Form_Report_BaseExtendedReport constructor.
    */
@@ -165,7 +174,10 @@ abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_
         $this->metaData['filters'][$fieldName] = $this->metaData['metadata'][$fieldName];
         $customFieldTitle = $customField['prefix_label'] . $customField['title'] . ' - ' . $customField['label'];
         $aggregateRowHeaderFields[$fieldName] = $customFieldTitle;
-        if (in_array($customField['html_type'], ['Select', 'CheckBox'])) {
+        if (in_array(
+          $customField['html_type'],
+          $this->aggregateColumnHtmlTypes
+        )) {
           $aggregateColumnHeaderFields[$fieldName] = $customFieldTitle;
         }
       }
@@ -309,9 +321,10 @@ abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_
       'type' => $this->getFieldType($field),
       'dbAlias' => $prefix . $field['table_key'] . '.' . $field['column_name'],
       'alias' => $prefix . $field['table_name'] . '_' . 'custom_' . $field['id'],
+      'filter' => $field['filter'],
     ]);
     $field['is_aggregate_columns'] =
-      in_array($field['html_type'], ['Select', 'Radio']);
+      in_array($field['html_type'], $this->aggregateColumnHtmlTypes);
 
     if (!empty($field['option_group_id'])) {
       if (in_array($field['html_type'], [
@@ -521,6 +534,254 @@ abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_
   }
 
   /**
+   * Get used options for column.
+   *
+   * @param string $dbAlias
+   *   Db alias.
+   * @param string $fieldName
+   *   Field name.
+   *
+   * @return array
+   *   Used options for column.
+   */
+  private function getUsedOptions($dbAlias, $fieldName) {
+    if (!empty($this->_having)) {
+      $having = "{$this->_having} AND COUNT(*) > 0";
+    }
+    else {
+      $having = "HAVING COUNT(*) > 0";
+    }
+    $query = "SELECT {$dbAlias} {$this->_from} {$this->_where} GROUP BY {$dbAlias} {$having}";
+    $dao = CRM_Core_DAO::executeQuery($query);
+    $result = $dao->fetchAll();
+    $validOptions = [];
+    foreach ($result as $option) {
+      if (!empty($option[$fieldName])) {
+        if (strpos($option[$fieldName], CRM_Core_DAO::VALUE_SEPARATOR) !== FALSE) {
+          $multiOptions = explode(
+            CRM_Core_DAO::VALUE_SEPARATOR,
+            trim($option[$fieldName], CRM_Core_DAO::VALUE_SEPARATOR)
+          );
+          foreach ($multiOptions as $opt) {
+            $validOptions[$opt] = TRUE;
+          }
+        }
+        else {
+          $validOptions[$option[$fieldName]] = TRUE;
+        }
+      }
+    }
+
+    return $validOptions;
+  }
+
+  /**
+   * Build the report query.
+   *
+   * @param bool $applyLimit
+   *   Limit should be applied or not.
+   *
+   * @return string
+   *   Report query.
+   */
+  public function buildQuery($applyLimit = TRUE) {
+    if (empty($this->_params)) {
+      $this->_params = $this->controller->exportValues($this->_name);
+    }
+    $this->buildGroupTempTable();
+    $this->storeJoinFiltersArray();
+    $this->storeWhereHavingClauseArray();
+    $this->storeGroupByArray();
+    $this->storeOrderByArray();
+    $this->select();
+    $this->from();
+    $this->where();
+    $this->extendedCustomDataFrom();
+    $this->aggregateSelect();
+
+    if ($this->isInProcessOfPreconstraining()) {
+      $this->generateTempTable();
+      $this->_preConstrained = TRUE;
+      $this->select();
+      $this->from();
+      $this->extendedCustomDataFrom();
+      $this->constrainedWhere();
+      $this->aggregateSelect();
+    }
+    $this->orderBy();
+    $this->groupBy();
+
+    if ($applyLimit && !CRM_Utils_Array::value('charts', $this->_params)) {
+      if (!empty($this->_params['number_of_rows_to_render'])) {
+        $this->_dashBoardRowCount = $this->_params['number_of_rows_to_render'];
+      }
+      $this->limit();
+    }
+
+    CRM_Utils_Hook::alterReportVar('sql', $this, $this);
+    $sql = "{$this->_select} {$this->_from} {$this->_where} {$this->_groupBy} {$this->_having} {$this->_orderBy} ";
+    if (!$this->_rollup) {
+      $sql .= $this->_limit;
+    }
+
+    return $sql;
+  }
+
+  /**
+   * Get custom fields.
+   *
+   * @param mixed $extends
+   *   Extend list.
+   *
+   * @return array
+   *   Custom data.
+   */
+  protected function getCustomDataDAOs($extends) {
+    $extendsKey = implode(',', $extends);
+    if (isset($this->customDataDAOs[$extendsKey])) {
+      return $this->customDataDAOs[$extendsKey];
+    }
+    $customGroupWhere = '';
+    if (!$this->userHasAllCustomGroupAccess()) {
+      $permissionedCustomGroupIDs = CRM_ACL_API::group(CRM_Core_Permission::VIEW, NULL, 'civicrm_custom_group', NULL, NULL);
+      if (empty($permissionedCustomGroupIDs)) {
+        return [];
+      }
+      $customGroupWhere = "cg.id IN (" . implode(',', $permissionedCustomGroupIDs) . ") AND";
+    }
+    $extendsMap = [];
+    $extendsEntities = array_flip($extends);
+    foreach (array_keys($extendsEntities) as $extendsEntity) {
+      if (in_array($extendsEntity, [
+        'Individual',
+        'Household',
+        'Organziation',
+      ])) {
+        $extendsEntities['Contact'] = TRUE;
+        unset($extendsEntities[$extendsEntity]);
+      }
+    }
+    foreach ($this->_columns as $table => $spec) {
+      $entityName = (isset($spec['bao']) ? CRM_Core_DAO_AllCoreTables::getBriefName(str_replace('BAO', 'DAO', $spec['bao'])) : '');
+      if ($entityName && in_array($entityName, $extendsEntities)) {
+        $extendsMap[$entityName][$spec['prefix']] = $spec['prefix_label'];
+      }
+    }
+    $extendsString = implode("','", $extends);
+    $sql = "
+        SELECT cg.table_name, cg.title, cg.extends, cf.id as cf_id, cf.label,
+               cf.column_name, cf.data_type, cf.html_type, cf.option_group_id, cf.time_format, cf.filter
+        FROM   civicrm_custom_group cg
+        INNER  JOIN civicrm_custom_field cf ON cg.id = cf.custom_group_id
+        WHERE cg.extends IN ('" . $extendsString . "') AND
+          {$customGroupWhere}
+          cg.is_active = 1 AND
+          cf.is_active = 1 AND
+          cf.is_searchable = 1
+          ORDER BY cg.weight, cf.weight";
+    $customDAO = CRM_Core_DAO::executeQuery($sql);
+
+    $curTable = NULL;
+    $fields = [];
+    while ($customDAO->fetch()) {
+      $entityName = $customDAO->extends;
+      if (in_array($entityName, ['Individual', 'Household', 'Organization'])) {
+        $entityName = 'Contact';
+      }
+      foreach ($extendsMap[$entityName] as $prefix => $label) {
+        $fields[$prefix . $customDAO->column_name] = [
+          'title' => $customDAO->title,
+          'extends' => $customDAO->extends,
+          'id' => $customDAO->cf_id,
+          'label' => $customDAO->label,
+          'table_label' => $customDAO->title,
+          'column_name' => $customDAO->column_name,
+          'data_type' => $customDAO->data_type,
+          'dataType' => $customDAO->data_type,
+          'html_type' => $customDAO->html_type,
+          'option_group_id' => $customDAO->option_group_id,
+          'time_format' => $customDAO->time_format,
+          'prefix' => $prefix,
+          'table_key' => $prefix . $customDAO->table_name,
+          'prefix_label' => $label,
+          'table_name' => $customDAO->table_name,
+          'filter' => $customDAO->filter,
+        ];
+        $fields[$prefix . $customDAO->column_name]['type'] = $this->getFieldType($fields[$prefix . $customDAO->column_name]);
+      }
+    }
+    $this->customDataDAOs[$extendsKey] = $fields;
+
+    return $fields;
+  }
+
+  /**
+   * Returns options for a contact reference field.
+   *
+   * @param array $spec
+   *   Specifications.
+   * @param array $usedIds
+   *   List of used contact ids.
+   *
+   * @return array
+   *   Contact column options.
+   */
+  public function getContactColumnOptions(array $spec, array $usedIds) {
+    $options = $usedFilters = [];
+    parse_str($spec['filter'], $usedFilters);
+    unset($usedFilters['action']);
+    $usedFilters['return'] = ['id', 'display_name'];
+    $usedFilters['sequential'] = 1;
+    $usedFilters['options'] = ['limit' => 0];
+    $usedFilters['id'] = ['IN' => $usedIds];
+    try {
+      $contacts = civicrm_api3(
+        'Contact',
+        'get',
+        $usedFilters
+      );
+      if ($contacts['is_error'] === 0) {
+        $contacts = CRM_Utils_Array::value('values', $contacts);
+        foreach ($contacts as $contact) {
+          $options[$contact['id']] = $contact['display_name'];
+        }
+      }
+    }
+    catch (Throwable $ex) {
+    }
+
+    return $options;
+  }
+
+  /**
+   * Return used column options.
+   *
+   * @param array $spec
+   *   Specifications.
+   * @param string $fieldName
+   *   Field name.
+   *
+   * @return array
+   *   Used column options.
+   */
+  private function getFieldOptions(array $spec, $fieldName) {
+    if (CRM_Utils_Array::value('data_type', $spec) === 'ContactReference') {
+      $this->_aggregatesIncludeNULL = FALSE;
+      $usedIds = array_keys($this->getUsedOptions($spec['dbAlias'], $fieldName));
+      if (empty($usedIds)) {
+        return [];
+      }
+
+      return $this->getContactColumnOptions($spec, $usedIds);
+    }
+
+    return array_intersect_key(
+      $this->getCustomFieldOptions($spec),
+      $this->getUsedOptions($spec['dbAlias'], $fieldName)
+    );
+  }
+
+  /**
    * Add Select for pivot chart style report.
    *
    * @param string $fieldName
@@ -536,9 +797,11 @@ abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_
       return;
     }
     $spec['dbAlias'] = $dbAlias;
-    $options = $this->getCustomFieldOptions($spec);
+    $options = $this->getFieldOptions($spec, $fieldName);
 
-    if (!empty($this->_params[$fieldName . '_value']) && CRM_Utils_Array::value($fieldName . '_op', $this->_params) == 'in') {
+    if (!empty($this->_params[$fieldName . '_value'])
+      && CRM_Utils_Array::value($fieldName . '_op', $this->_params) == 'in'
+    ) {
       $options['values'] = array_intersect_key($options, array_flip($this->_params[$fieldName . '_value']));
     }
 


### PR DESCRIPTION
## Overview
This pr adds contact reference custom fields to the column header on the pivot reports. Secondly, it removes the options from columns which are not used yet.

## Before
Previously the contact reference custom fields were available only in the rows header not in the column headers.
![Peek 2021-02-03 15-58](https://user-images.githubusercontent.com/68388745/106738300-92620b00-6639-11eb-9eea-da0efe0fa1df.gif)
![Peek 2021-02-03 16-03](https://user-images.githubusercontent.com/68388745/106738313-95f59200-6639-11eb-8047-0beb606ec55f.gif)

## After
Now the contact reference fields are available in the column headers. Also the unused columns are removed now.
![Peek 2021-02-03 15-59](https://user-images.githubusercontent.com/68388745/106738333-9c840980-6639-11eb-8177-1a7892116912.gif)
![Peek 2021-02-03 16-04](https://user-images.githubusercontent.com/68388745/106738344-9f7efa00-6639-11eb-8e79-2f746ad0f066.gif)

## Technical Details
This pr makes a number of changes to the file ` CRM/Civicase/Form/Report/BaseExtendedReport.php` in order to remove the unused column values and also to include all the custom fields that are of type contact reference.

Note: There is a linter issue in this pr which is due to the fact that the code style is from an imported class from an external extension and we would not want to change that file.