### PR TITLE
CATL-2139: Show All Relationships in People's tab

### DIFF
--- a/ang/civicase/case/details/people-tab/directives/roles-tab.directive.html
+++ b/ang/civicase/case/details/people-tab/directives/roles-tab.directive.html
@@ -199,7 +199,9 @@
           >
             <i class="fa fa-user-plus"></i>
           </button>
-          <div ng-if="role.contact_id" class="btn-group btn-group-sm">
+          <div
+            ng-if="(role.is_active === '1' || role.role === ts('Client')) && role.contact_id"
+            class="btn-group btn-group-sm">
             <button
               type="button"
               class="btn btn-default dropdown-toggle"

--- a/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
+++ b/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
@@ -2,7 +2,7 @@
   var module = angular.module('civicase');
 
   module.service('civicasePeopleTabRoles', function (isTruthy, RelationshipType,
-    ts) {
+    ts, allowMultipleCaseClients) {
     var caseContacts = [];
     var caseRelationships = [];
     var roles = this;
@@ -262,7 +262,9 @@
      *   a given case.
      */
     function setCaseRelationships (newCaseRelationships) {
-      caseRelationships = getUniqueCaseRelationships(newCaseRelationships);
+      caseRelationships = !allowMultipleCaseClients
+        ? newCaseRelationships
+        : getUniqueCaseRelationships(newCaseRelationships);
     }
 
     /**

--- a/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
+++ b/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
@@ -4,7 +4,9 @@
   describe('PeopleTabRoles', () => {
     let caseItem, caseType, peopleTabRoles, relationships, relationshipTypes;
 
-    beforeEach(module('civicase', 'civicase.data'));
+    beforeEach(module('civicase', 'civicase.data', ($provide) => {
+      $provide.constant('allowMultipleCaseClients', false);
+    }));
 
     beforeEach(inject((_CasesData_, _CaseTypesMockData_,
       _civicasePeopleTabRoles_, _RelationshipTypeData_) => {
@@ -179,6 +181,34 @@
           expect(peopleTabRoles.list).not.toContain(jasmine.objectContaining({
             contact_id: relationships[0].contact_id_b
           }));
+        });
+      });
+
+      describe('when showing inactive roles', () => {
+        describe('when the same contact holds multiple inactive roles', () => {
+          var displaysAllTheInactiveRoles;
+
+          beforeEach(() => {
+            peopleTabRoles.list = [];
+            peopleTabRoles.fullRolesList = [];
+            const inactiveRelationships = [
+              _.extend({}, relationships[0], { is_active: '0' }),
+              _.extend({}, relationships[0], { is_active: '0' }),
+              _.extend({}, relationships[0], { is_active: '0' }),
+              _.extend({}, relationships[0], { is_active: '0' })
+            ];
+
+            peopleTabRoles.setCaseRelationships(inactiveRelationships);
+            peopleTabRoles.updateRolesList({ showInactiveRoles: true });
+
+            displaysAllTheInactiveRoles = _.filter(peopleTabRoles.list, function (a) {
+              return a.relationship_type_id === relationships[0].relationship_type_id;
+            }).length === 4;
+          });
+
+          it('includes all the contact relations', () => {
+            expect(displaysAllTheInactiveRoles).toBe(true);
+          });
         });
       });
     });


### PR DESCRIPTION
## Overview
In the Peoples tab of Case Summary, if we
1. Assign a Contact to a Role.
2. Assign another Contact to the same role,
3. Assign back the Contact from Step 1 to the same role again.
4. Click "Display previous case role assignments" checkbox.

It did not show 3 Roles in total. Instead it skipped the Role from Step 1. This PR fixes that issue.

**Note:** This issue still exists for Cases with Multiple clients. But thats hard to fix as the logic is very complex. For the time being and because of time constraints, we have fixed it, only when "Allow Multiple Case Clients" is set to Single Client.

Also the dropdown menu was visible for Inactive Roles as well, it has been removed now.

## Before
![2021-03-10 at 4 03 PM](https://user-images.githubusercontent.com/5058867/110616096-2b94bc00-81ba-11eb-8096-51aa7539a92e.png)

## After
![2021-03-10 at 4 04 PM](https://user-images.githubusercontent.com/5058867/110616189-47985d80-81ba-11eb-8326-7944a72acb0e.png)

## Technical Details
1. In `ang/civicase/case/details/people-tab/directives/roles-tab.directive.html` hiding the dropdown menu when the role is inactive.
2. In `ang/civicase/case/details/people-tab/services/people-tab-roles.service.js`, not applying any modifications to the Roles when `Single Client` is turned on
```javascript
caseRelationships = !allowMultipleCaseClients
  ? newCaseRelationships
  : getUniqueCaseRelationships(newCaseRelationships);
```
Because `getUniqueCaseRelationships` is only required for multiple clients.