### PR TITLE
CATL-2142: Do Not Recreate Existent Relationships

### DIFF
--- a/CRM/Civicase/Event/Listener/CaseRoleCreation.php
+++ b/CRM/Civicase/Event/Listener/CaseRoleCreation.php
@@ -67,12 +67,62 @@ class CRM_Civicase_Event_Listener_CaseRoleCreation {
       return;
     }
 
-    $action = !empty($apiRequest['params']['id']) ? 'update' : 'create';
-    if ($action == 'create') {
+    $relationshipId = self::getRelationshipIdFromRequestParams($apiRequest['params']);
+    if ($relationshipId === NULL) {
       $caseCreationPreProcess = new CaseRoleCreationPreProcess();
       $caseCreationPreProcess->onCreate($apiRequest);
       $event->setApiRequest($apiRequest);
     }
+    elseif (!isset($apiRequest['params']['id'])) {
+      $apiRequest['params']['id'] = $relationshipId;
+      $event->setApiRequest($apiRequest);
+    }
+  }
+
+  /**
+   * Return the Id of the relationship for the API request params.
+   *
+   * The code looks from the ID param, or try to find it by the other received
+   * information.
+   *
+   * @param array $params
+   *   Params received from the API request.
+   *
+   * @return int|null
+   *   The ID of the relationship, or NULL in case of not being found.
+   */
+  private static function getRelationshipIdFromRequestParams(array $params) {
+    if (isset($params['id']) && is_numeric($params['id'])) {
+      return $params['id'];
+    }
+
+    $requiredFields = [
+      'relationship_type_id',
+      'case_id',
+      'contact_id_a',
+      'contact_id_b',
+    ];
+
+    foreach ($requiredFields as $field) {
+      if (!isset($params[$field]) || !is_numeric($params[$field])) {
+        return NULL;
+      }
+    }
+
+    $relationship = civicrm_api3('Relationship', 'get', [
+      'relationship_type_id' => $params['relationship_type_id'],
+      'contact_id_a' => $params['contact_id_a'],
+      'contact_id_b' => $params['contact_id_b'],
+      'case_id' => $params['case_id'],
+      'is_active' => 1,
+      'return' => ['id'],
+    ]);
+
+    if ($relationship['count'] === 0) {
+      return NULL;
+    }
+
+    return array_shift($relationship['values'])['id'];
   }
 
   /**

--- a/tests/phpunit/api/v3/CaseRoleCreationTest.php
+++ b/tests/phpunit/api/v3/CaseRoleCreationTest.php
@@ -149,7 +149,7 @@ class api_v3_CaseRoleCreationTest extends BaseHeadlessTest {
     $relationshipCreated->id = $relationshipCreatedId;
     $relationshipCreated->find();
 
-    $this->assertNotEquals($relationshipCreated->is_active, $relationshipUpdated['id']);
+    $this->assertNotEquals($relationshipCreated->id, $relationshipUpdated['id']);
     $this->assertEquals(1, $relationshipUpdated['is_active']);
     $this->assertEquals(0, $relationshipCreated->is_active);
   }

--- a/tests/phpunit/api/v3/CaseRoleCreationTest.php
+++ b/tests/phpunit/api/v3/CaseRoleCreationTest.php
@@ -111,6 +111,50 @@ class api_v3_CaseRoleCreationTest extends BaseHeadlessTest {
   }
 
   /**
+   * Test an existent relationship is not created again.
+   */
+  public function testExistentRelationshipIsNotCreatedAgain() {
+    $caseClient = ContactFabricator::fabricate();
+    $contact = ContactFabricator::fabricate();
+    $relationshipParams = $this->getRelationshipBaseParamsForCaseClient($caseClient);
+
+    $relationshipParams['contact_id_b'] = $contact['id'];
+    $relationshipCreated = civicrm_api3('Relationship', 'create', $relationshipParams);
+    $relationshipCreatedAgain = civicrm_api3('Relationship', 'create', $relationshipParams);
+
+    $this->assertEquals($relationshipCreated['id'], $relationshipCreatedAgain['id']);
+  }
+
+  /**
+   * Test an existent relationship is correctly updated.
+   */
+  public function testExistentRelationshipIsCorrectlyUpdated() {
+    $caseClient = ContactFabricator::fabricate();
+    $firstContact = ContactFabricator::fabricate();
+    $secondContact = ContactFabricator::fabricate();
+    $relationshipParams = $this->getRelationshipBaseParamsForCaseClient($caseClient);
+
+    // Create first relationship.
+    $relationshipParams['contact_id_b'] = $firstContact['id'];
+    $relationshipCreated = civicrm_api3('Relationship', 'create', $relationshipParams);
+    $relationshipCreatedId = array_shift($relationshipCreated['values'])['id'];
+
+    // Update relationship with second contact.
+    $relationshipParams['contact_id_b'] = $secondContact['id'];
+    $relationshipUpdated = civicrm_api3('Relationship', 'create', $relationshipParams);
+    $relationshipUpdated = array_shift($relationshipUpdated['values']);
+
+    // Refresh previous relationship.
+    $relationshipCreated = new CRM_Contact_DAO_Relationship();
+    $relationshipCreated->id = $relationshipCreatedId;
+    $relationshipCreated->find();
+
+    $this->assertNotEquals($relationshipCreated->is_active, $relationshipUpdated['id']);
+    $this->assertEquals(1, $relationshipUpdated['is_active']);
+    $this->assertEquals(0, $relationshipCreated->is_active);
+  }
+
+  /**
    * Get created activity data.
    *
    * @param int|null $caseId
@@ -134,6 +178,28 @@ class api_v3_CaseRoleCreationTest extends BaseHeadlessTest {
     $result = civicrm_api3('Activity', 'get', $params);
 
     return $result;
+  }
+
+  /**
+   * Return the params for creating a relationship, for the given contact.
+   *
+   * @param array $caseClient
+   *   Contact details.
+   */
+  private function getRelationshipBaseParamsForCaseClient(array $caseClient) {
+    $case = CaseFabricator::fabricate(
+      [
+        'case_type_id' => CaseTypeFabricator::fabricate()['id'],
+        'contact_id' => $caseClient['id'],
+        'creator_id' => $caseClient['id'],
+      ]
+    );
+
+    return [
+      'relationship_type_id' => RelationshipTypeFabricator::fabricate()['id'],
+      'contact_id_a' => $caseClient['id'],
+      'case_id' => $case['id'],
+    ];
   }
 
 }


### PR DESCRIPTION
## Overview
This PR makes that when a webform is sent with relationships information for a Case, the relationship is not recreated if it was not modified.

## Before
When using a WebForm for updating relationships for a Case, even when the relationship was not modified (I mean, it continues being between the same contacts, and type, case, etc), it was being recreated, causing problems for identifying the past roles.

## After
If a relationship is not modified, then it is not recreated.

## Technical Details
As we can see on the webform_civicrm extension, the relationships selected are being sent without the identifier:
https://github.com/compucorp/webform_civicrm/blob/7.x-5.1-patches/includes/wf_crm_webform_postprocess.inc#L1297
That is the same if the relationship is new or if it didn't change.

These changes identify on the hook that is executed before the actual change occur, if the relationship type, for the received contacts and case, is currently active. In that case, we know that this can be handled as an update, then we can insert the ID on the request.

## Comments
This handles correctly the changes using the webform, but we can still have a relationship recreated if the exact same contact is chosen from the People tab on Case. But in my opinion, the chances of somebody choosing the same contact manually are not worth to be considered.
