### PR TITLE
CPS-525: Fix Marking an email as save draft sends out the email

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/HandleDraftActivities.php
+++ b/CRM/Civicase/Hook/BuildForm/HandleDraftActivities.php
@@ -80,6 +80,7 @@ class CRM_Civicase_Hook_BuildForm_HandleDraftActivities {
           'xbutton',
           $form->getButtonName('refresh'),
           ts('Save Draft'), [
+            'type' => 'submit',
             'crm-icon' => 'fa-pencil-square-o',
             'class' => 'crm-form-submit',
           ]


### PR DESCRIPTION
## Overview
When creating an Email activity and marking as draft, rather than a draft activity being created, the email is sent out.

## Before
![SaveDraftBefore](https://user-images.githubusercontent.com/6951813/112611125-b7931e80-8e1d-11eb-8698-25344f68bcfa.gif)


## After
![SaveDraftAfter](https://user-images.githubusercontent.com/6951813/112611148-c1b51d00-8e1d-11eb-9a55-c0fee526d939.gif)


## Technical Details
The code works fine on sites running civicrm 5.28 but something seems to have changed in civicrm 5.35. The issue is because the code [here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/Hook/ValidateForm/SaveActivityDraft.php#L37) does a return and the `CRM_Civicase_Hook_ValidateForm_SaveActivityDraft` class responsible for handling the draft activity logic is not executed because the `fields` variable does not contain the `button` key. The fields variable is populated via POST and the save draft button is not part of the form values submitted when the save draft button is clicked.

This is fixed by setting the button to be of type `submit` when being added. Looking through core code, this is also very common to set the button type when adding a button,[ see](https://github.com/civicrm/civicrm-core/commit/cbd83ddebb3c7e88157f90905c4ac63bf5214c44#diff-110b654b39ff76de17a677646d9b521049d2afaf24201c953bbfb83808eb552fR53). 

I did not bother to check what changed in Civicrm 5.35 that made previous code not to work since the fix is a small one and checking might take too much time.
