### PR TITLE
CPS-472: Add My Activities Feed dashlet

### DIFF
--- a/CRM/Civicase/Hook/PageRun/AddCivicaseDashlets.php
+++ b/CRM/Civicase/Hook/PageRun/AddCivicaseDashlets.php
@@ -1,0 +1,42 @@
+<?php
+
+use Civi\Angular\AngularLoader;
+
+/**
+ * Loads Civicase Angular dashlets when viewing the dashboard page.
+ */
+class CRM_Civicase_Hook_PageRun_AddCivicaseDashlets {
+
+  /**
+   * Runs the hook.
+   *
+   * @param object $page
+   *   Page Object.
+   */
+  public function run($page) {
+    if (!$this->shouldRun($page)) {
+      return;
+    }
+
+    CRM_Core_Resources::singleton()
+      ->addScriptFile('uk.co.compucorp.civicase', 'packages/moment.min.js');
+
+    $loader = new AngularLoader();
+    $loader->setModules(['civicase']);
+    $loader->load();
+  }
+
+  /**
+   * Determines if the hook should run.
+   *
+   * @param object $page
+   *   Page Object.
+   *
+   * @return bool
+   *   True when viewing the dashboard page.
+   */
+  private function shouldRun($page) {
+    return get_class($page) === CRM_Contact_Page_DashBoard::class;
+  }
+
+}

--- a/CRM/Civicase/Upgrader/Steps/Step0015.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0015.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Adds the My Activities Feed dashlet to the dashboard.
+ */
+class CRM_Civicase_Upgrader_Steps_Step0015 {
+
+  /**
+   * Runs the upgrader changes.
+   *
+   * @return bool
+   *   Return TRUE when the upgrader runs successfully.
+   */
+  public function apply() {
+    civicrm_api3('Dashboard', 'create', [
+      'name' => 'myactivitiesfeed',
+      'label' => 'My Activities Feed',
+      'url' => '',
+      'fullscreen_url' => '',
+      'permission' => 'access all cases and activities,access my cases and activities',
+      'permission_operator' => 'OR',
+      'is_active' => '1',
+      'is_reserved' => '1',
+      'cache_minutes' => '7200',
+      'directive' => 'civicase-my-activities-feed-dashlet',
+    ]);
+
+    return TRUE;
+  }
+
+}

--- a/ang/civicase/activity/feed/directives/activity-feed.directive.js
+++ b/ang/civicase/activity/feed/directives/activity-feed.directive.js
@@ -13,6 +13,7 @@
         canSelectCaseTypeCategory: '=',
         caseTypeId: '=',
         refreshCase: '=?refreshCallback',
+        skipUrlParamatersBinding: '<',
         hideQuickNavWhenDetailsIsVisible: '='
       }
     };
@@ -79,6 +80,11 @@
     var pageNum = { down: 0, up: 0 };
     var activitySets = $scope.caseTypeId &&
       CaseType.getById($scope.caseTypeId).definition.activitySets;
+    var DEFAULT_DISPLAY_OPTIONS = angular.extend({}, {
+      followup_nested: true,
+      overdue_first: true,
+      include_case: true
+    }, $scope.params.displayOptions || {});
 
     $scope.filters = {};
     $scope.isMonthNavVisible = true;
@@ -100,7 +106,13 @@
 
     (function init () {
       applyFiltersFromBindings();
-      bindRouteParamsToScope();
+
+      if ($scope.skipUrlParamatersBinding) {
+        $scope.displayOptions = DEFAULT_DISPLAY_OPTIONS;
+      } else {
+        bindRouteParamsToScope();
+      }
+
       initiateWatchersAndEvents();
     }());
 
@@ -226,11 +238,7 @@
       $scope.$bindToRoute({
         expr: 'displayOptions',
         param: 'ado',
-        default: angular.extend({}, {
-          followup_nested: true,
-          overdue_first: true,
-          include_case: true
-        }, $scope.params.displayOptions || {})
+        default: DEFAULT_DISPLAY_OPTIONS
       });
     }
 

