### PR TITLE
CPS-430: Fix Case Statuses sort order

### DIFF
--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -98,9 +98,10 @@
       getCaseTypes()
         .then(function () {
           caseStatusNames = getCaseStatusNamesBelongingToCaseTypes($scope.caseTypes);
-          $scope.caseStatuses = getStatusesByName(caseStatusNames)
-            .sortBy('weight')
-            .value();
+          $scope.caseStatuses = _.sortBy(
+            getStatusesByName(caseStatusNames),
+            'weight'
+          );
           $scope.showBreakdown = $scope.caseTypes.length <=
             MAXIMUM_CASE_TYPES_TO_DISPLAY_BREAKDOWN;
           loadStatsData(caseFilters);
@@ -160,18 +161,13 @@
     /**
      * Returns the case statuses belonging to the given list of status names.
      *
-     * The statuses are returned in a lodash wrapped object. This can help
-     * with further manipulations and filterings before extracting the final
-     * value.
-     *
      * @param {string[]} caseStatusNames a list of case status names.
-     * @returns {object} A lodash object reference.
+     * @returns {object[]} A list of case status objects.
      */
     function getStatusesByName (caseStatusNames) {
-      return _.chain(caseStatusNames)
-        .map(function (caseStatusName) {
-          return caseStatusesIndexedByName[caseStatusName];
-        });
+      return _.map(caseStatusNames, function (caseStatusName) {
+        return caseStatusesIndexedByName[caseStatusName];
+      });
     }
 
     /**

--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -98,7 +98,9 @@
       getCaseTypes()
         .then(function () {
           caseStatusNames = getCaseStatusNamesBelongingToCaseTypes($scope.caseTypes);
-          $scope.caseStatuses = getSortedCaseStatusesByName(caseStatusNames);
+          $scope.caseStatuses = getStatusesByName(caseStatusNames)
+            .sortBy('weight')
+            .value();
           $scope.showBreakdown = $scope.caseTypes.length <=
             MAXIMUM_CASE_TYPES_TO_DISPLAY_BREAKDOWN;
           loadStatsData(caseFilters);
@@ -156,18 +158,20 @@
     }
 
     /**
+     * Returns the case statuses belonging to the given list of status names.
+     *
+     * The statuses are returned in a lodash wrapped object. This can help
+     * with further manipulations and filterings before extracting the final
+     * value.
+     *
      * @param {string[]} caseStatusNames a list of case status names.
-     * @returns {object[]} the full case status details belonging to the
-     *   given case status names.
+     * @returns {object} A lodash object reference.
      */
-    function getSortedCaseStatusesByName (caseStatusNames) {
+    function getStatusesByName (caseStatusNames) {
       return _.chain(caseStatusNames)
         .map(function (caseStatusName) {
           return caseStatusesIndexedByName[caseStatusName];
-        })
-        .sortBy('weight')
-        .indexBy('value')
-        .value();
+        });
     }
 
     /**

--- a/ang/test/civicase/case/directives/case-overview.directive.spec.js
+++ b/ang/test/civicase/case/directives/case-overview.directive.spec.js
@@ -113,7 +113,6 @@
 
           expectedCaseStatuses = _.chain(sampleCaseStatuses)
             .sortBy('weight')
-            .indexBy('value')
             .value();
 
           CaseManagementWorkflow.getWorkflowsListForCaseOverview.and.returnValue($q.resolve({
@@ -140,7 +139,6 @@
 
           expectedCaseStatuses = _.chain(allCaseStatuses)
             .sortBy('weight')
-            .indexBy('value')
             .value();
 
           CaseManagementWorkflow.getWorkflowsListForCaseOverview.and.returnValue($q.resolve({


### PR DESCRIPTION
## Overview
This PR fixes the sort order of the case statuses displayed on dashboards.

Previously we were displaying these statuses by the order they were created instead of their weight value as defined in the admin area.

This fixes https://github.com/compucorp/uk.co.compucorp.civicase/issues/559

## Before & After
Won and Lost have weight 1 and 2 respectively and as such should be displayed before any other status.

### Before
![compuclient-case-master-npi compubox co uk_civicrm_case_a_ (1)](https://user-images.githubusercontent.com/1642119/115319801-92f54280-a14e-11eb-8f41-08733d2d312d.png)
Won and Lost are outside of the screenshot because they are the last statuses created in civicase.

### After
![compuclient-case-master-npi compubox co uk_civicrm_case_a_](https://user-images.githubusercontent.com/1642119/115319803-94bf0600-a14e-11eb-844b-779fafe461e8.png)

## Technical Details

When we were working on https://github.com/compucorp/uk.co.compucorp.civicase/pull/427 we sorted the statuses by weight, but indexed the list right after. Indexing removes any sort order. We indexed these statuses because the previous data structure was indexed as well, but was indexed by weight. Indexing by weight is dangerous since values may be repeated and data might be lost so our current implementation was indexing by value, which must to be unique. We determined that after the refactoring done in https://github.com/compucorp/uk.co.compucorp.civicase/pull/427 we no longer need to index the statuses so this was dropped and the sort by weight is preserved.

As a note, we refactored the name and return value of the `getSortedCaseStatusesByName` because it was confusing and it was doing too many things. Now the function is only called `getStatusesByName`, and it will return the list of case statuses for the passed status names parameter. These statuses are passed as a lodash chained object so further alterations can be done outside of the function. And the sorting happens outside of it. Now it's more clear what the function does, and the sorting as well.