### PR TITLE
CATL-2095: Change Default Activity Status For Link Case

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/LinkCaseActivityDefaultStatus.php
+++ b/CRM/Civicase/Hook/BuildForm/LinkCaseActivityDefaultStatus.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Change default status to completed for link case activity.
+ */
+class CRM_Civicase_Hook_BuildForm_LinkCaseActivityDefaultStatus {
+
+  /**
+   * Handles the hook's implementation.
+   *
+   * @param CRM_Core_Form $form
+   *   The current form's instance.
+   * @param string $formName
+   *   The name for the current form.
+   */
+  public function run(CRM_Core_Form $form, $formName) {
+    if (!$this->shouldRun($formName)) {
+      return;
+    }
+
+    $this->changeActivityDefaultStatus($form);
+  }
+
+  /**
+   * Determines if the hook should run.
+   *
+   * @param string $formName
+   *   Form name.
+   *
+   * @return bool
+   *   True when the hook can run.
+   */
+  private function shouldRun($formName) {
+    return $formName === CRM_Case_Form_Activity::class &&
+      CRM_Utils_Request::retrieve('atype', 'Integer') === CRM_Core_PseudoConstant::getKey(
+        'CRM_Activity_BAO_Activity',
+        'activity_type_id',
+        'Link Cases'
+      );
+  }
+
+  /**
+   * Change default status to completed for link case activity.
+   *
+   * @param CRM_Core_Form $form
+   *   The current form's instance.
+   */
+  private function changeActivityDefaultStatus(CRM_Core_Form $form) {
+    if ($form->elementExists('status_id')) {
+      $completedStatusId = CRM_Core_PseudoConstant::getKey(
+        'CRM_Activity_BAO_Activity',
+        'status_id',
+        'Completed'
+      );
+      if ($completedStatusId) {
+        $form->setDefaults(['status_id' => $completedStatusId]);
+      }
+    }
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -217,6 +217,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_RestrictCaseEmailContacts(),
     new CRM_Civicase_Hook_BuildForm_LimitRecipientFieldsToOnlySelectedContacts(),
     new CRM_Civicase_Hook_BuildForm_TokenTree(),
+    new CRM_Civicase_Hook_BuildForm_LinkCaseActivityDefaultStatus(),
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview
This pr changes the default status for link case activity from `schedule` to `completed`.

## Before
The default status for link case activity was `scheduled`.
![before](https://user-images.githubusercontent.com/68388745/108244214-c75d7a00-7170-11eb-973b-3eb186ffbb2c.gif)

## After
The default status is changed to `completed`.
![after](https://user-images.githubusercontent.com/68388745/108244283-dc3a0d80-7170-11eb-96f2-0cdda4d106ca.gif)

## Technical Details
This pr adds a new build form hook in `CRM/Civicase/Hook/BuildForm/LinkCaseActivityDefaultStatus.php` which changes the default status for link case activity.