### PR TITLE
CPS-488: Fix for Client role

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "extends": ["semistandard", "plugin:jsdoc/recommended"],
+  "ignorePatterns": ["packages/*.js"],
   "globals": {
     "CRM": "writable",
     "angular": "readonly",

--- a/ang/civicase/activity/calendar/decorators/uib-daypicker.decorator.js
+++ b/ang/civicase/activity/calendar/decorators/uib-daypicker.decorator.js
@@ -33,7 +33,7 @@
         /**
          * Returns the current day of the week.
          *
-         * @return {Number}
+         * @returns {number} current day of the week
          */
         function getCurrentWeekDay () {
           var currentWeekDay = moment().isoWeekday() - 1; // Force Monday as the first day

--- a/ang/civicase/activity/factories/format-activity.factory.js
+++ b/ang/civicase/activity/factories/format-activity.factory.js
@@ -1,7 +1,7 @@
 (function (angular, $, _, CRM) {
   var module = angular.module('civicase');
 
-  module.factory('formatActivity', function (ContactsCache, ActivityStatusType,
+  module.factory('formatActivity', function (CasesUtils, ActivityStatusType,
     ActivityStatus, ActivityType, CaseStatus, CaseType, isTruthy) {
     var activityTypes = ActivityType.getAll(true);
     var activityStatuses = ActivityStatus.getAll();
@@ -48,7 +48,7 @@
         act.case.type = CaseType.getById(act.case.case_type_id);
 
         _.each(act.case.contacts, function (contact) {
-          if (!contact.relationship_type_id) {
+          if (CasesUtils.isClientRole(contact)) {
             act.case.client.push(contact);
           }
           if (isTruthy(contact.manager)) {

--- a/ang/civicase/activity/filters/directives/activity-filters-contact.directive.js
+++ b/ang/civicase/activity/filters/directives/activity-filters-contact.directive.js
@@ -15,7 +15,7 @@
     /**
      * Link function for civicaseActivityFiltersContact
      *
-     * @param {object} $scope
+     * @param {object} $scope scope object
      */
     function civicaseActivityFiltersContactLink ($scope) {
       $scope.ts = CRM.ts('civicase');
@@ -38,8 +38,8 @@
       /**
        * Subscribe listener for civicaseActivityFeed.query
        *
-       * @param {object} event
-       * @param {object} feedQueryParams
+       * @param {object} event event object
+       * @param {object} feedQueryParams query parameters
        */
       function feedQueryListener (event, feedQueryParams) {
         if (feedQueryParams.reset) {

--- a/ang/civicase/activity/services/activity-feed-measurements.service.js
+++ b/ang/civicase/activity/services/activity-feed-measurements.service.js
@@ -7,7 +7,7 @@
     /**
      * Returns the offset of feed body from top
      *
-     * @return {Number}
+     * @returns {number} top offset
      */
     function getTopOffset () {
       var $feedBody = $('.civicase__activity-feed__body');
@@ -29,7 +29,7 @@
      * So If that height is fetched and again set to activity feed,
      * means nothing has changed, Thats why calculating child height is necessary.
      *
-     * @return {Number}
+     * @returns {number} tab height
      */
     function getCivicrmContactTabHeight () {
       var height = 0;
@@ -45,8 +45,7 @@
     /**
      * Sets height of the given element for scrolling
      *
-     * @param {Object} $element
-     * @return {Number}
+     * @param {object} $element element
      */
     function setScrollHeightOf ($element) {
       var $civicrmContactTabs = $('.crm-contact-tabs-list');

--- a/ang/civicase/bulk-action/services/bulk-actions.service.js
+++ b/ang/civicase/bulk-action/services/bulk-actions.service.js
@@ -3,11 +3,14 @@
 
   module.service('BulkActions', BulkActionsService);
 
+  /**
+   * Bulk Action service.
+   */
   function BulkActionsService () {
     /**
      * Checks if bulkactions are available
      *
-     * @return {Boolean}
+     * @returns {boolean} if allowed
      */
     this.isAllowed = function () {
       if (CRM.checkPerm('basic case information') &&

--- a/ang/civicase/case/actions/services/delete-cases-case-action.service.js
+++ b/ang/civicase/case/actions/services/delete-cases-case-action.service.js
@@ -3,13 +3,16 @@
 
   module.service('DeleteCasesCaseAction', DeleteCasesCaseAction);
 
+  /**
+   * Delete case action service
+   */
   function DeleteCasesCaseAction () {
     /**
      * Click event handler for the Action
      *
-     * @param {Array} cases
-     * @param {Object} action
-     * @param {Function} callbackFn
+     * @param {Array} cases list of cases
+     * @param {object} action action object
+     * @param {Function} callbackFn callback function
      */
     this.doAction = function (cases, action, callbackFn) {
       var ts = CRM.ts('civicase');
@@ -19,15 +22,15 @@
       switch (action.type) {
         case 'delete':
           trash = 0;
-          msg = cases.length === 1 ? ts('Permanently delete selected case? This cannot be undone.') : ts('Permanently delete %1 cases? This cannot be undone.', { '1': cases.length });
+          msg = cases.length === 1 ? ts('Permanently delete selected case? This cannot be undone.') : ts('Permanently delete %1 cases? This cannot be undone.', { 1: cases.length });
           break;
 
         case 'restore':
-          msg = cases.length === 1 ? ts('Undelete selected case?') : ts('Undelete %1 cases?', { '1': cases.length });
+          msg = cases.length === 1 ? ts('Undelete selected case?') : ts('Undelete %1 cases?', { 1: cases.length });
           break;
 
         default:
-          msg = cases.length === 1 ? ts('This case and all associated activities will be moved to the trash.') : ts('%1 cases and all associated activities will be moved to the trash.', { '1': cases.length });
+          msg = cases.length === 1 ? ts('This case and all associated activities will be moved to the trash.') : ts('%1 cases and all associated activities will be moved to the trash.', { 1: cases.length });
           action.type = 'delete';
       }
 

--- a/ang/civicase/case/card/directives/case-activity-count.directive.js
+++ b/ang/civicase/case/card/directives/case-activity-count.directive.js
@@ -11,8 +11,8 @@
     /**
      * Link function for civicaseCaseActivityCount
      *
-     * @param {Object} scope
-     * @param {Object} $elm
+     * @param {object} scope scope object
+     * @param {object} $elm element
      */
     function civicaseCaseActivityCountLink (scope, $elm) {
       (function init () {
@@ -22,7 +22,7 @@
       /**
        * Detect the elements which needs to be moved to the tooltip
        *
-       * @return {Array}
+       * @returns {Array} elements to be moved
        */
       function detectElementsToBeMoved () {
         var parentWidth = $elm[0].offsetWidth;
@@ -41,7 +41,7 @@
       /**
        * Detect if tooltip needs to be shown
        *
-       * @return {Boolean}
+       * @returns {boolean} if tooltip is necessary
        */
       function detectIfToolTipIsNecessary () {
         var $element = $elm[0];
@@ -52,7 +52,7 @@
       /**
        * Hide the Moved elements
        *
-       * @param {Array} elementsToBeMoved
+       * @param {Array} elementsToBeMoved elements to be moved
        */
       function hideMovedElements (elementsToBeMoved) {
         _.each(elementsToBeMoved, function ($element) {
@@ -81,7 +81,7 @@
       /**
        * Move the sent elements to the tooltip
        *
-       * @param {Array} elementsToBeMoved
+       * @param {Array} elementsToBeMoved elements to be moved
        */
       function moveElements (elementsToBeMoved) {
         var dynamicTooltipContent = '';

--- a/ang/civicase/case/details/directives/case-tab-affix.directive.js
+++ b/ang/civicase/case/details/directives/case-tab-affix.directive.js
@@ -9,9 +9,9 @@
     /**
      * Link function for civicaseCaseTabAffix
      *
-     * @param {Object} scope
-     * @param {Object} $el
-     * @param {Object} attrs
+     * @param {object} scope scope object
+     * @param {object} $el element
+     * @param {object} attrs attributes
      */
     function civicaseCaseTabAffixLink (scope, $el, attrs) {
       var $caseNavigation = $('.civicase__case-body_tab');

--- a/ang/civicase/case/details/people-tab/directives/roles-tab.directive.html
+++ b/ang/civicase/case/details/people-tab/directives/roles-tab.directive.html
@@ -200,7 +200,7 @@
             <i class="fa fa-user-plus"></i>
           </button>
           <div
-            ng-if="(role.is_active === '1' || role.role === ts('Client')) && role.contact_id"
+            ng-if="(role.is_active === '1' || role.is_client === '1') && role.contact_id"
             class="btn-group btn-group-sm">
             <button
               type="button"

--- a/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
+++ b/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
@@ -2,7 +2,7 @@
   var module = angular.module('civicase');
 
   module.service('civicasePeopleTabRoles', function (isTruthy, RelationshipType,
-    ts, allowMultipleCaseClients) {
+    ts, allowMultipleCaseClients, CasesUtils) {
     var caseContacts = [];
     var caseRelationships = [];
     var roles = this;
@@ -33,7 +33,7 @@
         caseTypeRole.count = _.filter(roles.list, function (role) {
           var roleIsAssigned = !!role.display_name;
           var roleBelongsToType = role.role === caseTypeRole.role;
-          var isClientRole = role.role === ts('Client');
+          var isClientRole = role.is_client === '1';
 
           return roleIsAssigned && roleBelongsToType &&
             (isClientRole || role.is_active === '1');
@@ -166,8 +166,8 @@
      *   contacts list.
      */
     function getClientRoles () {
-      return _.filter(caseContacts, {
-        role: ts('Client')
+      return _.filter(caseContacts, function (role) {
+        return CasesUtils.isClientRole(role);
       })
         .map(function (contact) {
           return {
@@ -179,6 +179,7 @@
             email: contact.email,
             phone: contact.phone,
             role: ts('Client'),
+            is_client: '1',
             start_date: null
           };
         });

--- a/ang/civicase/case/factories/format-case.factory.js
+++ b/ang/civicase/case/factories/format-case.factory.js
@@ -1,7 +1,7 @@
 (function (angular, $, _, CRM) {
   var module = angular.module('civicase');
 
-  module.factory('formatCase', function (formatActivity, ContactsCache,
+  module.factory('formatCase', function (formatActivity, CasesUtils,
     CaseStatus, CaseType, isTruthy) {
     var caseStatuses = CaseStatus.getAll(true);
 
@@ -29,7 +29,7 @@
       });
 
       _.each(item.contacts, function (contact) {
-        if (!contact.relationship_type_id) {
+        if (CasesUtils.isClientRole(contact)) {
           item.client.push(contact);
         }
 

--- a/ang/civicase/case/list/directives/case-list-sort-header.directive.js
+++ b/ang/civicase/case/list/directives/case-list-sort-header.directive.js
@@ -13,9 +13,9 @@
     /**
      * Link function for civicaseSortheaderLink Directive
      *
-     * @param {object} scope
-     * @param {object} $el
-     * @param {object} attrs
+     * @param {object} scope scope object
+     * @param {object} element element
+     * @param {object} attrs attributes
      */
     function civicaseSortheaderLink (scope, element, attrs) {
       (function init () {

--- a/ang/civicase/case/list/directives/sticky-footer-pager.directive.js
+++ b/ang/civicase/case/list/directives/sticky-footer-pager.directive.js
@@ -30,7 +30,7 @@
        * Checks if loading completes and add logic
        * for fixed footer
        *
-       * @param {boolean} loading
+       * @param {boolean} loading if loading
        */
       function checkIfLoadingCompleted (loading) {
         if (!loading) {
@@ -54,7 +54,7 @@
       /**
        * Applies fixed pager class based on scroll position
        *
-       * @param {int} topPos
+       * @param {number} topPos top position
        */
       function applyFixedPager (topPos) {
         if ((topPos - $($window).height() - $($window).scrollTop()) > 0) {

--- a/ang/civicase/case/list/directives/sticky-table-header.directive.js
+++ b/ang/civicase/case/list/directives/sticky-table-header.directive.js
@@ -51,8 +51,6 @@
       /**
        * Loads only if loading completes and case is not focused and
        * not viewing the case details for fixed header
-       *
-       * @param {boolean} loading
        */
       function fixPositioning () {
         if (!scope.loading && !scope.caseIsFocused && !scope.viewingCase) {

--- a/ang/civicase/case/search/controllers/search.controller.js
+++ b/ang/civicase/case/search/controllers/search.controller.js
@@ -3,6 +3,9 @@
 
   module.controller('civicaseSearchPageController', civicaseSearchPageController);
 
+  /**
+   * @param {object} $scope scope object
+   */
   function civicaseSearchPageController ($scope) {
     $scope.ts = CRM.ts('civicase');
     $scope.selections = {};
@@ -12,7 +15,7 @@
     $scope.$bindToRoute({
       expr: 'selections',
       param: 's',
-      default: {status_id: ['Urgent']}
+      default: { status_id: ['Urgent'] }
     });
   }
 })(angular, CRM.$, CRM._);

--- a/ang/civicase/case/services/cases-utils.service.js
+++ b/ang/civicase/case/services/cases-utils.service.js
@@ -1,7 +1,15 @@
 (function (angular, _) {
   var module = angular.module('civicase');
 
-  module.service('CasesUtils', function (ContactsCache, ts) {
+  module.service('CasesUtils', function (ContactsCache) {
+    /**
+     * @param {object} role role object
+     * @returns {boolean} if its a client role
+     */
+    this.isClientRole = function (role) {
+      return !role.relationship_type_id;
+    };
+
     /**
      * Fetch additional information about the contacts
      *

--- a/ang/civicase/dashboard/directives/dashboard-tabset-affix.directive.js
+++ b/ang/civicase/dashboard/directives/dashboard-tabset-affix.directive.js
@@ -6,6 +6,9 @@
       link: civicaseDashboardTabsetAffixLink
     };
 
+    /**
+     * @param {object} scope scope object
+     */
     function civicaseDashboardTabsetAffixLink (scope) {
       var $tabNavigation = $('.civicase__dashboard__tab-container ul.nav');
       var $civicrmMenu = $('#civicrm-menu');

--- a/ang/civicase/shared/directives/crm-form-success.directive.js
+++ b/ang/civicase/shared/directives/crm-form-success.directive.js
@@ -9,7 +9,10 @@
         element
           .on('crmFormSuccess', function (event, data) {
             scope.$apply(function () {
-              scope.$eval(attrs.crmFormSuccess, {'$event': event, '$data': data});
+              scope.$eval(attrs.crmFormSuccess, {
+                $event: event,
+                $data: data
+              });
             });
           });
       }

--- a/ang/civicase/shared/directives/crm-popup-form-success.directive.js
+++ b/ang/civicase/shared/directives/crm-popup-form-success.directive.js
@@ -9,7 +9,7 @@
         element.addClass('crm-popup')
           .on('crmPopupFormSuccess', function (event, element, data) {
             scope.$apply(function () {
-              scope.$eval(attrs.crmPopupFormSuccess, {'$event': event, '$data': data});
+              scope.$eval(attrs.crmPopupFormSuccess, { $event: event, $data: data });
             });
           });
       }

--- a/ang/civicase/shared/directives/crm-ui-number-range.directive.js
+++ b/ang/civicase/shared/directives/crm-ui-number-range.directive.js
@@ -20,11 +20,11 @@
         element.on('change', function () {
           $timeout(function () {
             if (scope.input.from && scope.input.to) {
-              scope.data = {BETWEEN: [scope.input.from, scope.input.to]};
+              scope.data = { BETWEEN: [scope.input.from, scope.input.to] };
             } else if (scope.input.from) {
-              scope.data = {'>=': scope.input.from};
+              scope.data = { '>=': scope.input.from };
             } else if (scope.input.to) {
-              scope.data = {'<=': scope.input.to};
+              scope.data = { '<=': scope.input.to };
             } else {
               scope.data = null;
             }
@@ -38,9 +38,9 @@
             scope.input.from = scope.data.BETWEEN[0];
             scope.input.to = scope.data.BETWEEN[1];
           } else if (scope.data['>=']) {
-            scope.input = {from: scope.data['>=']};
+            scope.input = { from: scope.data['>='] };
           } else if (scope.data['<=']) {
-            scope.input = {to: scope.data['<=']};
+            scope.input = { to: scope.data['<='] };
           }
         });
       }

--- a/ang/civicase/shared/directives/custom-scrollbar.directive.js
+++ b/ang/civicase/shared/directives/custom-scrollbar.directive.js
@@ -12,9 +12,9 @@
     /**
      * Link function for civicaseCustomScrollbar
      *
-     * @param {Object} $scope
-     * @param {jQuery} element
-     * @param {Object} attrs
+     * @param {object} $scope scope object
+     * @param {object} element element
+     * @param {object} attrs attributes
      */
     function civicaseCustomScrollbarLink ($scope, element, attrs) {
       var simplebarScroller, options;

--- a/ang/civicase/shared/directives/filesize.directive.js
+++ b/ang/civicase/shared/directives/filesize.directive.js
@@ -1,15 +1,9 @@
 (function (angular, $, _) {
-  function filesize (size) {
-    size = parseInt(size); // paranoid
-    if (size === 0) return '0 B';
-    // Courtesy of Andrew V, https://stackoverflow.com/questions/10420352/converting-file-size-in-bytes-to-human-readable
-    var i = Math.floor(Math.log(size) / Math.log(1024));
-    return (size / Math.pow(1024, i)).toFixed(2) * 1 + ' ' + ['B', 'KB', 'MB', 'GB', 'TB'][i];
-  }
+  var module = angular.module('civicase');
 
   // "civicaseFilesize" displays file size using KB, MB, etc
   // Example usage: <div civicase-filesize="numberOfBytes"></div>
-  angular.module('civicase').directive('civicaseFilesize', function () {
+  module.directive('civicaseFilesize', function () {
     return {
       restrict: 'AE',
       scope: {
@@ -22,4 +16,16 @@
       }
     };
   });
+
+  /**
+   * @param {string} size size
+   * @returns {string} file size
+   */
+  function filesize (size) {
+    size = parseInt(size); // paranoid
+    if (size === 0) return '0 B';
+    // Courtesy of Andrew V, https://stackoverflow.com/questions/10420352/converting-file-size-in-bytes-to-human-readable
+    var i = Math.floor(Math.log(size) / Math.log(1024));
+    return (size / Math.pow(1024, i)).toFixed(2) * 1 + ' ' + ['B', 'KB', 'MB', 'GB', 'TB'][i];
+  }
 })(angular, CRM.$, CRM._);

--- a/ang/civicase/shared/directives/masonry-grid.directive.js
+++ b/ang/civicase/shared/directives/masonry-grid.directive.js
@@ -11,10 +11,10 @@
     /**
      * Masonry Grid link function.
      *
-     * @param {Object} $scope the directive's scope.
-     * @param {Object} $element a reference to the directive's element.
-     * @param {Object} attrs a map of attributes associated to the element.
-     * @param {Object} ctrl a reference to the directive's controller.
+     * @param {object} $scope the directive's scope.
+     * @param {object} $element a reference to the directive's element.
+     * @param {object} attrs a map of attributes associated to the element.
+     * @param {object} ctrl a reference to the directive's controller.
      */
     function civicaseMasonryGridLink ($scope, $element, attrs, ctrl) {
       var NO_OF_COLUMNS = 2;
@@ -61,7 +61,7 @@
     /**
      * Adds an item element to the grid.
      *
-     * @param {Object} $gridItem a reference to the item element to be added.
+     * @param {object} $gridItem a reference to the item element to be added.
      */
     vm.addGridItem = function ($gridItem) {
       removeDuplicatedGridItem($gridItem);
@@ -72,7 +72,8 @@
     /**
      * Adds an item element to the grid at the given index.
      *
-     * @param {Object} $gridItem a reference to the item element to be added.
+     * @param {object} $gridItem a reference to the item element to be added.
+     * @param {number} atIndex index
      */
     vm.addGridItemAt = function ($gridItem, atIndex) {
       removeDuplicatedGridItem($gridItem);
@@ -83,7 +84,7 @@
     /**
      * Removes the item element from the grid.
      *
-     * @param {Object} $gridItem a reference to the item element to be removed.
+     * @param {object} $gridItem a reference to the item element to be removed.
      */
     vm.removeGridItem = function ($gridItem) {
       _.remove(vm.$gridItems, $gridItem);
@@ -95,7 +96,7 @@
      * This is done in case the grid item needs to be moved from one position to
      * another.
      *
-     * @param {Object} $gridItem a reference to the item element to be removed.
+     * @param {object} $gridItem a reference to the item element to be removed.
      */
     function removeDuplicatedGridItem ($gridItem) {
       _.remove(vm.$gridItems, $gridItem);
@@ -112,10 +113,10 @@
     /**
      * Masonry grid item link function.
      *
-     * @param {Object} $scope the directive's scope.
-     * @param {Object} $element a reference to the directive's element.
-     * @param {Object} attrs a map of attributes associated to the element.
-     * @param {Object} masonryGrid a reference to the parent masonry grid directive's controller.
+     * @param {object} $scope the directive's scope.
+     * @param {object} $element a reference to the directive's element.
+     * @param {object} attrs a map of attributes associated to the element.
+     * @param {object} masonryGrid a reference to the parent masonry grid directive's controller.
      */
     function civicaseMasonryGridItemLink ($scope, $element, attrs, masonryGrid) {
       (function init () {

--- a/ang/civicase/shared/directives/popover-append-to-element.directive.js
+++ b/ang/civicase/shared/directives/popover-append-to-element.directive.js
@@ -7,6 +7,11 @@
       link: civicasePopoverAppendToElementLink
     };
 
+    /**
+     * @param {object} $scope scope object
+     * @param {object} $element element
+     * @param {object} attrs attributes
+     */
     function civicasePopoverAppendToElementLink ($scope, $element, attrs) {
       (function init () {
         $scope.$on('$includeContentLoaded', appendPopoverToElement);

--- a/ang/civicase/shared/directives/popover.directive.js
+++ b/ang/civicase/shared/directives/popover.directive.js
@@ -20,11 +20,18 @@
       link: civicasePopoverLink
     };
 
+    /**
+     * @param {object} $scope scope object
+     * @param {object} $element element
+     * @param {object} attrs attributes
+     * @param {object} ctrl controller
+     * @param {Function} $transcludeFn transclude function
+     */
     function civicasePopoverLink ($scope, $element, attrs, ctrl, $transcludeFn) {
       var $bootstrapThemeContainer, $popover, $popoverArrow, $toggleButton, mouseLeaveTimeout;
       var HOVER_THRESHOLD = 300;
       var ARROW_POSITION_VALUES = {
-        'bottom': '50%',
+        bottom: '50%',
         'bottom-left': '%width%px',
         'bottom-right': 'calc(100% - %width%px)'
       };
@@ -125,10 +132,11 @@
       }
 
       /**
-       * Returns the number of pixes the popover needs to be adjusted to take into
+       * Returns the number of pixels the popover needs to be adjusted to take into
        * consideration the position of the popover arrow.
        *
-       * @param {String} direction the direction the popover will be aligned to.
+       * @param {string} direction the direction the popover will be aligned to.
+       * @returns {number} pixels
        */
       function getArrowPositionModifier (direction) {
         if (direction === 'bottom-left') {
@@ -145,8 +153,8 @@
        * If the position would make the popover hidden from the viewport, it will return
        * the proper alignment, otherwise it returns "default".
        *
-       * @param {Object} position
-       * @return {String}
+       * @param {object} position position
+       * @returns {string} direction
        */
       function getPopoverDirection (position) {
         var directions = {
@@ -163,9 +171,10 @@
        * Get the left and top position for the popover relative to the given element
        * and direction.
        *
-       * @param {Object} $element the DOM element to use as reference.
-       * @param {String} direction which can be "bottom", "bottom-left", "bottom-right", etc.
+       * @param {object} $element the DOM element to use as reference.
+       * @param {string} direction which can be "bottom", "bottom-left", "bottom-right", etc.
        *   defaults to "bottom".
+       * @returns {object} position
        */
       function getPopoverPositionUnderElement ($element, direction) {
         var arrowPositionModifier, position, bootstrapThemeContainerOffset;
@@ -215,7 +224,7 @@
         initPopoverReference();
 
         /**
-         * @note The post digest helps determine the real width of the popover because
+         * The post digest helps determine the real width of the popover because
          * it waits for content to be rendered. $timeout is too slow for this and has a
          * noticeable delay that makes the popover jump for a brief second.
          */

--- a/ang/civicase/shared/directives/tooltip.directive.js
+++ b/ang/civicase/shared/directives/tooltip.directive.js
@@ -16,8 +16,8 @@
     /**
      * Link function for caseTooltip
      *
-     * @param {Object} scope
-     * @param {Object} $elm
+     * @param {object} scope scope object
+     * @param {object} $elm element
      */
     function caseTooltipLink (scope, $elm) {
       scope.tooltipEnabled = false;

--- a/ang/test/.eslintrc.json
+++ b/ang/test/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "jasmine": true
+  }
+}

--- a/ang/test/civicase-base/decorators/root-scope.decorator.spec.js
+++ b/ang/test/civicase-base/decorators/root-scope.decorator.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (() => {
   describe('$rootScope decorator', () => {
     let $rootScope, ts;

--- a/ang/test/civicase-base/directives/checkbox.directive.spec.js
+++ b/ang/test/civicase-base/directives/checkbox.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (() => {
   describe('checkbox', () => {
     let $controller, $scope, event;

--- a/ang/test/civicase-base/directives/inline-datepicker.directive.spec.js
+++ b/ang/test/civicase-base/directives/inline-datepicker.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (($, _) => {
   describe('civicaseInlineDatepicker', () => {
     const NG_INVALID_CLASS = 'ng-invalid';

--- a/ang/test/civicase-base/directives/tags-selector.directive.spec.js
+++ b/ang/test/civicase-base/directives/tags-selector.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_) => {
   describe('civicaseTagsSelector', () => {
     let $controller, TagsMockData, $rootScope, $scope;

--- a/ang/test/civicase-base/factories/is-truthy.factory.spec.js
+++ b/ang/test/civicase-base/factories/is-truthy.factory.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (() => {
   describe('isTruthy', () => {
     let isTruthy;

--- a/ang/test/civicase-base/filters/crm-date.filter.spec.js
+++ b/ang/test/civicase-base/filters/crm-date.filter.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 describe('CRM Date Filter', () => {
   let crmDate;
 

--- a/ang/test/civicase-base/providers/activity-forms.provider.spec.js
+++ b/ang/test/civicase-base/providers/activity-forms.provider.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 ((_, angular) => {
   describe('ActivityForms', () => {
     let activity, activityForm, ActivityForms, CatchAllActivityFormSpy, SpyActivityForm2;

--- a/ang/test/civicase-base/providers/case-details-summary-blocks.provider.spec.js
+++ b/ang/test/civicase-base/providers/case-details-summary-blocks.provider.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 ((_, angular) => {
   describe('CaseDetailsSummaryBlocks Provider', () => {
     let CaseDetailsSummaryBlocks;

--- a/ang/test/civicase-base/providers/case-details-tabs.provider.spec.js
+++ b/ang/test/civicase-base/providers/case-details-tabs.provider.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 ((_, angular) => {
   describe('CaseDetailsTabs Provider', () => {
     let $injector, CaseDetailsTabs;

--- a/ang/test/civicase-base/providers/case-type-category.provider.spec.js
+++ b/ang/test/civicase-base/providers/case-type-category.provider.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 ((_, angular) => {
   describe('CaseTypeCategory Provider', () => {
     let CaseTypeCategory, CaseCategoryInstanceTypeData;

--- a/ang/test/civicase-base/providers/case-type.provider.spec.js
+++ b/ang/test/civicase-base/providers/case-type.provider.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_) => {
   describe('Case Type', () => {
     let CaseType, CaseTypesData, CaseTypesMockData, CaseTypesMockDataProvider;

--- a/ang/test/civicase-base/providers/dashboard-action-items.provider.spec.js
+++ b/ang/test/civicase-base/providers/dashboard-action-items.provider.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_, angular) {
   describe('DashboardActionItems', () => {
     let DashboardActionItems, DashboardActionItemsProvider;

--- a/ang/test/civicase-base/providers/dashboard-case-type-items.provider.spec.js
+++ b/ang/test/civicase-base/providers/dashboard-case-type-items.provider.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_, angular) {
   describe('DashboardCaseTypeItems', () => {
     let DashboardCaseTypeItems, DashboardCaseTypeItemsProvider;

--- a/ang/test/civicase-base/providers/url-parameters.provider.spec.js
+++ b/ang/test/civicase-base/providers/url-parameters.provider.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (() => {
   describe('UrlParameters', () => {
     let UrlParameters;

--- a/ang/test/civicase-base/providers/workflow-list-columns.provider.spec.js
+++ b/ang/test/civicase-base/providers/workflow-list-columns.provider.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 ((_, angular) => {
   describe('WorkflowListColumns Provider', () => {
     let WorkflowListColumns;

--- a/ang/test/civicase-base/providers/workflow-list-filters.provider.spec.js
+++ b/ang/test/civicase-base/providers/workflow-list-filters.provider.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 ((_, angular) => {
   describe('WorkflowListFilters Provider', () => {
     let WorkflowListFilters;

--- a/ang/test/civicase-base/services/activity-status.service.spec.js
+++ b/ang/test/civicase-base/services/activity-status.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (() => {
   describe('Activity Status', () => {
     let ActivityStatus, ActivityStatusesData;

--- a/ang/test/civicase-base/services/case-actions.service.spec.js
+++ b/ang/test/civicase-base/services/case-actions.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (() => {
   describe('Case Actions', () => {
     let CaseActions, CaseActionsData;

--- a/ang/test/civicase-base/services/case-management-workflow.service.spec.js
+++ b/ang/test/civicase-base/services/case-management-workflow.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_) => {
   describe('case management workflow', () => {
     let $q, $rootScope, $window, civicaseCrmApiMock, CaseTypesMockData,

--- a/ang/test/civicase-base/services/case-status.service.spec.js
+++ b/ang/test/civicase-base/services/case-status.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (() => {
   describe('Case Status', () => {
     let CaseStatus, CaseStatusData;

--- a/ang/test/civicase-base/services/case-type-category-translation.service.spec.js
+++ b/ang/test/civicase-base/services/case-type-category-translation.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_, CRM) => {
   describe('CaseTypeCategoryTranslationService', () => {
     const CIVICASE_TRANSLATION_DOMAIN_NAME = 'strings::uk.co.compucorp.civicase';

--- a/ang/test/civicase-base/services/contacts-cache.service.spec.js
+++ b/ang/test/civicase-base/services/contacts-cache.service.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function (_) {
   describe('ContactsCache', function () {
     var $q, $rootScope, ContactsCache, ContactsData, civicaseCrmApi;

--- a/ang/test/civicase-base/services/crm-api.service.spec.js
+++ b/ang/test/civicase-base/services/crm-api.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_) => {
   describe('crm service', () => {
     let $q, $rootScope, crmApiMock, civicaseCrmApi;

--- a/ang/test/civicase-base/services/crm-load-form.service.spec.js
+++ b/ang/test/civicase-base/services/crm-load-form.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((loadForm) => {
   describe('crm load form service', () => {
     let civicaseCrmLoadForm;

--- a/ang/test/civicase-base/services/crm-url.service.spec.js
+++ b/ang/test/civicase-base/services/crm-url.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((url) => {
   describe('crm url service', () => {
     let civicaseCrmUrl;

--- a/ang/test/civicase-base/services/relationship-type.service.spec.js
+++ b/ang/test/civicase-base/services/relationship-type.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (() => {
   describe('Relationship Type', () => {
     let RelationshipType, RelationshipTypeData;

--- a/ang/test/civicase-base/services/select2-utils.service.spec.js
+++ b/ang/test/civicase-base/services/select2-utils.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (() => {
   describe('Select2Utils', () => {
     let Select2Utils;

--- a/ang/test/civicase/activity/actions/directives/activity-actions.directive.spec.js
+++ b/ang/test/civicase/activity/actions/directives/activity-actions.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_) => {
   describe('civicaseActivityActions', () => {
     describe('Activity Actions Controller', () => {

--- a/ang/test/civicase/activity/actions/services/delete-activity-action.service.spec.js
+++ b/ang/test/civicase/activity/actions/services/delete-activity-action.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (() => {
   describe('DeleteActivityAction', () => {
     var DeleteActivityAction, $provide;

--- a/ang/test/civicase/activity/actions/services/download-all-action.service.spec.js
+++ b/ang/test/civicase/activity/actions/services/download-all-action.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_, $) => {
   describe('DownloadAllActivityAction', () => {
     var DownloadAllActivityAction, $window, civicaseCrmUrl;

--- a/ang/test/civicase/activity/actions/services/edit-activity-action.service.spec.js
+++ b/ang/test/civicase/activity/actions/services/edit-activity-action.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_, $) => {
   describe('EditActivityAction', () => {
     var EditActivityAction;

--- a/ang/test/civicase/activity/actions/services/move-copy-activity-action.service.spec.js
+++ b/ang/test/civicase/activity/actions/services/move-copy-activity-action.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_, $) => {
   describe('MoveCopyActivityAction', () => {
     let $q, $rootScope, MoveCopyActivityAction, activitiesMockData,

--- a/ang/test/civicase/activity/actions/services/print-activity-action.service.spec.js
+++ b/ang/test/civicase/activity/actions/services/print-activity-action.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_, $) => {
   describe('PrintReportActivityAction', () => {
     var PrintReportActivityAction, $window;

--- a/ang/test/civicase/activity/actions/services/resume-draft-activity-action.service.spec.js
+++ b/ang/test/civicase/activity/actions/services/resume-draft-activity-action.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_, $) => {
   describe('ResumeDraftActivityAction', () => {
     var ResumeDraftActivityAction, viewInPopup;

--- a/ang/test/civicase/activity/actions/services/tags-activity-action.service.spec.js
+++ b/ang/test/civicase/activity/actions/services/tags-activity-action.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_, $) {
   describe('TagsActivityAction', function () {
     var $q, $rootScope, TagsActivityAction, activitiesMockData, TagsMockData,

--- a/ang/test/civicase/activity/actions/services/view-activity-action.service.spec.js
+++ b/ang/test/civicase/activity/actions/services/view-activity-action.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_, $) => {
   describe('ViewActivityAction', () => {
     var ViewActivityAction;

--- a/ang/test/civicase/activity/actions/services/view-in-feed-activity-action.service.spec.js
+++ b/ang/test/civicase/activity/actions/services/view-in-feed-activity-action.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_, $) => {
   describe('ViewInFeedActivityAction', () => {
     var ViewInFeedActivityAction, $window, getActivityFeedUrl;

--- a/ang/test/civicase/activity/activity-forms/activity-forms.config.spec.js
+++ b/ang/test/civicase/activity/activity-forms/activity-forms.config.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (() => {
   describe('Activity forms configuration', () => {
     let ActivityFormsProvider;

--- a/ang/test/civicase/activity/activity-forms/services/activity-forms-services/add-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/activity-forms-services/add-activity-form.service.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 ((_) => {
   describe('AddActivityForm', () => {
     let civicaseCrmUrl, AddActivityForm, activity, canHandle;

--- a/ang/test/civicase/activity/activity-forms/services/activity-forms-services/add-custom-path-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/activity-forms-services/add-custom-path-activity-form.service.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 ((_) => {
   describe('AddCustomPathActivityForm', () => {
     let AddCustomPathActivityForm, activity, civicaseCrmUrl, canHandle;

--- a/ang/test/civicase/activity/activity-forms/services/activity-forms-services/draft-email-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/activity-forms-services/draft-email-activity-form.service.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 ((_) => {
   describe('DraftEmailActivityForm', () => {
     let activity, checkIfDraftActivity,

--- a/ang/test/civicase/activity/activity-forms/services/activity-forms-services/draft-pdf-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/activity-forms-services/draft-pdf-activity-form.service.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 ((_) => {
   describe('DraftPdfActivityForm', () => {
     let civicaseCrmUrl, activity, checkIfDraftActivity,

--- a/ang/test/civicase/activity/activity-forms/services/activity-forms-services/email-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/activity-forms-services/email-activity-form.service.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 ((_) => {
   describe('EmailActivityForm', () => {
     let civicaseCrmUrl, activity, EmailActivityForm, canHandle;

--- a/ang/test/civicase/activity/activity-forms/services/activity-forms-services/update-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/activity-forms-services/update-activity-form.service.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 ((_) => {
   describe('UpdateActivityForm', () => {
     let civicaseCrmUrl, activity, UpdateActivityForm, canHandle;

--- a/ang/test/civicase/activity/activity-forms/services/view-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/view-activity-form.service.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 ((_) => {
   describe('ViewActivityForm', () => {
     let activity, civicaseCrmUrl, canHandle, ViewActivityForm;

--- a/ang/test/civicase/activity/calendar/decorators/uib-datepicker.decorator.spec.js
+++ b/ang/test/civicase/activity/calendar/decorators/uib-datepicker.decorator.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (angular) {
   describe('day picker decorator', function () {
     var $compile, $rootScope, $scope, daypicker;
@@ -54,7 +52,7 @@
        * Setups the test for the current week day by mocking the clock's date,
        * initializing the directive and ticking the clock forward.
        *
-       * @param {Object} momentDate a reference to a moment date.
+       * @param {object} momentDate a reference to a moment date.
        * @param {Function} done the function to execute after the clock moves forward.
        */
       function setupCUrrentWeekDayTest (momentDate, done) {

--- a/ang/test/civicase/activity/calendar/directives/activities-calendar.directive.spec.js
+++ b/ang/test/civicase/activity/calendar/directives/activities-calendar.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function ($, _, moment) {
   describe('civicaseActivitiesCalendarController', function () {
     var $controller, $q, $scope, $rootScope, $route, civicaseCrmApi, formatActivity, dates,

--- a/ang/test/civicase/activity/card/directives/activity-card.directive.spec.js
+++ b/ang/test/civicase/activity/card/directives/activity-card.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (($, _) => {
   describe('ActivityCard', () => {
     let $compile, $filter, $rootScope, $scope, viewInPopup, activityCard,

--- a/ang/test/civicase/activity/directives/activity-icon.directive.spec.js
+++ b/ang/test/civicase/activity/directives/activity-icon.directive.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function (_) {
   describe('ActivityIcon', function () {
     var $compile, $rootScope, $scope, ActivityType;

--- a/ang/test/civicase/activity/directives/add-activity-menu.directive.spec.js
+++ b/ang/test/civicase/activity/directives/add-activity-menu.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_) {
   describe('AddActivityMenu', function () {
     describe('Add Activity Menu Controller', function () {

--- a/ang/test/civicase/activity/factories/check-if-draft-activity.factory.spec.js
+++ b/ang/test/civicase/activity/factories/check-if-draft-activity.factory.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 ((_) => {
   describe('checkIfDraftActivity', () => {
     let activity, checkIfDraftActivity, emailActivityTypeId,

--- a/ang/test/civicase/activity/factories/get-activity-feed-url.factory.spec.js
+++ b/ang/test/civicase/activity/factories/get-activity-feed-url.factory.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_, extractQueryStringParams) {
   describe('getActivityFeedUrl', function () {
     var $location, $route, $sce, activityFeedUrlObject, getActivityFeedUrl, ActivityStatusType;

--- a/ang/test/civicase/activity/factories/view-in-popup.factory.spec.js
+++ b/ang/test/civicase/activity/factories/view-in-popup.factory.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (($, _, loadCrmForm) => {
   describe('viewInPopup', () => {
     let viewInPopup, mockGetActivityFormService, mockGetActivityFormUrl;

--- a/ang/test/civicase/activity/feed/directives/activity-feed.directive.spec.js
+++ b/ang/test/civicase/activity/feed/directives/activity-feed.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_) => {
   describe('civicaseActivityFeed', () => {
     describe('Activity Feed Controller', () => {

--- a/ang/test/civicase/activity/feed/directives/activity-month-nav.directive.spec.js
+++ b/ang/test/civicase/activity/feed/directives/activity-month-nav.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_) {
   describe('civicaseActivityMonthNav', function () {
     beforeEach(function () {

--- a/ang/test/civicase/activity/filters/directives/activity-filters.directive.spec.js
+++ b/ang/test/civicase/activity/filters/directives/activity-filters.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function ($, _) {
   describe('civicaseActivityFilters', function () {
     var $compile, $rootScope, $scope, activityFilters, CaseTypeCategory,

--- a/ang/test/civicase/activity/panel/directives/activity-panel.directive.spec.js
+++ b/ang/test/civicase/activity/panel/directives/activity-panel.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function ($, _, loadCrmForm) {
   describe('civicaseActivityPanel', function () {
     var $compile, $rootScope, $scope, activityPanel, activitiesMockData,

--- a/ang/test/civicase/activity/services/activity-feed-measurements.service.spec.js
+++ b/ang/test/civicase/activity/services/activity-feed-measurements.service.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function (_) {
   describe('ActivityFeedMeasurements', function () {
     var ActivityFeedMeasurements;

--- a/ang/test/civicase/bulk-action/directives/bulk-actions-checkboxes.directive.spec.js
+++ b/ang/test/civicase/bulk-action/directives/bulk-actions-checkboxes.directive.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function ($) {
   describe('BulkActionsCheckboxes', function () {
     var $compile, $rootScope, $scope, element;

--- a/ang/test/civicase/bulk-action/directives/bulk-actions-message.directive.spec.js
+++ b/ang/test/civicase/bulk-action/directives/bulk-actions-message.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 describe('BulkActionsMessage', function () {
   var $compile, $rootScope, $scope, element;
 

--- a/ang/test/civicase/case/actions/directives/case-actions.directive.spec.js
+++ b/ang/test/civicase/case/actions/directives/case-actions.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_, $) {
   describe('case actions', function () {
     let $q, element, $provide, $compile, $rootScope, CaseActionsData,

--- a/ang/test/civicase/case/actions/services/edit-tags-case-action.service.spec.js
+++ b/ang/test/civicase/case/actions/services/edit-tags-case-action.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_, $) {
   describe('EditTagsCaseAction', function () {
     var $q, $rootScope, EditTagsCaseAction, CasesData,

--- a/ang/test/civicase/case/actions/services/email-case-action.service.spec.js
+++ b/ang/test/civicase/case/actions/services/email-case-action.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_, $) {
   describe('Email Case Action', function () {
     var $q, $rootScope, EmailCaseAction, CasesMockData, caseObj,

--- a/ang/test/civicase/case/actions/services/go-to-webforms-case-action.service.spec.js
+++ b/ang/test/civicase/case/actions/services/go-to-webforms-case-action.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_, $) {
   describe('GoToWebformCaseAction', function () {
     var GoToWebformCaseAction, CaseActionsData, CasesData;

--- a/ang/test/civicase/case/actions/services/print-merge-case-action.service.spec.js
+++ b/ang/test/civicase/case/actions/services/print-merge-case-action.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_, $) {
   describe('MoveCopyActivityAction', function () {
     var $rootScope, PrintMergeCaseAction, CasesMockData;

--- a/ang/test/civicase/case/actions/services/webforms-case-action.service.spec.js
+++ b/ang/test/civicase/case/actions/services/webforms-case-action.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_, $) {
   describe('WebformsCaseAction', function () {
     var WebformsCaseAction, attributes, CaseActionsData, CasesData, webformsList;

--- a/ang/test/civicase/case/card/directives/case-card.directive.spec.js
+++ b/ang/test/civicase/case/card/directives/case-card.directive.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (($) => {
   describe('civicaseCaseCard', () => {
     let element, $compile, $rootScope, $route, $scope, CasesData;

--- a/ang/test/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.spec.js
+++ b/ang/test/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_) => {
   describe('Contact Case Tab Case Details', () => {
     let $controller, $rootScope, $scope, CaseTypeCategory, mockCase;

--- a/ang/test/civicase/case/contact-case-tab/directives/contact-case-tab-case-list.directive.spec.js
+++ b/ang/test/civicase/case/contact-case-tab/directives/contact-case-tab-case-list.directive.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function ($, _) {
   describe('ContactCaseTabCaseList', function () {
     var $compile, $scope, $rootScope, element, eventResponse, CasesData;

--- a/ang/test/civicase/case/details/configs/add-case-details-tabs.config.spec.js
+++ b/ang/test/civicase/case/details/configs/add-case-details-tabs.config.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 ((_, angular) => {
   describe('CaseDetailsTabs', () => {
     let CaseDetailsTabsProvider;

--- a/ang/test/civicase/case/details/directives/case-details-header.directive.spec.js
+++ b/ang/test/civicase/case/details/directives/case-details-header.directive.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function (_) {
   describe('civicaseCaseDetailsHeaderController', function () {
     var $controller, $rootScope, $scope, CasesData,

--- a/ang/test/civicase/case/details/directives/case-details.directive.spec.js
+++ b/ang/test/civicase/case/details/directives/case-details.directive.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function ($, _) {
   describe('civicaseCaseDetails', function () {
     var $httpBackend, element, controller, activitiesMockData, $controller, $compile,

--- a/ang/test/civicase/case/details/file-tab/directives/case-details-file-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/file-tab/directives/case-details-file-tab.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_) {
   describe('civicaseCaseDetailsFileTab', function () {
     var $q, $controller, $rootScope, $scope, civicaseCrmApiMock, activitiesMockData;

--- a/ang/test/civicase/case/details/file-tab/directives/file-filter.directive.spec.js
+++ b/ang/test/civicase/case/details/file-tab/directives/file-filter.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_) {
   describe('civicaseFileFilter', function () {
     var $controller, $rootScope, $scope;

--- a/ang/test/civicase/case/details/linked-cases-tab/directives/case-details-linked-cases-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/linked-cases-tab/directives/case-details-linked-cases-tab.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (($, _) => {
   describe('linked cases tab', () => {
     let $controller, $scope, LinkCasesCaseAction, civicaseCrmUrl;

--- a/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-details-people-tab.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 describe('Case Details People Tab', () => {
   let $controller, $rootScope, $scope, CasesData, caseRoleSelectorContact,
     civicasePeopleTabRoles, civicaseRoleDatesUpdater, ContactsData,

--- a/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
+++ b/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
@@ -2,15 +2,17 @@
 
 ((_) => {
   describe('PeopleTabRoles', () => {
-    let caseItem, caseType, peopleTabRoles, relationships, relationshipTypes;
+    let caseItem, caseType, peopleTabRoles, relationships, relationshipTypes,
+      CasesUtils;
 
     beforeEach(module('civicase', 'civicase.data', ($provide) => {
       $provide.constant('allowMultipleCaseClients', false);
     }));
 
     beforeEach(inject((_CasesData_, _CaseTypesMockData_,
-      _civicasePeopleTabRoles_, _RelationshipTypeData_) => {
+      _civicasePeopleTabRoles_, _RelationshipTypeData_, _CasesUtils_) => {
       peopleTabRoles = _civicasePeopleTabRoles_;
+      CasesUtils = _CasesUtils_;
       caseItem = _.first(_CasesData_.get().values);
       caseType = _CaseTypesMockData_.get()['1'];
       relationshipTypes = _RelationshipTypeData_.values;
@@ -61,7 +63,9 @@
         let caseClient;
 
         beforeEach(() => {
-          caseClient = _.find(caseItem.contacts, { role: 'Client' });
+          caseClient = _.find(caseItem.contacts, function (role) {
+            return CasesUtils.isClientRole(role);
+          });
 
           peopleTabRoles.updateRolesList();
         });
@@ -283,7 +287,9 @@
         let caseClient;
 
         beforeEach(() => {
-          caseClient = _.find(caseItem.contacts, { role: 'Client' });
+          caseClient = _.find(caseItem.contacts, function (role) {
+            return CasesUtils.isClientRole(role);
+          });
 
           peopleTabRoles.updateRolesList();
           peopleTabRoles.filterRoles(caseClient.display_name[0], '');
@@ -300,7 +306,9 @@
         let caseClient;
 
         beforeEach(() => {
-          caseClient = _.find(caseItem.contacts, { role: 'Client' });
+          caseClient = _.find(caseItem.contacts, function (role) {
+            return CasesUtils.isClientRole(role);
+          });
 
           peopleTabRoles.updateRolesList();
           peopleTabRoles.filterRoles(caseClient.display_name[0], 'Client');

--- a/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
+++ b/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_) => {
   describe('PeopleTabRoles', () => {
     let caseItem, caseType, peopleTabRoles, relationships, relationshipTypes,

--- a/ang/test/civicase/case/details/people-tab/services/role-dates-updater.service.spec.js
+++ b/ang/test/civicase/case/details/people-tab/services/role-dates-updater.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_) => {
   describe('RoleDatesUpdater', () => {
     let roleDatesUpdater, roleData, caseId, loggedInContactId, returnedApiCalls;

--- a/ang/test/civicase/case/details/service/case-details-linked-cases-tab.service.spec.js
+++ b/ang/test/civicase/case/details/service/case-details-linked-cases-tab.service.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (() => {
   describe('case details linked cases tab service', () => {
     let LinkedCasesCaseTab;

--- a/ang/test/civicase/case/directives/case-overview.directive.spec.js
+++ b/ang/test/civicase/case/directives/case-overview.directive.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (($, _) => {
   describe('CaseOverview', () => {
     let $compile, $provide, $q, $rootScope, $scope, BrowserCache,

--- a/ang/test/civicase/case/factories/get-case-query-params.factory.spec.js
+++ b/ang/test/civicase/case/factories/get-case-query-params.factory.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 ((_) => {
   describe('getCaseQueryParams', () => {
     let getCaseQueryParams;

--- a/ang/test/civicase/case/list/directives/case-list-sort-header.directive.spec.js
+++ b/ang/test/civicase/case/list/directives/case-list-sort-header.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 describe('civicaseCaseListSortHeader directive', function () {
   var element, $compile, $rootScope, scope;
 
@@ -148,8 +146,8 @@ describe('civicaseCaseListSortHeader directive', function () {
   /**
    * Compiles the directive
    *
-   * @param {object} scope
-   * @param {string} header
+   * @param {object} scope scope object
+   * @param {string} header header
    */
   function compileDirective (scope, header) {
     element = $compile(angular.element('<div civicase-case-list-sort-header=' + header + '></div>'))(scope);

--- a/ang/test/civicase/case/list/directives/case-list-table.directive.spec.js
+++ b/ang/test/civicase/case/list/directives/case-list-table.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_, $) {
   describe('CivicaseCaseListTable Directive', function () {
     var $compile, $rootScope, $scope, originaljQueryHeightFn;

--- a/ang/test/civicase/case/list/directives/sticky-footer-pager.directive.spec.js
+++ b/ang/test/civicase/case/list/directives/sticky-footer-pager.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 describe('civicaseStickyFooterPager directive', function () {
   var element, $compile, $rootScope, scope, offsetOriginalFunction, scrollTopOriginalFunction, $timeout;
 
@@ -89,9 +87,9 @@ describe('civicaseStickyFooterPager directive', function () {
   /**
    * Common setup for tests
    *
-   * @params {boolean} loading - wheather loading is complete
-   * @params {Object} scope
-   * @params {Number} top - px from top the screen should scroll to.
+   * @param {boolean} loading wheather loading is complete
+   * @param {object} scope scope object
+   * @param {number} top px from top the screen should scroll to.
    */
   function setupCommonSteps (loading, scope, top) {
     scope.isLoading = loading;

--- a/ang/test/civicase/case/list/directives/sticky-table-header.directive.spec.js
+++ b/ang/test/civicase/case/list/directives/sticky-table-header.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 describe('civicaseStickyTableHeader directive', function () {
   var element, $compile, $rootScope, scope, affixReturnValue, affixOriginalFunction;
 
@@ -51,7 +49,7 @@ describe('civicaseStickyTableHeader directive', function () {
     });
 
     it('does not makes the header sticky', function () {
-      expect(CRM.$.fn.affix).not.toHaveBeenCalledWith(jasmine.objectContaining({offset: {top: jasmine.any(Number)}}));
+      expect(CRM.$.fn.affix).not.toHaveBeenCalledWith(jasmine.objectContaining({ offset: { top: jasmine.any(Number) } }));
     });
 
     it('does not binds the scroll position of table content to the table header', function () {
@@ -75,7 +73,7 @@ describe('civicaseStickyTableHeader directive', function () {
     });
 
     it('does not makes the header sticky', function () {
-      expect(CRM.$.fn.affix).not.toHaveBeenCalledWith(jasmine.objectContaining({offset: {top: jasmine.any(Number)}}));
+      expect(CRM.$.fn.affix).not.toHaveBeenCalledWith(jasmine.objectContaining({ offset: { top: jasmine.any(Number) } }));
     });
 
     it('does not binds the scroll position of table content to the table header', function () {
@@ -99,7 +97,7 @@ describe('civicaseStickyTableHeader directive', function () {
     });
 
     it('does not makes the header sticky', function () {
-      expect(CRM.$.fn.affix).not.toHaveBeenCalledWith(jasmine.objectContaining({offset: {top: jasmine.any(Number)}}));
+      expect(CRM.$.fn.affix).not.toHaveBeenCalledWith(jasmine.objectContaining({ offset: { top: jasmine.any(Number) } }));
     });
 
     it('does not binds the scroll position of table content to the table header', function () {
@@ -127,7 +125,7 @@ describe('civicaseStickyTableHeader directive', function () {
       });
 
       it('makes the header sticky', function () {
-        expect(CRM.$.fn.affix).toHaveBeenCalledWith(jasmine.objectContaining({offset: {top: jasmine.any(Number)}}));
+        expect(CRM.$.fn.affix).toHaveBeenCalledWith(jasmine.objectContaining({ offset: { top: jasmine.any(Number) } }));
       });
 
       it('binds the scroll position of table content to the table header', function () {
@@ -152,7 +150,7 @@ describe('civicaseStickyTableHeader directive', function () {
       });
 
       it('does not makes the header sticky', function () {
-        expect(CRM.$.fn.affix).not.toHaveBeenCalledWith(jasmine.objectContaining({offset: {top: jasmine.any(Number)}}));
+        expect(CRM.$.fn.affix).not.toHaveBeenCalledWith(jasmine.objectContaining({ offset: { top: jasmine.any(Number) } }));
       });
 
       it('does not binds the scroll position of table content to the table header', function () {

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (($, _, crmCheckPerm) => {
   describe('civicaseSearch', () => {
     let $controller, $rootScope, $scope, $window, $timeout, CaseFilters,

--- a/ang/test/civicase/case/services/add-case.service.spec.js
+++ b/ang/test/civicase/case/services/add-case.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (($, loadForm) => {
   describe('AddCaseService', () => {
     let $window, AddCase, CaseCategoryWebformSettings, civicaseCrmUrl;

--- a/ang/test/civicase/case/services/cases-utils.service.spec.js
+++ b/ang/test/civicase/case/services/cases-utils.service.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_) => {
   describe('CasesUtils', () => {
     var CasesData, ContactsCache, CasesUtils, mockTs;

--- a/ang/test/civicase/case/services/cases-utils.service.spec.js
+++ b/ang/test/civicase/case/services/cases-utils.service.spec.js
@@ -40,5 +40,33 @@
         expect(contactsFetched).toEqual(expectedContacts);
       });
     });
+
+    describe('when checking if a role is client', () => {
+      let role;
+
+      describe('and the role is client', () => {
+        beforeEach(() => {
+          role = CasesData.get().values[0].contacts[0];
+
+          role.relationship_type_id = false;
+        });
+
+        it('returns true', () => {
+          expect(CasesUtils.isClientRole(role)).toEqual(true);
+        });
+      });
+
+      describe('and the role is not client', () => {
+        beforeEach(() => {
+          role = CasesData.get().values[0].contacts[0];
+
+          role.relationship_type_id = '11';
+        });
+
+        it('returns false', () => {
+          expect(CasesUtils.isClientRole(role)).toEqual(false);
+        });
+      });
+    });
   });
 })(CRM._);

--- a/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
+++ b/ang/test/civicase/contact-case-tab/directives/contact-case-tab.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_) => {
   describe('Contact Case Tab', () => {
     var $q, $controller, $rootScope, $scope, CaseTypeCategoryTranslationService,

--- a/ang/test/civicase/contact/directives/contact-card.directive.spec.js
+++ b/ang/test/civicase/contact/directives/contact-card.directive.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function ($) {
   describe('contactCard', function () {
     var element, civicaseCrmApi, $q, $compile, $rootScope, $scope, ContactsData, ContactsCache;

--- a/ang/test/civicase/contact/directives/contact-icon.directive.spec.js
+++ b/ang/test/civicase/contact/directives/contact-icon.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_) {
   describe('ContactPopoverContent', function () {
     var $controller, $rootScope, $scope, contactsDataServiceMock;
@@ -46,6 +44,9 @@
       });
     });
 
+    /**
+     * Initialise controller
+     */
     function initController () {
       $scope = $rootScope.$new();
       $scope.contactId = _.uniqueId();

--- a/ang/test/civicase/contact/directives/contact-popover-content.directive.spec.js
+++ b/ang/test/civicase/contact/directives/contact-popover-content.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_) {
   describe('ContactPopoverContent', function () {
     var $controller, $rootScope, $scope, contactsDataServiceMock, civicaseCrmUrl;

--- a/ang/test/civicase/dashboard/configs/dashboard-action-items.config.spec.js
+++ b/ang/test/civicase/dashboard/configs/dashboard-action-items.config.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (() => {
   describe('Dashboard Action Buttons', () => {
     let DashboardActionItemsProvider;

--- a/ang/test/civicase/dashboard/directives/add-case-dashboard-action-button.controller.spec.js
+++ b/ang/test/civicase/dashboard/directives/add-case-dashboard-action-button.controller.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (($) => {
   describe('AddCaseDashboardActionButtonController', () => {
     let $rootScope, $scope, $controller, $window, AddCase, currentCaseCategory;

--- a/ang/test/civicase/dashboard/directives/dashboard-tab.directive.spec.js
+++ b/ang/test/civicase/dashboard/directives/dashboard-tab.directive.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function ($, _, moment) {
   describe('dashboardTabController', function () {
     var $controller, $rootScope, $scope, civicaseCrmApi, formatActivity, formatCase,

--- a/ang/test/civicase/dashboard/directives/dashboard.directive.spec.js
+++ b/ang/test/civicase/dashboard/directives/dashboard.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_, $) {
   describe('civicaseDashboardController', function () {
     var $controller, $rootScope, $scope, DashboardActionItems;

--- a/ang/test/civicase/shared/directives/custom-scrollbar.directive.spec.js
+++ b/ang/test/civicase/shared/directives/custom-scrollbar.directive.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 /* global SimpleBar */
 /* eslint-disable no-global-assign */
 (function (_) {
@@ -12,7 +11,7 @@
       $rootScope = _$rootScope_;
       $scope = $rootScope.$new();
       $scope.options = {
-        'autoHide': true
+        autoHide: true
       };
     }));
 
@@ -29,16 +28,16 @@
       describe('called with default options overrided', function () {
         beforeEach(function () {
           $scope.options = {
-            'autoHide': true,
-            'otherOptions': 'otherValue'
+            autoHide: true,
+            otherOptions: 'otherValue'
           };
           compileDirective();
         });
 
         it('should call SimpleBar()', function () {
           expect(SimpleBar).toHaveBeenCalledWith(element[0], {
-            'autoHide': true,
-            'otherOptions': 'otherValue'
+            autoHide: true,
+            otherOptions: 'otherValue'
           });
         });
       });
@@ -46,15 +45,15 @@
       describe('called with default options not overrided', function () {
         beforeEach(function () {
           $scope.options = {
-            'otherOptions': 'otherValue'
+            otherOptions: 'otherValue'
           };
           compileDirective();
         });
 
         it('should call SimpleBar()', function () {
           expect(SimpleBar).toHaveBeenCalledWith(element[0], {
-            'autoHide': false,
-            'otherOptions': 'otherValue'
+            autoHide: false,
+            otherOptions: 'otherValue'
           });
         });
       });

--- a/ang/test/civicase/shared/directives/dropdown.directive.spec.js
+++ b/ang/test/civicase/shared/directives/dropdown.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (($) => {
   describe('Dropdown', () => {
     var $compile, $rootScope, dropdowns, dropdownContainer, scope;

--- a/ang/test/civicase/shared/directives/file-uploader.directive.spec.js
+++ b/ang/test/civicase/shared/directives/file-uploader.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (_) {
   describe('civicaseFileUploader', function () {
     var $q, $controller, $rootScope, $scope, $timeout, civicaseCrmApi,

--- a/ang/test/civicase/shared/directives/masonry-grid.directive.spec.js
+++ b/ang/test/civicase/shared/directives/masonry-grid.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function ($, _) {
   describe('Masonry Grid', function () {
     var $compile, $masonryGrid, $rootScope, $scope, $timeout;
@@ -74,8 +72,8 @@
        * Returns a string representation of the elements inside a given column.
        * Ex.: "1, 2, Special, 3"
        *
-       * @param {Number} columnIndex
-       * @return {String}
+       * @param {number} columnIndex column index
+       * @returns {string} text
        */
       function getGridItemsTextsForColumn (columnIndex) {
         return $masonryGrid.find('.civicase__masonry-grid__column')
@@ -91,6 +89,8 @@
 
     /**
      * Initialzes the masonry grid directive.
+     *
+     * @param {object} scopeValues scope values
      */
     function initDirective (scopeValues) {
       var defaultScopeValues = {

--- a/ang/test/civicase/shared/directives/on-contact-tab-change.directive.spec.js
+++ b/ang/test/civicase/shared/directives/on-contact-tab-change.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (($) => {
   describe('civicaseOnContactTabChange', () => {
     let $compile, $rootScope, $scope, element;

--- a/ang/test/civicase/shared/directives/panel-query.directive.spec.js
+++ b/ang/test/civicase/shared/directives/panel-query.directive.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function ($, _) {
   describe('panelQuery', function () {
     var element, $compile, $q, $rootScope, $scope, civicaseCrmApi, panelQueryScope, mockedResults;

--- a/ang/test/civicase/shared/directives/popover-append-to-element.directive.spec.js
+++ b/ang/test/civicase/shared/directives/popover-append-to-element.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function ($) {
   describe('PopoverAppendToElement', function () {
     var $compile, $rootScope, $timeout, popover, popoverContainer, originalJQueryOffset;
@@ -47,6 +45,9 @@
       });
     });
 
+    /**
+     * @param {object} options options
+     */
     function initDirective (options) {
       var scope;
       var html = `<div class="popover-container">
@@ -66,6 +67,9 @@
       $rootScope.$digest();
     }
 
+    /**
+     * Simulate popover open
+     */
     function simulatePopoverOpen () {
       popover = $('<div class="popover"></div>');
 

--- a/ang/test/civicase/shared/directives/popover.directive.spec.js
+++ b/ang/test/civicase/shared/directives/popover.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function ($) {
   describe('Popover', function () {
     var $compile, $rootScope, $scope, $sampleReference, $timeout, $toggleButton,

--- a/ang/test/civicase/shared/directives/tag.directive.spec.js
+++ b/ang/test/civicase/shared/directives/tag.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (colorContrast) {
   describe('civicaseTag', function () {
     var $controller, $rootScope, $scope, mockTag;
@@ -52,6 +50,9 @@
       });
     });
 
+    /**
+     * @param {object} tag tag object
+     */
     function initController (tag) {
       $scope = $rootScope.$new();
       $scope.tag = tag;

--- a/ang/test/civicase/shared/directives/tags-container.directive.spec.js
+++ b/ang/test/civicase/shared/directives/tags-container.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (() => {
   describe('civicaseTag', () => {
     let $controller, $rootScope, $scope, mockTags;

--- a/ang/test/civicase/shared/filters/crm-url.filter.spec.js
+++ b/ang/test/civicase/shared/filters/crm-url.filter.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function (_) {
   describe('crmUrl', function () {
     var $filter, crmUrl, civicaseCrmUrl;

--- a/ang/test/civicase/shared/services/date-helper.service.spec.js
+++ b/ang/test/civicase/shared/services/date-helper.service.spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 (function ($) {
   describe('DateHelper', function () {
     var DateHelper;

--- a/ang/test/global.js
+++ b/ang/test/global.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (CRM) {
   CRM['civicase-base'] = {};
   CRM.civicase = {};

--- a/ang/test/mocks/data/cases-filter.data.js
+++ b/ang/test/mocks/data/cases-filter.data.js
@@ -1,13 +1,13 @@
 (function () {
   var module = angular.module('civicase.data');
   var filter = {
-    'case_type_id': [
+    case_type_id: [
       'housing_support'
     ]
   };
   var hiddenFilters = {
-    'hiddenfilter1': {},
-    'hiddenfilter2': {}
+    hiddenfilter1: {},
+    hiddenfilter2: {}
   };
 
   module.constant('CaseFilters', {

--- a/ang/test/mocks/data/cases-overview-stats.data.js
+++ b/ang/test/mocks/data/cases-overview-stats.data.js
@@ -5,19 +5,19 @@
     var CasesOverviewStatsDataMockData = {
       values: [
         {
-          '1': {
-            '1': '47',
-            '2': '28'
+          1: {
+            1: '47',
+            2: '28'
           },
-          '2': {
-            '1': '43',
-            '2': '28',
-            '3': '4'
+          2: {
+            1: '43',
+            2: '28',
+            3: '4'
           },
-          'all': {
-            '1': 90,
-            '2': 56,
-            '3': 4
+          all: {
+            1: 90,
+            2: 56,
+            3: 4
           }
         }
       ]
@@ -27,7 +27,7 @@
       /**
        * Returns a list of mocked cases
        *
-       * @return {Array} each array contains an object with the activity data.
+       * @returns {Array} each array contains an object with the activity data.
        */
       get: function () {
         return _.clone(CasesOverviewStatsDataMockData);

--- a/ang/test/mocks/services/browser-cache.factory.mock.js
+++ b/ang/test/mocks/services/browser-cache.factory.mock.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function () {
   var module = angular.module('civicase');
 

--- a/ang/test/mocks/services/crm-api.factory.mock.js
+++ b/ang/test/mocks/services/crm-api.factory.mock.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function () {
   var module = angular.module('crmUtil');
 

--- a/ang/test/mocks/services/crm-blocker.factory.mock.js
+++ b/ang/test/mocks/services/crm-blocker.factory.mock.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function () {
   var module = angular.module('crmUtil');
 

--- a/ang/test/mocks/services/crm-status.factory.mock.js
+++ b/ang/test/mocks/services/crm-status.factory.mock.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function () {
   var module = angular.module('crmUtil');
 

--- a/ang/test/mocks/services/crm-throttle.factory.mock.js
+++ b/ang/test/mocks/services/crm-throttle.factory.mock.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function () {
   var module = angular.module('crmUtil');
 

--- a/ang/test/mocks/services/crm-ui-help.factory.mock.js
+++ b/ang/test/mocks/services/crm-ui-help.factory.mock.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function () {
   var module = angular.module('crmUtil');
 

--- a/ang/test/mocks/services/crm-url.service.mock.js
+++ b/ang/test/mocks/services/crm-url.service.mock.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function (CRM) {
   var module = angular.module('civicase-base');
 

--- a/ang/test/mocks/services/dialog-service.service.mock.js
+++ b/ang/test/mocks/services/dialog-service.service.mock.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function () {
   var module = angular.module('dialogService');
 

--- a/ang/test/mocks/services/format-activity.factory.mock.js
+++ b/ang/test/mocks/services/format-activity.factory.mock.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function () {
   var module = angular.module('civicase');
 

--- a/ang/test/mocks/services/format-case.factory.mock.js
+++ b/ang/test/mocks/services/format-case.factory.mock.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (function () {
   var module = angular.module('civicase');
 

--- a/ang/test/workflow/action-links/controllers/workflow-duplicate.controller.spec.js
+++ b/ang/test/workflow/action-links/controllers/workflow-duplicate.controller.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_) => {
   describe('workflow duplicate controller', () => {
     let $controller, $rootScope, $q, $scope, dialogService, CaseTypesMockData,

--- a/ang/test/workflow/action-links/controllers/workflow-edit.controller.spec.js
+++ b/ang/test/workflow/action-links/controllers/workflow-edit.controller.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_) => {
   describe('workflow edit controller', () => {
     let $controller, $rootScope, $scope, $window, civicaseCrmUrl,

--- a/ang/test/workflow/crm/case-type.controller.spec.js
+++ b/ang/test/workflow/crm/case-type.controller.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 (() => {
   describe('workflow list', () => {
     let $q, $controller, $rootScope, $scope, $window, CaseTypesMockData,

--- a/ang/test/workflow/directives/workflow-list.directive.spec.js
+++ b/ang/test/workflow/directives/workflow-list.directive.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 ((_) => {
   describe('workflow list', () => {
     let $q, $controller, $rootScope, $scope, CaseTypesMockData,


### PR DESCRIPTION
## Overview
The Applicant role was not visible in the Case Summary peoples tab. This PR fixes that issue.

## Before
![2021-03-15 at 2 41 PM](https://user-images.githubusercontent.com/5058867/111129910-a257fd80-859c-11eb-82eb-a8a4263e9e97.png)

## After
![2021-03-15 at 2 42 PM](https://user-images.githubusercontent.com/5058867/111129962-b13eb000-859c-11eb-8847-d91c6945a9ea.png)

## Technical Details
This is a regression issue caused by https://github.com/compucorp/uk.co.compucorp.civicase/pull/715.
In the above PR, `role: 'Client'` was changed to `ts('Client')`. But this fix was meant for NEU, where we have word replacements for the word "Client" to "Member". But this broke the Awards Applications. But if we revert the code, it will work in Awards, but not on NEU. So needed a new solution.

Instead of relying on the Role Name, which is subject to change depending upon Word Replacements, a new logic has been used. That is `!role.relationship_type_id`  means its a client. This logic was already present in `format-activity.factory.js` and `format-case.factory.js`. But it has been moved to `CasesUtils.isClientRole` function, and it has been reused in all places.

Also ESLint rules has been updated, to ignore vendor files and fixed all linting issues in CiviCase. 