### PR TITLE
ACU-489: Fix issues with Failing Form Tests

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/CaseCategoryCustomGroupDisplay.php
+++ b/CRM/Civicase/Hook/BuildForm/CaseCategoryCustomGroupDisplay.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * CRM_Civicase_Hook_BuildForm_CaseCategoryCustomGroupDisplay class.
+ * Case category custom group display build form hook class.
  */
 class CRM_Civicase_Hook_BuildForm_CaseCategoryCustomGroupDisplay {
 
@@ -60,7 +60,10 @@ class CRM_Civicase_Hook_BuildForm_CaseCategoryCustomGroupDisplay {
    */
   private function shouldRun($formName, CRM_Core_Form $form) {
     $defaults = $form->getVar('_defaults');
-    $extends = $defaults['extends'][0];
+    $extends = !empty($defaults['extends'][0]) ? $defaults['extends'][0] : [];
+    if (empty($extends)) {
+      return FALSE;
+    }
 
     return $formName == CRM_Custom_Form_Group::class &&
       $form->getVar('_action') != CRM_Core_Action::ADD &&


### PR DESCRIPTION
## Overview
In this PR https://github.com/compucorp/uk.co.compucorp.civiawards/pull/183, Some tests were added for the Award payments form. The Form tests calls some form hooks already added in the civicase extension and the tests was throwing some errors due to some non existent variables in the hooks. This PR fixes that.

