### PR TITLE
CPS-569: Fix Leaking Case Types On Add Case Form

### DIFF
--- a/CRM/Civicase/Helper/CaseCategory.php
+++ b/CRM/Civicase/Helper/CaseCategory.php
@@ -272,10 +272,10 @@ class CRM_Civicase_Helper_CaseCategory {
    * also so that the dashboard leads to the case category dashboard page
    * depending on the case category.
    *
-   * @param string $caseCategoryName
-   *   Case category name.
+   * @param string $caseCategoryId
+   *   Case category Id.
    */
-  public static function updateBreadcrumbs($caseCategoryName) {
+  public static function updateBreadcrumbs($caseCategoryId) {
     CRM_Utils_System::resetBreadCrumb();
     $breadcrumb = [
       [
@@ -288,8 +288,8 @@ class CRM_Civicase_Helper_CaseCategory {
       ],
       [
         'title' => ts('Case Dashboard'),
-        'url' => CRM_Utils_System::url('civicrm/case/a/', ['case_type_category' => $caseCategoryName], TRUE,
-          "/case?case_type_category={$caseCategoryName}"),
+        'url' => CRM_Utils_System::url('civicrm/case/a/', ['case_type_category' => $caseCategoryId], TRUE,
+          "/case?case_type_category={$caseCategoryId}"),
       ],
     ];
 

--- a/CRM/Civicase/Hook/BuildForm/CaseCategoryCustomFieldsProcessing.php
+++ b/CRM/Civicase/Hook/BuildForm/CaseCategoryCustomFieldsProcessing.php
@@ -3,7 +3,7 @@
 use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
 
 /**
- * CRM_Civicase_Hook_BuildForm_CaseCategoryCustomFieldsProcessing class.
+ * Case Category Post Processing.
  */
 class CRM_Civicase_Hook_BuildForm_CaseCategoryCustomFieldsProcessing {
 
@@ -18,17 +18,17 @@ class CRM_Civicase_Hook_BuildForm_CaseCategoryCustomFieldsProcessing {
    *   Form Name.
    */
   public function run(CRM_Core_Form &$form, $formName) {
-    $caseCategoryName = $this->getCaseCategoryName($form);
+    $caseCategoryId = $this->getCaseCategoryId($form);
 
-    if (!$this->shouldRun($formName, $caseCategoryName)) {
+    if (!$this->shouldRun($formName, $caseCategoryId)) {
       return;
     }
 
-    if (!CaseTypeCategoryHelper::isValidCategory($caseCategoryName)) {
+    if (!CaseTypeCategoryHelper::isValidCategory($caseCategoryId)) {
       return;
     }
 
-    $this->filterCaseTypeOptionValues($form, $caseCategoryName);
+    $this->filterCaseTypeOptionValues($form, $caseCategoryId);
   }
 
   /**
@@ -36,11 +36,11 @@ class CRM_Civicase_Hook_BuildForm_CaseCategoryCustomFieldsProcessing {
    *
    * @param CRM_Core_Form $form
    *   Form class object.
-   * @param string $caseCategoryName
-   *   Case category name.
+   * @param int $caseCategoryId
+   *   Case category Id.
    */
-  private function filterCaseTypeOptionValues(CRM_Core_Form $form, $caseCategoryName) {
-    $caseTypesInCategory = CaseTypeCategoryHelper::getCaseTypesForCategory($caseCategoryName);
+  private function filterCaseTypeOptionValues(CRM_Core_Form $form, $caseCategoryId) {
+    $caseTypesInCategory = CaseTypeCategoryHelper::getCaseTypesForCategory($caseCategoryId);
 
     if (!$caseTypesInCategory) {
       $caseTypesInCategory = [];
@@ -65,36 +65,36 @@ class CRM_Civicase_Hook_BuildForm_CaseCategoryCustomFieldsProcessing {
    *
    * @param string $formName
    *   Form name.
-   * @param string $caseCategoryName
+   * @param int $caseCategoryId
    *   Case category name.
    *
    * @return bool
    *   returns a boolean to determine if hook will run or not.
    */
-  private function shouldRun($formName, $caseCategoryName) {
-    if (!$caseCategoryName) {
+  private function shouldRun($formName, $caseCategoryId) {
+    if (!$caseCategoryId) {
       return FALSE;
     }
 
     $isCaseForm = $formName == CRM_Case_Form_Case::class;
 
-    return $isCaseForm && $caseCategoryName;
+    return $isCaseForm && $caseCategoryId;
   }
 
   /**
-   * Gets the Category Name for the case.
+   * Gets the Category Id for the case.
    *
    * @param CRM_Core_Form $form
    *   Form name.
    *
-   * @return string|null
-   *   case category name.
+   * @return int
+   *   Case category id.
    */
-  private function getCaseCategoryName(CRM_Core_Form $form) {
+  private function getCaseCategoryId(CRM_Core_Form $form) {
     $urlParams = parse_url(htmlspecialchars_decode($form->controller->_entryURL), PHP_URL_QUERY);
     parse_str($urlParams, $urlParams);
 
-    return !empty($urlParams['case_type_category']) ? $urlParams['case_type_category'] : 'cases';
+    return !empty($urlParams['case_type_category']) ? $urlParams['case_type_category'] : CRM_Civicase_Helper_CaseCategory::getOptionValue();
   }
 
 }

--- a/CRM/Civicase/Hook/BuildForm/CaseCategoryFormLabelTranslationForNewCase.php
+++ b/CRM/Civicase/Hook/BuildForm/CaseCategoryFormLabelTranslationForNewCase.php
@@ -16,17 +16,17 @@ class CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslationForNewCase {
    *   Form Name.
    */
   public function run(CRM_Core_Form &$form, $formName) {
-    $caseCategoryName = $this->getCaseCategoryName($form);
+    $caseCategoryId = $this->getCaseCategoryId($form);
 
-    if (!$this->shouldRun($formName, $caseCategoryName)) {
+    if (!$this->shouldRun($formName, $caseCategoryId)) {
       return;
     }
 
-    if (!CaseTypeCategoryHelper::isValidCategory($caseCategoryName)) {
+    if (!CaseTypeCategoryHelper::isValidCategory($caseCategoryId)) {
       return;
     }
 
-    $this->translateFormLabels($form, $caseCategoryName);
+    $this->translateFormLabels($form);
   }
 
   /**
@@ -37,10 +37,8 @@ class CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslationForNewCase {
    *
    * @param CRM_Core_Form $form
    *   Page class.
-   * @param string $caseCategoryName
-   *   Case category name.
    */
-  private function translateFormLabels(CRM_Core_Form $form, $caseCategoryName) {
+  private function translateFormLabels(CRM_Core_Form $form) {
     $caseTypeIdElement = &$form->getElement('case_type_id');
     $caseStatusElement = &$form->getElement('status_id');
     $this->translateLabel([$caseTypeIdElement, $caseStatusElement]);
@@ -65,10 +63,10 @@ class CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslationForNewCase {
    * @param CRM_Core_Form $form
    *   Form name.
    *
-   * @return string|null
-   *   case category name.
+   * @return int|null
+   *   case category Id.
    */
-  private function getCaseCategoryName(CRM_Core_Form $form) {
+  private function getCaseCategoryId(CRM_Core_Form $form) {
     $urlParams = parse_url(htmlspecialchars_decode($form->controller->_entryURL), PHP_URL_QUERY);
     parse_str($urlParams, $urlParams);
 
@@ -80,21 +78,21 @@ class CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslationForNewCase {
    *
    * @param string $formName
    *   Form name.
-   * @param string $caseCategoryName
-   *   Case category name.
+   * @param string $caseCategoryId
+   *   Case category Id.
    *
    * @return bool
    *   returns a boolean to determine if hook will run or not.
    */
-  private function shouldRun($formName, $caseCategoryName) {
-    if (!$caseCategoryName) {
+  private function shouldRun($formName, $caseCategoryId) {
+    if (!$caseCategoryId) {
       return FALSE;
     }
 
     $isCaseForm = $formName == CRM_Case_Form_Case::class;
-    $caseCategoryNameNotCase = $caseCategoryName != 'cases';
+    $caseCategoryIdNotCase = $caseCategoryId != CRM_Civicase_Helper_CaseCategory::getOptionValue();
 
-    return $isCaseForm && $caseCategoryName && $caseCategoryNameNotCase;
+    return $isCaseForm && $caseCategoryId && $caseCategoryIdNotCase;
   }
 
 }

--- a/CRM/Civicase/Hook/BuildForm/FilterCaseTypesByCategoryForNewCase.php
+++ b/CRM/Civicase/Hook/BuildForm/FilterCaseTypesByCategoryForNewCase.php
@@ -3,9 +3,9 @@
 use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
 
 /**
- * Case Category Post Processing.
+ * Filter case types select field based on case category.
  */
-class CRM_Civicase_Hook_BuildForm_CaseCategoryCustomFieldsProcessing {
+class CRM_Civicase_Hook_BuildForm_FilterCaseTypesByCategoryForNewCase {
 
   /**
    * Filters the options for the case type select element based on the category.

--- a/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
+++ b/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
@@ -11,22 +11,16 @@ class CRM_Civicase_Hook_Helper_CaseTypeCategory {
   /**
    * Checks if the case type category is valid or not.
    *
-   * @param string $caseCategoryName
+   * @param int $caseCategoryId
    *   Category Name.
    *
    * @return bool
    *   return value.
    */
-  public static function isValidCategory($caseCategoryName) {
-    $caseCategoryName = strtolower($caseCategoryName);
-    if ($caseCategoryName == 'cases') {
-      return TRUE;
-    }
-
+  public static function isValidCategory($caseCategoryId) {
     $caseCategoryOptions = CRM_Case_BAO_CaseType::buildOptions('case_type_category', 'validate');
-    $caseCategoryOptions = array_map('strtolower', $caseCategoryOptions);
 
-    if (!in_array($caseCategoryName, $caseCategoryOptions)) {
+    if (!in_array($caseCategoryId, array_flip($caseCategoryOptions))) {
       return FALSE;
     }
 

--- a/CRM/Civicase/Hook/PreProcess/CaseCategoryWordReplacementsForNewCase.php
+++ b/CRM/Civicase/Hook/PreProcess/CaseCategoryWordReplacementsForNewCase.php
@@ -17,17 +17,17 @@ class CRM_Civicase_Hook_PreProcess_CaseCategoryWordReplacementsForNewCase {
    *   Form Class object.
    */
   public function run($formName, CRM_Core_Form &$form) {
-    $caseCategoryName = $this->getCaseCategoryName($form);
+    $caseCategoryId = $this->getCaseCategoryId($form);
 
     if (!$this->shouldRun($formName)) {
       return;
     }
 
-    if (!CaseTypeCategoryHelper::isValidCategory($caseCategoryName)) {
+    if (!CaseTypeCategoryHelper::isValidCategory($caseCategoryId)) {
       return;
     }
 
-    $this->addWordReplacements($form, $caseCategoryName);
+    $this->addWordReplacements($form, $caseCategoryId);
   }
 
   /**
@@ -38,16 +38,17 @@ class CRM_Civicase_Hook_PreProcess_CaseCategoryWordReplacementsForNewCase {
    *
    * @param CRM_Core_Form $form
    *   Page class.
-   * @param string $caseCategoryName
-   *   Case category name.
+   * @param string $caseCategoryId
+   *   Case category Id.
    */
-  private function addWordReplacements(CRM_Core_Form $form, $caseCategoryName) {
+  private function addWordReplacements(CRM_Core_Form $form, $caseCategoryId) {
+    $caseCategoryName = CRM_Civicase_Helper_CaseCategory::getCaseCategoryNameFromOptionValue($caseCategoryId);
     CRM_Civicase_Hook_Helper_CaseTypeCategory::addWordReplacements($caseCategoryName);
     // We need to translate this manually as Civi does not the page title
     // through the ts function.
     $pageTitle = $form->get_template_vars('activityType');
     CRM_Utils_System::setTitle(ts($pageTitle));
-    CaseCategoryHelper::updateBreadcrumbs($caseCategoryName);
+    CaseCategoryHelper::updateBreadcrumbs($caseCategoryId);
   }
 
   /**
@@ -57,13 +58,13 @@ class CRM_Civicase_Hook_PreProcess_CaseCategoryWordReplacementsForNewCase {
    *   Form name.
    *
    * @return string|null
-   *   case category name.
+   *   case category Id.
    */
-  private function getCaseCategoryName(CRM_Core_Form $form) {
+  private function getCaseCategoryId(CRM_Core_Form $form) {
     $urlParams = parse_url(htmlspecialchars_decode($form->controller->_entryURL), PHP_URL_QUERY);
     parse_str($urlParams, $urlParams);
 
-    return !empty($urlParams['case_type_category']) ? $urlParams['case_type_category'] : CRM_Civicase_Helper_CaseCategory::CASE_TYPE_CATEGORY_NAME;
+    return !empty($urlParams['case_type_category']) ? $urlParams['case_type_category'] : CRM_Civicase_Helper_CaseCategory::getOptionValue();
   }
 
   /**

--- a/CRM/Civicase/Hook/PreProcess/CaseTypeCategoryWebFormRedirect.php
+++ b/CRM/Civicase/Hook/PreProcess/CaseTypeCategoryWebFormRedirect.php
@@ -62,7 +62,9 @@ class CRM_Civicase_Hook_PreProcess_CaseTypeCategoryWebFormRedirect {
    *   Form object.
    */
   private function redirectToWebForm(CRM_Core_Form $form) {
-    $caseTypeCategoryName = CRM_Utils_Array::value('case_type_category', $_GET, 'Cases');
+    $caseCategoryId = CRM_Utils_Array::value('case_type_category', $_GET, CRM_Civicase_Helper_CaseCategory::getOptionValue());
+    $caseTypeCategoryName = CRM_Civicase_Helper_CaseCategory::getCaseCategoryNameFromOptionValue($caseCategoryId);
+
     $webFormUrl = CaseTypeCategoryHelper::getNewCaseCategoryWebformUrl($caseTypeCategoryName, $this->caseCategorySetting);
     if (!$webFormUrl) {
       return;

--- a/ang/civicase.ang.php
+++ b/ang/civicase.ang.php
@@ -29,7 +29,7 @@ $caseCategoryPermissions = $permissionService->get($caseCategoryName);
 // The following changes are only relevant to the full-page app.
 if (CRM_Utils_System::getUrlPath() == 'civicrm/case/a') {
   adds_shoreditch_css();
-  CaseCategoryHelper::updateBreadcrumbs($caseCategoryName);
+  CaseCategoryHelper::updateBreadcrumbs($caseCategoryId);
 }
 
 $options = [];

--- a/ang/civicase/case/services/add-case.service.js
+++ b/ang/civicase/case/services/add-case.service.js
@@ -51,11 +51,9 @@
      * @param {addCaseConfig} params parameters
      */
     function openNewCaseForm (params) {
-      var caseTypeCategoryName = CaseTypeCategory.findById(params.caseTypeCategoryId).name;
-
       var formParams = {
         action: 'add',
-        case_type_category: caseTypeCategoryName,
+        case_type_category: params.caseTypeCategoryId,
         context: 'standalone',
         reset: 1
       };

--- a/ang/test/civicase/case/services/add-case.service.spec.js
+++ b/ang/test/civicase/case/services/add-case.service.spec.js
@@ -79,7 +79,7 @@
         it('opens the new case form', () => {
           expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/case/add', {
             action: 'add',
-            case_type_category: 'Cases',
+            case_type_category: '1',
             civicase_cid: '5',
             context: 'standalone',
             reset: 1

--- a/civicase.php
+++ b/civicase.php
@@ -208,7 +208,7 @@ function civicase_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
 function civicase_civicrm_buildForm($formName, &$form) {
   $hooks = [
     new CRM_Civicase_Hook_BuildForm_CaseClientPopulator(),
-    new CRM_Civicase_Hook_BuildForm_CaseCategoryCustomFieldsProcessing(),
+    new CRM_Civicase_Hook_BuildForm_FilterCaseTypesByCategoryForNewCase(),
     new CRM_Civicase_Hook_BuildForm_FilterByCaseCategoryOnChangeCaseType(),
     new CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslationForNewCase(),
     new CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslationForChangeCase(),


### PR DESCRIPTION
## Overview
When trying to add a new case for a case type belonging to a Case management instance, the case type dropdown contains case types from other case categories belonging to other instances.


## Before
The issue described above exists.

## After
The the case type dropdown now contains only case types for the case category under consideration
The reason for the leakage is as a result of the validation of the category [here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/Hook/BuildForm/CaseCategoryCustomFieldsProcessing.php#L27) where the function expects a case category name but it was the category ID that was passed. Refactoring the `CRM_Civicase_Hook_Helper_CaseTypeCategory::isValidCategory` to expect the category Id fixed the issue.

A couple of issues found was also fixed in the course of fixing the above issue
- Some hook classes were refactored to use the case category ID rather than the case category name
- The `updateBreadcrumbs` function was updated to accept the case category ID rather than the case category name in generating links
- The Add Case category button on the dashboard page was updated to use the categoryID rather than the name on the Add new form.
- The `redirectToWebForm` function  needs to use the case category name to fetch stored settings from the DB, this was fixed by gettting the case category name from the category ID in the function

