### PR TITLE
CPS-583: Fix Issue With Only client role is displayed when selecting case roles for bulk emails

### DIFF
--- a/ang/civicase-base/providers/case-type.provider.js
+++ b/ang/civicase-base/providers/case-type.provider.js
@@ -99,7 +99,7 @@
      */
     function getByCategory (categoryValue) {
       return _.filter(caseTypes, function (caseType) {
-        return caseType.case_type_category === categoryValue;
+        return parseInt(caseType.case_type_category) === parseInt(categoryValue);
       });
     }
 


### PR DESCRIPTION
## Overview
When selecting the client roles dropdown on the popup modal, only the Client role is displayed and other relevant roles that should be displayed is missing.

## Before
<img width="1280" alt="Manage Cases  CiviQA 2021-04-30 15-42-25" src="https://user-images.githubusercontent.com/6951813/116711496-ce9fd000-a9ca-11eb-9a6f-262d596fe3c3.png">


## After
<img width="1280" alt="Manage Cases  CiviQA 2021-04-30 15-44-22" src="https://user-images.githubusercontent.com/6951813/116711737-0e66b780-a9cb-11eb-9945-93a651ec3746.png">


## Technical Details
Due to a recent change, the case category Id is being passed in the URL rather than the case category name. The value of the case category Id fetched from the URL is passed on to JS as an integer. 
However when the dropdown for the case roles selection popup is built, it needs the [Case roles](https://github.com/compucorp/uk.co.compucorp.civicase/blob/6a61010e2b5e46013cec0e5d04a09a4d70bf0637/ang/civicase/case/actions/services/email-case-action.service.js#L131) for the current case category and when the case roles is filtered [here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/ang/civicase-base/providers/case-type.provider.js#L102), the data type does not match, the `caseType.case_type_category` is a string because it is stored as a string in the db and the `categoryValue` is the integer fetched from the URL. 
The fix was to parse both as integer before comparing. 

