### PR TITLE
CPS-495: Fix People Tab pagination

### DIFF
--- a/ang/civicase/case/details/people-tab/directives/roles-tab.directive.html
+++ b/ang/civicase/case/details/people-tab/directives/roles-tab.directive.html
@@ -58,7 +58,7 @@
   <div class="civicase__people-tab__filter">
     <paging
       class="paging-top"
-      page="rolesPage"
+      page="$parent.rolesPage"
       page-size="roles.ROLES_PER_PAGE"
       total="roles.totalCount"
       ng-show="roles.totalCount > roles.ROLES_PER_PAGE"
@@ -253,7 +253,7 @@
     </div>
     <paging
       class="center-block"
-      page="rolesPage"
+      page="$parent.rolesPage"
       page-size="roles.ROLES_PER_PAGE"
       total="roles.totalCount"
       ng-show="roles.totalCount > roles.ROLES_PER_PAGE"


### PR DESCRIPTION
## Overview
In Peoples Tab, the pagination was broken for the Case Roles sub tab. This PR fixes that.

## Before
![before](https://user-images.githubusercontent.com/5058867/112137177-f3e43600-8bf5-11eb-88f7-68d7e0a543a8.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/112137093-d9aa5800-8bf5-11eb-9de5-8692d3752260.gif)

## Technical Details
In https://github.com/compucorp/uk.co.compucorp.civicase/pull/574, the Peoples tab html was refactored and moved into partials. But in Angular when a partial is created, it creates a Child Scope, so the properties changed in the partial cannot be used by the parent Controller.
Now using `$parent.rolesPage` instead of `rolesPage` to fix this issue.