### PR TITLE
RSE-1551: Hide New Case Type button on Case Type list

### DIFF
--- a/CRM/Civicase/Hook/alterAngular/AngularChangeSet.php
+++ b/CRM/Civicase/Hook/alterAngular/AngularChangeSet.php
@@ -35,4 +35,23 @@ class CRM_Civicase_Hook_alterAngular_AngularChangeSet {
       });
   }
 
+  /**
+   * Returns ChangeSet for hiding New Case Type button.
+   *
+   * On the case type listing, we don't want to show the "New Case Type" button
+   * because that action is performed specifically on every "Manage Workflows".
+   *
+   * @return \Civi\Angular\ChangeSet
+   *   Angular ChangeSet.
+   */
+  public static function getForHidingNewCaseTypeButton() {
+    return ChangeSet::create('hide-new-case-type-button')
+      ->alterHtml('~/crmCaseType/list.html', function (phpQueryObject $doc) {
+        $element = $doc->find("a[ng-href*=#/caseType/new");
+        if ($element->length) {
+          $element->remove();
+        }
+      });
+  }
+
 }

--- a/civicase.php
+++ b/civicase.php
@@ -664,6 +664,7 @@ function civicase_civicrm_alterAngular(Manager $angular) {
     [['administer CiviCase', 'administer CiviCRM']]
   )) {
     $angular->add(CRM_Civicase_Hook_alterAngular_AngularChangeSet::getForCaseTypeCategoryField());
+    $angular->add(CRM_Civicase_Hook_alterAngular_AngularChangeSet::getForHidingNewCaseTypeButton());
   }
 }
 


### PR DESCRIPTION
## Overview
This PR changes the Case Type listing page, URL: `civicrm/a/#/caseType` hiding the New Case Type button that appears at the end of the listing.
We do this because the preferred way to create case types is using the specific workflow, for example in Awards would be using `Create New Award`.

## Before
The button for creating a new Case Type is accessible on the Case Type listing page:
![image](https://user-images.githubusercontent.com/74304572/109282832-a1ab3180-7850-11eb-97c1-0a49549b8418.png)

## After
The button was removed from the view:
![image](https://user-images.githubusercontent.com/74304572/109282869-b091e400-7850-11eb-8675-6bbadcd041b4.png)

