### PR TITLE
Catl 2111 hide recipient tokens for pdf

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/LinkCaseActivityDefaultStatus.php
+++ b/CRM/Civicase/Hook/BuildForm/LinkCaseActivityDefaultStatus.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Change default status to completed for link case activity.
+ */
+class CRM_Civicase_Hook_BuildForm_LinkCaseActivityDefaultStatus {
+
+  /**
+   * Handles the hook's implementation.
+   *
+   * @param CRM_Core_Form $form
+   *   The current form's instance.
+   * @param string $formName
+   *   The name for the current form.
+   */
+  public function run(CRM_Core_Form $form, $formName) {
+    if (!$this->shouldRun($formName)) {
+      return;
+    }
+
+    $this->changeActivityDefaultStatus($form);
+  }
+
+  /**
+   * Determines if the hook should run.
+   *
+   * @param string $formName
+   *   Form name.
+   *
+   * @return bool
+   *   True when the hook can run.
+   */
+  private function shouldRun($formName) {
+    return $formName === CRM_Case_Form_Activity::class &&
+      CRM_Utils_Request::retrieve('atype', 'Integer') === CRM_Core_PseudoConstant::getKey(
+        'CRM_Activity_BAO_Activity',
+        'activity_type_id',
+        'Link Cases'
+      );
+  }
+
+  /**
+   * Change default status to completed for link case activity.
+   *
+   * @param CRM_Core_Form $form
+   *   The current form's instance.
+   */
+  private function changeActivityDefaultStatus(CRM_Core_Form $form) {
+    if ($form->elementExists('status_id')) {
+      $completedStatusId = CRM_Core_PseudoConstant::getKey(
+        'CRM_Activity_BAO_Activity',
+        'status_id',
+        'Completed'
+      );
+      if ($completedStatusId) {
+        $form->setDefaults(['status_id' => $completedStatusId]);
+      }
+    }
+  }
+
+}

