### PR TITLE
RSE-576: Fix Upgrader For Cases Navigation Menu Items

### DIFF
--- a/CRM/Civicase/Setup/UpdateCasesNavigationItems.php
+++ b/CRM/Civicase/Setup/UpdateCasesNavigationItems.php
@@ -1,12 +1,9 @@
 <?php
 
-use CRM_Civicase_Helper_CaseUrl as CaseUrlHelper;
+use CRM_Civicase_Helper_CaseCategory as CaseCategory;
 
 /**
  * Class for updating menus corresponding to Cases.
- *
- * This is the base Case category, and the menus that require update are
- * Manage Cases ('all' route) and Manage Workflows ('manage_workflows' route)
  */
 class CRM_Civicase_Setup_UpdateCasesNavigationItems {
 
@@ -14,19 +11,24 @@ class CRM_Civicase_Setup_UpdateCasesNavigationItems {
    * Update Cases items.
    */
   public function apply() {
-    $itemData = [
-      'Manage Cases' => 'all',
-      'manage_Cases_workflows' => 'manage_workflows',
-    ];
+    $casesId = CaseCategory::getOptionValue();
 
-    foreach ($itemData as $itemName => $itemRoute) {
+    $casesNavigationId = civicrm_api3('Navigation', 'getsingle', [
+      'name' => CaseCategory::CASE_TYPE_CATEGORY_NAME,
+      'return' => 'id',
+    ])['id'];
+
+    $navigationItems = civicrm_api3('Navigation', 'get', [
+      'parent_id' => $casesNavigationId,
+      'options' => ['limit' => 0],
+    ])['values'];
+
+    foreach ($navigationItems as $item) {
       civicrm_api3('Navigation', 'get', [
-        'parent_id' => CRM_Civicase_Helper_CaseCategory::CASE_TYPE_CATEGORY_NAME,
-        'name' => $itemName,
-        'options' => ['limit' => 1],
+        'id' => $item['id'],
         'api.Navigation.create' => [
           'id' => '$value.id',
-          'url' => CaseUrlHelper::getUrlByRouteType($itemRoute),
+          'url' => str_ireplace(CaseCategory::CASE_TYPE_CATEGORY_NAME, $casesId, $item['url']),
         ],
       ]);
     }


### PR DESCRIPTION
## Overview
This PR solve the problem with the Cases URL upgraded, observed on some installation of CiviCase, in which the name of some menus was changed.

## Before
The upgraded was trying to find the menu items by their names, but the find failed for example in `Manage Cases`, since it was renamed to `All Cases`, probably accessing directly to the database.


## After
Now the upgraded works as expected, tested on compuclient and NEU, locally (I will test on other sites also, I am checking the databases).

## Technical Details
- The code find for the ID of the main Cases menu, which is fixed in all the installations. With that information, later proceed to find all the menus with that ID as a parent_id. 
Later, we iterate over that list, updating the URL for the result of replacing the `Cases` text with the Cases Category ID.
- I use str_ireplace because in some menus the Cases occurrence is on lowercase.

