### PR TITLE
CATL-2119: Fix Client Role Display On Peoples Tab

### DIFF
--- a/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
+++ b/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
@@ -167,7 +167,7 @@
      */
     function getClientRoles () {
       return _.filter(caseContacts, {
-        role: 'Client'
+        role: ts('Client')
       })
         .map(function (contact) {
           return {


### PR DESCRIPTION
## Overview
This pr fixes a bug which caused the client role to disappear from peoples tab on any site that has a word replacement for client role. 

## Before
The client role was not visible on peoples tab
![Screenshot from 2021-02-24 18-53-26](https://user-images.githubusercontent.com/68388745/109010514-aac1c480-76d1-11eb-98ce-df77f949578f.png)

## After
The client role is visible
![Screenshot from 2021-02-24 18-53-45](https://user-images.githubusercontent.com/68388745/109010527-ae554b80-76d1-11eb-8dc9-07bf32858808.png)

## Technical Details
This pr fixes a glitch in file ` ang/civicase/case/details/people-tab/services/people-tab-roles.service.js` due to which the client role was not appearing