### PR TITLE
CATL-2140: Fix CC BCC field

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/LimitRecipientFieldsToOnlySelectedContacts.php
+++ b/CRM/Civicase/Hook/BuildForm/LimitRecipientFieldsToOnlySelectedContacts.php
@@ -31,6 +31,7 @@ class CRM_Civicase_Hook_BuildForm_LimitRecipientFieldsToOnlySelectedContacts {
       return [
         'email' => $contact['email'],
         'display_name' => $contact['display_name'],
+        'value' => $contact['contact_id'] . '::' . $contact['email'],
         'email_id' => $contact['email_id'],
         'contact_id' => $contact['contact_id'],
       ];

--- a/CRM/Civicase/Hook/BuildForm/LimitRecipientFieldsToOnlySelectedContacts.php
+++ b/CRM/Civicase/Hook/BuildForm/LimitRecipientFieldsToOnlySelectedContacts.php
@@ -28,10 +28,18 @@ class CRM_Civicase_Hook_BuildForm_LimitRecipientFieldsToOnlySelectedContacts {
    */
   public function limitRecipientFields(CRM_Core_Form &$form) {
     $contacts = array_map(function ($contact) {
+      $contactResponse = civicrm_api3('Contact', 'get', [
+        'sequential' => 1,
+        'id' => $contact['contact_id'],
+        'options' => ['limit' => 1],
+      ]);
+
+      $emailID = CRM_Utils_Array::first($contactResponse['values'])['email_id'];
+
       return [
         'email' => $contact['email'],
-        'value' => $contact['contact_id'] . '::' . $contact['email'],
         'display_name' => $contact['display_name'],
+        'email_id' => $emailID,
         'contact_id' => $contact['contact_id'],
       ];
     }, $form->_contactDetails);

--- a/CRM/Civicase/Hook/BuildForm/LimitRecipientFieldsToOnlySelectedContacts.php
+++ b/CRM/Civicase/Hook/BuildForm/LimitRecipientFieldsToOnlySelectedContacts.php
@@ -28,18 +28,10 @@ class CRM_Civicase_Hook_BuildForm_LimitRecipientFieldsToOnlySelectedContacts {
    */
   public function limitRecipientFields(CRM_Core_Form &$form) {
     $contacts = array_map(function ($contact) {
-      $contactResponse = civicrm_api3('Contact', 'get', [
-        'sequential' => 1,
-        'id' => $contact['contact_id'],
-        'options' => ['limit' => 1],
-      ]);
-
-      $emailID = CRM_Utils_Array::first($contactResponse['values'])['email_id'];
-
       return [
         'email' => $contact['email'],
         'display_name' => $contact['display_name'],
-        'email_id' => $emailID,
+        'email_id' => $contact['email_id'],
         'contact_id' => $contact['contact_id'],
       ];
     }, $form->_contactDetails);

--- a/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
+++ b/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
@@ -78,6 +78,7 @@ class CRM_Civicase_Hook_BuildForm_RestrictCaseEmailContacts {
       return [
         'role' => $caseContact['role'],
         'email' => $caseContact['email'],
+        'value' => $caseContact['contact_id'] . '::' . $caseContact['email'],
         'display_name' => $caseContact['display_name'],
         'email_id' => $emailID,
         'contact_id' => $caseContact['contact_id'],

--- a/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
+++ b/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
@@ -65,11 +65,19 @@ class CRM_Civicase_Hook_BuildForm_RestrictCaseEmailContacts {
     $caseDetails = CRM_Utils_Array::first($caseDetailsResponse['values']);
 
     $caseContacts = array_map(function ($caseContact) {
+      $contactResponse = civicrm_api3('Contact', 'get', [
+        'sequential' => 1,
+        'id' => $caseContact['contact_id'],
+        'options' => ['limit' => 1],
+      ]);
+
+      $emailID = CRM_Utils_Array::first($contactResponse['values'])['email_id'];
+
       return [
         'role' => $caseContact['role'],
         'email' => $caseContact['email'],
-        'value' => $caseContact['contact_id'] . '::' . $caseContact['email'],
         'display_name' => $caseContact['display_name'],
+        'email_id' => $emailID,
         'contact_id' => $caseContact['contact_id'],
       ];
     }, $caseDetails['contacts']);

--- a/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
+++ b/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
@@ -64,14 +64,16 @@ class CRM_Civicase_Hook_BuildForm_RestrictCaseEmailContacts {
     ]);
     $caseDetails = CRM_Utils_Array::first($caseDetailsResponse['values']);
 
-    $caseContacts = array_map(function ($caseContact) {
-      $contactResponse = civicrm_api3('Contact', 'get', [
-        'sequential' => 1,
-        'id' => $caseContact['contact_id'],
-        'options' => ['limit' => 1],
-      ]);
+    $contactResponse = civicrm_api3('Contact', 'get', [
+      'sequential' => 1,
+      'return' => ['email'],
+      'id' => ['IN' => array_column($caseDetails['contacts'], 'contact_id')],
+    ]);
 
-      $emailID = CRM_Utils_Array::first($contactResponse['values'])['email_id'];
+    $contactEmailds = array_column($contactResponse['values'], 'email_id', 'id');
+
+    $caseContacts = array_map(function ($caseContact) use ($contactEmailds) {
+      $emailID = $contactEmailds[$caseContact['contact_id']];
 
       return [
         'role' => $caseContact['role'],

--- a/js/restrict-email-contacts.js
+++ b/js/restrict-email-contacts.js
@@ -21,8 +21,8 @@
       var $field = $(this);
       var isToField = $field.attr('name') === 'to';
       var contactSelect2Options = isToField
-        ? getContactOptions({ idFieldName: 'value' })
-        : getContactOptions({ idFieldName: 'contact_id' });
+        ? getContactOptions({ idFieldName: 'contact_id' })
+        : getContactOptions({ idFieldName: 'email_id' });
 
       $field.crmSelect2({
         multiple: true,

--- a/js/restrict-email-contacts.js
+++ b/js/restrict-email-contacts.js
@@ -21,7 +21,7 @@
       var $field = $(this);
       var isToField = $field.attr('name') === 'to';
       var contactSelect2Options = isToField
-        ? getContactOptions({ idFieldName: 'contact_id' })
+        ? getContactOptions({ idFieldName: 'value' })
         : getContactOptions({ idFieldName: 'email_id' });
 
       $field.crmSelect2({


### PR DESCRIPTION
## Overview
When sending an email with CC and BCC field, in NEU site, the CC and BCC emails were not sent, this PR fixes that issue.

## Before
![2021-03-11 at 7 21 PM](https://user-images.githubusercontent.com/5058867/110797411-0f1e7f80-829f-11eb-8121-2d81c92d8857.png)

## After
![2021-03-11 at 7 09 PM](https://user-images.githubusercontent.com/5058867/110795843-48ee8680-829d-11eb-963b-d52890340373.png)

## Technical Details
In `js/restrict-email-contacts.js`, when assigning the `data` for each dropdown element, we were assigning the Contact ID, but should be the Email ID(email_id field in Contact API). It worked before, because in most cases the `contact_id` and `email_id` is same. But for NEU, its not the same, hence the issue was found on NEU.
