### PR TITLE
CPS-545: Remove Pagination from Pivot report

### DIFF
--- a/CRM/Civicase/Form/Report/BaseExtendedReport.php
+++ b/CRM/Civicase/Form/Report/BaseExtendedReport.php
@@ -595,7 +595,7 @@ abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_
    * @return string
    *   Report query.
    */
-  public function buildQuery($applyLimit = TRUE) {
+  public function buildQuery($applyLimit = FALSE) {
     if (empty($this->_params)) {
       $this->_params = $this->controller->exportValues($this->_name);
     }


### PR DESCRIPTION
## Overview
In Pivot Report, when there are more than 50 records to be shown, the UI was showing pagination of 50 records in every page. But this is wrong, since Pivot Report should not have pagination, as it shows grand total at the end of the report.

Also CiviCRM does not show pagination for core reports. Example: `civicrm/report/activitySummary`.

Now the pagination has been removed, so it works correctly.

## Before
![2021-04-21 at 4 53 PM](https://user-images.githubusercontent.com/5058867/115545950-11bebc80-a2c2-11eb-897c-0011dcd01f88.png)

## After
![2021-04-21 at 4 59 PM](https://user-images.githubusercontent.com/5058867/115546641-e9838d80-a2c2-11eb-89cf-35757e019360.png)

## Technical Details
The `CRM_Civicase_Form_Report_BaseExtendedReport` class overrides `CRM_Civicase_Form_Report_ExtendedReport`, which overrides `CRM_Report_Form`.

Now `CRM_Report_Form` has a logic to only show 50 records at a time, and have pagination. Now this is fine for normal forms. But in Pivot Report, we need to show all the records.

So in `CRM/Civicase/Form/Report/BaseExtendedReport.php`, removed `$this->limit();`, which was applying the pagination logic.