### PR TITLE
CPS-494: Fix View All links

### DIFF
--- a/ang/civicase/case/details/summary-tab/directives/case-summary-recent-communications.directive.html
+++ b/ang/civicase/case/details/summary-tab/directives/case-summary-recent-communications.directive.html
@@ -1,7 +1,7 @@
 <div ng-if="isMainContentVisible()" class="panel-heading clearfix">
   <h3 class="panel-title pull-left">{{ ts('Recent Communications') }}</h3>
   <a class="pull-right"
-     ng-href="{{getActivityFeedUrl({ caseId: item.id, category: 'communication', statusType: 'completed' })}}"
+     ng-href="{{getActivityFeedUrl({ caseId: item.id, category: 'communication' })}}"
      ng-if="item.category_count.communication.completed"
      title="{{ ts('View All') }}"
   >{{ ts('View All') }}</a>

--- a/ang/civicase/case/details/summary-tab/directives/case-summary-tasks.directive.html
+++ b/ang/civicase/case/details/summary-tab/directives/case-summary-tasks.directive.html
@@ -9,7 +9,7 @@
       {{item.category_count.task.overdue}} </span>
   </h3>
   <a class="pull-right"
-     ng-href="{{ getActivityFeedUrl({ caseId: item.id, category: 'task', statusType: 'completed' }) }}"
+     ng-href="{{ getActivityFeedUrl({ caseId: item.id, category: 'task' }) }}"
      ng-if="item.category_count.task.incomplete"
      title="{{ ts('View All') }}"
   >{{ ts('View All') }}</a>


### PR DESCRIPTION
## Overview
The "View All" links for Recent Communication redirected the user to the Activity Feed but only showed the Completed Activities. This PR fixes that to show all.

## Before
![2021-03-15 at 3 22 PM](https://user-images.githubusercontent.com/5058867/111135031-37a9c080-85a2-11eb-99cd-d0c8523cb8b4.png)

## After
![2021-03-15 at 3 16 PM](https://user-images.githubusercontent.com/5058867/111134968-2496f080-85a2-11eb-9590-3c4a64ec2cd7.png)

## Technical Details
Removed the `statusType: 'completed'` filter from HTML.