### PR TITLE
CPS-486: Fix Dashboard "Case Overview" Links

### DIFF
--- a/ang/civicase/dashboard/directives/dashboard-tab.directive.js
+++ b/ang/civicase/dashboard/directives/dashboard-tab.directive.js
@@ -5,7 +5,8 @@
     return {
       scope: {
         activityFilters: '=',
-        filters: '='
+        filters: '=',
+        linkToManageCase: '='
       },
       restrict: 'E',
       controller: 'dashboardTabController',

--- a/ang/civicase/dashboard/directives/dashboard.directive.html
+++ b/ang/civicase/dashboard/directives/dashboard.directive.html
@@ -10,6 +10,7 @@
         <uib-tab index="0" heading="{{ ts('Dashboard') }}" select="navTabs()">
           <civicase-dashboard-tab
             activity-filters="activityFilters"
+            link-to-manage-case="linkToManageCase"
             filters="filters"
             ng-if="activeTab === 0">
           </civicase-dashboard-tab>


### PR DESCRIPTION
## Overview
The Case Overview Links did not work in the Dashboard. This PR fixes that.

## Before


## After

## Technical Details
This is a regression issue caused by https://github.com/compucorp/uk.co.compucorp.civicase/pull/692.
In that PR we did this change
> In dashboard-tab.directive.js, we now have a isolate scope for the directive.

But `linkToManageCase` is defined in `civicaseDashboard`, so it needed to be passed as a parameter to `civicaseDashboardTab`, which is then passed to `civicaseCaseOverview`.