### PR TITLE
CATL-2136: Delete Draft Email when sending email

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/HandleDraftActivities.php
+++ b/CRM/Civicase/Hook/BuildForm/HandleDraftActivities.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * HandleDraftActivities BuildForm Hook Class.
+ */
+class CRM_Civicase_Hook_BuildForm_HandleDraftActivities {
+
+  const PDF_LETTER_ACTIVITY_TYPE = 'Print PDF Letter';
+  const EMAIL_ACTIVITY_TYPE = 'Email';
+  const SPECIAL_TYPES = [
+    self::PDF_LETTER_ACTIVITY_TYPE,
+    self::EMAIL_ACTIVITY_TYPE,
+  ];
+
+  const PDF_LETTER_FORM_NAME = 'CRM_Contact_Form_Task_PDF';
+  const EMAIL_FORM_NAME = 'CRM_Contact_Form_Task_Email';
+  const SPECIAL_FORMS = [
+    self::PDF_LETTER_FORM_NAME,
+    self::EMAIL_FORM_NAME,
+  ];
+
+  /**
+   * Adds Save Draft button.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   * @param string $formName
+   *   Form Name.
+   */
+  public function run(CRM_Core_Form &$form, $formName) {
+    if (!$this->shouldRun($form, $formName)) {
+      return;
+    }
+
+    $this->addSaveDraftButton($form, $formName);
+  }
+
+  /**
+   * Adds the Save Draft button in the form.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   * @param string $formName
+   *   Form Name.
+   */
+  private function addSaveDraftButton(CRM_Core_Form &$form, $formName) {
+    $activityTypeId = $form->getVar('_activityTypeId');
+    if ($activityTypeId) {
+      $activityType = civicrm_api3('OptionValue', 'getvalue', [
+        'return' => "name",
+        'option_group_id' => "activity_type",
+        'value' => $activityTypeId,
+      ]);
+    }
+    else {
+      $activityType = $formName == self::PDF_LETTER_FORM_NAME ? self::PDF_LETTER_ACTIVITY_TYPE : 'Email';
+    }
+    $id = $form->getVar('_activityId');
+    $status = NULL;
+    if ($id) {
+      $status = civicrm_api3('Activity', 'getsingle', [
+        'id' => $id,
+        'return' => 'status_id.name',
+      ]);
+      $status = $status['status_id.name'];
+    }
+    $checkParams = [
+      'option_group_id' => 'activity_type',
+      'grouping' => ['LIKE' => '%communication%'],
+      'value' => $activityTypeId,
+    ];
+    if (in_array($activityType, self::SPECIAL_TYPES) ||
+      ($activityTypeId && civicrm_api3('OptionValue', 'getcount', $checkParams))) {
+      $hideDraftButton = CRM_Utils_Request::retrieve('hideDraftButton', 'Boolean', $form);
+
+      if (($form->_action & (CRM_Core_Action::ADD + CRM_Core_Action::UPDATE)) && !$hideDraftButton) {
+        $buttonGroup = $form->getElement('buttons');
+        $buttons = $buttonGroup->getElements();
+        $buttons[] = $form->createElement('submit', $form->getButtonName('refresh'), ts('Save Draft'), [
+          'crm-icon' => 'fa-pencil-square-o',
+          'class' => 'crm-form-submit',
+        ]);
+        $buttonGroup->setElements($buttons);
+        $form->addGroup($buttons, 'buttons');
+        $form->setDefaults(['status_id' => 2]);
+      }
+      if ($status == 'Draft' && ($form->_action & CRM_Core_Action::VIEW)) {
+        if (in_array($activityType, self::SPECIAL_TYPES)) {
+          $atype = $activityType == self::EMAIL_ACTIVITY_TYPE ? 'email' : 'pdf';
+          $caseId = civicrm_api3('Activity', 'getsingle', [
+            'id' => $id,
+            'return' => 'case_id',
+          ]);
+          $composeUrl = CRM_Utils_System::url("civicrm/activity/$atype/add", [
+            'action' => 'add',
+            'reset' => 1,
+            'caseId' => $caseId['case_id'][0],
+            'context' => 'standalone',
+            'draft_id' => $id,
+          ]);
+          $buttonMarkup = '<a class="button" href="' . $composeUrl . '"><i class="crm-i fa-pencil-square-o"></i> &nbsp;' . ts('Continue Editing') . '</a>';
+          $form->assign('activityTypeDescription', $buttonMarkup);
+        }
+        else {
+          $form->assign('activityTypeDescription', '<i class="crm-i fa-pencil-square-o"></i> &nbsp;' . ts('Saved as a Draft'));
+        }
+      }
+    }
+    // Form email/print activities, set defaults from the original draft
+    // activity (which will be deleted on submit)
+    if (in_array($formName, self::SPECIAL_FORMS) && !empty($_GET['draft_id'])) {
+      $draft = civicrm_api3('Activity', 'get', [
+        'id' => $_GET['draft_id'],
+        'check_permissions' => TRUE,
+        'sequential' => TRUE,
+      ]);
+      $form->setVar('_activityId', $_GET['draft_id']);
+      if (isset($draft['values'][0])) {
+        $draft = $draft['values'][0];
+        if (in_array($formName, self::SPECIAL_FORMS)) {
+          $draft['html_message'] = CRM_Utils_Array::value('details', $draft);
+        }
+        // Set defaults for to email addresses.
+        if ($formName == self::EMAIL_FORM_NAME) {
+          $cids = CRM_Utils_Array::value('target_contact_id', civicrm_api3('Activity', 'getsingle', [
+            'id' => $draft['id'],
+            'return' => 'target_contact_id',
+          ]));
+          if ($cids) {
+            $toContacts = civicrm_api3('Contact', 'get', [
+              'id' => ['IN' => $cids],
+              'return' => ['email', 'sort_name'],
+            ]);
+            $toArray = [];
+            foreach ($toContacts['values'] as $cid => $contact) {
+              $toArray[] = [
+                'text' => '"' . $contact['sort_name'] . '" <' . $contact['email'] . '>',
+                'id' => "$cid::{$contact['email']}",
+              ];
+            }
+            $form->assign('toContact', json_encode($toArray));
+          }
+        }
+        $form->setDefaults($draft);
+      }
+    }
+  }
+
+  /**
+   * Check whether the form is for PDF of Email activity.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   * @param string $formName
+   *   Form Name.
+   *
+   * @return bool
+   *   Whether the hook should run or not.
+   */
+  private function shouldRun(CRM_Core_Form $form, $formName) {
+    return is_a($form, 'CRM_Activity_Form_Activity') || in_array($formName, self::SPECIAL_FORMS);
+  }
+
+}

