### PR TITLE
CPS-393: Generate CSS files

### DIFF
--- a/.github/workflows/backstop.yml
+++ b/.github/workflows/backstop.yml
@@ -81,6 +81,13 @@ jobs:
           drush en bootstrap -y
           drush vset theme_default bootstrap
 
+      - name: Generate CSS files for Reference Site
+        working-directory: ${{ env.REFERENCE_SITE_FOLDER }}/${{ env.CIVICRM_EXTENSIONS_DIR }}/org.civicrm.shoreditch
+        run: |
+          npm install
+          npx gulp sass
+          drush cc all && drush cc civicrm
+
       - name: Installing Shoreditch Companion Theme in Reference Site
         working-directory: ${{ env.REFERENCE_SITE_FOLDER }}/${{ env.DRUPAL_THEME_DIR }}
         run: |
@@ -118,6 +125,13 @@ jobs:
           drush en civicrmtheme -y
           drush en bootstrap -y
           drush vset theme_default bootstrap
+
+      - name: Generate CSS files for Test Site
+        working-directory: ${{ env.TEST_SITE_FOLDER }}/${{ env.CIVICRM_EXTENSIONS_DIR }}/org.civicrm.shoreditch
+        run: |
+          npm install
+          npx gulp sass
+          drush cc all && drush cc civicrm
 
       - name: Installing Shoreditch Companion Theme in Test Site
         working-directory: ${{ env.TEST_SITE_FOLDER }}/${{ env.DRUPAL_THEME_DIR }}


### PR DESCRIPTION
## Overview
The shoreditch branches does not include the CSS files. So this PR generates them before running the Backstop tests so that backstop can use the compiled CSS.

## Before/After
Not needed

## Technical Overview
Added the following steps before running Backstop test
```
npm install
npx gulp sass
```