### PR TITLE
CPS-39: Fix special characters in case subjects

### DIFF
--- a/ang/civicase-base/filters/escape-string.filter.js
+++ b/ang/civicase-base/filters/escape-string.filter.js
@@ -1,0 +1,26 @@
+(function (_, angular) {
+  var module = angular.module('civicase-base');
+
+  module.filter('civicaseEscapeString', civicaseEscapeString);
+
+  /**
+   * Escape String Filter.
+   *
+   * @returns {Function} the service reference.
+   */
+  function civicaseEscapeString () {
+    /**
+     * Escapes HTML entities for the given string.
+     *
+     * We unescape and then escape the string because the value might already
+     * be escaped and if we try to scape it twice the string might break.
+     * Ex: `&amp;` will turn into `&amp;amp;`.
+     *
+     * @param {string} stringToBeEscaped the string to be escaped.
+     * @returns {string} escaped tring.
+     */
+    return function escapeString (stringToBeEscaped) {
+      return _.escape(_.unescape(stringToBeEscaped));
+    };
+  }
+})(CRM._, angular);

--- a/ang/civicase/case/card/directives/case-card-contact-record.directive.html
+++ b/ang/civicase/case/card/directives/case-card-contact-record.directive.html
@@ -7,7 +7,7 @@
   }">
   <div class="panel-body">
     <div class="civicase__case-card__row civicase__case-card__row--primary clearfix">
-      <div class="pull-left civicase__case-card-subject">{{ data.subject }}</div>
+      <div class="pull-left civicase__case-card-subject" ng-bind-html="data.subject"></div>
       <div class="pull-right">
         <span> {{ ts('Case ID :') }} </span>
         <strong> {{ data.id }} </strong>

--- a/ang/civicase/case/card/directives/case-card-dashboard.directive.html
+++ b/ang/civicase/case/card/directives/case-card-dashboard.directive.html
@@ -18,7 +18,7 @@
       </div>
     </div>
     <div class="civicase__case-card__row civicase__case-card__row--primary clearfix">
-      <div class="pull-left civicase__case-card-subject">{{data.subject}}</div>
+      <div class="pull-left civicase__case-card-subject" ng-bind-html="data.subject"></div>
       <div class="pull-right">
         <span ng-if="data.status !== 'Resolved'">
           <span>Next Milestone: </span>

--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
@@ -102,9 +102,7 @@
             data-placeholder="Click to add subject"
             crm-form-success="onChangeSubject($data)">
           </p>
-          <p ng-if="item['case_type_id.is_active'] === '0'">
-            {{item.subject}}
-          </p>
+          <p ng-if="item['case_type_id.is_active'] === '0'" ng-bind-html="item.subject"></p>
         </div>
         <div
           class="civicase__summary-tab__description crm-entity"
@@ -187,9 +185,7 @@
         <div class="civicase__contact-cases-tab__panel-field-title">
           {{ ts('Summary') }}
         </div>
-        <div>
-          {{ item.subject }}
-        </div>
+        <div ng-bind-html="item.subject"></div>
       </div>
       <!--End Case Summary -->
       <!-- Last Activity -->

--- a/ang/civicase/case/details/summary-tab/directives/case-summary.directive.html
+++ b/ang/civicase/case/details/summary-tab/directives/case-summary.directive.html
@@ -10,9 +10,7 @@
           data-placeholder="Click to add subject"
           crm-form-success="onChangeSubject($data)"
         ></p>
-        <p ng-if="item['case_type_id.is_active'] === '0'">
-          {{item.subject}}
-        </p>
+        <p ng-if="item['case_type_id.is_active'] === '0'" ng-bind-html="item.subject"></p>
       </div>
       <div class="civicase__summary-tab__description">
         <p