--- a/CRM/Civicase/Hook/PostProcess/HandleDraftActivity.php
+++ b/CRM/Civicase/Hook/PostProcess/HandleDraftActivity.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Handle Draft Activity.
+ */
+class CRM_Civicase_Hook_PostProcess_HandleDraftActivity {
+
+  /**
+   * Add bulk email as an activity to all the selected cases.
+   *
+   * @param string $formName
+   *   The class name of the submitted form.
+   * @param object $form
+   *   The submitted form instance.
+   */
+  public function run($formName, $form) {
+    $urlParams = parse_url(
+      htmlspecialchars_decode($form->controller->_entryURL), PHP_URL_QUERY
+    );
+    parse_str($urlParams, $urlParams);
+
+    if (!$this->shouldRun($formName, $urlParams)) {
+      return;
+    }
+
+    $this->markPdfActivityAsComplete($form, $urlParams['draft_id']);
+    $this->deleteEmailDraftActivity($form, $urlParams['draft_id']);
+  }
+
+  /**
+   * Delete Email Draft Activity.
+   *
+   * @param object $form
+   *   Form object.
+   * @param string $draftActivityID
+   *   Draft Activity ID.
+   */
+  private function deleteEmailDraftActivity($form, $draftActivityID) {
+    $ifSendEmailButtonIsClicked = array_key_exists(
+      '_qf_Email_upload',
+      $form->getVar('_submitValues')['buttons']
+    );
+
+    if ($ifSendEmailButtonIsClicked) {
+      civicrm_api3('Activity', 'delete', [
+        'id' => $draftActivityID,
+      ]);
+    }
+  }
+
+  /**
+   * Mark Pdf Activity As Complete.
+   *
+   * @param object $form
+   *   Form object.
+   * @param string $draftActivityID
+   *   Draft Activity ID.
+   */
+  private function markPdfActivityAsComplete($form, $draftActivityID) {
+    $ifDownloadDocumentButtonClicked = array_key_exists(
+      '_qf_PDF_upload',
+      $form->getVar('_submitValues')['buttons']
+    );
+
+    if ($ifDownloadDocumentButtonClicked) {
+      civicrm_api3('Activity', 'create', [
+        'id' => $draftActivityID,
+        'status_id' => 'Completed',
+      ]);
+    }
+  }
+
+  /**
+   * Check whether the form is for PDF of Email activity.
+   *
+   * @param string $formName
+   *   The name for the current form.
+   * @param object $urlParams
+   *   URL parameters.
+   *
+   * @return bool
+   *   Whether the hook should run or not.
+   */
+  private function shouldRun($formName, $urlParams) {
+    $specialForms = ['CRM_Contact_Form_Task_PDF', 'CRM_Contact_Form_Task_Email'];
+
+    return in_array($formName, $specialForms) && !empty($urlParams['draft_id']);
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -434,6 +434,7 @@ function civicase_civicrm_postProcess($formName, &$form) {
     new CRM_Civicase_Hook_PostProcess_ActivityFormStatusWordReplacement(),
     new CRM_Civicase_Hook_PostProcess_RedirectToCaseDetails(),
     new CRM_Civicase_Hook_PostProcess_AttachEmailActivityToAllCases(),
+    new CRM_Civicase_Hook_PostProcess_HandleDraftActivity(),
   ];
 
   foreach ($hooks as $hook) {
@@ -443,27 +444,6 @@ function civicase_civicrm_postProcess($formName, &$form) {
   if (!empty($form->civicase_reload)) {
     $api = civicrm_api3('Case', 'getdetails', ['check_permissions' => 1] + $form->civicase_reload);
     $form->ajaxResponse['civicase_reload'] = $api['values'];
-  }
-  // When emailing/printing - delete draft.
-  $specialForms = ['CRM_Contact_Form_Task_PDF', 'CRM_Contact_Form_Task_Email'];
-  if (in_array($formName, $specialForms)) {
-    $urlParams = parse_url(htmlspecialchars_decode($form->controller->_entryURL), PHP_URL_QUERY);
-    parse_str($urlParams, $urlParams);
-
-    $ifDownloadDocumentButtonClicked = array_key_exists('_qf_PDF_upload', $form->getVar('_submitValues')['buttons']);
-    $ifSendEmailButtonIsClicked = array_key_exists('_qf_Email_upload', $form->getVar('_submitValues')['buttons']);
-
-    if ($ifDownloadDocumentButtonClicked && !empty($urlParams['draft_id'])) {
-      civicrm_api3('Activity', 'create', [
-        'id' => $urlParams['draft_id'],
-        'status_id' => 'Completed',
-      ]);
-    }
-    if ($ifSendEmailButtonIsClicked && !empty($urlParams['draft_id'])) {
-      civicrm_api3('Activity', 'delete', [
-        'id' => $urlParams['draft_id'],
-      ]);
-    }
   }
 }
 

--- a/civicase.php
+++ b/civicase.php
@@ -451,11 +451,17 @@ function civicase_civicrm_postProcess($formName, &$form) {
     parse_str($urlParams, $urlParams);
 
     $ifDownloadDocumentButtonClicked = array_key_exists('_qf_PDF_upload', $form->getVar('_submitValues')['buttons']);
+    $ifSendEmailButtonIsClicked = array_key_exists('_qf_Email_upload', $form->getVar('_submitValues')['buttons']);
 
     if ($ifDownloadDocumentButtonClicked && !empty($urlParams['draft_id'])) {
       civicrm_api3('Activity', 'create', [
         'id' => $urlParams['draft_id'],
         'status_id' => 'Completed',
+      ]);
+    }
+    if ($ifSendEmailButtonIsClicked && !empty($urlParams['draft_id'])) {
+      civicrm_api3('Activity', 'delete', [
+        'id' => $urlParams['draft_id'],
       ]);
     }
   }


### PR DESCRIPTION
## Overview
When sending a Draft Email, a duplicate activity was being created, but still the original draft activity was not deleted. This PR fixes that problem.

## Before
Draft Email Activity was not getting deleted.

## After
Draft Email Activity is now getting deleted.

## Technical Details
In https://github.com/compucorp/uk.co.compucorp.civicase/pull/629, the code to delete the activity was wrongly removed. 
@tunbola Pointed that
> Are we sure we can do away with this code? I think this deletes the draft activity right? Don't we still need to delete it at some point?

But I replied with 
> Yes, it is not required anymore. Because deletion of Activities are done seprately. But here once we want to move the Activity from Draft to Completed. It should not delete the activity, instead it should just change its status.

I think I misunderstood @tunbola 's comment when saying 
> Because deletion of Activities are done seprately

Anyways, this has been fixed now, and the previous is necessary for PDF activities, as we dont want to delete the activity. But for emails, deletion is required. So both code has been kept. 

Also as part of refactoring, 
`CRM/Civicase/Hook/PostProcess/HandleDraftActivity.php` has been created.

And `CRM/Civicase/Hook/BuildForm/HandleDraftActivities.php` is also created, where the code from BuildForm hook has been moved without any modification. But this file needs more refactoring in future, as the code is not readable at all.