### PR TITLE
RSESPRT-36: Fix Case Tokens icons

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/TokenTree.php
+++ b/CRM/Civicase/Hook/BuildForm/TokenTree.php
@@ -190,7 +190,14 @@ class CRM_Civicase_Hook_BuildForm_TokenTree {
     try {
       $customFields = civicrm_api3('CustomField', 'get', [
         'custom_group_id.extends' => [
-          'IN' => ['Contact', 'Individual', 'Household', 'Organization', 'Case'],
+          'IN' => [
+            'Contact',
+            'Individual',
+            'Household',
+            'Organization',
+            'Case',
+            'Address',
+          ],
         ],
         'options' => ['limit' => 0, 'sort' => "custom_group_id.weight ASC"],
         'sequential' => 1,
@@ -299,17 +306,26 @@ class CRM_Civicase_Hook_BuildForm_TokenTree {
    *   Restructured token tree.
    */
   private function addCaseTokens(array $caseTokens, array &$newTokenTree) {
-    $newTokenTree[self::CASE_TOKEN_TEXT] = [
-      'id' => self::CASE_TOKEN_TEXT,
-      'text' => self::CASE_TOKEN_TEXT,
-      'children' => [
-        [
-          'id' => 'CoreFields' . uniqid(),
-          'text' => self::CORE_FIELDS_TEXT,
-          'children' => $caseTokens,
+    if (empty($newTokenTree[self::CASE_TOKEN_TEXT]['children'][0])) {
+      if (!empty($newTokenTree[self::CASE_TOKEN_TEXT]['children'][1])) {
+        $customTokens = $newTokenTree[self::CASE_TOKEN_TEXT]['children'][1];
+      }
+      $newTokenTree[self::CASE_TOKEN_TEXT] = [
+        'id' => self::CASE_TOKEN_TEXT,
+        'text' => self::CASE_TOKEN_TEXT,
+        'children' => [
+          [
+            'id' => 'CoreFields' . uniqid(),
+            'text' => self::CORE_FIELDS_TEXT,
+            'children' => $caseTokens,
+          ],
         ],
-      ],
-    ];
+      ];
+      if (!empty($customTokens)) {
+        $newTokenTree[self::CASE_TOKEN_TEXT]['children'][1] = $customTokens;
+      }
+    }
+
   }
 
   /**
@@ -321,7 +337,10 @@ class CRM_Civicase_Hook_BuildForm_TokenTree {
    *   Restructured token tree.
    */
   private function addClientTokens(array $clientTokens, array &$newTokenTree) {
-    if (empty($newTokenTree[self::RECIPIENT_TOKEN_TEXT])) {
+    if (empty($newTokenTree[self::RECIPIENT_TOKEN_TEXT]['children'][0])) {
+      if (!empty($newTokenTree[self::RECIPIENT_TOKEN_TEXT]['children'][1])) {
+        $customTokens = $newTokenTree[self::RECIPIENT_TOKEN_TEXT]['children'][1];
+      }
       $newTokenTree[self::RECIPIENT_TOKEN_TEXT] = [
         'id' => $this->clean(self::RECIPIENT_TOKEN_TEXT) . uniqid(),
         'text' => self::RECIPIENT_TOKEN_TEXT,
@@ -333,6 +352,9 @@ class CRM_Civicase_Hook_BuildForm_TokenTree {
           ],
         ],
       ];
+      if (!empty($customTokens)) {
+        $newTokenTree[self::RECIPIENT_TOKEN_TEXT]['children'][1] = $customTokens;
+      }
     }
     else {
       $newTokenTree[self::RECIPIENT_TOKEN_TEXT]['children'][0]['children'] =

--- a/js/token-tree.js
+++ b/js/token-tree.js
@@ -148,9 +148,9 @@ CRM['civicase-base'].tokentree = {};
     if (item.children) {
       hasChildrenIdentifier = 'has-children ';
       if (isOpen) {
-        icon = '<i class="fa fa-minus-square-o" style="margin-right: 5px;"></i>';
+        icon = '<i class="fa fa-minus-square" style="margin-right: 5px;"></i>';
       } else {
-        icon = '<i class="fa fa-plus-square-o" style="margin-right: 5px;"></i>';
+        icon = '<i class="fa fa-plus-square" style="margin-right: 5px;"></i>';
       }
     }
 

--- a/tests/phpunit/CRM/Civicase/Hook/BuildForm/TokenTreeTest.php
+++ b/tests/phpunit/CRM/Civicase/Hook/BuildForm/TokenTreeTest.php
@@ -51,76 +51,76 @@ class CRM_Civicase_Hook_BuildForm_TokenTreeTest extends BaseHeadlessTest {
    */
   private function getTokens() {
     return [
-        [
-          'text' => 'Case Roles',
-          'children' => [
-            [
-              'id' => '{case_roles.benefits_specialist_id}',
-              'text' => 'Benefits Specialist - Contact ID',
-            ],
-            [
-              'id' => '{case_roles.benefits_specialist_custom_' . $this->contactCustomField['id'] . '}',
-              'text' => 'Benefits Specialist - ' . $this->contactCustomField['name'],
-            ],
-            [
-              'id' => '{case_roles.health_services_coordinator_contact_sub_type}',
-              'text' => 'Health Services Coordinator - Contact Subtype',
-            ],
-            [
-              'id' => '{case_roles.health_services_coordinator_custom_' . $this->contactCustomField['id'] . '}',
-              'text' => 'Health Services Coordinator - ' . $this->contactCustomField['name'],
-            ],
+      [
+        'text' => 'Case Roles',
+        'children' => [
+          [
+            'id' => '{case_roles.benefits_specialist_id}',
+            'text' => 'Benefits Specialist - Contact ID',
+          ],
+          [
+            'id' => '{case_roles.benefits_specialist_custom_' . $this->contactCustomField['id'] . '}',
+            'text' => 'Benefits Specialist - ' . $this->contactCustomField['name'],
+          ],
+          [
+            'id' => '{case_roles.health_services_coordinator_contact_sub_type}',
+            'text' => 'Health Services Coordinator - Contact Subtype',
+          ],
+          [
+            'id' => '{case_roles.health_services_coordinator_custom_' . $this->contactCustomField['id'] . '}',
+            'text' => 'Health Services Coordinator - ' . $this->contactCustomField['name'],
           ],
         ],
-        [
-          'text' => 'Current User',
-          'children' => [
-            [
-              'id' => '{current_user.contact_city}',
-              'text' => 'Current User City',
-            ],
-            [
-              'id' => '{current_user.contact_custom_' . $this->contactCustomField['id'] . '}',
-              'text' => 'Current User ' . $this->contactCustomField['name'],
-            ],
+      ],
+      [
+        'text' => 'Current User',
+        'children' => [
+          [
+            'id' => '{current_user.contact_city}',
+            'text' => 'Current User City',
+          ],
+          [
+            'id' => '{current_user.contact_custom_' . $this->contactCustomField['id'] . '}',
+            'text' => 'Current User ' . $this->contactCustomField['name'],
           ],
         ],
-        [
-          'text' => 'Case',
-          'children' => [
-            [
-              'id' => '{case.id}',
-              'text' => 'Case Id',
-            ],
+      ],
+      [
+        'text' => $this->caseCustomField['name'],
+        'children' => [
+          [
+            'id' => '{case.custom_' . $this->caseCustomField['id'] . '}',
+            'text' => $this->caseCustomField['name'],
           ],
         ],
-        [
-          'text' => 'Contact',
-          'children' => [
-            [
-              'id' => '{contact.addressee_id}',
-              'text' => 'Addressee ID',
-            ],
+      ],
+      [
+        'text' => 'Case',
+        'children' => [
+          [
+            'id' => '{case.id}',
+            'text' => 'Case Id',
           ],
         ],
-        [
-          'text' => $this->contactCustomField['name'],
-          'children' => [
-            [
-              'id' => '{contact.custom_' . $this->contactCustomField['id'] . '}',
-              'text' => $this->contactCustomField['name'],
-            ],
+      ],
+      [
+        'text' => $this->contactCustomField['name'],
+        'children' => [
+          [
+            'id' => '{contact.custom_' . $this->contactCustomField['id'] . '}',
+            'text' => $this->contactCustomField['name'],
           ],
         ],
-        [
-          'text' => $this->caseCustomField['name'],
-          'children' => [
-            [
-              'id' => '{case.custom_' . $this->caseCustomField['id'] . '}',
-              'text' => $this->caseCustomField['name'],
-            ],
+      ],
+      [
+        'text' => 'Contact',
+        'children' => [
+          [
+            'id' => '{contact.addressee_id}',
+            'text' => 'Addressee ID',
           ],
         ],
+      ],
     ];
   }
 

--- a/tests/phpunit/CRM/Civicase/Hook/BuildForm/TokenTreeTest.php
+++ b/tests/phpunit/CRM/Civicase/Hook/BuildForm/TokenTreeTest.php
@@ -59,16 +59,16 @@ class CRM_Civicase_Hook_BuildForm_TokenTreeTest extends BaseHeadlessTest {
             'text' => 'Benefits Specialist - Contact ID',
           ],
           [
-            'id' => '{case_roles.benefits_specialist_custom_' . $this->contactCustomField['id'] . '}',
-            'text' => 'Benefits Specialist - ' . $this->contactCustomField['name'],
+            'id' => '{case_roles.benefits_specialist_custom_' . $this->contactCustomField[0]['id'] . '}',
+            'text' => 'Benefits Specialist - ' . $this->contactCustomField[0]['name'],
           ],
           [
             'id' => '{case_roles.health_services_coordinator_contact_sub_type}',
             'text' => 'Health Services Coordinator - Contact Subtype',
           ],
           [
-            'id' => '{case_roles.health_services_coordinator_custom_' . $this->contactCustomField['id'] . '}',
-            'text' => 'Health Services Coordinator - ' . $this->contactCustomField['name'],
+            'id' => '{case_roles.health_services_coordinator_custom_' . $this->contactCustomField[0]['id'] . '}',
+            'text' => 'Health Services Coordinator - ' . $this->contactCustomField[0]['name'],
           ],
         ],
       ],
@@ -80,17 +80,17 @@ class CRM_Civicase_Hook_BuildForm_TokenTreeTest extends BaseHeadlessTest {
             'text' => 'Current User City',
           ],
           [
-            'id' => '{current_user.contact_custom_' . $this->contactCustomField['id'] . '}',
-            'text' => 'Current User ' . $this->contactCustomField['name'],
+            'id' => '{current_user.contact_custom_' . $this->contactCustomField[0]['id'] . '}',
+            'text' => 'Current User ' . $this->contactCustomField[0]['name'],
           ],
         ],
       ],
       [
-        'text' => $this->caseCustomField['name'],
+        'text' => $this->caseCustomField[0]['name'],
         'children' => [
           [
-            'id' => '{case.custom_' . $this->caseCustomField['id'] . '}',
-            'text' => $this->caseCustomField['name'],
+            'id' => '{case.custom_' . $this->caseCustomField[0]['id'] . '}',
+            'text' => $this->caseCustomField[0]['name'],
           ],
         ],
       ],
@@ -104,11 +104,20 @@ class CRM_Civicase_Hook_BuildForm_TokenTreeTest extends BaseHeadlessTest {
         ],
       ],
       [
-        'text' => $this->contactCustomField['name'],
+        'text' => $this->caseCustomField[1]['name'],
         'children' => [
           [
-            'id' => '{contact.custom_' . $this->contactCustomField['id'] . '}',
-            'text' => $this->contactCustomField['name'],
+            'id' => '{case.custom_' . $this->caseCustomField[1]['id'] . '}',
+            'text' => $this->caseCustomField[1]['name'],
+          ],
+        ],
+      ],
+      [
+        'text' => $this->contactCustomField[0]['name'],
+        'children' => [
+          [
+            'id' => '{contact.custom_' . $this->contactCustomField[0]['id'] . '}',
+            'text' => $this->contactCustomField[0]['name'],
           ],
         ],
       ],
@@ -118,6 +127,15 @@ class CRM_Civicase_Hook_BuildForm_TokenTreeTest extends BaseHeadlessTest {
           [
             'id' => '{contact.addressee_id}',
             'text' => 'Addressee ID',
+          ],
+        ],
+      ],
+      [
+        'text' => $this->contactCustomField[1]['name'],
+        'children' => [
+          [
+            'id' => '{contact.custom_' . $this->contactCustomField[1]['id'] . '}',
+            'text' => $this->contactCustomField[1]['name'],
           ],
         ],
       ],
@@ -159,11 +177,11 @@ class CRM_Civicase_Hook_BuildForm_TokenTreeTest extends BaseHeadlessTest {
       $newTokenTree[TokenTree::CURRENT_USER_TOKEN_TEXT]['children'][0]['children'][0]['text']
     );
     $this->assertEquals(
-      '{current_user.contact_custom_' . $this->contactCustomField['id'] . '}',
+      '{current_user.contact_custom_' . $this->contactCustomField[0]['id'] . '}',
       $newTokenTree[TokenTree::CURRENT_USER_TOKEN_TEXT]['children'][1]['children'][0]['children'][0]['id']
     );
     $this->assertEquals(
-      'Current User ' . $this->contactCustomField['name'],
+      'Current User ' . $this->contactCustomField[0]['name'],
       $newTokenTree[TokenTree::CURRENT_USER_TOKEN_TEXT]['children'][1]['children'][0]['children'][0]['text']
     );
   }
@@ -185,11 +203,11 @@ class CRM_Civicase_Hook_BuildForm_TokenTreeTest extends BaseHeadlessTest {
       $newTokenTree['Benefits Specialist']['children'][0]['children'][0]['text']
     );
     $this->assertEquals(
-      '{case_roles.benefits_specialist_custom_' . $this->contactCustomField['id'] . '}',
+      '{case_roles.benefits_specialist_custom_' . $this->contactCustomField[0]['id'] . '}',
       $newTokenTree['Benefits Specialist']['children'][1]['children'][0]['children'][0]['id']
     );
     $this->assertEquals(
-      'Benefits Specialist - ' . $this->contactCustomField['name'],
+      'Benefits Specialist - ' . $this->contactCustomField[0]['name'],
       $newTokenTree['Benefits Specialist']['children'][1]['children'][0]['children'][0]['text']
     );
     $this->assertNotEmpty($newTokenTree['Health Services Coordinator']);
@@ -202,11 +220,11 @@ class CRM_Civicase_Hook_BuildForm_TokenTreeTest extends BaseHeadlessTest {
       $newTokenTree['Health Services Coordinator']['children'][0]['children'][0]['text']
     );
     $this->assertEquals(
-      '{case_roles.health_services_coordinator_custom_' . $this->contactCustomField['id'] . '}',
+      '{case_roles.health_services_coordinator_custom_' . $this->contactCustomField[0]['id'] . '}',
       $newTokenTree['Health Services Coordinator']['children'][1]['children'][0]['children'][0]['id']
     );
     $this->assertEquals(
-      'Health Services Coordinator - ' . $this->contactCustomField['name'],
+      'Health Services Coordinator - ' . $this->contactCustomField[0]['name'],
       $newTokenTree['Health Services Coordinator']['children'][1]['children'][0]['children'][0]['text']
     );
   }
@@ -228,12 +246,20 @@ class CRM_Civicase_Hook_BuildForm_TokenTreeTest extends BaseHeadlessTest {
       $newTokenTree[TokenTree::RECIPIENT_TOKEN_TEXT]['children'][0]['children'][0]['text']
     );
     $this->assertEquals(
-      '{contact.custom_' . $this->contactCustomField['id'] . '}',
+      '{contact.custom_' . $this->contactCustomField[0]['id'] . '}',
       $newTokenTree[TokenTree::RECIPIENT_TOKEN_TEXT]['children'][1]['children'][0]['children'][0]['id']
     );
     $this->assertEquals(
-      $this->contactCustomField['name'],
+      $this->contactCustomField[0]['name'],
       $newTokenTree[TokenTree::RECIPIENT_TOKEN_TEXT]['children'][1]['children'][0]['children'][0]['text']
+    );
+    $this->assertEquals(
+      '{contact.custom_' . $this->contactCustomField[1]['id'] . '}',
+      $newTokenTree[TokenTree::RECIPIENT_TOKEN_TEXT]['children'][1]['children'][0]['children'][1]['id']
+    );
+    $this->assertEquals(
+      $this->contactCustomField[1]['name'],
+      $newTokenTree[TokenTree::RECIPIENT_TOKEN_TEXT]['children'][1]['children'][0]['children'][1]['text']
     );
   }
 
@@ -254,12 +280,20 @@ class CRM_Civicase_Hook_BuildForm_TokenTreeTest extends BaseHeadlessTest {
       $newTokenTree[TokenTree::CASE_TOKEN_TEXT]['children'][0]['children'][0]['text']
     );
     $this->assertEquals(
-      '{case.custom_' . $this->caseCustomField['id'] . '}',
+      '{case.custom_' . $this->caseCustomField[0]['id'] . '}',
       $newTokenTree[TokenTree::CASE_TOKEN_TEXT]['children'][1]['children'][0]['children'][0]['id']
     );
     $this->assertEquals(
-      $this->caseCustomField['name'],
+      $this->caseCustomField[0]['name'],
       $newTokenTree[TokenTree::CASE_TOKEN_TEXT]['children'][1]['children'][0]['children'][0]['text']
+    );
+    $this->assertEquals(
+      '{case.custom_' . $this->caseCustomField[1]['id'] . '}',
+      $newTokenTree[TokenTree::CASE_TOKEN_TEXT]['children'][1]['children'][0]['children'][1]['id']
+    );
+    $this->assertEquals(
+      $this->caseCustomField[1]['name'],
+      $newTokenTree[TokenTree::CASE_TOKEN_TEXT]['children'][1]['children'][0]['children'][1]['text']
     );
   }
 
@@ -280,10 +314,14 @@ class CRM_Civicase_Hook_BuildForm_TokenTreeTest extends BaseHeadlessTest {
     if (empty($contactCustomGroup['id'])) {
       return;
     }
-    $contactCustomField = $this->createCustomField($contactCustomGroup['id']);
-    if (!empty($contactCustomField['id'])) {
-      $this->contactCustomField['id'] = $contactCustomField['id'];
-      $this->contactCustomField['name'] = $contactCustomField['name'];
+    $contactCustomFields = [];
+    $contactCustomFields[] = $this->createCustomField($contactCustomGroup['id']);
+    $contactCustomFields[] = $this->createCustomField($contactCustomGroup['id']);
+    $i = 0;
+    foreach ($contactCustomFields as $contactCustomField) {
+      $this->contactCustomField[$i]['id'] = $contactCustomField['id'];
+      $this->contactCustomField[$i]['name'] = $contactCustomField['name'];
+      $i++;
     }
   }
 
@@ -304,10 +342,15 @@ class CRM_Civicase_Hook_BuildForm_TokenTreeTest extends BaseHeadlessTest {
     if (empty($caseCustomGroup['id'])) {
       return;
     }
-    $caseCustomField = $this->createCustomField($caseCustomGroup['id']);
-    if (!empty($caseCustomField['id'])) {
-      $this->caseCustomField['id'] = $caseCustomField['id'];
-      $this->caseCustomField['name'] = $caseCustomField['name'];
+
+    $caseCustomFields = [];
+    $caseCustomFields[] = $this->createCustomField($caseCustomGroup['id']);
+    $caseCustomFields[] = $this->createCustomField($caseCustomGroup['id']);
+    $i = 0;
+    foreach ($caseCustomFields as $caseCustomField) {
+      $this->caseCustomField[$i]['id'] = $caseCustomField['id'];
+      $this->caseCustomField[$i]['name'] = $caseCustomField['name'];
+      $i++;
     }
   }
 


### PR DESCRIPTION
## Overview
The Case Token + and - Icons was not working on RSE site. This PR fixes that issue.
When the email activity form is opened for a case, the token list is not properly displayed as one of the token category displays “Undefined“  instead of the token category.

## Before
![2021-04-12 at 6 08 PM](https://user-images.githubusercontent.com/5058867/114395502-15638c80-9bba-11eb-96c1-79d73d7efe21.png)
![image-20210409-114928](https://user-images.githubusercontent.com/6951813/114539577-8b183880-9c4c-11eb-8ba5-52b89faaff13.png)


## After
![2021-04-12 at 6 07 PM](https://user-images.githubusercontent.com/5058867/114395398-efd68300-9bb9-11eb-9a07-fc2f1292d76e.png)

<img width="1280" alt="Manage Applications  RSE 2021-04-13 11-38-21 (1)" src="https://user-images.githubusercontent.com/6951813/114541089-2f4eaf00-9c4e-11eb-901f-c11bf1eca07f.png">


## Technical Details FE
RSE site is using FontAwesome v5(needed in SSP), but `fa-minus-square-o` and `fa-plus-square-o` classes were not supported on v5. Hence removed `-o`, which is compatible with both v4 and v5.

## Technical Details BE
- The logic for initializing the Email Recipient Tokens [here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/Hook/BuildForm/TokenTree.php#L324) checks if the the token tree contains the `Email Recipient` key before it is intialized and the core field tokens added. However for this client, some custom fields for the contact has already been added to the `newTokenTree` variable [here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/Hook/BuildForm/TokenTree.php#L95) and [here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/Hook/BuildForm/TokenTree.php#L381), because of this, the Email Recipient is not initialized with core tokens and this resulted in unexpected results causing the token category to be displayed as Undefined. To fix this, the condition to check was changed to 
```php
if (empty($newTokenTree[self::RECIPIENT_TOKEN_TEXT]['children'][0])) 
```
Which correctly checks whether the core fields for the token has been added or not. Also if custom field tokens has already been added to the token category, they are re-added back when the token category is initialized with the core fields. 
Same issue could happen for case tokens and similar fix was applied there too. The token data in the tests was re-ordered and more custom fields added so that custom fields come before and after core fields to simulate the scenario for this issue.

- The Address extends entity was added to the list of custom fields to be fetched, this was missing before and was causing some custom fields token label to have an empty value based on the condition [here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/Hook/BuildForm/TokenTree.php#L415)