--- a/CRM/Civicase/Hook/BuildForm/TokenTree.php
+++ b/CRM/Civicase/Hook/BuildForm/TokenTree.php
@@ -13,7 +13,7 @@ class CRM_Civicase_Hook_BuildForm_TokenTree {
 
   const CONTACT_TOKEN_TEXT = 'Contact';
 
-  const CLIENT_TOKEN_TEXT = 'Client';
+  const RECIPIENT_TOKEN_TEXT = 'Email Recipient';
 
   const OTHER_TOKEN_TEXT = 'Other';
 
@@ -101,11 +101,26 @@ class CRM_Civicase_Hook_BuildForm_TokenTree {
    */
   private function reOrderTokens(array $newTokenTree) {
     $reorderedTree = [];
-    $tokenTexts = [
-      self::CASE_TOKEN_TEXT,
-      self::CLIENT_TOKEN_TEXT,
-      self::CURRENT_USER_TOKEN_TEXT,
-    ];
+    $caseClientRole = 'Case Client';
+    if (in_array($caseClientRole, $this->caseRolesTokenNames)) {
+      $this->caseRolesTokenNames = array_diff(
+        $this->caseRolesTokenNames,
+        [$caseClientRole]
+      );
+      $tokenTexts = [
+        self::CASE_TOKEN_TEXT,
+        $caseClientRole,
+        self::RECIPIENT_TOKEN_TEXT,
+        self::CURRENT_USER_TOKEN_TEXT,
+      ];
+    }
+    else {
+      $tokenTexts = [
+        self::CASE_TOKEN_TEXT,
+        self::RECIPIENT_TOKEN_TEXT,
+        self::CURRENT_USER_TOKEN_TEXT,
+      ];
+    }
     $tokenTexts = array_merge($tokenTexts, $this->caseRolesTokenNames);
     $tokenTexts[] = self::OTHER_TOKEN_TEXT;
     foreach ($tokenTexts as $tokenText) {
@@ -126,7 +141,7 @@ class CRM_Civicase_Hook_BuildForm_TokenTree {
   private function reFormatCustomTokens(array &$newTokenTree) {
     $tokenTexts = [
       self::CURRENT_USER_TOKEN_TEXT,
-      self::CLIENT_TOKEN_TEXT,
+      self::RECIPIENT_TOKEN_TEXT,
       self::CASE_TOKEN_TEXT,
     ];
 
@@ -299,10 +314,10 @@ class CRM_Civicase_Hook_BuildForm_TokenTree {
    *   Restructured token tree.
    */
   private function addClientTokens(array $clientTokens, array &$newTokenTree) {
-    if (empty($newTokenTree[self::CLIENT_TOKEN_TEXT])) {
-      $newTokenTree[self::CLIENT_TOKEN_TEXT] = [
-        'id' => self::CLIENT_TOKEN_TEXT,
-        'text' => self::CLIENT_TOKEN_TEXT,
+    if (empty($newTokenTree[self::RECIPIENT_TOKEN_TEXT])) {
+      $newTokenTree[self::RECIPIENT_TOKEN_TEXT] = [
+        'id' => self::RECIPIENT_TOKEN_TEXT,
+        'text' => self::RECIPIENT_TOKEN_TEXT,
         'children' => [
           [
             'id' => 'CoreFields' . uniqid(),
@@ -313,8 +328,8 @@ class CRM_Civicase_Hook_BuildForm_TokenTree {
       ];
     }
     else {
-      $newTokenTree[self::CLIENT_TOKEN_TEXT]['children'][0]['children'] =
-        array_merge($newTokenTree[self::CLIENT_TOKEN_TEXT]['children'][0]['children'], $clientTokens);
+      $newTokenTree[self::RECIPIENT_TOKEN_TEXT]['children'][0]['children'] =
+        array_merge($newTokenTree[self::RECIPIENT_TOKEN_TEXT]['children'][0]['children'], $clientTokens);
     }
   }
 
@@ -356,7 +371,7 @@ class CRM_Civicase_Hook_BuildForm_TokenTree {
   private function addOtherTokens(array $otherTokens, array &$newTokenTree) {
     foreach ($otherTokens as $key => $token) {
       if (strpos($token['id'], 'contact.custom_') !== FALSE) {
-        $this->addCustomTokens($newTokenTree, self::CLIENT_TOKEN_TEXT, $token);
+        $this->addCustomTokens($newTokenTree, self::RECIPIENT_TOKEN_TEXT, $token);
       }
       elseif (strpos($token['id'], 'case.custom_') !== FALSE) {
         $this->addCustomTokens($newTokenTree, self::CASE_TOKEN_TEXT, $token);

--- a/CRM/Civicase/Hook/BuildForm/TokenTree.php
+++ b/CRM/Civicase/Hook/BuildForm/TokenTree.php
@@ -195,7 +195,6 @@ class CRM_Civicase_Hook_BuildForm_TokenTree {
    *   Restructured token tree.
    */
   private function addCaseRoleTokens(array $caseRoleTokens, array &$newTokenTree) {
-    $contactRoleCount = 0;
     $contactRoleTokens = [];
     foreach ($caseRoleTokens as $key => $token) {
       if ($token['id'] === '{case_roles.client}') {
@@ -203,10 +202,8 @@ class CRM_Civicase_Hook_BuildForm_TokenTree {
       }
       $roleName = explode('-', $token['text']);
       $roleName = $roleName[0];
-      $tokenName = 'Case Role ' . $contactRoleCount . ' "' . trim($roleName) . '"';
+      $tokenName = trim($roleName);
       if (empty($contactRoleTokens[$tokenName])) {
-        $contactRoleCount++;
-        $tokenName = 'Case Role ' . $contactRoleCount . ' "' . trim($roleName) . '"';
         $this->caseRolesTokenNames[] = $tokenName;
         $this->initializeTokenType($contactRoleTokens, $tokenName);
       }

--- a/civicase.php
+++ b/civicase.php
@@ -217,6 +217,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_RestrictCaseEmailContacts(),
     new CRM_Civicase_Hook_BuildForm_LimitRecipientFieldsToOnlySelectedContacts(),
     new CRM_Civicase_Hook_BuildForm_TokenTree(),
+    new CRM_Civicase_Hook_BuildForm_LinkCaseActivityDefaultStatus(),
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview
This pr removes recipient tokens for pdf form.

## Before
Recipient tokens were available
![pdfbefore](https://user-images.githubusercontent.com/68388745/108513496-81292780-72e4-11eb-8fa7-84aded10d70c.gif)

## After
Recipient tokens are removed from pdf form.
![pdfafter](https://user-images.githubusercontent.com/68388745/108513513-84bcae80-72e4-11eb-9cbf-16ec26544b90.gif)

## Technical Details
This pr changes `RM/Civicase/Hook/BuildForm/TokenTree.php` hook file to hide recipient tokens for pdf form.