### PR TITLE
ACU-494: Update date range directive

### DIFF
--- a/ang/civicase/shared/directives/ui-date-range.directive.html
+++ b/ang/civicase/shared/directives/ui-date-range.directive.html
@@ -1,8 +1,8 @@
 <div class="civicase__ui-range">
   <input
     class="form-control" crm-ui-datepicker="{time: false}"
-    ng-model="input.from" ng-placeholder="ts('From')"/>
+    ng-model="input.from" placeholder="From"/>
   <input
     class="form-control" crm-ui-datepicker="{time: false}"
-    ng-model="input.to" ng-placeholder="ts('To')"/>
+    ng-model="input.to" placeholder="To"/>
 </div>

--- a/ang/civicase/shared/directives/ui-date-range.directive.js
+++ b/ang/civicase/shared/directives/ui-date-range.directive.js
@@ -81,7 +81,6 @@
    * Controller for civicaseUiDateRange directive
    */
   module.controller('civicaseUiDateRangeController', function ($scope) {
-    $scope.ts = CRM.ts('civicase');
     $scope.input = {};
 
     $scope.$watchCollection('data', function () {

--- a/ang/civicase/shared/directives/ui-date-range.directive.js
+++ b/ang/civicase/shared/directives/ui-date-range.directive.js
@@ -22,26 +22,28 @@
      * if the `enforce-time` attribute is applied, any selected "from" date is
      * set with the time = 00:00:00 and any selected "to" date with the time = 23:59:59
      *
-     * @param {Object} $scope
-     * @param {Object} element
-     * @param {Object} attrs
+     * @param {object} $scope Scope object reference.
+     * @param {object} element Directive element reference.
+     * @param {object} attrs Element attributes map.
      */
     function civicaseUiDateRangeLink ($scope, element, attrs) {
-      var enforceTime = attrs.hasOwnProperty('enforceTime');
+      var enforceTime = Object.prototype.hasOwnProperty.call(attrs, 'enforceTime');
 
       // Respond to user interaction with the date widgets
       element.on('change', function (e, context) {
         if (context === 'userInput' || context === 'crmClear') {
           $timeout(function () {
             if ($scope.input.from && $scope.input.to) {
-              $scope.data = { BETWEEN: [
-                setAsRangeLimit($scope.input.from, 'lower'),
-                setAsRangeLimit($scope.input.to, 'upper')
-              ] };
+              $scope.data = {
+                BETWEEN: [
+                  setAsRangeLimit($scope.input.from, 'lower'),
+                  setAsRangeLimit($scope.input.to, 'upper')
+                ]
+              };
             } else if ($scope.input.from) {
-              $scope.data = {'>=': setAsRangeLimit($scope.input.from, 'lower')};
+              $scope.data = { '>=': setAsRangeLimit($scope.input.from, 'lower') };
             } else if ($scope.input.to) {
-              $scope.data = {'<=': setAsRangeLimit($scope.input.to, 'upper')};
+              $scope.data = { '<=': setAsRangeLimit($scope.input.to, 'upper') };
             } else {
               $scope.data = null;
             }
@@ -56,11 +58,11 @@
        * If the directive didn't have the `enforce-time` attribute applied, then
        * it will simply return the original value
        *
-       * @param {String} dateTime
+       * @param {string} dateTime
        *   could be either YYYY-MM-DD or YYYY-MM-DD HH:mm:ss
-       * @param {String} [limit="lower"]
+       * @param {string} [limit="lower"]
        *   whether the datetime should be set as the lower or upper limit
-       * @return {String}
+       * @returns {string} A date string
        */
       function setAsRangeLimit (dateTime, limit) {
         var date;
@@ -89,9 +91,9 @@
         $scope.input.from = $scope.data.BETWEEN[0];
         $scope.input.to = $scope.data.BETWEEN[1];
       } else if ($scope.data['>=']) {
-        $scope.input = {from: $scope.data['>=']};
+        $scope.input = { from: $scope.data['>='] };
       } else if ($scope.data['<=']) {
-        $scope.input = {to: $scope.data['<=']};
+        $scope.input = { to: $scope.data['<='] };
       }
     });
   });

--- a/ang/civicase/shared/directives/ui-date-range.directive.js
+++ b/ang/civicase/shared/directives/ui-date-range.directive.js
@@ -7,7 +7,8 @@
       restrict: 'E',
       replace: true,
       scope: {
-        data: '=dateRange'
+        data: '=dateRange',
+        onChange: '&'
       },
       templateUrl: '~/civicase/shared/directives/ui-date-range.directive.html',
       controller: 'civicaseUiDateRangeController',
@@ -94,6 +95,8 @@
       } else if ($scope.data['<=']) {
         $scope.input = { to: $scope.data['<='] };
       }
+
+      $scope.onChange();
     });
   });
 })(angular, CRM.$, CRM._, CRM);


### PR DESCRIPTION
## Overview
This PR fixes the following issues on the date range directive:

* The placeholders are now visible.
* Provide a way for people implementing the range directive to listen to change events. These can be used to trigger events when the dates change.

This PR is related to https://github.com/compucorp/uk.co.compucorp.civiawards/pull/186

## Before
<img width="291" alt="Screen Shot 2021-02-10 at 7 02 24 PM" src="https://user-images.githubusercontent.com/1642119/107584341-a4602280-6bd2-11eb-834f-5dbc99f3e05e.png">


## After
<img width="289" alt="Screen Shot 2021-02-10 at 7 03 01 PM" src="https://user-images.githubusercontent.com/1642119/107584398-c0fc5a80-6bd2-11eb-8346-b2603adc35d2.png">

For change event listener example please check the implementation on https://github.com/compucorp/uk.co.compucorp.civiawards/pull/186

## Technical Details

* Fixed lint issues. The change to `enforceTime` was suggested by the linter and has the same result.
* Placeholders no longer use the `ts` service since the underlying `crm-ui-datepicker` does not support dynamic placeholders. If we want to fix this we'd need to fix the core service which would put this ticket out of scope.
*  `onChange` is a callback property that implementers can use to listen to changes to the date picker. The reason for this is to avoid adding watchers to determine when the range value changed since there is already a watcher inside of this directive we can avoid incrementing the number of watchers.