### PR TITLE
CATL-2096: Add Default Value To Relationship Id

### DIFF
--- a/CRM/Civicase/Service/CaseRoleCreationPreProcess.php
+++ b/CRM/Civicase/Service/CaseRoleCreationPreProcess.php
@@ -8,6 +8,17 @@ class CRM_Civicase_Service_CaseRoleCreationPreProcess extends CRM_Civicase_Servi
   /**
    * Function that handles pre-processing for a case related relationship.
    *
+   * @param array $requestParams
+   *   API request parameters.
+   */
+  public function onCreate(array &$requestParams) {
+    $this->processStartDate($requestParams);
+    $this->processRelationshipId($requestParams);
+  }
+
+  /**
+   * Process start_date param.
+   *
    * Basically, when the single case role per type setting is on and the
    * multiclient case setting is off, the start date for a case related
    * relationship is set to today's date.
@@ -15,12 +26,27 @@ class CRM_Civicase_Service_CaseRoleCreationPreProcess extends CRM_Civicase_Servi
    * @param array $requestParams
    *   API request parameters.
    */
-  public function onCreate(array &$requestParams) {
+  private function processStartDate(array &$requestParams) {
     if (
       $this->isSingleCaseRole && !$this->isMultiClient &&
       empty($requestParams['params']['start_date'])
     ) {
       $requestParams['params']['start_date'] = date('Y-m-d');
+    }
+  }
+
+  /**
+   * Adds a default value of false to relationship ID.
+   *
+   * The frontend code sends this parameter as false, then we fill it for
+   * ensuring the same behaviour of the related post handlers.
+   *
+   * @param array $requestParams
+   *   API request parameters.
+   */
+  private function processRelationshipId(array &$requestParams) {
+    if (isset($requestParams['params']) && !array_key_exists('id', $requestParams['params'])) {
+      $requestParams['params']['id'] = FALSE;
     }
   }
 

--- a/ang/civicase/case/factories/get-case-query-params.factory.js
+++ b/ang/civicase/case/factories/get-case-query-params.factory.js
@@ -111,6 +111,9 @@
           return: relationshipReturnParams,
           'api.Contact.get': {
             contact_id: '$value.contact_id_b'
+          },
+          options: {
+            limit: 0
           }
         },
         sequential: 1

--- a/ang/test/civicase/case/factories/get-case-query-params.factory.spec.js
+++ b/ang/test/civicase/case/factories/get-case-query-params.factory.spec.js
@@ -127,6 +127,9 @@
             'api.Contact.get': {
               contact_id: '$value.contact_id_b'
             },
+            options: {
+              limit: 0
+            },
             return: [
               'id', 'relationship_type_id', 'contact_id_a', 'contact_id_b',
               'description', 'end_date', 'is_active', 'start_date'

--- a/tests/phpunit/CRM/Civicase/Service/CaseRoleCreationPreProcessTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseRoleCreationPreProcessTest.php
@@ -48,6 +48,31 @@ class CRM_Civicase_Service_CaseRoleCreationPreProcessTest extends BaseHeadlessTe
   }
 
   /**
+   * Test relationship ID is filled when is not on request params.
+   */
+  public function testIdIsFilledWhenIsNotReceived() {
+    $this->setSingleCaseRoleSetting(FALSE);
+
+    $params = [];
+    $apiRequestParams = $this->callPreProcessCreate($params);
+
+    $this->assertArrayHasKey('id', $apiRequestParams['params']);
+    $this->assertFalse($apiRequestParams['params']['id']);
+  }
+
+  /**
+   * Test relationship ID is not replaced when is already present on params.
+   */
+  public function testIdIsNotReplacedWhenIsReceived() {
+    $this->setSingleCaseRoleSetting(FALSE);
+
+    $params = ['id' => rand()];
+    $apiRequestParams = $this->callPreProcessCreate($params);
+
+    $this->assertEquals($params['id'], $apiRequestParams['params']['id']);
+  }
+
+  /**
    * Call the case role pre process and return results.
    *
    * @param array $params


### PR DESCRIPTION
## Overview
This PR solves the problem observed while trying to update many consecutive times the relationships of a given case, using webforms.
Despite the problem occurs only when a webform is used, the error is related to the Pre and Post processes performed for the CaseRoles on the CiviCase package.

**UPDATE:**
This PR also contains the fix for another problem found during QA testing, related to People tab on Case view not showing the relationships correctly (despite they were correctly stored).

## Before
On the People tab of a given case, we can see the relationships with contacts. Example.: Case Manager, PI CaseWorker, etc
![image](https://user-images.githubusercontent.com/74304572/108233040-f75b4c00-7175-11eb-8da7-7fa20ba65ab4.png)

For a particular customer, these relationships can be changed using WebForms, like here:
![image](https://user-images.githubusercontent.com/74304572/108233274-2ffb2580-7176-11eb-92e4-79f950ebf808.png)

Before this change, a given contact can't be reassigned twice. In other words, having two contacts named `ContactA` and `ContactB`, if we assign for Case Manager one after the other, we will have these results.
Assign Case Manager to Contact A -> Ok
Assign Case Manager to Contact B -> Ok
Assign Case Manager to Contact A -> Fail

Also, after some re-assignations performed on the roles, the relationships stops to appear (all shown as unassigned)
![image](https://user-images.githubusercontent.com/74304572/108388933-b92b5e80-7241-11eb-9f07-8e38297cd737.png)


## After
Now the contact manager, case worker, or any other relationship, can be assigned as many times as needed.

## Technical Details
On our fork of the webform extension, we can see that the relationships for cases are being created here: https://github.com/compucorp/webform_civicrm/blob/7.x-5.x/includes/wf_crm_webform_postprocess.inc#L1301

We can see that the 'id' is not being passed, but in our fork of the core we are checking that value for knowing if we should validate the unicity of the relationship:
https://github.com/compucorp/civicrm-core/blob/master/CRM/Contact/BAO/Relationship.php#L54

The `!isset($params['id']) `, being the id equal to `false`, gives `false`, but when the param is not passed at all, it gives `true`, and then the second part is executed and checked the unicity, which fails, throwing an exception.
It is worth to mention that is exactly the presence of the params which make the request to fail, even keeping all the other params the same.

On the civicase frontend we are always sending the id as `false`, that is why the resignation works when it is executed directly in People tab of Cases, instead of using the webforms.
We could just modify the code of the `webform_civicrm` extension, but that would not be appropriate, since that requirement is related to the internal behaviour of relationships and cases, and the API call made by the extension is correct.
We count with a class in civicase in which we execute some handlers, for pre and post processing of the relationships: https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/Service/CaseRoleCreationPostProcess.php, then it is convenient to use that part for handling this particular issue.

We can note the not-consistent usage of `isset` and `empty` for determining the action that is tried to be performed. That should be improved and refactored, but the consequences of changing that could be huge, and required a good amount of testing.

As presented on this PR, the ID is ensured to be present on every call, with false as default value, assigned on the PreProcess service. The other calls made to this API in the frontend respect the id usage. I checked the execution paths and this can't cause problem. Feel free to contact me if something is not clear enough.

**Update about frontend changes:**
It was added the option that allows returning all available results on the request to the server (limit: 0)
This information is required for displaying correctly the history of re-assignations, and the current data itself. 
According to my testings, this API call is performed once per active case on the dashboard, not for all the cases listed on a page (if not, that could imply a high load to the server)


 
