### PR TITLE
CATL-2143: Show print merge case action only in bulk action

### DIFF
--- a/ang/civicase/case/actions/services/print-merge-case-action.service.js
+++ b/ang/civicase/case/actions/services/print-merge-case-action.service.js
@@ -9,6 +9,22 @@
    * @param {object} $q $q service
    */
   function PrintMergeCaseAction ($q) {
+    this.isActionAllowed = isActionAllowed;
+    this.doAction = doAction;
+
+    /**
+     * Check if action is allowed.
+     *
+     * @param {object} action - action data.
+     * @param {object} cases - cases.
+     * @param {object} attributes - item attributes.
+     *
+     * @returns {boolean} - true if action is allowed, false otherwise.
+     */
+    function isActionAllowed (action, cases, attributes) {
+      return attributes.mode === 'case-bulk-actions';
+    }
+
     /**
      * Click event handler for the Action
      *
@@ -18,7 +34,7 @@
      *
      * @returns {Promise} promise which resolves to the path for the popup
      */
-    this.doAction = function (cases, action, callbackFn) {
+    function doAction (cases, action, callbackFn) {
       var contactIds = [];
       var caseIds = [];
 
@@ -37,6 +53,6 @@
           caseid: caseIds.join()
         }
       });
-    };
+    }
   }
 })(angular, CRM.$, CRM._);

--- a/ang/test/civicase/case/actions/services/print-merge-case-action.service.spec.js
+++ b/ang/test/civicase/case/actions/services/print-merge-case-action.service.spec.js
@@ -39,5 +39,31 @@
         });
       });
     });
+
+    describe('visibility of the action', () => {
+      var caseObj, isVisible;
+
+      describe('when inside the bulk action', () => {
+        beforeEach(function () {
+          caseObj = CasesMockData.get().values[0];
+          isVisible = PrintMergeCaseAction.isActionAllowed('email', [caseObj], { mode: 'case-bulk-actions' });
+        });
+
+        it('shows the action', () => {
+          expect(isVisible).toBe(true);
+        });
+      });
+
+      describe('when outside the bulk block', () => {
+        beforeEach(function () {
+          caseObj = CasesMockData.get().values[0];
+          isVisible = PrintMergeCaseAction.isActionAllowed('email', [caseObj], { mode: 'not-case-bulk-actions' });
+        });
+
+        it('hides the action', () => {
+          expect(isVisible).toBe(false);
+        });
+      });
+    });
   });
 })(CRM._, CRM.$);


### PR DESCRIPTION
## Overview
"Print Merge document" case action is now visible only on the Bulk Action, not anywhere else.

## Before
![2021-03-11 at 5 52 PM](https://user-images.githubusercontent.com/5058867/110786772-8b5e9600-8292-11eb-9ab9-9ef9818ee808.png)

## After
![2021-03-11 at 5 51 PM](https://user-images.githubusercontent.com/5058867/110786722-7aae2000-8292-11eb-9004-3eb8b63c4caa.png)

## Technical Details
Added `isActionAllowed` function to `PrintMergeCaseAction` to implement this.