### PR TITLE
CPS-487: Capitalize Category Name on Label Menus

### DIFF
--- a/CRM/Civicase/Service/CaseCategoryMenu.php
+++ b/CRM/Civicase/Service/CaseCategoryMenu.php
@@ -16,6 +16,9 @@ class CRM_Civicase_Service_CaseCategoryMenu {
    *   Case Type category name.
    */
   public function createItems($caseTypeCategoryName) {
+    $caseTypeCategoryName = strtolower($caseTypeCategoryName);
+    $labelForMenu = ucfirst($caseTypeCategoryName);
+
     $result = civicrm_api3('Navigation', 'get', ['name' => $caseTypeCategoryName]);
 
     if ($result['count'] > 0) {
@@ -32,7 +35,7 @@ class CRM_Civicase_Service_CaseCategoryMenu {
     );
 
     $params = [
-      'label' => ts($caseTypeCategoryName),
+      'label' => ts($labelForMenu),
       'name' => $caseTypeCategoryName,
       'url' => NULL,
       'permission_operator' => 'OR',
@@ -62,6 +65,8 @@ class CRM_Civicase_Service_CaseCategoryMenu {
    *   Menu ID.
    */
   protected function createCaseCategorySubmenus($caseTypeCategoryName, array $permissions, $caseCategoryMenuId) {
+    $labelForMenu = ucfirst($caseTypeCategoryName);
+
     $submenus = [
       [
         'label' => ts('Dashboard'),
@@ -72,21 +77,21 @@ class CRM_Civicase_Service_CaseCategoryMenu {
         'has_separator' => 1,
       ],
       [
-        'label' => ts("New {$caseTypeCategoryName}"),
+        'label' => ts("New {$labelForMenu}"),
         'name' => "new_{$caseTypeCategoryName}",
         'url' => "civicrm/case/add?case_type_category={$caseTypeCategoryName}&action=add&reset=1&context=standalone",
         'permission' => "{$permissions['ADD_CASE_CATEGORY']['name']},{$permissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name']}",
         'permission_operator' => 'OR',
       ],
       [
-        'label' => ts("My {$caseTypeCategoryName}"),
+        'label' => ts("My {$labelForMenu}"),
         'name' => "my_{$caseTypeCategoryName}",
         'url' => '/civicrm/case/a/?case_type_category=' . $caseTypeCategoryName . '#/case/list?cf={"case_type_category":"' . $caseTypeCategoryName . '","case_manager":"user_contact_id"}',
         'permission' => "{$permissions['ACCESS_MY_CASE_CATEGORY_AND_ACTIVITIES']['name']},{$permissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name']}",
         'permission_operator' => 'OR',
       ],
       [
-        'label' => ts("My {$caseTypeCategoryName} activities"),
+        'label' => ts("My {$labelForMenu} activities"),
         'name' => "my_activities_{$caseTypeCategoryName}",
         'url' => '/civicrm/case/a/?case_type_category=' . $caseTypeCategoryName . '#/case?case_type_category=' . $caseTypeCategoryName . '&dtab=1&af={"case_filter":{"case_type_id.is_active":1,"contact_is_deleted":0,"case_type_id.case_type_category":"' . $caseTypeCategoryName . '"},
         "@involvingContact":"myActivities"}&drel=all',
@@ -94,7 +99,7 @@ class CRM_Civicase_Service_CaseCategoryMenu {
         'has_separator' => 1,
       ],
       [
-        'label' => ts("All {$caseTypeCategoryName}"),
+        'label' => ts("All {$labelForMenu}"),
         'name' => "all_{$caseTypeCategoryName}",
         'url' => 'civicrm/case/a/?case_type_category=' . $caseTypeCategoryName . '#/case/list?cf={"case_type_category":"' . $caseTypeCategoryName . '"}',
         'permission' => "{$permissions['ACCESS_MY_CASE_CATEGORY_AND_ACTIVITIES']['name']},{$permissions['ACCESS_CASE_CATEGORY_AND_ACTIVITIES']['name']}",

--- a/CRM/Civicase/Service/CaseCategoryMenu.php
+++ b/CRM/Civicase/Service/CaseCategoryMenu.php
@@ -16,8 +16,7 @@ class CRM_Civicase_Service_CaseCategoryMenu {
    *   Case Type category name.
    */
   public function createItems($caseTypeCategoryName) {
-    $caseTypeCategoryName = strtolower($caseTypeCategoryName);
-    $labelForMenu = ucfirst($caseTypeCategoryName);
+    $labelForMenu = ucfirst(strtolower($caseTypeCategoryName));
 
     $result = civicrm_api3('Navigation', 'get', ['name' => $caseTypeCategoryName]);
 
@@ -65,7 +64,7 @@ class CRM_Civicase_Service_CaseCategoryMenu {
    *   Menu ID.
    */
   protected function createCaseCategorySubmenus($caseTypeCategoryName, array $permissions, $caseCategoryMenuId) {
-    $labelForMenu = ucfirst($caseTypeCategoryName);
+    $labelForMenu = ucfirst(strtolower($caseTypeCategoryName));
 
     $submenus = [
       [

--- a/tests/phpunit/CRM/Civicase/Service/CaseCategoryMenuTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseCategoryMenuTest.php
@@ -187,7 +187,8 @@ class CRM_Civicase_Service_CaseCategoryMenuTest extends BaseHeadlessTest {
     $menuCreated = civicrm_api3('Navigation', 'getsingle', ['name' => $caseCategory['name']]);
 
     $this->assertEquals(ts($caseCategory['name']), $menuCreated['name']);
-    $this->assertEquals($caseCategory['label'], $menuCreated['label']);
+    $expectedCategoryLabel = ucfirst(strtolower($caseCategory['label']));
+    $this->assertEquals($expectedCategoryLabel, $menuCreated['label']);
     $this->assertEquals(1, $menuCreated['is_active']);
     $this->assertEquals($this->getPermissionForNavigationMenu($caseCategory['name']), $menuCreated['permission']);
     $this->assertEquals('OR', $menuCreated['permission_operator']);


### PR DESCRIPTION
## Overview
This PR modifies the name and label of the navigation menu created for a new Case Type Category.

## Before
For the case category menus created, the name of the category is used as a label. Then, when we generate a menu using 'awards' as a name, this is the result:
![image](https://user-images.githubusercontent.com/74304572/111303483-2b4b6380-8687-11eb-887c-0816f7e255d4.png)

## After
Now the case category name is firstly changed to lowercase completely, and later capitalized the first letter.
![image](https://user-images.githubusercontent.com/74304572/111303763-7b2a2a80-8687-11eb-853b-b8935e8f887e.png)