--- a/ang/civicase/dashlets/my-activities-feed-dashlet.directive.html
+++ b/ang/civicase/dashlets/my-activities-feed-dashlet.directive.html
@@ -1,0 +1,8 @@
+<div id="bootstrap-theme">
+  <div
+    civicase-activity-feed="{ filters: filters }"
+    hide-quick-nav-when-details-is-visible="true"
+    show-bulk-actions="true"
+    skip-url-paramaters-binding="true"
+  ></div>
+</div>

--- a/ang/civicase/dashlets/my-activities-feed-dashlet.directive.js
+++ b/ang/civicase/dashlets/my-activities-feed-dashlet.directive.js
@@ -1,0 +1,35 @@
+(function (_, angular) {
+  var module = angular.module('civicase');
+
+  module.directive('civicaseMyActivitiesFeedDashlet', function () {
+    return {
+      controller: 'civicaseMyActivitiesFeedDashletController',
+      templateUrl: '~/civicase/dashlets/my-activities-feed-dashlet.directive.html'
+    };
+  });
+
+  module.controller('civicaseMyActivitiesFeedDashletController', civicaseMyActivitiesFeedDashletController);
+
+  /**
+   * My Activities Feed Dashlet controller.
+   *
+   * @param {object} $scope Scope Object reference.
+   * @param {object} ActivityStatus Activity Status service.
+   * @param {object} Contact Contact service.
+   */
+  function civicaseMyActivitiesFeedDashletController ($scope, ActivityStatus, Contact) {
+    (function init () {
+      var INCOMPLETE_ACTIVITY_STATUS_CATEGORY = '0';
+      var incompletedActivityStatusIds = _.chain(ActivityStatus.getAll())
+        .filter({ filter: INCOMPLETE_ACTIVITY_STATUS_CATEGORY })
+        .map('value')
+        .value();
+
+      $scope.filters = {
+        $contact_id: Contact.getCurrentContactID(),
+        '@involvingContact': 'myActivities',
+        status_id: incompletedActivityStatusIds
+      };
+    })();
+  }
+})(CRM._, angular);

--- a/ang/test/civicase-base/services/activity-status.service.spec.js
+++ b/ang/test/civicase-base/services/activity-status.service.spec.js
@@ -35,7 +35,9 @@
           color: '#d9534f',
           name: 'Unread',
           grouping: 'communication',
-          is_active: '1'
+          is_active: '1',
+          weight: '9',
+          filter: '0'
         });
       });
     });

--- a/ang/test/civicase/activity/feed/directives/activity-feed.directive.spec.js
+++ b/ang/test/civicase/activity/feed/directives/activity-feed.directive.spec.js
@@ -24,6 +24,12 @@
         showFullContactNameOnActivityFeed = _showFullContactNameOnActivityFeed_;
 
         $scope = $rootScope.$new();
+        $scope.caseTypeId = '1';
+        $scope.filters = {};
+        $scope.displayOptions = {};
+        $scope.params = {
+          displayOptions: 1
+        };
         $scope.$bindToRoute = jasmine.createSpy('$bindToRoute');
         civicaseCrmApi = _civicaseCrmApi_;
       }));
