### PR TITLE
CATL-2093: Remove Case Role Count From Token Tree

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/TokenTree.php
+++ b/CRM/Civicase/Hook/BuildForm/TokenTree.php
@@ -195,7 +195,6 @@ class CRM_Civicase_Hook_BuildForm_TokenTree {
    *   Restructured token tree.
    */
   private function addCaseRoleTokens(array $caseRoleTokens, array &$newTokenTree) {
-    $contactRoleCount = 0;
     $contactRoleTokens = [];
     foreach ($caseRoleTokens as $key => $token) {
       if ($token['id'] === '{case_roles.client}') {
@@ -203,10 +202,8 @@ class CRM_Civicase_Hook_BuildForm_TokenTree {
       }
       $roleName = explode('-', $token['text']);
       $roleName = $roleName[0];
-      $tokenName = 'Case Role ' . $contactRoleCount . ' "' . trim($roleName) . '"';
+      $tokenName = trim($roleName);
       if (empty($contactRoleTokens[$tokenName])) {
-        $contactRoleCount++;
-        $tokenName = 'Case Role ' . $contactRoleCount . ' "' . trim($roleName) . '"';
         $this->caseRolesTokenNames[] = $tokenName;
         $this->initializeTokenType($contactRoleTokens, $tokenName);
       }


### PR DESCRIPTION
## Overview
This pr removes the case role count from the token tree so if before if it was `Case Role 1 "Role Name"` no it is changed to `Role Name`

## Before
The role count existed
![Screenshot from 2021-02-16 16-59-21](https://user-images.githubusercontent.com/68388745/108061246-d9a8bc80-7079-11eb-8f5b-b2d4de68fcd7.png)

## After
The role count is removed
![Screenshot from 2021-02-16 17-59-16](https://user-images.githubusercontent.com/68388745/108066330-03191680-7081-11eb-8b92-c804dc541180.png)


## Technical Details
` CRM/Civicase/Hook/BuildForm/TokenTree.php` file was handling the logic for role count in token tree so it is removed from this file.