### PR TITLE
CPS-576: Add Upgrader For All Case Categories

### DIFF
--- a/CRM/Civicase/Setup/UpdateCategoryNavigationItems.php
+++ b/CRM/Civicase/Setup/UpdateCategoryNavigationItems.php
@@ -1,12 +1,7 @@
 <?php
 
-use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
-
 /**
  * Class for updating menus of Case Categories dynamically created.
- *
- * These are marked as "not reserved" ('is_reserved' == 0) and have all the
- * same set of items, according to instance type. *
  */
 class CRM_Civicase_Setup_UpdateCategoryNavigationItems {
 
@@ -14,32 +9,27 @@ class CRM_Civicase_Setup_UpdateCategoryNavigationItems {
    * Update category navigation items.
    */
   public function apply() {
-    // Update menu corresponding to not reserved case categories.
-    $categories = $this->getNotReservedCategories();
+    $categories = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'case_type_categories',
+    ])['values'];
 
     foreach ($categories as $category) {
-      $categoryInstance = CaseCategoryHelper::getInstanceObject($category['value']);
-      $categoryMenu = $categoryInstance->getMenuObject();
-      $categoryMenu->resetCaseCategorySubmenusUrl($category['name']);
+      $items = civicrm_api3('Navigation', 'get', [
+        'sequential' => 1,
+        'url' => ['LIKE' => "%case_type_category={$category['name']}%"],
+      ])['values'];
+
+      foreach ($items as $item) {
+        civicrm_api3('Navigation', 'get', [
+          'id' => $item['id'],
+          'api.Navigation.create' => [
+            'id' => '$value.id',
+            'url' => str_ireplace($category['name'], $category['value'], $item['url']),
+          ],
+        ]);
+      }
     }
 
     CRM_Core_BAO_Navigation::resetNavigation();
   }
-
-  /**
-   * Get categories with `is_reserved` equal to 0.
-   */
-  private function getNotReservedCategories() {
-    $categories = civicrm_api3('OptionValue', 'get', [
-      'option_group_id' => 'case_type_categories',
-      'is_reserved' => 0,
-    ]);
-
-    if ($categories['count'] === 0) {
-      return [];
-    }
-
-    return $categories['values'];
-  }
-
 }


### PR DESCRIPTION
## Overview
This PR updates the upgrader that changes the corresponding navigation items of the existing case categories.

## Before
Identifying the navigation items using the name was failing, mainly in some client sites, where the names were modified manually on the database directly.
That caused that some URLs of the navigation items to get not updated as expected.

## After
All the navigation items are correctly identified and updated. 

## Technical Details
The exact name of the case category has to be passed currently in the parameter `case_type_category=` of the query string. That allows us to identify the URLs that need to be updated, iterating over the list of categories names. 