@@ -35,6 +41,92 @@
 
         it('provides the value for the "Show Full Contact Name On ActivityFeed" setting', () => {
           expect($scope.showFullContactNameOnActivityFeed).toBe(showFullContactNameOnActivityFeed);
+        });
+      });
+
+      describe('binding URL parameters to scope', () => {
+        describe('when we do not skip URL parameters binding', () => {
+          beforeEach(() => {
+            initController();
+          });
+
+          it('binds the current activity ID parameter', () => {
+            expect($scope.$bindToRoute).toHaveBeenCalledWith(jasmine.objectContaining({
+              param: 'aid',
+              expr: 'aid'
+            }));
+          });
+
+          it('binds the activity filters parameters', () => {
+            expect($scope.$bindToRoute).toHaveBeenCalledWith(jasmine.objectContaining({
+              param: 'af',
+              expr: 'filters'
+            }));
+          });
+
+          it('binds the activity display option parameters', () => {
+            expect($scope.$bindToRoute).toHaveBeenCalledWith(jasmine.objectContaining({
+              param: 'ado',
+              expr: 'displayOptions'
+            }));
+          });
+
+          describe('when passing display options', () => {
+            beforeEach(() => {
+              $scope.params.displayOptions = { custom_display_option: true };
+
+              initController();
+            });
+
+            it('adds default parameters to the display options URL binding', () => {
+              expect($scope.$bindToRoute).toHaveBeenCalledWith(jasmine.objectContaining({
+                param: 'ado',
+                expr: 'displayOptions',
+                default: jasmine.objectContaining({
+                  followup_nested: true,
+                  overdue_first: true,
+                  include_case: true
+                })
+              }));
+            });
+
+            it('uses the values passed as defaults for the display options URL binding', () => {
+              expect($scope.$bindToRoute).toHaveBeenCalledWith(jasmine.objectContaining({
+                param: 'ado',
+                expr: 'displayOptions',
+                default: jasmine.objectContaining({
+                  custom_display_option: true
+                })
+              }));
+            });
+          });
+        });
+
+        describe('when we skip the URL paramaters binding', () => {
+          beforeEach(() => {
+            $scope.skipUrlParamatersBinding = true;
+            $scope.params.displayOptions = { custom_display_option: true };
+
+            initController();
+          });
+
+          it('does not bind the URL parameters to the scope', () => {
+            expect($scope.$bindToRoute).not.toHaveBeenCalled();
+          });
+
+          it('sets the default values for the display options', () => {
+            expect($scope.displayOptions).toEqual(jasmine.objectContaining({
+              followup_nested: true,
+              overdue_first: true,
+              include_case: true
+            }));
+          });
+
+          it('includes the default values passed to the display options', () => {
+            expect($scope.displayOptions).toEqual(jasmine.objectContaining({
+              custom_display_option: true
+            }));
+          });
         });
       });
 