--- a/ang/civicase/case/factories/format-case.factory.js
+++ b/ang/civicase/case/factories/format-case.factory.js
@@ -1,13 +1,15 @@
 (function (angular, $, _, CRM) {
   var module = angular.module('civicase');
 
-  module.factory('formatCase', function (formatActivity, CasesUtils,
+  module.factory('formatCase', function ($sce, formatActivity, CasesUtils,
     CaseStatus, CaseType, isTruthy) {
     var caseStatuses = CaseStatus.getAll(true);
 
     return function (item) {
       item.client = [];
-      item.subject = (typeof item.subject === 'undefined') ? '' : item.subject;
+      item.subject = (typeof item.subject === 'undefined')
+        ? ''
+        : $sce.trustAsHtml(item.subject);
       item.status = caseStatuses[item.status_id].label;
       item.color = caseStatuses[item.status_id].color;
       item.case_type = CaseType.getById(item.case_type_id).title;

--- a/ang/civicase/case/factories/format-case.factory.js
+++ b/ang/civicase/case/factories/format-case.factory.js
@@ -7,9 +7,7 @@
 
     return function (item) {
       item.client = [];
-      item.subject = (typeof item.subject === 'undefined')
-        ? ''
-        : $sce.trustAsHtml(item.subject);
+      item.subject = getFormattedCaseSubject(item.subject);
       item.status = caseStatuses[item.status_id].label;
       item.color = caseStatuses[item.status_id].color;
       item.case_type = CaseType.getById(item.case_type_id).title;
@@ -43,6 +41,27 @@
 
       return item;
     };
+
+    /**
+     * Returns a formatted subject for the case.
+     *
+     * If the subject is not defined will return an empty string. Otherwise it
+     * will return an escaped subject string free of HTML entities.
+     *
+     * We unwrap (valueOf) and then wrap (trustAsHtml) the subject as a trusted
+     * HTML value because the value could have already been wrapped and trying
+     * to wrap the value again would throw an error.
+     *
+     * @param {string} subject the case subject before being formatted.
+     * @returns {string} The formatted subject.
+     */
+    function getFormattedCaseSubject (subject) {
+      if (typeof subject === 'undefined') {
+        return '';
+      }
+
+      return $sce.trustAsHtml($sce.valueOf(subject));
+    }
 
     /**
      * Accumulates non communication and task counts as

--- a/ang/civicase/shared/directives/crm-editable.directive.js
+++ b/ang/civicase/shared/directives/crm-editable.directive.js
@@ -2,7 +2,9 @@
   var module = angular.module('civicase');
 
   // Angular binding for CiviCRM's jQuery-based crm-editable
-  module.directive('crmEditable', function ($timeout) {
+  module.directive('crmEditable', function ($filter, $timeout) {
+    var escapeString = $filter('civicaseEscapeString');
+
     return {
       restrict: 'A',
       link: crmEditableLink,
@@ -67,10 +69,6 @@
      * Retuns the text to be shown as HTML,
      * if the model value is null or empty string, retuns the placeholder.
      *
-     * We unescape and then escape the string because the value might already
-     * be escaped and if we try to scape it twice the string might break.
-     * Ex: `&amp;` will turn into `&amp;amp;`.
-     *
      * @param {object} scope scope object
      * @param {object} elem element
      * @param {object} attrs attributes
@@ -81,7 +79,7 @@
       var placeholder = attrs.placeholder;
 
       return (scope.model[field] && scope.model[field] !== '')
-        ? _.escape(_.unescape(scope.model[field]))
+        ? escapeString(scope.model[field])
         : placeholder;
     }
 

--- a/ang/civicase/shared/directives/crm-editable.directive.js
+++ b/ang/civicase/shared/directives/crm-editable.directive.js
@@ -28,7 +28,7 @@
             .html(
               textarea
                 ? nl2br(getHTMLToShow(scope, elem, attrs))
-                : _.escape(getHTMLToShow(scope, elem, attrs))
+                : getHTMLToShow(scope, elem, attrs)
             )
             .on('crmFormSuccess', function (e, value) {
               $timeout(function () {
@@ -39,11 +39,12 @@
               });
             })
             .crmEditable();
+
           scope.$watchCollection('model', function (model) {
             elem.html(
               textarea
                 ? nl2br(getHTMLToShow(scope, elem, attrs))
-                : _.escape(getHTMLToShow(scope, elem, attrs)));
+                : getHTMLToShow(scope, elem, attrs));
 
             applyLineLimitIfApplicableWithTimeout(scope, elem);
           });
@@ -64,7 +65,11 @@
 
     /**
      * Retuns the text to be shown as HTML,
-     * if the model value is null or empty string, retuns the placeholder
+     * if the model value is null or empty string, retuns the placeholder.
+     *
+     * We unescape and then escape the string because the value might already
+     * be escaped and if we try to scape it twice the string might break.
+     * Ex: `&amp;` will turn into `&amp;amp;`.
      *
      * @param {object} scope scope object
      * @param {object} elem element
@@ -76,7 +81,7 @@
       var placeholder = attrs.placeholder;
 
       return (scope.model[field] && scope.model[field] !== '')
-        ? scope.model[field]
+        ? _.escape(_.unescape(scope.model[field]))
         : placeholder;
     }
 

--- a/ang/test/civicase-base/filters/escape-string.spec.js
+++ b/ang/test/civicase-base/filters/escape-string.spec.js
@@ -1,0 +1,27 @@
+describe('Civicase Escape String', () => {
+  let civicaseEscapeString;
+
+  beforeEach(module('civicase-base'));
+
+  beforeEach(inject(($filter) => {
+    civicaseEscapeString = $filter('civicaseEscapeString');
+  }));
+
+  describe('when escaping a string containing special HTML characters', () => {
+    it('escapes the special characters', () => {
+      expect(civicaseEscapeString('You & Me')).toBe('You &amp; Me');
+    });
+  });
+
+  describe('when escaping strings that have previously been escaped', () => {
+    it('leaves the string as is', () => {
+      expect(civicaseEscapeString('You &amp; Me')).toBe('You &amp; Me');
+    });
+  });
+
+  describe('whnen escaping partially escaped strings', () => {
+    it('only escapes the HTML entities that have not already been escaped', () => {
+      expect(civicaseEscapeString('You &amp; Me & Myself')).toBe('You &amp; Me &amp; Myself');
+    });
+  });
+});

--- a/ang/test/civicase/case/factories/format-case.factory.spec.js
+++ b/ang/test/civicase/case/factories/format-case.factory.spec.js
@@ -1,10 +1,11 @@
 ((_) => {
   describe('formatCase', () => {
-    let caseItem, customDataBlocks, formatCase;
+    let $sce, caseItem, customDataBlocks, formatCase;
 
     beforeEach(module('civicase', 'civicase.data'));
 
-    beforeEach(inject((CasesData, _formatCase_) => {
+    beforeEach(inject((_$sce_, CasesData, _formatCase_) => {
+      $sce = _$sce_;
       formatCase = _formatCase_;
 
       caseItem = _.extend({}, _.cloneDeep(CasesData.get().values[0]), {
@@ -75,6 +76,19 @@
             jasmine.objectContaining({ weight: 3 })
           ]);
         });
+      });
+    });
+
+    describe('when formatting the case fields', () => {
+      let formattedCase;
+
+      beforeEach(() => {
+        caseItem.subject = 'You &amp; Me';
+        formattedCase = formatCase(caseItem);
+      });
+
+      it('allows special HTML characters in the case subject', () => {
+        expect($sce.getTrustedHtml(formattedCase.subject)).toEqual('You &amp; Me');
       });
     });
 


### PR DESCRIPTION
## Overview
This PR fixes an issue where special characters such as &, <, >, etc. would not be properly displayed when present in the Case subject.

## Before & After

<table>
<tr>
<th>Area</th>
<th>Before</th>
<th>After</th>
</tr>

<tr>
<th>Dashboard</th>
<td><img src="https://user-images.githubusercontent.com/1642119/112220096-3d378400-8bfc-11eb-9aaf-6875353665e0.png" /></td>
<td><img src="https://user-images.githubusercontent.com/1642119/112217652-2b081680-8bf9-11eb-9962-785cb21e445a.png" /></td>
</tr>

<tr>
<th>Contact Details</th>
<td><img src="https://user-images.githubusercontent.com/1642119/112220259-6eb04f80-8bfc-11eb-881e-99c3f5605fff.png" /></td>
<td><img src="https://user-images.githubusercontent.com/1642119/112217661-2cd1da00-8bf9-11eb-9bcd-f6b3885dec39.png" /></td>
</tr>

<tr>
<th>Case Details</th>
<td><img src="https://user-images.githubusercontent.com/1642119/112220099-3e68b100-8bfc-11eb-8e79-9df10fb3dd36.png" /></td>
<td><img src="https://user-images.githubusercontent.com/1642119/112217636-280d2600-8bf9-11eb-91ec-e4da06124026.png" /></td>
</tr>

</table>

## Technical Details

The problem happens when these values have been escaped and returned as escaped from the API. AngularJS would not try to display HTML entities or HTML elements by default to prevent injection attacks so we wrapped the case subject using `$sce.trustAsHtml` and displayed it using `ng-bind-html`.

We also had to update the CRM Editable directive because it was escaping the subject when it was already escaped. In order to allow escaped values we unescape then escape the subject. The escape was added to the directive because special characters would not be properly rendered without escaping them first, the directive would think these are HTML elements. For example, if you type `<h1>hello</h1>` as the subject you'd see a heading instead of seeing that literal text.