### PR TITLE
CPS-477: Add Tests for CaseCategoryMenu class

### DIFF
--- a/CRM/Civicase/Service/CaseCategoryInstance.php
+++ b/CRM/Civicase/Service/CaseCategoryInstance.php
@@ -11,18 +11,18 @@ class CRM_Civicase_Service_CaseCategoryInstance {
   /**
    * Get case categories instances.
    *
-   * @param string $instanceName
-   *   Instance ID.
+   * @param string $instanceTypeName
+   *   Case Category Instance Type name.
    */
-  public function getCaseCategoryInstances($instanceName = NULL) {
+  public function getCaseCategoryInstances($instanceTypeName = NULL) {
     $caseCategoryInstances = [];
     $caseCategoryInstance = new CaseCategoryInstance();
 
-    if ($instanceName) {
+    if ($instanceTypeName) {
       $instanceId = civicrm_api3('OptionValue', 'get', [
         'sequential' => 1,
         'option_group_id' => 'case_category_instance_type',
-        'name' => $instanceName,
+        'name' => $instanceTypeName,
       ])['values'][0]['value'];
 
       $caseCategoryInstance->instance_id = $instanceId;

--- a/CRM/Civicase/Service/CaseCategoryMenu.php
+++ b/CRM/Civicase/Service/CaseCategoryMenu.php
@@ -209,16 +209,16 @@ class CRM_Civicase_Service_CaseCategoryMenu {
   /**
    * Creates Manage Workflow menu for existing case categories.
    *
-   * @param string $instanceName
-   *   Case category instance name..
-   * @param bool $ifMenuLabelHasInstanceName
-   *   Label for the menu to be added.
+   * @param string $instanceTypeName
+   *   Case category instance type name..
+   * @param bool $showCategoryNameOnMenuLabel
+   *   Flag for using the case type category name on the menu label.
    */
-  public function createManageWorkflowMenu(string $instanceName, $ifMenuLabelHasInstanceName) {
+  public function createManageWorkflowMenu(string $instanceTypeName, bool $showCategoryNameOnMenuLabel) {
     $caseTypeCategories = CaseCategory::getCaseCategories();
 
     $instanceObj = new CaseCategoryInstance();
-    $instances = $instanceObj->getCaseCategoryInstances($instanceName);
+    $instances = $instanceObj->getCaseCategoryInstances($instanceTypeName);
 
     foreach ($caseTypeCategories as $caseTypeCategory) {
       $isInstanceCaseCategory = NULL;
@@ -239,7 +239,7 @@ class CRM_Civicase_Service_CaseCategoryMenu {
         'label' => $caseTypeCategory['name'],
       ])['values'][0];
 
-      $menuLabel = $ifMenuLabelHasInstanceName
+      $menuLabel = $showCategoryNameOnMenuLabel
         ? 'Manage ' . $caseTypeCategory['name']
         : 'Manage Workflows';
 
@@ -270,11 +270,11 @@ class CRM_Civicase_Service_CaseCategoryMenu {
     $caseCategoryPermission = new CaseCategoryPermission();
     $permissions = $caseCategoryPermission->get($caseTypeCategoryName);
 
-    $ifMenuExist = count(civicrm_api3('Navigation', 'get', [
+    $menuExists = civicrm_api3('Navigation', 'getcount', [
       'name' => 'manage_' . $caseTypeCategoryName . '_workflows',
-    ])['values']) > 0;
+    ]) > 0;
 
-    if (!$ifMenuExist) {
+    if (!$menuExists) {
       civicrm_api3('Navigation', 'create', [
         'parent_id' => $parentId,
         'url' => '/civicrm/workflow/a?case_type_category=' . $caseTypeCategoryName . '#/list',

--- a/CRM/Civicase/Test/Fabricator/CaseCategory.php
+++ b/CRM/Civicase/Test/Fabricator/CaseCategory.php
@@ -31,7 +31,7 @@ class CRM_Civicase_Test_Fabricator_CaseCategory {
    *   Resulting merged parameters.
    */
   private static function mergeDefaultParams(array $params) {
-    $name = 'n' . substr(uniqid(), 1, 4);
+    $name = 'n' . rand(1000, 9999);
     $defaultParams = [
       'option_group_id' => 'case_type_categories',
       'label' => $name,

--- a/CRM/Civicase/Test/Fabricator/CaseCategoryInstanceType.php
+++ b/CRM/Civicase/Test/Fabricator/CaseCategoryInstanceType.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * CaseCategoryInstanceType Fabricator class.
+ */
+class CRM_Civicase_Test_Fabricator_CaseCategoryInstanceType {
+
+  /**
+   * Fabricate a case category instance type.
+   *
+   * @param array $params
+   *   Parameters.
+   *
+   * @return array
+   *   Results.
+   */
+  public static function fabricate(array $params = []) {
+    $params = self::mergeDefaultParams($params);
+    $result = civicrm_api3('OptionValue', 'create', $params);
+
+    return array_shift($result['values']);
+  }
+
+  /**
+   * Merge to default parameters.
+   *
+   * @param array $params
+   *   Parameters.
+   *
+   * @return array
+   *   Resulting merged parameters.
+   */
+  private static function mergeDefaultParams(array $params) {
+    $randomIdentifier = rand();
+    $defaultParams = [
+      'name' => 'test_category_instance_type_' . $randomIdentifier,
+      'label' => 'Test Category Instance Type ' . $randomIdentifier,
+      'grouping' => 'CRM_Civicase_Service_CaseManagementUtils',
+      'is_active' => TRUE,
+      'is_reserved' => TRUE,
+    ];
+
+    $mergedParams = array_merge($defaultParams, $params);
+    $mergedParams['option_group_id'] = 'case_category_instance_type';
+
+    return $mergedParams;
+  }
+
+}

--- a/tests/phpunit/CRM/Civicase/Service/CaseCategoryInstanceTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseCategoryInstanceTest.php
@@ -3,6 +3,7 @@
 use CRM_Civicase_Service_CaseCategoryInstance as CaseCategoryInstanceService;
 use CRM_Civicase_Test_Fabricator_CaseCategoryInstance as CaseCategoryInstanceFabricator;
 use CRM_Civicase_Test_Fabricator_CaseCategory as CaseCategoryFabricator;
+use CRM_Civicase_Test_Fabricator_CaseCategoryInstanceType as CaseCategoryInstanceTypeFabricator;
 
 /**
  * Runs tests on CaseCategoryInstance Service tests.
@@ -59,8 +60,8 @@ class CRM_Civicase_Service_CaseCategoryInstanceTest extends BaseHeadlessTest {
     // Clean current category instances for doing an appropriate count later.
     $this->cleanCategoryInstances();
     // We generate two different category instance types.
-    $categoryInstanceTypeOne = $this->createCategoryInstanceType();
-    $categoryInstanceTypeTwo = $this->createCategoryInstanceType();
+    $categoryInstanceTypeOne = CaseCategoryInstanceTypeFabricator::fabricate();
+    $categoryInstanceTypeTwo = CaseCategoryInstanceTypeFabricator::fabricate();
     // And two random category instances associated with them.
     $categoryInstanceOne = CaseCategoryInstanceFabricator::fabricate([
       'instance_id' => $categoryInstanceTypeOne['value'],
@@ -121,28 +122,6 @@ class CRM_Civicase_Service_CaseCategoryInstanceTest extends BaseHeadlessTest {
     }
 
     return FALSE;
-  }
-
-  /**
-   * Generates a random category instance type.
-   *
-   * @return array
-   *   Category instance type details.
-   */
-  private function createCategoryInstanceType() {
-    $randomIdentifier = rand();
-    $params = [
-      'option_group_id' => 'case_category_instance_type',
-      'name' => 'test_category_instance_type_' . $randomIdentifier,
-      'label' => 'Test Category Instance Type ' . $randomIdentifier,
-      'grouping' => 'CRM_Civicase_Service_CaseManagementUtils',
-      'is_active' => TRUE,
-      'is_reserved' => TRUE,
-    ];
-
-    $result = civicrm_api3('OptionValue', 'create', $params);
-
-    return array_shift($result['values']);
   }
 
   /**

--- a/tests/phpunit/CRM/Civicase/Service/CaseCategoryMenuTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseCategoryMenuTest.php
@@ -1,0 +1,237 @@
+<?php
+
+use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
+use CRM_Civicase_Service_CaseCategoryMenu as CaseCategoryMenuService;
+use CRM_Civicase_Test_Fabricator_CaseCategory as CaseCategoryFabricator;
+use CRM_Civicase_Test_Fabricator_CaseCategoryInstance as CaseCategoryInstanceFabricator;
+use CRM_Civicase_Test_Fabricator_CaseCategoryInstanceType as CaseCategoryInstanceTypeFabricator;
+
+/**
+ * Test class for the CRM_Civicase_Service_CaseCategoryMenu.
+ *
+ * @group headless
+ */
+class CRM_Civicase_Service_CaseCategoryMenuTest extends BaseHeadlessTest {
+
+  /**
+   * Instance of CaseCategoryMenu service.
+   *
+   * @var CRM_Civicase_Service_CaseCategoryMenu
+   */
+  private $caseCategoryMenu;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->caseCategoryMenu = new CaseCategoryMenuService();
+  }
+
+  /**
+   * Test createItems method adds the expected menus.
+   */
+  public function testCreateNewItemsAddsExpectedMenus() {
+    $caseCategory = CaseCategoryFabricator::fabricate();
+
+    $this->caseCategoryMenu->createItems($caseCategory['name']);
+
+    $this->assertMenuCreatedForCaseCategory($caseCategory);
+  }
+
+  /**
+   * Test calling twice createItems does not create duplicates.
+   */
+  public function testCreateTwiceSameItemsDoesNotCreateDuplicates() {
+    $caseCategory = CaseCategoryFabricator::fabricate();
+
+    // First call.
+    $this->caseCategoryMenu->createItems($caseCategory['name']);
+    // Second call.
+    $this->caseCategoryMenu->createItems($caseCategory['name']);
+
+    $menuCreatedCount = civicrm_api3('Navigation', 'getcount', ['name' => $caseCategory['name']]);
+    $this->assertEquals(1, $menuCreatedCount);
+  }
+
+  /**
+   * Test createItems method assigns same weight to different menus.
+   */
+  public function testCreateTwoDifferentMenusAssignsSameWeight() {
+    $caseCategoryOne = CaseCategoryFabricator::fabricate();
+    $caseCategoryTwo = CaseCategoryFabricator::fabricate();
+    $expectWeightForMenu = $this->getExpectedWeightForCategoryMenu();
+
+    $this->caseCategoryMenu->createItems($caseCategoryOne['name']);
+    // This clears the cache.
+    civicrm_api3('Navigation', 'getfields', ['cache_clear' => 1]);
+    $this->caseCategoryMenu->createItems($caseCategoryTwo['name']);
+
+    $menuOneWeight = civicrm_api3('Navigation', 'getsingle',
+      [
+        'name' => $caseCategoryOne['name'],
+        'return' => ['weight'],
+      ]
+    )['weight'];
+    $menuTwoWeight = civicrm_api3('Navigation', 'getsingle',
+      [
+        'name' => $caseCategoryTwo['name'],
+        'return' => ['weight'],
+      ]
+    )['weight'];
+    $this->assertEquals($expectWeightForMenu, $menuOneWeight);
+    $this->assertEquals($expectWeightForMenu, $menuTwoWeight);
+  }
+
+  /**
+   * Test deleteItems method removes menus and submenus.
+   */
+  public function testDeleteItemsRemovesMenusAndSubMenus() {
+    $caseCategory = CaseCategoryFabricator::fabricate();
+
+    $this->caseCategoryMenu->createItems($caseCategory['name']);
+    $menuCreatedId = civicrm_api3('Navigation', 'getsingle',
+      [
+        'name' => $caseCategory['name'],
+        'return' => ['id'],
+      ]
+    )['id'];
+
+    $this->caseCategoryMenu->deleteItems($caseCategory['name']);
+
+    $menuCreatedCount = civicrm_api3('Navigation', 'getcount', ['id' => $menuCreatedId]);
+    $subMenusCreatedCount = civicrm_api3('Navigation', 'getcount', ['parent_id' => $menuCreatedId]);
+    $this->assertEquals(0, $menuCreatedCount);
+    $this->assertEquals(0, $subMenusCreatedCount);
+  }
+
+  /**
+   * Test updateItems method produces expected changes.
+   */
+  public function testUpdateItemsProducesExpectedChanges() {
+    $caseCategory = CaseCategoryFabricator::fabricate();
+    $newValues = [
+      'icon' => 'new icon',
+      'is_active' => 0,
+    ];
+
+    $this->caseCategoryMenu->createItems($caseCategory['name']);
+    $menuCreated = civicrm_api3('Navigation', 'getsingle', ['name' => $caseCategory['name']]);
+    foreach ($newValues as $key => $value) {
+      $this->assertNotEquals($value, $menuCreated[$key]);
+    }
+
+    $this->caseCategoryMenu->updateItems($caseCategory['id'], $newValues);
+    $menuCreated = civicrm_api3('Navigation', 'getsingle', ['name' => $caseCategory['name']]);
+    foreach ($newValues as $key => $value) {
+      $this->assertEquals($value, $menuCreated[$key]);
+    }
+  }
+
+  /**
+   * Test createManageWorkflowMenu method creates expected submenu.
+   *
+   * @param bool $showCategoryNameOnMenuLabel
+   *   Value for the second parameter of tested method.
+   *
+   * @dataProvider getDataForCreateManageWorkflowMenu
+   */
+  public function testCreateManageWorkflowMenuCreatesExpectedSubitem(bool $showCategoryNameOnMenuLabel) {
+    $caseCategory = CaseCategoryFabricator::fabricate();
+    $caseCategoryInstanceType = CaseCategoryInstanceTypeFabricator::fabricate();
+    CaseCategoryInstanceFabricator::fabricate([
+      'category_id' => $caseCategory['value'],
+      'instance_id' => $caseCategoryInstanceType['value'],
+    ]);
+    $menuCreated = $this->createMainMenuWithFirstSubItem($caseCategory['name']);
+
+    $this->caseCategoryMenu->createManageWorkflowMenu($caseCategoryInstanceType['name'], $showCategoryNameOnMenuLabel);
+
+    $subMenuCreated = civicrm_api3('Navigation', 'getsingle', [
+      'name' => 'manage_' . $caseCategory['name'] . '_workflows',
+    ]);
+    $menuLabel = $showCategoryNameOnMenuLabel
+      ? 'Manage ' . $caseCategory['name']
+      : 'Manage Workflows';
+    $this->assertEquals($menuLabel, $subMenuCreated['label']);
+    $parentMenu = civicrm_api3('Navigation', 'getsingle', ['id' => $subMenuCreated['parent_id']]);
+    $this->assertEquals($menuCreated['id'], $parentMenu['id']);
+  }
+
+  /**
+   * Creates the expected menus for a given category name.
+   *
+   * It creates the main menu, and a first submenu assigned to it. This is
+   * required for correctly testing createManageWorkflowMenu method.
+   *
+   * @param string $caseCategoryName
+   *   Case Type Category name.
+   */
+  public function createMainMenuWithFirstSubItem(string $caseCategoryName) {
+    $menuCreated = civicrm_api3('Navigation', 'create', ['label' => $caseCategoryName]);
+    civicrm_api3('Navigation', 'create',
+      [
+        'parent_id' => $menuCreated['id'],
+        'label' => 'First subitem',
+      ]
+    );
+
+    return $menuCreated;
+  }
+
+  /**
+   * Assert the menu created for the given category has expected information.
+   */
+  private function assertMenuCreatedForCaseCategory(array $caseCategory) {
+    $menuCreated = civicrm_api3('Navigation', 'getsingle', ['name' => $caseCategory['name']]);
+
+    $this->assertEquals(ts($caseCategory['name']), $menuCreated['name']);
+    $this->assertEquals($caseCategory['label'], $menuCreated['label']);
+    $this->assertEquals(1, $menuCreated['is_active']);
+    $this->assertEquals($this->getPermissionForNavigationMenu($caseCategory['name']), $menuCreated['permission']);
+    $this->assertEquals('OR', $menuCreated['permission_operator']);
+    $this->assertEquals($this->getExpectedWeightForCategoryMenu(), $menuCreated['weight']);
+
+    $subMenusCreatedCount = civicrm_api3('Navigation', 'getcount', ['parent_id' => $menuCreated['id']]);
+    $this->assertEquals(6, $subMenusCreatedCount);
+  }
+
+  /**
+   * Returns permissions that the menu should have.
+   */
+  private function getPermissionForNavigationMenu(string $caseTypeCategoryName) {
+    $permissions = (new CaseCategoryPermission())->get($caseTypeCategoryName);
+
+    return sprintf(
+      "%s,%s",
+      $permissions['ACCESS_MY_CASE_CATEGORY_AND_ACTIVITIES']['name'],
+      $permissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name']
+    );
+  }
+
+  /**
+   * Get the expected weight for the category menu.
+   */
+  private static function getExpectedWeightForCategoryMenu() {
+    return CRM_Core_DAO::getFieldValue(
+        'CRM_Core_DAO_Navigation',
+        'Cases',
+        'weight',
+        'name'
+      ) + 1;
+  }
+
+  /**
+   * Data provider for returning options for createManageWorkflowMenu method.
+   *
+   * Returns the two possible options for the boolean flag.
+   */
+  public function getDataForCreateManageWorkflowMenu() {
+    return [
+      [TRUE],
+      [FALSE],
+    ];
+  }
+
+}

--- a/tests/phpunit/CRM/Civicase/Service/CaseTypeCategoryEventHandlerTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseTypeCategoryEventHandlerTest.php
@@ -42,6 +42,8 @@ class CRM_Civicase_Service_CaseTypeCategoryEventHandlerTest extends BaseHeadless
     $caseTypeCategory = CaseCategoryFabricator::fabricate(
       [
         'id' => $caseTypeCategory['id'],
+        'name' => $caseTypeCategory['name'],
+        'label' => $caseTypeCategory['label'],
         'is_active' => 0,
         'icon' => 'fa-folder-open-o',
       ]


### PR DESCRIPTION
## Overview
This PR has the main purpose of adding unit tests for CaseCategoryMenu service class, but also adds refactorings to other related entities. 
It is important to mention that related changes will not require extra QA manual testing, since are just improving readability, or applies only to other unit tests code.

## Before
There were no unit tests for this service.

## After
All the public methods were tested, both for creating and deleting menus. 

## Technical Details
- A fabricator for `CaseCategoryInstaceType` was added, since the action was required not only on these tests but also on the CaseCategoryInstance tests. Commit: https://github.com/compucorp/uk.co.compucorp.civicase/commit/e17979d91f4a845cbb8129a08262dda43bfd7a3f
- The method for generating random names on `CaseCategory` fabricator was replaced, since uniqid output repeated strings when called once after the other (an example here https://www.php.net/manual/en/function.uniqid.php#120123). I did the change, and fix a test, that had a hidden error, because of this same situation. Commit: https://github.com/compucorp/uk.co.compucorp.civicase/commit/33c876c29ff54d987458afa85486fd9e7f826feb 
- I added a minor and not risky refactoring here https://github.com/compucorp/uk.co.compucorp.civicase/commit/f4f37e8b25163f081c0203ccc950ac78afa8800f (I put emphasis on this because the intention is to merge without QA)
- The last commit contains the tests for the class: https://github.com/compucorp/uk.co.compucorp.civicase/commit/eb2bb2f77ed8181d7cdf050ccf6c55bd8faa4102

