### PR TITLE
CPS-246: Fix Issue with Cache Files Being Regenerated On Every Page Load

### DIFF
--- a/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
+++ b/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
@@ -63,12 +63,17 @@ class CRM_Civicase_Hook_Helper_CaseTypeCategory {
    *   Case category name.
    */
   public static function addWordReplacements($caseCategoryName) {
-    CRM_Core_Resources::singleton()->flushStrings()->resetCacheCode();
-
     if (!$caseCategoryName) {
       return;
     }
 
+    $currentCaseCategory = \Civi::cache('metadata')->get('current_case_category');
+    if ($currentCaseCategory === $caseCategoryName) {
+      return;
+    }
+
+    CRM_Core_Resources::singleton()->flushStrings()->resetCacheCode();
+    \Civi::cache('metadata')->set('current_case_category', $caseCategoryName);
     $wordReplacements = CaseCategoryHelper::getWordReplacements($caseCategoryName);
     if (empty($wordReplacements)) {
       return;

--- a/ang/civicase.ang.php
+++ b/ang/civicase.ang.php
@@ -20,7 +20,10 @@ load_resources();
 
 // Word replacements are already loaded for the contact tab ContactCaseTab.
 if (CRM_Utils_System::currentPath() !== 'civicrm/case/contact-case-tab') {
-  CRM_Civicase_Hook_Helper_CaseTypeCategory::addWordReplacements($caseCategoryName);
+  $notTranslationPath = $caseCategoryName == CaseCategoryHelper::CASE_TYPE_CATEGORY_NAME && CRM_Utils_System::currentPath() != 'civicrm/case/a';
+  if (!$notTranslationPath) {
+    CRM_Civicase_Hook_Helper_CaseTypeCategory::addWordReplacements($caseCategoryName);
+  }
 }
 
 $permissionService = new CaseCategoryPermission();


### PR DESCRIPTION
## Overview
When pages that requires angular to be bootstrapped are loaded in civicrm e.g `/civicrm` (Civicrm Dashboard) and a couple other pages, the `js_strings` cache in civicrm cache table keeps getting cleared even though the cache is not yet expired and this results in new cache files being regenerated in the `/sites/default/files/civicrm/persist/contribute/dyn/` folder in a site.
This causes a large number of files to be present in this folder as the files keep growing at a fast rate (Although the files are deleted when civicrm cache is flushed). Also updating the cache for every page request could have some significant impact in performance as has been reported for a site recently. 
This PR optimizes the way the cache is regenerated and ensures the cache is not invalidated on every page load and only when necessary.

## Before
The issue described above exists.

## After
The issue described above is fixed and optimized so that cache files are not re-generated for every page request.

## Technical Details
- Given that a fair number of civicrm pages bootstrap angular, this [hook](https://github.com/compucorp/uk.co.compucorp.civicase/blob/1d4386f5cf2ce5a7e65c2641883f0499aac3733d/civicase.php#L179) is called and eventually this [line](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/ang/civicase.ang.php#L23) gets called for all of these pages and the js_strings cache is [flushed](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/Hook/Helper/CaseTypeCategory.php#L66).  The issue here is that word replacements is only needed for case category related pages, so it is an overkill to have this run for almost every page. 
The fix here is to only run the word replacements on case category related pages. 
Since the `$caseCategoryName` will always [default to](https://github.com/compucorp/uk.co.compucorp.civicase/blob/b7497f5f9c4491c7bb5d1fbcfc83ce7fa781c692/CRM/Civicase/Helper/CaseUrl.php#L85) `Cases` when there is no case category, the paths that does not need translation are excluded for when the case category is `Cases`.  Other case categories will work fine with this logic. 

```php
if (CRM_Utils_System::currentPath() !== 'civicrm/case/contact-case-tab') {
  $notTranslationPath = $caseCategoryName == CaseCategoryHelper::CASE_TYPE_CATEGORY_NAME && CRM_Utils_System::currentPath() != 'civicrm/case/a';
  if (!$notTranslationPath) {
    CRM_Civicase_Hook_Helper_CaseTypeCategory::addWordReplacements($caseCategoryName);
  }
}
```

- Also it does not make sense to invalidate the cache each time if the case category does not change, so a new key `current_case_category` is used to store the current case category at the point of generating the word replacement cache strings so that this can be used to track whether to invalidate the cache or not.
