### PR TITLE
ACU-540: Restrict Default Custom Fields Load For Case.Get API

### DIFF
--- a/CRM/Civicase/Event/Listener/CaseCustomFields.php
+++ b/CRM/Civicase/Event/Listener/CaseCustomFields.php
@@ -1,0 +1,77 @@
+<?php
+
+use Civi\API\Event\PrepareEvent;
+
+/**
+ * Case Custom Fields Load Listener Class.
+ */
+class CRM_Civicase_Event_Listener_CaseCustomFields {
+
+  /**
+   * Avoid unnecessary joins to custom Field tables.
+   *
+   * When no return parameters is passed, instead of returning all basic Case
+   * fields in addition to the case custom date, only the case basic fields are
+   * returned.
+   *
+   * By default civicrm will join to all custom field tables for an entity
+   * in order to return all the custom fields for that entity in the case where
+   * specific return parameters are not passed.
+   *
+   * This can cause issues in sites that have more than 61 custom fields
+   * enabled for the Case entity as there is a Mysql 61 tables Join limit.
+   *
+   * Civi does not do the JOIN intelligently because there might just be
+   * 20 related custom field set for a particular Case but civi joins to all
+   * the custom field tables even the unnecessary ones.
+   *
+   * This change allows to pass the custom fields needed in return parameters
+   * and will not return custom data otherwise.
+   * Also the CustomTree.gettreevalues API will return exactly the related
+   * custom data for an entity without any unnecessary join to all the
+   * custom group tables.
+   *
+   * @param \Civi\API\Event\PrepareEvent $event
+   *   API Prepare Event Object.
+   */
+  public static function loadOnDemand(PrepareEvent $event) {
+    $apiRequest = $event->getApiRequest();
+    if ($apiRequest['version'] != 3) {
+      return;
+    }
+
+    if (!self::shouldRun($apiRequest)) {
+      return;
+    }
+
+    if (empty($apiRequest['params']['return'])) {
+      $supportedFields = array_keys(CRM_Case_DAO_Case::getSupportedFields());
+      $supportedFields = array_merge($supportedFields, [
+        'contact_id',
+        'client_id',
+      ]);
+      if (!empty($apiRequest['params']['id'])) {
+        $supportedFields = array_merge($supportedFields, [
+          'contacts',
+          'activities',
+        ]);
+      }
+      $apiRequest['params']['return'] = $supportedFields;
+      $event->setApiRequest($apiRequest);
+    }
+  }
+
+  /**
+   * Determines if the processing will run.
+   *
+   * @param array $apiRequest
+   *   Api request data.
+   *
+   * @return bool
+   *   TRUE if processing should run, FALSE otherwise.
+   */
+  protected static function shouldRun(array $apiRequest) {
+    return $apiRequest['entity'] == 'Case' && $apiRequest['action'] == 'get';
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -71,6 +71,12 @@ function civicase_civicrm_config(&$config) {
     ['CRM_Civicase_Event_Listener_CaseRoleCreation', 'onPrepare'],
     10
   );
+
+  Civi::dispatcher()->addListener(
+    'civi.api.prepare',
+    ['CRM_Civicase_Event_Listener_CaseCustomFields', 'loadOnDemand'],
+    10
+  );
 }
 
 /**


### PR DESCRIPTION
## Overview
Recently we had an issue on one of our client sites when we have multiple Custom field sets enabled for the Case entity:  `Mysql can only use 61 tables in a join`. This error made the award review screen unusable and also affected some parts of the cases extensions screen, e.g when saving a case data on the manage cases screen, an error occurs. The temporary fix for this error is to disable some custom field sets to bring the number of enabled custom field sets down to be below 61.

## Before
The issue described above exists.

## After
By default Civicrm will join to all custom field tables for an entity (Even those that are not necessary) in order to return all the custom fields for that entity in the case where specific return parameters are not passed in the Entity.get API parameters.  This can cause issues in sites that have more than 61 custom fields enabled for an entity as there is a Mysql 61 tables Join limit.
This issue has been reported in [core](https://lab.civicrm.org/dev/core/-/issues/1191) with no solution yet, there is some POC that someone put up but has not been discussed and it involves splitting the sql queries in batches and executing per batch, this approach might probably cause performance issues on sites with a lot custom field sets enabled.

This PR takes another approach to this issue. The PR does not totally fix the issue but it tries to optimize the way joins to custom fields are made.
It involves an on-demand load for custom field results when calling the Case.get API calls. Basically, custom field tables are not joined to by default except the custom fields to be fetched is specified in the parameters to be returned. When an API call is made to the Case entity with no return parameters specified, rather than join to custom field sets and try to return all fields, only the core case fields minus custom fields are returned.

The simple solution to this issue would have been to make sure we supply return parameters in places where Case.get API calls are made in the cases/awards/prospects extensions but there are some places in [core ](https://github.com/civicrm/civicrm-core/blob/master/Civi/CCase/Analyzer.php#L165)where these API calls are made without specifying return parameters hence the need to add an Event Listener to handle this.

**The Pros**
The pros of this approach is that, we can have more custom field set enabled without having to hit the max of 60 tables on the Case entity as the situation is right now. So basically, the custom field table joins will only be to tables that are relevant to the Case under consideration (either by passing in the needed custom fields or by using the Custom.getTreevalues API which is what is used on manage cases screen).
For example, the maximum number of custom field set for an Award type on the ACU site is around 24 currently, which means we can add more field sets for that particular award type before hitting 60 with this approach.

This will actually help in performance improvements in places in core where Case.get API calls are made without specifying parameters to return especially in sites with a large number of Case custom field sets.

**The Cons**
The con of this approach is the fact that there might possibly be an extension (that is not ours) that relies on the fact that a particular custom field will be returned by simply calling the Case.get API without specifying the custom field as part of the return parameter i.e without specifying any return parameters. Looked through the code and this seems not to be happening currently in our extensions and other installed extensions in compuclient but then it's a possibility, probably an edge case.


## Comments
- No unit tests was added for this change for now, will be added in another PR and also the change is easily verifiable via the API explorer. 
- Manual tests were done extensively to be sure that webforms, cases screens, review fields and other screens works as expected.
