### PR TITLE
CPS-478: Add tests for CaseCategoryCustomDataType class

### DIFF
--- a/tests/phpunit/CRM/Civicase/Hook/SelectWhereClause/LimitCaseQueryToAccessibleCaseCategoriesTest.php
+++ b/tests/phpunit/CRM/Civicase/Hook/SelectWhereClause/LimitCaseQueryToAccessibleCaseCategoriesTest.php
@@ -28,39 +28,66 @@ class CRM_Civicase_Hook_SelectWhereClause_LimitCaseQueryToAccessibleCaseCategori
   private static $caseTypes;
 
   /**
+   * Fabricated cases.
+   *
+   * @var array
+   */
+  private static $cases;
+
+  /**
    * Setup case types and cases before running of tests.
    */
   public static function setupBeforeClass() {
-    civicrm_api3('OptionValue', 'create', [
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists([
       'option_group_id' => 'case_type_categories',
       'name' => 'award',
       'value' => 2,
     ]);
+
     static::$caseTypes[] = CaseTypeFabricator::fabricate([
       'name' => 'Case_type_first',
       'case_type_category' => 1,
-
     ]);
+
     static::$caseTypes[] = CaseTypeFabricator::fabricate([
       'name' => 'Case_type_second',
       'case_type_category' => 2,
     ]);
     static::$client = ContactFabricator::fabricate();
 
-    CaseFabricator::fabricate(
+    static::$cases[] = CaseFabricator::fabricate(
       [
         'case_type_id' => static::$caseTypes[0]['id'],
         'contact_id' => static::$client['id'],
         'creator_id' => static::$client['id'],
       ]
     );
-    CaseFabricator::fabricate(
+    static::$cases[] = CaseFabricator::fabricate(
       [
         'case_type_id' => static::$caseTypes[1]['id'],
         'contact_id' => static::$client['id'],
         'creator_id' => static::$client['id'],
       ]
     );
+  }
+
+  /**
+   * Clean the cases and types created.
+   */
+  public static function tearDownAfterClass() {
+    civicrm_api3('Case', 'delete', [
+      'id' => static::$cases[0]['id'],
+    ]);
+    civicrm_api3('Case', 'delete', [
+      'id' => static::$cases[1]['id'],
+    ]);
+
+    civicrm_api3('CaseType', 'delete', [
+      'id' => static::$caseTypes[0]['id'],
+    ]);
+    civicrm_api3('CaseType', 'delete', [
+      'id' => static::$caseTypes[1]['id'],
+    ]);
   }
 
   /**

--- a/tests/phpunit/CRM/Civicase/Hook/SelectWhereClause/LimitCaseQueryToAccessibleCaseCategoriesTest.php
+++ b/tests/phpunit/CRM/Civicase/Hook/SelectWhereClause/LimitCaseQueryToAccessibleCaseCategoriesTest.php
@@ -75,19 +75,17 @@ class CRM_Civicase_Hook_SelectWhereClause_LimitCaseQueryToAccessibleCaseCategori
    * Clean the cases and types created.
    */
   public static function tearDownAfterClass() {
-    civicrm_api3('Case', 'delete', [
-      'id' => static::$cases[0]['id'],
-    ]);
-    civicrm_api3('Case', 'delete', [
-      'id' => static::$cases[1]['id'],
-    ]);
+    foreach (static::$cases as $case) {
+      civicrm_api3('Case', 'delete', [
+        'id' => $case['id'],
+      ]);
+    }
 
-    civicrm_api3('CaseType', 'delete', [
-      'id' => static::$caseTypes[0]['id'],
-    ]);
-    civicrm_api3('CaseType', 'delete', [
-      'id' => static::$caseTypes[1]['id'],
-    ]);
+    foreach (static::$caseTypes as $caseType) {
+      civicrm_api3('CaseType', 'delete', [
+        'id' => $caseType['id'],
+      ]);
+    }
   }
 
   /**

--- a/tests/phpunit/CRM/Civicase/Service/CaseCategoryCustomDataTypeTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseCategoryCustomDataTypeTest.php
@@ -4,7 +4,7 @@ use CRM_Civicase_Service_CaseCategoryCustomDataType as CaseCategoryCustomDataSer
 use CRM_Civicase_Test_Fabricator_CaseCategory as CaseCategoryFabricator;
 
 /**
- * Runs tests on CaseCategoryCustomData Service tests.
+ * Runs tests on CaseCategoryCustomDataType Service tests.
  *
  * @group headless
  */
@@ -117,7 +117,7 @@ WHERE g.id = v.option_group_id AND
    * @param string $caseCategoryName
    *   Case Category Name.
    *
-   * @return array
+   * @return array|null
    *   Custom data type option value.
    */
   private function getCustomDataOptionValue(string $caseCategoryName) {

--- a/tests/phpunit/CRM/Civicase/Service/CaseCategoryCustomDataTypeTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseCategoryCustomDataTypeTest.php
@@ -103,12 +103,11 @@ class CRM_Civicase_Service_CaseCategoryCustomDataTypeTest extends BaseHeadlessTe
    * Delete all existent custom data types.
    */
   private function cleanCustomDataTypes() {
-    $query = "DELETE v
-FROM civicrm_option_group g, civicrm_option_value v
-WHERE g.id = v.option_group_id AND
-      g.name = 'custom_data_type'";
-
-    CRM_Core_DAO::executeQuery($query);
+    CRM_Core_DAO::executeQuery("
+      DELETE v
+      FROM civicrm_option_group g, civicrm_option_value v
+      WHERE g.id = v.option_group_id AND g.name = 'custom_data_type'
+    ");
   }
 
   /**

--- a/tests/phpunit/CRM/Civicase/Service/CaseCategoryCustomDataTypeTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseCategoryCustomDataTypeTest.php
@@ -47,7 +47,7 @@ class CRM_Civicase_Service_CaseCategoryCustomDataTypeTest extends BaseHeadlessTe
   /**
    * Try to create twice the same Custom Data Type.
    */
-  public function testCreateTwiceSameCustomDataType() {
+  public function testCreateTwiceSameCustomDataTypeDoesNotCreateDuplicates() {
     $this->cleanCustomDataTypes();
 
     $caseCategory = CaseCategoryFabricator::fabricate();

--- a/tests/phpunit/CRM/Civicase/Service/CaseCategoryCustomDataTypeTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseCategoryCustomDataTypeTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use CRM_Civicase_Service_CaseCategoryCustomDataType as CaseCategoryCustomDataService;
+use CRM_Civicase_Test_Fabricator_CaseCategory as CaseCategoryFabricator;
+
+/**
+ * Runs tests on CaseCategoryCustomData Service tests.
+ *
+ * @group headless
+ */
+class CRM_Civicase_Service_CaseCategoryCustomDataTypeTest extends BaseHeadlessTest {
+  /**
+   * Instance of CaseCategoryCustomDataType service.
+   *
+   * @var CRM_Civicase_Service_CaseCategoryCustomDataType
+   */
+  private $caseCategoryCustomDataService;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->cleanCustomDataTypes();
+    $this->caseCategoryCustomDataService = new CaseCategoryCustomDataService();
+  }
+
+  /**
+   * Test the creation of a new Custom Data Type.
+   */
+  public function testCreateNewCustomDataType() {
+    $this->cleanCustomDataTypes();
+
+    $caseCategory = CaseCategoryFabricator::fabricate();
+    $this->assertNull($this->getCustomDataOptionValue($caseCategory['name']));
+
+    $this->caseCategoryCustomDataService->create($caseCategory['name']);
+    $optionValueCreated = $this->getCustomDataOptionValue($caseCategory['name']);
+
+    $this->assertNotNull($optionValueCreated);
+    $this->assertEquals($caseCategory['name'], $optionValueCreated['name']);
+    $this->assertEquals($caseCategory['name'], $optionValueCreated['label']);
+    $this->assertEquals($caseCategory['value'], $optionValueCreated['value']);
+  }
+
+  /**
+   * Try to create twice the same Custom Data Type.
+   */
+  public function testCreateTwiceSameCustomDataType() {
+    $this->cleanCustomDataTypes();
+
+    $caseCategory = CaseCategoryFabricator::fabricate();
+    $this->assertNull($this->getCustomDataOptionValue($caseCategory['name']));
+
+    // First call.
+    $this->caseCategoryCustomDataService->create($caseCategory['name']);
+    // Second call.
+    $this->caseCategoryCustomDataService->create($caseCategory['name']);
+    $optionValueCreated = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'name' => $caseCategory['name'],
+      'option_group_id' => 'custom_data_type',
+    ]);
+
+    $this->assertEquals(1, $optionValueCreated['count']);
+    $optionValueCreated = array_shift($optionValueCreated['values']);
+    $this->assertEquals($caseCategory['name'], $optionValueCreated['name']);
+    $this->assertEquals($caseCategory['name'], $optionValueCreated['label']);
+    $this->assertEquals($caseCategory['value'], $optionValueCreated['value']);
+  }
+
+  /**
+   * Test delete an existent Custom Data Type.
+   */
+  public function testDeleteAnExistentCustomDataType() {
+    $this->cleanCustomDataTypes();
+
+    $caseCategory = CaseCategoryFabricator::fabricate();
+    $this->caseCategoryCustomDataService->create($caseCategory['name']);
+    $this->assertNotNull($this->getCustomDataOptionValue($caseCategory['name']));
+
+    $this->caseCategoryCustomDataService->delete($caseCategory['name']);
+
+    $this->assertNull($this->getCustomDataOptionValue($caseCategory['name']));
+  }
+
+  /**
+   * Test delete a non existent Custom Data Type.
+   */
+  public function testDeleteNonExistentCustomDataType() {
+    $this->cleanCustomDataTypes();
+
+    $caseCategory = CaseCategoryFabricator::fabricate();
+    $this->assertNull($this->getCustomDataOptionValue($caseCategory['name']));
+
+    $this->caseCategoryCustomDataService->delete($caseCategory['name']);
+
+    $this->assertNull($this->getCustomDataOptionValue($caseCategory['name']));
+  }
+
+  /**
+   * Delete all existent custom data types.
+   */
+  private function cleanCustomDataTypes() {
+    $query = "DELETE v
+FROM civicrm_option_group g, civicrm_option_value v
+WHERE g.id = v.option_group_id AND
+      g.name = 'custom_data_type'";
+
+    CRM_Core_DAO::executeQuery($query);
+  }
+
+  /**
+   * Return Custom Data type option value.
+   *
+   * @param string $caseCategoryName
+   *   Case Category Name.
+   *
+   * @return array
+   *   Custom data type option value.
+   */
+  private function getCustomDataOptionValue(string $caseCategoryName) {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'name' => $caseCategoryName,
+      'option_group_id' => 'custom_data_type',
+    ]);
+
+    if (!empty($result['values'])) {
+      return array_shift($result['values']);
+    }
+
+    return NULL;
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR adds unit tests for the `CaseCategoryCustomDataType` class.
This class has only two public methods, that creates and deletes the required `OptionValues` for `CustomDataType` groups. Both methods have been fully tested.

Also, this PR provides a fix to two relatively minor problems on other unit tests, that caused warnings, or errors if we run them more than once.

## Before
There were no unit tests for `CaseCategoryCustomDataType` class.

The tests for `AttachEmailActivityToAllCases` were throwing a warning:
![image](https://user-images.githubusercontent.com/74304572/110298323-0face100-8027-11eb-9d5e-b28c0b713d19.png)

The tests for `LimitCaseQueryToAccessibleCaseCategories` thrown errors if we run them more than once (not visible on GitHub hooks since they run only once)
![image](https://user-images.githubusercontent.com/74304572/110298476-3834db00-8027-11eb-83bd-61ffc4385a43.png)


## After
Tests added for `CaseCategoryCustomDataType`, which covers all possible usages.
All the suite runs correctly, without warning or errors:
![image](https://user-images.githubusercontent.com/74304572/110298619-5ef31180-8027-11eb-9cc4-298096335005.png)


## Technical Details

**New tests added on CaseCategoryCustomDataType**
It is worth to mention that I added a method for cleaning all the existing option values on `custom_data_type` group. The base data on tests makes sometimes this fail by unicity, which can't happen on the normal execution. 

**Fix of warning on `AttachEmailActivityToAllCases`.**
The test was using a dataProvider, which did not work correctly. Anyway, there was no need to have a dataProvider, since it was generating 3 random cases with no real differences on them. I moved the data inside the test itself.

**Fix on error `LimitCaseQueryToAccessibleCaseCategories`.**
The changes in `setupBeforeClass` needed to be cleaned after execution. I added the logic for correctly delete the data created.


