### PR TITLE
CATL-2082: Restrict Rows To Only Used Options

### DIFF
--- a/CRM/Civicase/Form/Report/ExtendedReport.php
+++ b/CRM/Civicase/Form/Report/ExtendedReport.php
@@ -6704,7 +6704,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
     $aggregateRowHeaderFields = $this->getAggregateRowFields();
 
     foreach ($this->_customGroupExtended as $key => $groupSpec) {
-      $customDAOs = $this->getCustomDataDAOs($groupSpec['extends']);
+      $customDAOs = $this->getCustomDataDaos($groupSpec['extends']);
       foreach ($customDAOs as $customField) {
         $tableKey = $customField['prefix'] . $customField['table_name'];
         $prefix = $customField['prefix'];
@@ -7385,7 +7385,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
    * @param array $extends
    */
   protected function addCustomDataForEntities($extends) {
-    $fields = $this->getCustomDataDAOs($extends);
+    $fields = $this->getCustomDataDaos($extends);
     foreach ($fields as $field) {
       $prefixLabel = trim(CRM_Utils_Array::value('prefix_label', $field));
       $prefix = trim(CRM_Utils_Array::value('prefix', $field));
@@ -7404,7 +7404,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
    *
    * @return array
    */
-  protected function getCustomDataDAOs($extends) {
+  protected function getCustomDataDaos($extends) {
     $extendsKey = implode(',', $extends);
     if (isset($this->customDataDAOs[$extendsKey])) {
       return $this->customDataDAOs[$extendsKey];

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -15,6 +15,8 @@
     <exclude name="Drupal.Classes.UseGlobalClass.RedundantUseStatement"/>
     <!-- These files are mainly auto generated and has some rules we want to exclude -->
     <exclude-pattern>tests/phpunit/bootstrap.php</exclude-pattern>
+    <!-- This file is from an external extension and we dont want to modify it  -->
+    <exclude-pattern>CRM/Civicase/Form/Report/ExtendedReport.php</exclude-pattern>
     <exclude-pattern>civicase.civix.php</exclude-pattern>
     <exclude-pattern>CRM/Civicase/DAO/*</exclude-pattern>
     <!-- Civicrm APi tests classes do have names beginning with lower case -->


### PR DESCRIPTION
## Overview
This pr removes a bug from pivot report that resulted in an out of memory error which happened when any custom field of type contact reference was selected as row header in the pivot report.

## Before
If a contact reference type custom field was selected as a row header in the report an error was thrown due to the fact that number of contacts were more than the memory limit.
![before](https://user-images.githubusercontent.com/68388745/107377614-fb032900-6b0c-11eb-902f-cfbf9d011ada.gif)

## After
This pr restricts the rows to only those contacts which has been used atleast once.
![after](https://user-images.githubusercontent.com/68388745/107377642-00f90a00-6b0d-11eb-9095-79e1bd425274.gif)

## Technical Details
This pr makes a number of changes to the file ` CRM/Civicase/Form/Report/BaseExtendedReport.php` in order to remove the unused row values.

Note: There is a linter issue in this pr which is due to the fact that the code style is from an imported class from an external extension and we would not want to change that file.
