### PR TITLE
CPS-554: Changes to support CiviProspect

### DIFF
--- a/CRM/Civicase/Service/ManageWorkflowMenu.php
+++ b/CRM/Civicase/Service/ManageWorkflowMenu.php
@@ -17,8 +17,10 @@ class CRM_Civicase_Service_ManageWorkflowMenu {
    *   Case category instance type name..
    * @param bool $showCategoryNameOnMenuLabel
    *   Flag for using the case type category name on the menu label.
+   * @param string $parentMenuLabel
+   *   Name of the existing parent menu label.
    */
-  public function create(string $instanceTypeName, bool $showCategoryNameOnMenuLabel) {
+  public function create(string $instanceTypeName, bool $showCategoryNameOnMenuLabel, string $parentMenuLabel = NULL) {
     $caseTypeCategories = CaseCategoryHelper::getCaseCategories();
 
     $instanceObj = new CaseCategoryInstance();
@@ -40,7 +42,7 @@ class CRM_Civicase_Service_ManageWorkflowMenu {
 
       $parentMenuForCaseCategory = civicrm_api3('Navigation', 'get', [
         'sequential' => 1,
-        'label' => $caseTypeCategory['name'],
+        'label' => $parentMenuLabel ? $parentMenuLabel : $caseTypeCategory['name'],
       ])['values'][0];
 
       $menuLabel = $showCategoryNameOnMenuLabel

--- a/ang/civicase/case/actions/directives/case-actions.directive.js
+++ b/ang/civicase/case/actions/directives/case-actions.directive.js
@@ -128,7 +128,6 @@
                 .on('crmFormSuccess crmPopupFormSuccess', function (e, data) {
                   formData = data;
                   $rootScope.$broadcast('updateCaseData');
-                  refreshDataForActions();
                 })
                 .on('dialogclose.crmPopup', function (e, data) {
                   if (formData) {
@@ -160,7 +159,6 @@
             _.remove($scope.caseActions, { action: 'changeStatus(cases)' });
           }
         }
-        refreshDataForActions();
       }
 
       /**
@@ -175,19 +173,6 @@
         } catch (e) {
           return null;
         }
-      }
-
-      /**
-       * Refreshes the case data for each one of the defined actions.
-       */
-      function refreshDataForActions () {
-        _.each($scope.caseActions, function (action) {
-          var caseActionService = getCaseActionService(action.action);
-
-          if (caseActionService && caseActionService.refreshData) {
-            caseActionService.refreshData($scope.cases);
-          }
-        });
       }
     }
   });

--- a/ang/test/civicase/case/actions/directives/case-actions.directive.spec.js
+++ b/ang/test/civicase/case/actions/directives/case-actions.directive.spec.js
@@ -10,7 +10,6 @@
 
       $provide.service('PrintCaseAction', function () {
         this.doAction = jasmine.createSpy('doAction');
-        this.refreshData = jasmine.createSpy('refreshData');
         this.isActionAllowed = jasmine.createSpy('isActionAllowed');
         this.isActionAllowed.and.returnValue(true);
       });
@@ -376,12 +375,6 @@
           describe('when form is submitted succesfully', () => {
             beforeEach(() => {
               crmFormSuccessFunction(jasmine.any(Object), 'somedata');
-            });
-
-            it('refreshes the case information', () => {
-              expect($rootScope.$broadcast)
-                .toHaveBeenCalledWith('updateCaseData');
-              expect(PrintCaseAction.refreshData).toHaveBeenCalled();
             });
           });
 

--- a/ang/test/mocks/data/case-category-instance-mapping.data.js
+++ b/ang/test/mocks/data/case-category-instance-mapping.data.js
@@ -11,6 +11,11 @@
       id: '2',
       category_id: '1',
       instance_id: '1'
+    },
+    3: {
+      id: '3',
+      category_id: '4',
+      instance_id: '3'
     }
   };
 

--- a/ang/test/mocks/data/case-category-instance-type.data.js
+++ b/ang/test/mocks/data/case-category-instance-type.data.js
@@ -19,6 +19,15 @@
       is_active: '1',
       weight: '2',
       filter: '0'
+    },
+    3: {
+      value: '3',
+      label: 'Prospect Management',
+      name: 'sales_opportunity_tracking',
+      grouping: 'CRM_Prospect_Service_SalesOpportunityTrackingUtils',
+      is_active: '1',
+      weight: '2',
+      filter: '0'
     }
   };
 


### PR DESCRIPTION
## Overview
Added Support for CiviProspect extension.
Related to https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/pull/80

## Technical Details
In `CRM/Civicase/Service/ManageWorkflowMenu.php`, added a optional parameter called `$parentMenuLabel`, using which the parent menu label can be sent, incase its not same as the Case Type Category name.

Removed `refreshData` function from Case Actions, because its not required by Prospect anymore.

Updated FE mock data.
