### PR TITLE
CPS-571: Fix Issue With Multiple Redirects When Creating A Case Of Another Instance As Non Admin

### DIFF
--- a/CRM/Civicase/Service/CaseCategoryFromUrl.php
+++ b/CRM/Civicase/Service/CaseCategoryFromUrl.php
@@ -97,17 +97,18 @@ class CRM_Civicase_Service_CaseCategoryFromUrl {
    */
   private function getCaseCategoryFromUrl($caseTypeCategoryParam) {
     $caseCategory = CRM_Utils_Request::retrieve($caseTypeCategoryParam, 'String');
+    $caseTypeCategories = CaseType::buildOptions($caseTypeCategoryParam, 'validate');
     if ($caseCategory) {
       if (is_numeric($caseCategory)) {
-        $caseTypeCategories = CaseType::buildOptions($caseTypeCategoryParam, 'validate');
-
         return $caseTypeCategories[$caseCategory] ?? NULL;
       }
 
       return $caseCategory;
     }
 
-    return $this->getParamValueFromEntryUrl($caseTypeCategoryParam);
+    $caseCategoryId = $this->getParamValueFromEntryUrl($caseTypeCategoryParam);
+
+    return $caseTypeCategories[$caseCategoryId] ?? NULL;
   }
 
   /**


### PR DESCRIPTION
## Overview
When trying to create a case for a case category instance as non admin, the action is not successfully and the broswer gives an error about multiple redirects. Refreshing the page after the failure will give a notice popup about a permission error for the logged in user.

## Before
![RedirectB](https://user-images.githubusercontent.com/6951813/116260181-5e950e00-a76e-11eb-99fd-4802beb7e7e2.gif)

## After
![RedirectAfter](https://user-images.githubusercontent.com/6951813/116259910-27266180-a76e-11eb-9e4d-ba89dfeb60ed.gif)

## Technical Details
The error was traced to this line https://github.com/civicrm/civicrm-core/blob/master/CRM/Case/Form/Case.php#L118 which means user was being denied access to some functionalities in the case form. The issue was because the hook class responsible for adding appropriate permissions based on case category was getting the case category Id value here: https://github.com/compucorp/uk.co.compucorp.civicase/blob/eca3321348bcef534937dc91f845e82a6d5e6a94/CRM/Civicase/Hook/PermissionCheck/CaseCategory.php#L44 rather than the case category name. 
The fix was to modify the `getCaseCategoryFromUrl` function to return the case category name instead of the ID for this scenario.

