### PR TITLE
CATL-1442: Fix Case Filter order

### DIFF
--- a/ang/civicase/case/list/directives/case-list-table.directive.js
+++ b/ang/civicase/case/list/directives/case-list-table.directive.js
@@ -1,7 +1,7 @@
 (function (angular, $, _) {
   var module = angular.module('civicase');
 
-  module.directive('civicaseCaseListTable', function ($document, $timeout) {
+  module.directive('civicaseCaseListTable', function () {
     return {
       controller: 'CivicaseCaseListTableController',
       link: civicaseCaseListTableLink,
@@ -137,7 +137,13 @@
       backgroundLoading = backgroundLoading || false;
       $scope.isLoading = true && !backgroundLoading;
       apiCalls = apiCalls || [];
-      apiCalls = apiCalls.concat(getCaseApiParams(angular.extend({}, $scope.filters, $scope.hiddenFilters), $scope.sort, $scope.page));
+      apiCalls = apiCalls.concat(
+        getCaseApiParams(
+          angular.extend({}, $scope.filters, $scope.hiddenFilters),
+          $scope.sort,
+          $scope.page
+        )
+      );
 
       civicaseCrmApi(apiCalls, true)
         .then(function (result) {

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -34,9 +34,9 @@
       tag_id: { label: ts('Tags') }
     };
     var caseRelationshipConfig = [
-      { text: ts('All Cases'), id: 'all' },
       { text: ts('My Cases'), id: 'is_case_manager' },
-      { text: ts('Cases I am involved in'), id: 'is_involved' }
+      { text: ts('Cases I am involved in'), id: 'is_involved' },
+      { text: ts('All Cases'), id: 'all' }
     ];
     var DEFAULT_CASE_FILTERS = {
       case_type_category: currentCaseCategory

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -100,9 +100,9 @@
       describe('case relationship options', () => {
         it('contains a list of case relationship options', () => {
           expect($scope.caseRelationshipOptions).toEqual([
-            { text: ts('All Cases'), id: 'all' },
             { text: ts('My Cases'), id: 'is_case_manager' },
-            { text: ts('Cases I am involved in'), id: 'is_involved' }
+            { text: ts('Cases I am involved in'), id: 'is_involved' },
+            { text: ts('All Cases'), id: 'all' }
           ]);
         });
       });


### PR DESCRIPTION
## Overview
The Order of the filters in Manage Cases page and Dashboard was different. Now they have been aligned.

## Before
![2021-03-05 at 3 36 PM](https://user-images.githubusercontent.com/5058867/110100589-93b55d80-7dc8-11eb-8128-46717fa60988.png)

## After
![2021-03-05 at 3 36 PM](https://user-images.githubusercontent.com/5058867/110100537-87310500-7dc8-11eb-8c6e-e7dec8b262e5.png)
