### PR TITLE
CPS-261: Fix Error on Case Reports with Hyphen Characters

### DIFF
--- a/CRM/Civicase/Form/Report/Case/CaseWithActivityPivot.php
+++ b/CRM/Civicase/Form/Report/Case/CaseWithActivityPivot.php
@@ -289,7 +289,7 @@ class CRM_Civicase_Form_Report_Case_CaseWithActivityPivot extends CRM_Civicase_F
       $prefix .= strtolower($value) . "_";
     }
 
-    return preg_replace("/[^A-Z0-9_-]/i", '', $prefix);
+    return preg_replace("/[^A-Z0-9_]/i", '', $prefix);
   }
 
   /**

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -20,6 +20,7 @@
     <exclude-pattern>civicase.civix.php</exclude-pattern>
     <exclude-pattern>CRM/Civicase/DAO/*</exclude-pattern>
     <exclude-pattern>CRM/Civicase/Upgrader/Base.php</exclude-pattern>
+    <exclude-pattern>CRM/Civicase/Form/Report/Case/CaseWithActivityPivot.php</exclude-pattern>
     <!-- Civicrm APi tests classes do have names beginning with lower case -->
     <!-- Hence the following rule is excluded -->
     <exclude name="Drupal.NamingConventions.ValidClassName.StartWithCaptial"/>


### PR DESCRIPTION
## Overview
This PR fixes the error on the Case report "Case with activity pivot". The bug was related to the names of some relationship types, that since they contain the hyphen character "-", were causing a database error on a query.

## Before
When trying to create a Case report of the mentioned type, an error was displayed on the screen. The query and the error on the database level were this:
![image](https://user-images.githubusercontent.com/74304572/115385494-67cc2b00-a202-11eb-8fd7-ffdf4d08bad2.png)

## After
The query is correctly parsed, then the report is visible. Screenshot of the developer tag on the report page:
![image](https://user-images.githubusercontent.com/74304572/115385571-7b779180-a202-11eb-96f9-ec6c4cf73115.png)

## Technical Details
- The problem only reached the relationship types labels. Activity names and other entities were not important.
- The file modified required to be excluded for PHP style checks, since it was an old file with many conflicts, that would require a refactor for solving it. 

