### PR TITLE
CPS-480: Change button markup

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/HandleDraftActivities.php
+++ b/CRM/Civicase/Hook/BuildForm/HandleDraftActivities.php
@@ -76,10 +76,14 @@ class CRM_Civicase_Hook_BuildForm_HandleDraftActivities {
       if (($form->_action & (CRM_Core_Action::ADD + CRM_Core_Action::UPDATE)) && !$hideDraftButton) {
         $buttonGroup = $form->getElement('buttons');
         $buttons = $buttonGroup->getElements();
-        $buttons[] = $form->createElement('submit', $form->getButtonName('refresh'), ts('Save Draft'), [
-          'crm-icon' => 'fa-pencil-square-o',
-          'class' => 'crm-form-submit',
-        ]);
+        $buttons[] = $form->createElement(
+          'xbutton',
+          $form->getButtonName('refresh'),
+          ts('Save Draft'), [
+            'crm-icon' => 'fa-pencil-square-o',
+            'class' => 'crm-form-submit',
+          ]
+        );
         $buttonGroup->setElements($buttons);
         $form->addGroup($buttons, 'buttons');
         $form->setDefaults(['status_id' => 2]);


### PR DESCRIPTION
Moved from https://github.com/compucorp/uk.co.compucorp.civicase/pull/593
## Overview
This PR changes the "Save Draft" button for Email and PDF Letter activity forms from input elements to button elements. The reason for the change is that Core is moving away from input elements and Shoreditch styles break for these type of elements.

Note: this PR depends on https://github.com/civicrm/org.civicrm.shoreditch/pull/492

## Before
![civibox2020 local_8005_civicrm_case_a_case_type_category=cases (2)](https://user-images.githubusercontent.com/1642119/110536500-eb6d0500-80f7-11eb-8df1-37b4b04eb77b.png)


## After

![civibox2020 local_8005_civicrm_case_a_case_type_category=cases (1)](https://user-images.githubusercontent.com/1642119/110535258-6af9d480-80f6-11eb-9997-7d355ddc9cf7.png)

## Technical Details

We changed the button type from `submit` to `xbutton`.

## Backstop Report:

https://github.com/compucorp/backstopjs-config/actions/runs/636368203

Some artifacts were found, but manually confirmed that no actual regressions were introduced.

