### PR TITLE
CPS-511: Do not allow client to be assigned to existing contacts

### DIFF
--- a/ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.js
@@ -629,7 +629,7 @@
           $scope.roles.getActiveNonClientContacts().indexOf(contactPromptResult.contact.id) !== -1) {
           contactPromptResult.showErrorMessageFor(
             'contactSelection',
-            PeoplesTabMessageConstants.CLIENT_CANT_BE_SAME_AS_CLIENT
+            PeoplesTabMessageConstants.ROLES_CANT_BE_ASSIGNED_AS_CLIENTS
           );
           isError = true;
         }

--- a/ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.js
@@ -624,6 +624,13 @@
           );
 
           isError = true;
+        } else if (contactPromptResult.role.role === 'Client' &&
+          $scope.roles.getActiveNonClientContacts().indexOf(contactPromptResult.contact.id) !== -1) {
+          contactPromptResult.showErrorMessageFor(
+            'contactSelection',
+            PeoplesTabMessageConstants.CLIENT_CANT_BE_SAME_AS_CLIENT
+          );
+          isError = true;
         }
 
         if (

--- a/ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.js
@@ -42,6 +42,7 @@
   /**
    * civicaseCaseRolesTabController Controller
    *
+   * @param {object} ts translation service
    * @param {object} $scope $scope
    * @param {object} allowMultipleCaseClients allow multiple clients configuration value
    * @param {object} civicasePeopleTabRoles People's tab roles list service
@@ -51,7 +52,7 @@
    * @param {object} dialogService A reference to the dialog service
    * @param {Function} removeDatePickerHrefs Removes date picker href attributes
    */
-  function civicaseCaseRolesTabController ($scope,
+  function civicaseCaseRolesTabController (ts, $scope,
     allowMultipleCaseClients, civicasePeopleTabRoles,
     PeoplesTabMessageConstants,
     civicaseRoleDatesUpdater, civicaseSingleCaseRolePerType, dialogService,
@@ -624,7 +625,7 @@
           );
 
           isError = true;
-        } else if (contactPromptResult.role.role === 'Client' &&
+        } else if (contactPromptResult.role.role === ts('Client') &&
           $scope.roles.getActiveNonClientContacts().indexOf(contactPromptResult.contact.id) !== -1) {
           contactPromptResult.showErrorMessageFor(
             'contactSelection',

--- a/ang/civicase/case/details/people-tab/messages.constants.js
+++ b/ang/civicase/case/details/people-tab/messages.constants.js
@@ -7,7 +7,7 @@
 
     $provide.constant('PeoplesTabMessageConstants', {
       CONTACT_CANT_HAVE_ROLE_MESSAGE: ts('Case clients cannot be selected for a case role. Please select another contact.'),
-      CLIENT_CANT_BE_SAME_AS_CLIENT: ts('Case clients cannot be same as other case roles. Please select another contact.'),
+      ROLES_CANT_BE_ASSIGNED_AS_CLIENTS: ts('Case clients cannot be same as other case roles. Please select another contact.'),
       CONTACT_NOT_SELECTED_MESSAGE: ts('Please select a contact.'),
       RELATIONSHIP_END_DATE_MESSAGE: ts('End date cannot be before start date of the relationship.'),
       RELATIONSHIP_REASSIGNMENT_DATE_MESSAGE: ts('Reassignment date cannot be before start date of the relationship.')

--- a/ang/civicase/case/details/people-tab/messages.constants.js
+++ b/ang/civicase/case/details/people-tab/messages.constants.js
@@ -7,6 +7,7 @@
 
     $provide.constant('PeoplesTabMessageConstants', {
       CONTACT_CANT_HAVE_ROLE_MESSAGE: ts('Case clients cannot be selected for a case role. Please select another contact.'),
+      CLIENT_CANT_BE_SAME_AS_CLIENT: ts('Case clients cannot be same as other case roles. Please select another contact.'),
       CONTACT_NOT_SELECTED_MESSAGE: ts('Please select a contact.'),
       RELATIONSHIP_END_DATE_MESSAGE: ts('End date cannot be before start date of the relationship.'),
       RELATIONSHIP_REASSIGNMENT_DATE_MESSAGE: ts('Reassignment date cannot be before start date of the relationship.')

--- a/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
+++ b/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
@@ -14,6 +14,7 @@
     roles.isLoading = true;
     roles.list = [];
 
+    roles.getActiveNonClientContacts = getActiveNonClientContacts;
     roles.filterRoles = filterRoles;
     roles.getCountOfAssignedRoles = getCountOfAssignedRoles;
     roles.goToPage = goToPage;
@@ -21,6 +22,20 @@
     roles.setCaseRelationships = setCaseRelationships;
     roles.setCaseTypeRoles = setCaseTypeRoles;
     roles.updateRolesList = updateRolesList;
+
+    /**
+     * @returns {Array} contact ids for active non client roles
+     */
+    function getActiveNonClientContacts () {
+      return _.chain(roles.fullRolesList)
+        .filter(function (role) {
+          return !!role.relationship_type_id && isTruthy(role.is_active);
+        })
+        .map(function (role) {
+          return role.contact_id;
+        })
+        .value();
+    }
 
     /**
      * Assign number of roles present per type of relationship.

--- a/ang/test/civicase/case/details/people-tab/directives/case-roles-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-roles-tab.directive.spec.js
@@ -348,75 +348,107 @@ describe('Case Roles Tab', () => {
     });
 
     describe('when replacing the case client', () => {
-      beforeEach(() => {
-        previousContact = CRM._.sample(ContactsData.values);
+      describe('and not selecting a contact already assigned to another role', () => {
+        beforeEach(() => {
+          previousContact = CRM._.sample(ContactsData.values);
 
-        $scope.replaceRoleOrClient({
-          contact_id: previousContact.contact_id,
-          display_name: previousContact.display_name,
-          role: 'Client'
-        }, true);
-        selectDialogContact(contact);
-        submitDialog();
-        $rootScope.$digest();
-      });
-
-      it('does not show the reassignment datepicker', () => {
-        expect(dialogServiceMock.open).toHaveBeenCalledWith(
-          'PromptForContactDialog',
-          '~/civicase/case/details/people-tab/directives/contact-prompt-dialog.html',
-          jasmine.objectContaining({
-            reassignmentDate: {
-              value: undefined,
-              show: false,
-              maxDate: undefined
-            }
-          }),
-          jasmine.any(Object)
-        );
-      });
-
-      it('replaces the old client with the new selected contact', () => {
-        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
-          ['CaseContact', 'get', {
-            case_id: $scope.item.id,
+          $scope.replaceRoleOrClient({
             contact_id: previousContact.contact_id,
-            'api.CaseContact.create': {
+            display_name: previousContact.display_name,
+            role: 'Client'
+          }, true);
+          selectDialogContact(contact);
+          submitDialog();
+          $rootScope.$digest();
+        });
+
+        it('does not show the reassignment datepicker', () => {
+          expect(dialogServiceMock.open).toHaveBeenCalledWith(
+            'PromptForContactDialog',
+            '~/civicase/case/details/people-tab/directives/contact-prompt-dialog.html',
+            jasmine.objectContaining({
+              reassignmentDate: {
+                value: undefined,
+                show: false,
+                maxDate: undefined
+              }
+            }),
+            jasmine.any(Object)
+          );
+        });
+
+        it('replaces the old client with the new selected contact', () => {
+          expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
+            ['CaseContact', 'get', {
               case_id: $scope.item.id,
-              contact_id: parseInt(contact.contact_id)
-            }
-          }]
-        ]));
+              contact_id: previousContact.contact_id,
+              'api.CaseContact.create': {
+                case_id: $scope.item.id,
+                contact_id: parseInt(contact.contact_id)
+              }
+            }]
+          ]));
+        });
+
+        it('updates all existing relationships for the old contact with the new client', () => {
+          expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
+            ['Relationship', 'get', {
+              case_id: $scope.item.id,
+              is_active: true,
+              contact_id_a: previousContact.contact_id,
+              'api.Relationship.update': { contact_id_a: contact.contact_id }
+            }]
+          ]));
+        });
+
+        it('creates a new completed activity to record the case being reassigned to another client', () => {
+          expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
+            ['Activity', 'create', {
+              case_id: $scope.item.id,
+              target_contact_id: jasmine.arrayContaining([
+                previousContact.contact_id,
+                contact.contact_id
+              ]),
+              status_id: 'Completed',
+              activity_type_id: 'Reassigned Case',
+              subject: `${contact.display_name} replaced ${previousContact.display_name} as Client`
+            }]
+          ]));
+        });
+
+        it('closes the contact selection dialog', () => {
+          expect(dialogServiceMock.close).toHaveBeenCalled();
+        });
       });
 
-      it('updates all existing relationships for the old contact with the new client', () => {
-        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
-          ['Relationship', 'get', {
-            case_id: $scope.item.id,
-            is_active: true,
-            contact_id_a: previousContact.contact_id,
-            'api.Relationship.update': { contact_id_a: contact.contact_id }
-          }]
-        ]));
-      });
+      describe('and selecting a contact already assigned to another role', () => {
+        beforeEach(() => {
+          previousContact = CRM._.sample(ContactsData.values);
+          spyOn($scope.roles, 'getActiveNonClientContacts')
+            .and.returnValue([previousContact.contact_id]);
 
-      it('creates a new completed activity to record the case being reassigned to another client', () => {
-        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
-          ['Activity', 'create', {
-            case_id: $scope.item.id,
-            target_contact_id: jasmine.arrayContaining([
-              previousContact.contact_id,
-              contact.contact_id
-            ]),
-            status_id: 'Completed',
-            activity_type_id: 'Reassigned Case',
-            subject: `${contact.display_name} replaced ${previousContact.display_name} as Client`
-          }]
-        ]));
-      });
+          $scope.replaceRoleOrClient({
+            contact_id: previousContact.contact_id,
+            display_name: previousContact.display_name,
+            role: 'Client'
+          }, true);
+          selectDialogContact(previousContact);
+          submitDialog();
+          $rootScope.$digest();
+        });
 
-      it('closes the contact selection dialog', () => {
-        expect(dialogServiceMock.close).toHaveBeenCalled();
+        it('shows an error message', () => {
+          expect(getDialogModel().errorMessage.contactSelection)
+            .toBe(PeoplesTabMessageConstants.CLIENT_CANT_BE_SAME_AS_CLIENT);
+        });
+
+        it('does not close the contact selection dialog', () => {
+          expect(dialogServiceMock.close).not.toHaveBeenCalled();
+        });
+
+        it('does not replace the client', () => {
+          expect($scope.refresh).not.toHaveBeenCalledWith();
+        });
       });
     });
 

--- a/ang/test/civicase/case/details/people-tab/directives/case-roles-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-roles-tab.directive.spec.js
@@ -293,57 +293,87 @@ describe('Case Roles Tab', () => {
     });
 
     describe('when adding a new case client', () => {
-      beforeEach(() => {
-        $scope.assignRoleOrClient({
-          role: 'Client'
+      describe('and not selecting a contact already assigned to another role', () => {
+        beforeEach(() => {
+          $scope.assignRoleOrClient({
+            role: 'Client'
+          });
+          selectDialogContact(contact);
+          submitDialog();
+          $rootScope.$digest();
         });
-        selectDialogContact(contact);
-        submitDialog();
-        $rootScope.$digest();
+
+        it('creates a new client using the selected contact', () => {
+          expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
+            ['CaseContact', 'create', {
+              case_id: $scope.item.id,
+              contact_id: contact.contact_id
+            }]
+          ]));
+        });
+
+        it('creates a new completed activity to record the contact being assigned as a client to the case', () => {
+          expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
+            ['Activity', 'create', {
+              case_id: $scope.item.id,
+              target_contact_id: contact.contact_id,
+              status_id: 'Completed',
+              activity_type_id: 'Add Client To Case',
+              subject: `${contact.display_name} added as Client`
+            }]
+          ]));
+        });
+
+        it('duplicates all existing relations for current case for the new client', () => {
+          expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
+            ['Relationship', 'get', {
+              case_id: $scope.item.id,
+              contact_id_a: $scope.item.client[0].contact_id,
+              is_active: 1,
+              'api.Relationship.create': {
+                id: false,
+                contact_id_a: contact.contact_id,
+                start_date: 'now',
+                contact_id_b: '$value.contact_id_b',
+                relationship_type_id: '$value.relationship_type_id',
+                description: '$value.description',
+                case_id: '$value.case_id'
+              }
+            }]
+          ]));
+        });
+
+        it('closes the contact selection dialog', () => {
+          expect(dialogServiceMock.close).toHaveBeenCalled();
+        });
       });
 
-      it('creates a new client using the selected contact', () => {
-        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
-          ['CaseContact', 'create', {
-            case_id: $scope.item.id,
-            contact_id: contact.contact_id
-          }]
-        ]));
-      });
+      describe('and selecting a contact already assigned to another role', () => {
+        beforeEach(() => {
+          previousContact = CRM._.sample(ContactsData.values);
+          spyOn($scope.roles, 'getActiveNonClientContacts')
+            .and.returnValue([previousContact.contact_id]);
 
-      it('creates a new completed activity to record the contact being assigned as a client to the case', () => {
-        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
-          ['Activity', 'create', {
-            case_id: $scope.item.id,
-            target_contact_id: contact.contact_id,
-            status_id: 'Completed',
-            activity_type_id: 'Add Client To Case',
-            subject: `${contact.display_name} added as Client`
-          }]
-        ]));
-      });
+          $scope.assignRoleOrClient({
+            role: 'Client'
+          });
+          selectDialogContact(previousContact);
+          submitDialog();
+          $rootScope.$digest();
+        });
 
-      it('duplicates all existing relations for current case for the new client', () => {
-        expect($scope.refresh).toHaveBeenCalledWith(jasmine.arrayContaining([
-          ['Relationship', 'get', {
-            case_id: $scope.item.id,
-            contact_id_a: $scope.item.client[0].contact_id,
-            is_active: 1,
-            'api.Relationship.create': {
-              id: false,
-              contact_id_a: contact.contact_id,
-              start_date: 'now',
-              contact_id_b: '$value.contact_id_b',
-              relationship_type_id: '$value.relationship_type_id',
-              description: '$value.description',
-              case_id: '$value.case_id'
-            }
-          }]
-        ]));
-      });
+        it('shows an error message', () => {
+          expect(getDialogModel().errorMessage.contactSelection)
+            .toBe(PeoplesTabMessageConstants.ROLES_CANT_BE_ASSIGNED_AS_CLIENTS);
+        });
 
-      it('closes the contact selection dialog', () => {
-        expect(dialogServiceMock.close).toHaveBeenCalled();
+        it('does not close the contact selection dialog', () => {
+          expect(dialogServiceMock.close).not.toHaveBeenCalled();
+        });
+
+        it('does not assign the client', () => {
+          expect($scope.refresh).not.toHaveBeenCalledWith();
+        });
       });
     });
 

--- a/ang/test/civicase/case/details/people-tab/directives/case-roles-tab.directive.spec.js
+++ b/ang/test/civicase/case/details/people-tab/directives/case-roles-tab.directive.spec.js
@@ -439,7 +439,7 @@ describe('Case Roles Tab', () => {
 
         it('shows an error message', () => {
           expect(getDialogModel().errorMessage.contactSelection)
-            .toBe(PeoplesTabMessageConstants.CLIENT_CANT_BE_SAME_AS_CLIENT);
+            .toBe(PeoplesTabMessageConstants.ROLES_CANT_BE_ASSIGNED_AS_CLIENTS);
         });
 
         it('does not close the contact selection dialog', () => {

--- a/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
+++ b/ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
@@ -209,6 +209,26 @@
           });
         });
       });
+
+      describe('when returning non client active contact ids', () => {
+        var returnValue;
+
+        beforeEach(() => {
+          const relationshipsToBeAdded = [
+            _.extend({}, relationships[0], { contact_id: '1', is_active: '1' }),
+            _.extend({}, relationships[0], { contact_id: '3', is_active: '1' }),
+            _.extend({}, relationships[0], { relationship_type_id: null, contact_id: '4', is_active: '1' }),
+            _.extend({}, relationships[0], { contact_id: '2', is_active: '0' })
+          ];
+          peopleTabRoles.fullRolesList = relationshipsToBeAdded;
+
+          returnValue = peopleTabRoles.getActiveNonClientContacts();
+        });
+
+        it('returns all non client active contact ids', () => {
+          expect(returnValue).toEqual(['1', '3']);
+        });
+      });
     });
 
     describe('role types and counts', () => {


### PR DESCRIPTION
## Overview
In People's tab, if the Client is reassigned to a contact from existing relationships, of the case, no error was shown, and the client was changed. But this is not correct, as client should not be assigned to a contact from existing active roles.
This PR fixes this.

## Before
Client was reassigned.

## After
Client is not reassigned.
![2021-04-23 at 4 40 PM](https://user-images.githubusercontent.com/5058867/115863117-a22c0700-a452-11eb-9279-e9c7c894845a.png)

## Technical Details
This logic was completely missing. So added a condition in `promptForContactThatIsNotCaseClient` to implement this.
```javascript
if (contactPromptResult.role.role === ts('Client') &&
  $scope.roles.getActiveNonClientContacts().indexOf(contactPromptResult.contact.id) !== -1) {
  contactPromptResult.showErrorMessageFor(
    'contactSelection',
    PeoplesTabMessageConstants.CLIENT_CANT_BE_SAME_AS_CLIENT
  )
};
```

## Reopened Fixes
The validation logic was not applied when creating a new client. So moved the validation logic inside a new function called `validateContact` and reused.