### PR TITLE
RSE-1276: Fix for Word Replacements Using Singular and Plural Labels

### DIFF
--- a/CRM/Civicase/Helper/CaseCategory.php
+++ b/CRM/Civicase/Helper/CaseCategory.php
@@ -145,10 +145,10 @@ class CRM_Civicase_Helper_CaseCategory {
       $category = CRM_Civicase_Helper_Category::get($caseTypeCategoryName);
 
       return [
-        'Case' => ucfirst($category['singular_label']),
         'Cases' => ucfirst($category['label']),
-        'case' => strtolower($category['singular_label']),
+        'Case' => ucfirst($category['singular_label']),
         'cases' => strtolower($category['label']),
+        'case' => strtolower($category['singular_label']),
       ];
     }
 

--- a/CRM/Civicase/Helper/CaseCategory.php
+++ b/CRM/Civicase/Helper/CaseCategory.php
@@ -145,10 +145,14 @@ class CRM_Civicase_Helper_CaseCategory {
       $category = CRM_Civicase_Helper_Category::get($caseTypeCategoryName);
 
       return [
-        'Cases' => ucfirst($category['label']),
-        'Case' => ucfirst($category['singular_label']),
-        'cases' => strtolower($category['label']),
-        'case' => strtolower($category['singular_label']),
+        'Cases' => '_PLURAL_WILDCARD_',
+        'Case' => '_SINGULAR_WILDCARD_',
+        '_PLURAL_WILDCARD_' => ucfirst($category['label']),
+        '_SINGULAR_WILDCARD_' => ucfirst($category['singular_label']),
+        'cases' => '_plural_wildcard_',
+        'case' => '_singular_wildcard_',
+        '_plural_wildcard_' => strtolower($category['label']),
+        '_singular_wildcard_' => strtolower($category['singular_label']),
       ];
     }
 


### PR DESCRIPTION
## Overview
This PR fix a problem discovered by QA on the code for adding singular and plural labels to case type categories.

## Before
Two problems were discovered, related to the usage of word replacement.
- First, if we have, for example, these labels:
Plural: X-Prospects
Singular: X-Prospecting.
The word `Case`, singular, get replaced first by the `X-Prospecting` labels, generating the incorrect word `X-Prospectings`
![image](https://user-images.githubusercontent.com/74304572/117974453-c5621c00-b357-11eb-9126-e6c1c13ecad7.png)
- Second, if the new word for singular or plural, contains the word "case", the replacement get done twice.
![image](https://user-images.githubusercontent.com/74304572/117974763-25f15900-b358-11eb-8164-1ae0a34ca068.png)

## After
Word replacements are correctly done, with any singular or plural label.

## Technical Details
In the first commit, the order of replacements is changed. Replace first the plural and later the singular, avoiding to capture first the singular occurrence (which will always happen). This problem existed before, but is visible now that we do specific replacement for plural or singular.
In the other commit I introduce some "wildcard", that allow the code to find correctly the words for singular and plural, and later do the real replacement. Before this change, what happened was that with these labels:
Plural: `X-Cases`
Singular: `X-Case`
First we replaced in this way:
`Cases` -> `X-Cases`
and on the second step:
`X-Cases` -> `X-X-Cases` (because it matched `Case`)
Now first we separate the replacement using the wildcards, and in the next steps we do the proper replacements.





