### PR TITLE
CATL-2137: Show "Email-Send Now" case action only in bulk action

### DIFF
--- a/ang/civicase/case/actions/services/email-case-action.service.js
+++ b/ang/civicase/case/actions/services/email-case-action.service.js
@@ -18,6 +18,22 @@
    */
   function EmailCaseAction ($q, ts, isTruthy, dialogService, CaseType,
     CaseTypeCategory, civicaseCrmApi, Select2Utils, currentCaseCategory) {
+    this.isActionAllowed = isActionAllowed;
+    this.doAction = doAction;
+
+    /**
+     * Check if action is allowed.
+     *
+     * @param {object} action - action data.
+     * @param {object} cases - cases.
+     * @param {object} attributes - item attributes.
+     *
+     * @returns {boolean} - true if action is allowed, false otherwise.
+     */
+    function isActionAllowed (action, cases, attributes) {
+      return attributes.mode === 'case-bulk-actions';
+    }
+
     /**
      * Returns the configuration options to open up a mail popup to
      * communicate with the selected role. Displays an error message
@@ -29,7 +45,7 @@
      *
      * @returns {Promise} promise which resolves to the path for the popup
      */
-    this.doAction = function (cases, action, callbackFn) {
+    function doAction (cases, action, callbackFn) {
       var model = {
         caseRoles: [],
         selectedCaseRoles: '',
@@ -46,7 +62,7 @@
       openRoleSelectorPopUp(model);
 
       return model.deferObject.promise;
-    };
+    }
 
     /**
      * @param {string|number[]} caseRoleIds list of case roles ids

--- a/ang/test/civicase/case/actions/services/email-case-action.service.spec.js
+++ b/ang/test/civicase/case/actions/services/email-case-action.service.spec.js
@@ -31,152 +31,180 @@
       CRM.alert = actualCRMAlert;
     });
 
-    describe('when clicking on the action with one case selected', () => {
-      var modalOpenCall, returnValue, expectedModelObject;
+    describe('on click', () => {
+      describe('when clicking on the action with one case selected', () => {
+        var modalOpenCall, returnValue, expectedModelObject;
 
-      beforeEach(function () {
-        caseObj = CasesMockData.get().values[0];
-        EmailCaseAction.doAction([caseObj], 'email', jasmine.any(Function))
-          .then(function (result) {
-            returnValue = result;
-          });
-        expectedModelObject = {
-          caseRoles: [
-            { name: 'Client', id: 'client', text: 'Client' },
-            { name: 'Homeless Services Coordinator', id: '11', text: 'Homeless Services Coordinator' },
-            { name: 'Health Services Coordinator', id: '12', text: 'Health Services Coordinator' },
-            { name: 'Benefits Specialist', id: '14', text: 'Benefits Specialist' },
-            { name: 'Senior Services Coordinator', id: '16', text: 'Senior Services Coordinator' }
-          ],
-          caseClientIDs: ['170'],
-          selectedCaseRoles: '',
-          caseIds: [caseObj.id],
-          deferObject: jasmine.any(Object)
-        };
+        beforeEach(function () {
+          caseObj = CasesMockData.get().values[0];
+          EmailCaseAction.doAction([caseObj], 'email', jasmine.any(Function))
+            .then(function (result) {
+              returnValue = result;
+            });
+          expectedModelObject = {
+            caseRoles: [
+              { name: 'Client', id: 'client', text: 'Client' },
+              { name: 'Homeless Services Coordinator', id: '11', text: 'Homeless Services Coordinator' },
+              { name: 'Health Services Coordinator', id: '12', text: 'Health Services Coordinator' },
+              { name: 'Benefits Specialist', id: '14', text: 'Benefits Specialist' },
+              { name: 'Senior Services Coordinator', id: '16', text: 'Senior Services Coordinator' }
+            ],
+            caseClientIDs: ['170'],
+            selectedCaseRoles: '',
+            caseIds: [caseObj.id],
+            deferObject: jasmine.any(Object)
+          };
 
-        modalOpenCall = dialogServiceMock.open.calls.mostRecent().args;
-      });
+          modalOpenCall = dialogServiceMock.open.calls.mostRecent().args;
+        });
 
-      it('opens a popup with list of case roles', () => {
-        expect(dialogServiceMock.open).toHaveBeenCalledWith('EmailCaseActionRoleSelector',
-          '~/civicase/case/actions/directives/email-role-selector.html',
-          expectedModelObject,
-          {
-            autoOpen: false,
-            height: '300px',
-            width: '40%',
-            title: 'Email Case Role(s)',
-            buttons: [{
-              text: ts('Draft Email'),
-              icons: { primary: 'fa-check' },
-              click: jasmine.any(Function)
-            }]
-          }
-        );
-      });
+        it('opens a popup with list of case roles', () => {
+          expect(dialogServiceMock.open).toHaveBeenCalledWith('EmailCaseActionRoleSelector',
+            '~/civicase/case/actions/directives/email-role-selector.html',
+            expectedModelObject,
+            {
+              autoOpen: false,
+              height: '300px',
+              width: '40%',
+              title: 'Email Case Role(s)',
+              buttons: [{
+                text: ts('Draft Email'),
+                icons: { primary: 'fa-check' },
+                click: jasmine.any(Function)
+              }]
+            }
+          );
+        });
 
-      describe('when submitting the role selector popup', () => {
-        describe('and there are roles present for the selected relationships', () => {
-          beforeEach(() => {
-            civicaseCrmApiMock.and.returnValue($q.resolve({ values: RelationshipData.get() }));
-            modalOpenCall[2].selectedCaseRoles = 'client,11,12';
-            modalOpenCall[3].buttons[0].click();
+        describe('when submitting the role selector popup', () => {
+          describe('and there are roles present for the selected relationships', () => {
+            beforeEach(() => {
+              civicaseCrmApiMock.and.returnValue($q.resolve({ values: RelationshipData.get() }));
+              modalOpenCall[2].selectedCaseRoles = 'client,11,12';
+              modalOpenCall[3].buttons[0].click();
 
-            $rootScope.$digest();
-          });
+              $rootScope.$digest();
+            });
 
-          it('fetches the active relationships', () => {
-            expect(civicaseCrmApiMock).toHaveBeenCalledWith('Relationship', 'get', {
-              sequential: 1,
-              is_active: 1,
-              case_id: { IN: ['141'] },
-              relationship_type_id: { IN: ['11', '12'] },
-              options: { limit: 0 }
+            it('fetches the active relationships', () => {
+              expect(civicaseCrmApiMock).toHaveBeenCalledWith('Relationship', 'get', {
+                sequential: 1,
+                is_active: 1,
+                case_id: { IN: ['141'] },
+                relationship_type_id: { IN: ['11', '12'] },
+                options: { limit: 0 }
+              });
+            });
+
+            it('returns the path to open the send email popup and hides the draft button', () => {
+              expect(returnValue).toEqual({
+                path: 'civicrm/activity/email/add',
+                query: {
+                  action: 'add',
+                  reset: 1,
+                  cid: '170,4,6',
+                  hideDraftButton: 1,
+                  caseid: '141',
+                  caseRolesBulkEmail: 1
+                }
+              });
             });
           });
 
-          it('returns the path to open the send email popup and hides the draft button', () => {
-            expect(returnValue).toEqual({
-              path: 'civicrm/activity/email/add',
-              query: {
-                action: 'add',
-                reset: 1,
-                cid: '170,4,6',
-                hideDraftButton: 1,
-                caseid: '141',
-                caseRolesBulkEmail: 1
-              }
+          describe('and there are no roles present for the selected relationships', () => {
+            beforeEach(() => {
+              civicaseCrmApiMock.and.returnValue($q.resolve({ values: [] }));
+              modalOpenCall[2].selectedCaseRoles = '11,12';
+              modalOpenCall[3].buttons[0].click();
+
+              $rootScope.$digest();
+            });
+
+            it('shows an error message', () => {
+              expect(returnValue).toBeUndefined();
+              expect(CRM.alert).toHaveBeenCalledWith(
+                'Please add a contact for the selected role(s).',
+                'No contacts available for selected role(s)',
+                'error'
+              );
+            });
+          });
+
+          describe('and there are no roles selected on the popup', () => {
+            beforeEach(() => {
+              CRM.alert.calls.reset();
+              modalOpenCall[2].selectedCaseRoles = '';
+              modalOpenCall[3].buttons[0].click();
+
+              $rootScope.$digest();
+            });
+
+            it('shows an error message', () => {
+              expect(CRM.alert).toHaveBeenCalledWith(
+                'Select case role(s).',
+                'No case roles are selected',
+                'error'
+              );
             });
           });
         });
+      });
+      describe('when clicking on the action with more than one case selected', () => {
+        var modalOpenCall, returnValue;
 
-        describe('and there are no roles present for the selected relationships', () => {
-          beforeEach(() => {
-            civicaseCrmApiMock.and.returnValue($q.resolve({ values: [] }));
-            modalOpenCall[2].selectedCaseRoles = '11,12';
-            modalOpenCall[3].buttons[0].click();
-
-            $rootScope.$digest();
-          });
-
-          it('shows an error message', () => {
-            expect(returnValue).toBeUndefined();
-            expect(CRM.alert).toHaveBeenCalledWith(
-              'Please add a contact for the selected role(s).',
-              'No contacts available for selected role(s)',
-              'error'
-            );
-          });
+        beforeEach(function () {
+          caseObj = CasesMockData.get().values[0];
+          var case2Obj = CasesMockData.get().values[1];
+          EmailCaseAction.doAction([caseObj, case2Obj], 'email', jasmine.any(Function))
+            .then(function (result) {
+              returnValue = result;
+            });
+          modalOpenCall = dialogServiceMock.open.calls.mostRecent().args;
+          civicaseCrmApiMock.and.returnValue($q.resolve({ values: RelationshipData.get() }));
+          modalOpenCall[2].selectedCaseRoles = 'client,11,12';
+          modalOpenCall[3].buttons[0].click();
+          $rootScope.$digest();
         });
 
-        describe('and there are no roles selected on the popup', () => {
-          beforeEach(() => {
-            CRM.alert.calls.reset();
-            modalOpenCall[2].selectedCaseRoles = '';
-            modalOpenCall[3].buttons[0].click();
-
-            $rootScope.$digest();
-          });
-
-          it('shows an error message', () => {
-            expect(CRM.alert).toHaveBeenCalledWith(
-              'Select case role(s).',
-              'No case roles are selected',
-              'error'
-            );
+        it('adds bulk email activitiy to all the selected cases', () => {
+          expect(returnValue).toEqual({
+            path: 'civicrm/activity/email/add',
+            query: {
+              action: 'add',
+              reset: 1,
+              cid: '170,4,6',
+              hideDraftButton: 1,
+              caseid: '141',
+              allCaseIds: '141,3',
+              caseRolesBulkEmail: 1
+            }
           });
         });
       });
     });
-    describe('when clicking on the action with more than one case selected', () => {
-      var modalOpenCall, returnValue;
 
-      beforeEach(function () {
-        caseObj = CasesMockData.get().values[0];
-        var case2Obj = CasesMockData.get().values[1];
-        EmailCaseAction.doAction([caseObj, case2Obj], 'email', jasmine.any(Function))
-          .then(function (result) {
-            returnValue = result;
-          });
-        modalOpenCall = dialogServiceMock.open.calls.mostRecent().args;
-        civicaseCrmApiMock.and.returnValue($q.resolve({ values: RelationshipData.get() }));
-        modalOpenCall[2].selectedCaseRoles = 'client,11,12';
-        modalOpenCall[3].buttons[0].click();
-        $rootScope.$digest();
+    describe('visibility of the action', () => {
+      var caseObj, isVisible;
+
+      describe('when inside the bulk action', () => {
+        beforeEach(function () {
+          caseObj = CasesMockData.get().values[0];
+          isVisible = EmailCaseAction.isActionAllowed('email', [caseObj], { mode: 'case-bulk-actions' });
+        });
+
+        it('shows the action', () => {
+          expect(isVisible).toBe(true);
+        });
       });
 
-      it('adds bulk email activitiy to all the selected cases', () => {
-        expect(returnValue).toEqual({
-          path: 'civicrm/activity/email/add',
-          query: {
-            action: 'add',
-            reset: 1,
-            cid: '170,4,6',
-            hideDraftButton: 1,
-            caseid: '141',
-            allCaseIds: '141,3',
-            caseRolesBulkEmail: 1
-          }
+      describe('when outside the bulk block', () => {
+        beforeEach(function () {
+          caseObj = CasesMockData.get().values[0];
+          isVisible = EmailCaseAction.isActionAllowed('email', [caseObj], { mode: 'not-case-bulk-actions' });
+        });
+
+        it('hides the action', () => {
+          expect(isVisible).toBe(false);
         });
       });
     });


### PR DESCRIPTION
## Overview
"Email - Send Now" case action is now visible only on the Bulk Action, not anywhere else.

## Before
In Case Summary Page
![2021-03-09 at 4 17 PM](https://user-images.githubusercontent.com/5058867/110459413-f5403980-80f2-11eb-8490-547903681387.png)

In Contact Case Tab
![2021-03-09 at 4 17 PM](https://user-images.githubusercontent.com/5058867/110459395-ee192b80-80f2-11eb-86ce-60e902b86eda.png)

## After
In Case Summary Page
![2021-03-09 at 4 16 PM](https://user-images.githubusercontent.com/5058867/110459251-c32ed780-80f2-11eb-92ad-a8bb0e5f9626.png)

In Contact Case Tab
![2021-03-09 at 4 16 PM](https://user-images.githubusercontent.com/5058867/110459278-cb871280-80f2-11eb-8eb3-26f0652a5d40.png)

## Technical Details
Added `isActionAllowed` function to `EmailCaseAction` to implement this.