### PR TITLE
CPS-512: Fix Add Activity button in Contact Case Tab

### DIFF
--- a/ang/civicase/activity/card/directives/activity-card-short.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-short.directive.html
@@ -126,7 +126,7 @@
         <div class="civicase__activity-empty-message">No upcoming activity</div>
         <span civicase-dropdown>
           <a
-            ng-if="isReadOnly !== true"
+            ng-show="isReadOnly !== true"
             class="civicase__activity-empty-link"
             href
             civicase-dropdown-toggle


### PR DESCRIPTION
## Overview
The Add Activity Button in Contact case tab was not working. This PR fixes that.

## Before
![2021-04-26 at 3 27 PM](https://user-images.githubusercontent.com/5058867/116064785-f843b900-a6a3-11eb-85f4-717476a1726c.png)

## After
![2021-04-26 at 3 27 PM](https://user-images.githubusercontent.com/5058867/116064738-ea8e3380-a6a3-11eb-846d-f5c3d3678a7b.png)

## Technical Details
This is a regression of https://github.com/compucorp/uk.co.compucorp.civicase/pull/678. Where `ng-if` was used. But using `ng-if` is not recommended with Directives(`civicase-dropdown-toggle` in this case). So changed it to `ng-show`.