### PR TITLE
IO-143: Add methods to activate/deactivate menu/option group

### DIFF
--- a/CRM/Civicase/Service/CaseCategoryCustomFieldExtends.php
+++ b/CRM/Civicase/Service/CaseCategoryCustomFieldExtends.php
@@ -41,6 +41,40 @@ class CRM_Civicase_Service_CaseCategoryCustomFieldExtends {
   }
 
   /**
+   * Activates the Custom field extend option group for case category.
+   *
+   * @param string $entityValue
+   *   Entity Value for the custom entity.
+   */
+  public function activate($entityValue) {
+    $result = $this->getCgExtendOptionValue($entityValue);
+
+    if ($result['count'] == 0) {
+      return;
+    }
+
+    $isActive = TRUE;
+    CRM_Core_BAO_OptionValue::setIsActive($result['values'][0]['id'], $isActive);
+  }
+
+  /**
+   * Deactivates the Custom field extend option group for case category.
+   *
+   * @param string $entityValue
+   *   Entity Value for the custom entity.
+   */
+  public function deactivate($entityValue) {
+    $result = $this->getCgExtendOptionValue($entityValue);
+
+    if ($result['count'] == 0) {
+      return;
+    }
+
+    $isActive = FALSE;
+    CRM_Core_BAO_OptionValue::setIsActive($result['values'][0]['id'], $isActive);
+  }
+
+  /**
    * Deletes the Custom field extend option group for case category.
    *
    * @param string $entityValue

--- a/CRM/Civicase/Service/CaseCategoryMenu.php
+++ b/CRM/Civicase/Service/CaseCategoryMenu.php
@@ -220,4 +220,46 @@ class CRM_Civicase_Service_CaseCategoryMenu {
     civicrm_api3('Navigation', 'create', $menuParams);
   }
 
+  /**
+   * Activates Case Category Main menu.
+   *
+   * @param string $caseTypeCategoryName
+   *   Case Type category name.
+   */
+  public function activateItem($caseTypeCategoryName) {
+    $this->setStatus($caseTypeCategoryName, TRUE);
+  }
+
+  /**
+   * Deactivates Case Category Main menu.
+   *
+   * @param string $caseTypeCategoryName
+   *   Case Type category name.
+   */
+  public function deactivateItem($caseTypeCategoryName) {
+    $this->setStatus($caseTypeCategoryName, FALSE);
+  }
+
+  /**
+   * Sets the status of Case Category Main menu.
+   *
+   * @param string $caseTypeCategoryName
+   *   Case Type category name.
+   * @param bool $status
+   *   Case Type status.
+   */
+  private function setStatus($caseTypeCategoryName, $status) {
+    $result = civicrm_api3('Navigation', 'get', ['name' => $caseTypeCategoryName]);
+
+    if ($result['count'] === 0) {
+      return;
+    }
+
+    $navigationItem = array_shift($result['values']);
+    civicrm_api3('Navigation', 'create', [
+      'id' => $navigationItem['id'],
+      'is_active' => $status,
+    ]);
+  }
+
 }

--- a/tests/phpunit/CRM/Civicase/Service/CaseCategoryCustomFieldExtendsTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseCategoryCustomFieldExtendsTest.php
@@ -77,6 +77,43 @@ class CRM_Civicase_Service_CaseCategoryCustomFieldExtendsTest extends BaseHeadle
   }
 
   /**
+   * Test activating an existing CG extend option value.
+   */
+  public function testIsSuccessfullyActivated() {
+    // Create a random CG extend option value.
+    $cgExtendOptionValue = $this->createCgExtendOptionValue();
+    // We deactivate it and verify that is correctly stored.
+    (new CaseCategoryCustomFieldExtendsService())->deactivate($cgExtendOptionValue['value']);
+    $cgExtendOptionValue = $this->getCgExtendOptionValue($cgExtendOptionValue['value'])['values'][0];
+    $this->assertEquals(0, $cgExtendOptionValue['is_active']);
+
+    // Activate the CG extend option value.
+    (new CaseCategoryCustomFieldExtendsService())->activate($cgExtendOptionValue['value']);
+
+    // And verify that is not counted anymore.
+    $cgExtendOptionValue = $this->getCgExtendOptionValue($cgExtendOptionValue['value'])['values'][0];
+    $this->assertEquals(1, $cgExtendOptionValue['is_active']);
+  }
+
+  /**
+   * Test deactivating an existing CG extend option value.
+   */
+  public function testIsSuccessfullyDeactivated() {
+    // Create a random CG extend option value.
+    $cgExtendOptionValue = $this->createCgExtendOptionValue();
+    // We verify that is correctly stored.
+    $cgExtendOptionValue = $this->getCgExtendOptionValue($cgExtendOptionValue['value'])['values'][0];
+    $this->assertEquals(1, $cgExtendOptionValue['is_active']);
+
+    // Activate the CG extend option value.
+    (new CaseCategoryCustomFieldExtendsService())->deactivate($cgExtendOptionValue['value']);
+
+    // And verify that is not counted anymore.
+    $cgExtendOptionValue = $this->getCgExtendOptionValue($cgExtendOptionValue['value'])['values'][0];
+    $this->assertEquals(0, $cgExtendOptionValue['is_active']);
+  }
+
+  /**
    * Test that calling twice the delete method does not produce an error.
    */
   public function testDeleteCanBeCalledTwice() {


### PR DESCRIPTION
## Overview
This PR adds the required methods for CiviAwards - https://github.com/compucorp/uk.co.compucorp.civiawards/pull/206 - to call them when is disabled/enabled.

## Technical Details

- Added methods for activating/deactivating the custom field extend option group for the case
category according to the extension status.
- Added methods for activating/deactivating  a menu item.