@@ -389,13 +481,6 @@
        * Initializes the activity feed controller.
        */
       function initController () {
-        $scope.caseTypeId = '1';
-        $scope.filters = {};
-        $scope.displayOptions = {};
-        $scope.params = {
-          displayOptions: 1
-        };
-
         $controller('civicaseActivityFeedController', {
           $scope: $scope
         });

--- a/ang/test/civicase/dashlets/my-activities-feed-dashlet.directive.spec.js
+++ b/ang/test/civicase/dashlets/my-activities-feed-dashlet.directive.spec.js
@@ -1,0 +1,51 @@
+((_) => {
+  describe('civicaseMyActivitiesFeedDashlet', () => {
+    let $controller, $rootScope, $scope, Contact;
+
+    beforeEach(module('civicase', 'civicase.data'));
+
+    beforeEach(inject((_$controller_, _$rootScope_, _Contact_) => {
+      $controller = _$controller_;
+      $rootScope = _$rootScope_;
+      Contact = _Contact_;
+
+      $scope = $rootScope.$new();
+    }));
+
+    describe('activity filters', () => {
+      const INCOMPLETE_ACTIVITY_STATUSES = [
+        { value: '1', label: 'Scheduled' },
+        { value: '4', label: 'Left Message' },
+        { value: '7', label: 'Available' },
+        { value: '9', label: 'Unread' },
+        { value: '10', label: 'Draft' }
+      ];
+
+      beforeEach(() => {
+        initController();
+      });
+
+      it('filters activities by the current logged in user ID', () => {
+        expect($scope.filters.$contact_id).toEqual(Contact.getCurrentContactID());
+      });
+
+      it('filters activities assigned to the current logged in user', () => {
+        expect($scope.filters['@involvingContact']).toEqual('myActivities');
+      });
+
+      it('filters activities that have not been completed', () => {
+        expect($scope.filters.status_id)
+          .toEqual(_.map(INCOMPLETE_ACTIVITY_STATUSES, 'value'));
+      });
+    });
+
+    /**
+     * Initializes the directive's controller.
+     */
+    function initController () {
+      $controller('civicaseMyActivitiesFeedDashletController', {
+        $scope: $scope
+      });
+    }
+  });
+})(CRM._);

--- a/ang/test/mocks/data/activity-statuses.data.js
+++ b/ang/test/mocks/data/activity-statuses.data.js
@@ -8,7 +8,9 @@
       color: '#42afcb',
       name: 'Scheduled',
       grouping: 'none,task,file,communication,milestone,system',
-      is_active: '1'
+      is_active: '1',
+      weight: '1',
+      filter: '0'
     },
     2: {
       value: '2',
@@ -16,14 +18,18 @@
       color: '#8ec68a',
       name: 'Completed',
       grouping: 'none,task,file,communication,milestone,alert,system',
-      is_active: '1'
+      is_active: '1',
+      weight: '2',
+      filter: '1'
     },
     3: {
       value: '3',
       label: 'Cancelled',
       name: 'Cancelled',
       grouping: 'none,communication,milestone,alert',
-      is_active: '1'
+      is_active: '1',
+      weight: '3',
+      filter: '2'
     },
     4: {
       value: '4',
@@ -31,21 +37,27 @@
       color: '#eca67f',
       name: 'Left Message',
       grouping: 'none,communication,milestone',
-      is_active: '1'
+      is_active: '1',
+      weight: '4',
+      filter: '0'
     },
     5: {
       value: '5',
       label: 'Unreachable',
       name: 'Unreachable',
       grouping: 'none,communication,milestone',
-      is_active: '1'
+      is_active: '1',
+      weight: '5',
+      filter: '2'
     },
     6: {
       value: '6',
       label: 'Not Required',
       name: 'Not Required',
       grouping: 'none,task,milestone',
-      is_active: '1'
+      is_active: '1',
+      weight: '6',
+      filter: '2'
     },
     7: {
       value: '7',
@@ -53,14 +65,18 @@
       color: '#5bc0de',
       name: 'Available',
       grouping: 'none,milestone',
-      is_active: '1'
+      is_active: '1',
+      weight: '7',
+      filter: '0'
     },
     8: {
       value: '8',
       label: 'No-show',
       name: 'No_show',
       grouping: 'none,milestone',
-      is_active: '1'
+      is_active: '1',
+      weight: '8',
+      filter: '2'
     },
     9: {
       value: '9',
@@ -68,7 +84,9 @@
       color: '#d9534f',
       name: 'Unread',
       grouping: 'communication',
-      is_active: '1'
+      is_active: '1',
+      weight: '9',
+      filter: '0'
     },
     10: {
       value: '10',
@@ -76,7 +94,9 @@
       color: '#c2cfd8',
       name: 'Draft',
       grouping: 'communication',
-      is_active: '1'
+      is_active: '1',
+      weight: '10',
+      filter: '0'
     }
   };
 

--- a/civicase.php
+++ b/civicase.php
@@ -427,6 +427,7 @@ function civicase_civicrm_pageRun(&$page) {
     new CRM_Civicase_Hook_PageRun_AddCaseAngularPageResources(),
     new CRM_Civicase_Hook_PageRun_AddContactPageSummaryResources(),
     new CRM_Civicase_Hook_PageRun_CaseCategoryCustomGroupListing(),
+    new CRM_Civicase_Hook_PageRun_AddCivicaseDashlets(),
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview
This PR reintroduces the My Activities dashboard tab, but as a dashlet instead.

The My Activities tab was removed in https://github.com/compucorp/uk.co.compucorp.civicase/pull/717

## How it looks

![pr](https://user-images.githubusercontent.com/1642119/113070246-219a2380-9190-11eb-96de-27179cc29486.gif)

## Technical Details

We created a new directive that has all the filters needed for the activity feed to display the incomplete activities belonging to the logged in user. This directive is used as the dashlet on the dashboard.

The `skipUrlParamatersBinding` parameter was added to the activity feed directive because the dashboard doesn't have the angular router enabled and binding URL parameters break. This only blocks the filters from being stored in the URL in case they refreshe it.