### PR TITLE
ACU-495: Add civicase paging component

### DIFF
--- a/ang/civicase-base.ang.php
+++ b/ang/civicase-base.ang.php
@@ -196,7 +196,7 @@ function set_custom_fields_info_to_js_vars(&$options) {
 return [
   'js' => get_base_js_files(),
   'settings' => $options,
-  'requires' => ['crmUtil'],
+  'requires' => ['crmUtil', 'bw.paging'],
   'partials' => [
     'ang/civicase-base',
   ],

--- a/ang/civicase-base/directives/paging.html
+++ b/ang/civicase-base/directives/paging.html
@@ -1,0 +1,16 @@
+<paging
+  class="civicase__paging"
+  page="pagingData.page"
+  page-size="pagingData.pageSize"
+  total="pagingData.total"
+  adjacent="1"
+  dots="..."
+  disabled="{{ pagingData.isDisabled }}"
+  show-prev-next="true"
+  show-first-last="true"
+  text-first="&laquo;"
+  text-last="&raquo;"
+  text-next="&rsaquo;"
+  text-prev="&lsaquo;"
+  paging-action="pagingAction({ $page: page, $pageSize: pageSize, $total: total })"
+></paging>

--- a/ang/civicase-base/directives/paging.js
+++ b/ang/civicase-base/directives/paging.js
@@ -1,0 +1,23 @@
+(function (angular) {
+  var module = angular.module('civicase-base');
+
+  /**
+   * Paging directive.
+   *
+   * Usage:
+   *
+   * <civicase-paging
+   *   paging-data="{ page: 3, pageSize: 25, total: 100, isDisabled: false }"
+   *   paging-action="myPageChangeHandle($page, $pageSize, $total)"
+   * ></civicase-paging>
+   */
+  module.directive('civicasePaging', function () {
+    return {
+      templateUrl: '~/civicase-base/directives/paging.html',
+      scope: {
+        pagingData: '<',
+        pagingAction: '&'
+      }
+    };
+  });
+})(angular);


### PR DESCRIPTION
## Overview
This PR adds a pagination component that should be used throughout civicase and other extensions.

This PR is part of https://github.com/compucorp/uk.co.compucorp.civiawards/pull/188

## How it looks
<img width="226" alt="Screen Shot 2021-02-15 at 9 56 18 PM" src="https://user-images.githubusercontent.com/1642119/108009293-c5f94980-6fd8-11eb-8490-ca88446f1945.png">

## Usage

```html
<civicase-paging
  paging-data="{ page: 3, pageSize: 25, total: 100, isDisabled: false }"
  paging-action="myPageChangeHandle($page, $pageSize, $total)"
></civicase-paging>
```

## Technical Details

There are two reasons for creating this component:

1. Creating pagination is too verbose because of all the default parameters that need to be filled. An example of this is https://github.com/compucorp/uk.co.compucorp.civicase/pull/692/files#diff-fe4606fd0c0d06a47f3fb4a80357d9705ffd57497f09e468a4db14ed8e0f8b73R82-R97 where adding the properties text-first, text-last, text-next, etc must always be done when implementing pagination. We try to avoid having to do the repetition and at the same time enforce a standard.
2. The values passed to the `paging-action` callback have been prefixed with a `$` sign. Missing this prefix can be confusing because one might mistake the `page` value as being defined by us instead of the component, and more importantly if we have a `page` or `total` property in our directive the value might be replaced in the right circumstances. 
