### PR TITLE
CPS-539: Fix Activity Type filter in Activity Feed

### DIFF
--- a/ang/civicase/activity/filters/directives/activity-filters.directive.js
+++ b/ang/civicase/activity/filters/directives/activity-filters.directive.js
@@ -2,8 +2,8 @@
   var module = angular.module('civicase');
 
   module.directive('civicaseActivityFilters', function ($rootScope, $timeout, ts,
-    crmUiHelp, ActivityCategory, ActivityStatus, ActivityType,
-    CustomActivityField, CaseTypeCategory) {
+    ActivityCategory, ActivityStatus, ActivityType, CustomActivityField,
+    CaseTypeCategory) {
     return {
       restrict: 'A',
       scope: {
@@ -138,7 +138,7 @@
             name: 'activity_type_id',
             label: ts('Activity type'),
             html_type: 'Select',
-            options: _.map(CRM.civicase.activityTypes, mapSelectOptions)
+            options: _.map(ActivityType.getAll(), mapSelectOptions)
           },
           {
             name: 'status_id',

--- a/ang/test/civicase/activity/directives/add-activity-menu.directive.spec.js
+++ b/ang/test/civicase/activity/directives/add-activity-menu.directive.spec.js
@@ -2,7 +2,7 @@
   describe('AddActivityMenu', function () {
     describe('Add Activity Menu Controller', function () {
       var $controller, $rootScope, $scope, ActivityForms, activityForm, CaseType,
-        mockCase;
+        mockCase, CasesData;
 
       beforeEach(module('civicase', 'civicase.data', ($provide) => {
         ActivityForms = jasmine.createSpyObj('ActivityForms', ['getActivityFormService']);
@@ -14,10 +14,11 @@
         $provide.value('ActivityForms', ActivityForms);
       }));
 
-      beforeEach(inject(function (_$controller_, _$rootScope_, _CaseType_) {
+      beforeEach(inject(function (_$controller_, _$rootScope_, _CaseType_, _CasesData_) {
         $controller = _$controller_;
         $rootScope = _$rootScope_;
         CaseType = _CaseType_;
+        CasesData = _CasesData_;
       }));
 
       describe('activity menu', function () {
@@ -28,11 +29,8 @@
           activityTypeWithMaxInstance = activityTypes.find(function (activity) {
             return activity.max_instances;
           });
-          mockCase = {
-            case_type_id: 1
-          };
 
-          initController(mockCase);
+          initController(CasesData.get().values[0]);
 
           activityTypeExceedingMaxInstanceIsHidden = !_.find($scope.availableActivityTypes, function (activityType) {
             return activityType.name === activityTypeWithMaxInstance.name;

--- a/ang/test/civicase/activity/filters/directives/activity-filters.directive.spec.js
+++ b/ang/test/civicase/activity/filters/directives/activity-filters.directive.spec.js
@@ -1,16 +1,19 @@
 (function ($, _) {
-  describe('civicaseActivityFilters', function () {
+  describe('civicaseActivityFilters', () => {
     var $compile, $rootScope, $scope, activityFilters, CaseTypeCategory,
-      categoryWhereUserCanAccessActivities;
+      categoryWhereUserCanAccessActivities, ActivityType, ActivityStatus;
 
-    beforeEach(module('civicase', 'civicase.templates', function () {
+    beforeEach(module('civicase.data', 'civicase', 'civicase.templates', () => {
       killDirective('civicaseActivityFiltersContact');
     }));
 
-    beforeEach(inject(function (_$compile_, _$rootScope_, _CaseTypeCategory_) {
+    beforeEach(inject((_$compile_, _$rootScope_, _CaseTypeCategory_,
+      _ActivityType_, _ActivityStatus_) => {
       $compile = _$compile_;
       $rootScope = _$rootScope_;
       CaseTypeCategory = _CaseTypeCategory_;
+      ActivityType = _ActivityType_;
+      ActivityStatus = _ActivityStatus_;
 
       categoryWhereUserCanAccessActivities = _.sample(CaseTypeCategory.getAll(), 1);
       spyOn($rootScope, '$broadcast').and.callThrough();
@@ -46,19 +49,151 @@
       });
     });
 
-    describe('when clicking more filters button', function () {
-      beforeEach(function () {
+    describe('when clicking more filters button', () => {
+      beforeEach(() => {
         activityFilters.isolateScope().filters['@moreFilters'] = true;
         activityFilters.isolateScope().toggleMoreFilters();
       });
 
-      it('toggles more filters visibility', function () {
+      it('toggles more filters visibility', () => {
         expect(activityFilters.isolateScope().filters['@moreFilters']).toEqual(false);
       });
 
-      it('fires an event', function () {
+      it('fires an event', () => {
         expect($rootScope.$broadcast)
           .toHaveBeenCalledWith('civicase::activity-filters::more-filters-toggled');
+      });
+    });
+
+    describe('Activity Type Filters', () => {
+      var activityTypeFilters;
+
+      beforeEach(() => {
+        activityTypeFilters = angular.copy(
+          _.find(activityFilters.isolateScope().availableFilters, { name: 'activity_type_id' })
+        );
+      });
+
+      it('shows the activity type filters', () => {
+        expect(activityTypeFilters).toEqual({
+          name: 'activity_type_id',
+          label: 'Activity type',
+          html_type: 'Select',
+          options: _.map(ActivityType.getAll(), mapSelectOptions)
+        });
+      });
+    });
+
+    describe('Activity Status Filters', () => {
+      var activityStatusFilters;
+
+      beforeEach(() => {
+        activityStatusFilters = angular.copy(
+          _.find(activityFilters.isolateScope().availableFilters, { name: 'status_id' })
+        );
+      });
+
+      it('shows the activity status filters', () => {
+        expect(activityStatusFilters).toEqual({
+          name: 'status_id',
+          label: 'Status',
+          html_type: 'Select',
+          options: _.map(ActivityStatus.getAll(), mapSelectOptions)
+        });
+      });
+    });
+
+    describe('Target Contact Filters', () => {
+      var targetContactFilters;
+
+      beforeEach(() => {
+        targetContactFilters = angular.copy(
+          _.find(activityFilters.isolateScope().availableFilters, { name: 'target_contact_id' })
+        );
+      });
+
+      it('shows the target contact filters', () => {
+        expect(targetContactFilters).toEqual({
+          name: 'target_contact_id',
+          label: ts('With'),
+          html_type: 'Autocomplete-Select',
+          entity: 'Contact'
+        });
+      });
+    });
+
+    describe('Assignee Contact Filters', () => {
+      var assigneeContactFilters;
+
+      beforeEach(() => {
+        assigneeContactFilters = angular.copy(
+          _.find(activityFilters.isolateScope().availableFilters, { name: 'assignee_contact_id' })
+        );
+      });
+
+      it('shows the Assignee contact filters', () => {
+        expect(assigneeContactFilters).toEqual({
+          name: 'assignee_contact_id',
+          label: ts('Assigned to'),
+          html_type: 'Autocomplete-Select',
+          entity: 'Contact'
+        });
+      });
+    });
+
+    describe('Tags Filters', () => {
+      var tagsFilters;
+
+      beforeEach(() => {
+        tagsFilters = angular.copy(
+          _.find(activityFilters.isolateScope().availableFilters, { name: 'tag_id' })
+        );
+      });
+
+      it('shows the Tags filters', () => {
+        expect(tagsFilters).toEqual({
+          name: 'tag_id',
+          label: ts('Tagged'),
+          html_type: 'Autocomplete-Select',
+          entity: 'Tag',
+          api_params: { used_for: { LIKE: '%civicrm_activity%' }, is_tagset: 0 }
+        });
+      });
+    });
+
+    describe('Text Filters', () => {
+      var textFilters;
+
+      beforeEach(() => {
+        textFilters = angular.copy(
+          _.find(activityFilters.isolateScope().availableFilters, { name: 'text' })
+        );
+      });
+
+      it('shows the text filters', () => {
+        expect(textFilters).toEqual({
+          name: 'text',
+          label: ts('Contains text'),
+          html_type: 'Text'
+        });
+      });
+    });
+
+    describe('Date Filters', () => {
+      var dateFilters;
+
+      beforeEach(() => {
+        dateFilters = angular.copy(
+          _.find(activityFilters.isolateScope().availableFilters, { name: 'activity_date_time' })
+        );
+      });
+
+      it('shows the text filters', () => {
+        expect(dateFilters).toEqual({
+          name: 'activity_date_time',
+          label: ts('Activity date'),
+          html_type: 'Select Date'
+        });
       });
     });
 
@@ -79,14 +214,29 @@
      * @param {string} directiveName name of the directive
      */
     function killDirective (directiveName) {
-      angular.mock.module(function ($compileProvider) {
-        $compileProvider.directive(directiveName, function () {
+      angular.mock.module(($compileProvider) => {
+        $compileProvider.directive(directiveName, () => {
           return {
             priority: 9999999,
             terminal: true
           };
         });
       });
+    }
+
+    /**
+     * Maps Options to be used in the dropdown
+     *
+     * @param {object} option option
+     * @returns {object} options
+     */
+    function mapSelectOptions (option) {
+      return {
+        id: option.value,
+        text: option.label,
+        color: option.color,
+        icon: option.icon
+      };
     }
   });
 })(CRM.$, CRM._);

--- a/ang/test/mocks/data/activity-types.data.js
+++ b/ang/test/mocks/data/activity-types.data.js
@@ -7,381 +7,447 @@
       icon: 'fa-slideshare',
       name: 'Meeting',
       grouping: 'communication',
-      is_active: '1'
+      is_active: '1',
+      value: '1'
     },
     2: {
       label: 'Phone Call',
       icon: 'fa-phone',
       name: 'Phone Call',
       grouping: 'communication',
-      is_active: '1'
+      is_active: '1',
+      value: '2'
     },
     3: {
       label: 'Email',
       icon: 'fa-envelope-o',
       name: 'Email',
       grouping: 'communication',
-      is_active: '1'
+      is_active: '1',
+      value: '3'
     },
     4: {
       label: 'Outbound SMS',
       icon: 'fa-mobile',
       name: 'SMS',
       grouping: 'communication',
-      is_active: '1'
+      is_active: '1',
+      value: '4'
     },
     5: {
       label: 'Event Registration',
       name: 'Event Registration',
-      is_active: '1'
+      is_active: '1',
+      value: '5'
     },
     6: {
       label: 'Contribution',
       name: 'Contribution',
-      is_active: '1'
+      is_active: '1',
+      value: '6'
     },
     7: {
       label: 'Membership Signup',
       name: 'Membership Signup',
-      is_active: '1'
+      is_active: '1',
+      value: '7'
     },
     8: {
       label: 'Membership Renewal',
       name: 'Membership Renewal',
-      is_active: '1'
+      is_active: '1',
+      value: '8'
     },
     9: {
       label: 'Tell a Friend',
       name: 'Tell a Friend',
-      is_active: '1'
+      is_active: '1',
+      value: '9'
     },
     10: {
       label: 'Pledge Acknowledgment',
       name: 'Pledge Acknowledgment',
-      is_active: '1'
+      is_active: '1',
+      value: '10'
     },
     11: {
       label: 'Pledge Reminder',
       name: 'Pledge Reminder',
-      is_active: '1'
+      is_active: '1',
+      value: '11'
     },
     12: {
       label: 'Inbound Email',
       name: 'Inbound Email',
       grouping: 'communication',
-      is_active: '1'
+      is_active: '1',
+      value: '12'
     },
     13: {
       label: 'Open Case',
       icon: 'fa-folder-open-o',
       name: 'Open Case',
       grouping: 'milestone',
-      is_active: '1'
+      is_active: '1',
+      value: '13'
     },
     14: {
       label: 'Follow up',
       icon: 'fa-share-square-o',
       name: 'Follow up',
       grouping: 'communication',
-      is_active: '1'
+      is_active: '1',
+      value: '14'
     },
     15: {
       label: 'Change Case Type',
       icon: 'fa-random',
       name: 'Change Case Type',
       grouping: 'system',
-      is_active: '1'
+      is_active: '1',
+      value: '15'
     },
     16: {
       label: 'Change Case Status',
       icon: 'fa-pencil-square-o',
       name: 'Change Case Status',
       grouping: 'system',
-      is_active: '1'
+      is_active: '1',
+      value: '16'
     },
     17: {
       label: 'Membership Renewal Reminder',
       name: 'Membership Renewal Reminder',
-      is_active: '1'
+      is_active: '1',
+      value: '17'
     },
     18: {
       label: 'Change Case Start Date',
       icon: 'fa-calendar',
       name: 'Change Case Start Date',
       grouping: 'system',
-      is_active: '1'
+      is_active: '1',
+      value: '18'
     },
     19: {
       label: 'Bulk Email',
       name: 'Bulk Email',
-      is_active: '1'
+      is_active: '1',
+      value: '19'
     },
     20: {
       label: 'Assign Case Role',
       icon: 'fa-user-plus',
       name: 'Assign Case Role',
       grouping: 'system',
-      is_active: '1'
+      is_active: '1',
+      value: '20'
     },
     21: {
       label: 'Remove Case Role',
       icon: 'fa-user-times',
       name: 'Remove Case Role',
       grouping: 'system',
-      is_active: '1'
+      is_active: '1',
+      value: '21'
     },
     22: {
       label: 'Print/Merge Document',
       icon: 'fa-file-pdf-o',
       name: 'Print PDF Letter',
       grouping: 'communication',
-      is_active: '1'
+      is_active: '1',
+      value: '22'
     },
     23: {
       label: 'Merge Case',
       icon: 'fa-compress',
       name: 'Merge Case',
       grouping: 'system',
-      is_active: '1'
+      is_active: '1',
+      value: '23'
     },
     24: {
       label: 'Reassigned Case',
       icon: 'fa-user-circle-o',
       name: 'Reassigned Case',
       grouping: 'system',
-      is_active: '1'
+      is_active: '1',
+      value: '24'
     },
     25: {
       label: 'Link Cases',
       icon: 'fa-link',
       name: 'Link Cases',
       grouping: 'system',
-      is_active: '1'
+      is_active: '1',
+      value: '25'
     },
     26: {
       label: 'Change Case Tags',
       icon: 'fa-tags',
       name: 'Change Case Tags',
       grouping: 'system',
-      is_active: '1'
+      is_active: '1',
+      value: '26'
     },
     27: {
       label: 'Add Client To Case',
       icon: 'fa-users',
       name: 'Add Client To Case',
       grouping: 'system',
-      is_active: '1'
+      is_active: '1',
+      value: '27'
     },
     28: {
       label: 'Survey',
       name: 'Survey',
-      is_active: '1'
+      is_active: '1',
+      value: '28'
     },
     29: {
       label: 'Canvass',
       name: 'Canvass',
-      is_active: '1'
+      is_active: '1',
+      value: '29'
     },
     30: {
       label: 'PhoneBank',
       name: 'PhoneBank',
-      is_active: '1'
+      is_active: '1',
+      value: '30'
     },
     31: {
       label: 'WalkList',
       name: 'WalkList',
-      is_active: '1'
+      is_active: '1',
+      value: '31'
     },
     32: {
       label: 'Petition Signature',
       name: 'Petition',
-      is_active: '1'
+      is_active: '1',
+      value: '32'
     },
     33: {
       label: 'Change Custom Data',
       icon: 'fa-table',
       name: 'Change Custom Data',
       grouping: 'system',
-      is_active: '1'
+      is_active: '1',
+      value: '33'
     },
     34: {
       label: 'Mass SMS',
       name: 'Mass SMS',
-      is_active: '1'
+      is_active: '1',
+      value: '34'
     },
     35: {
       label: 'Change Membership Status',
       name: 'Change Membership Status',
-      is_active: '1'
+      is_active: '1',
+      value: '35'
     },
     36: {
       label: 'Change Membership Type',
       name: 'Change Membership Type',
-      is_active: '1'
+      is_active: '1',
+      value: '36'
     },
     37: {
       label: 'Cancel Recurring Contribution',
       name: 'Cancel Recurring Contribution',
-      is_active: '1'
+      is_active: '1',
+      value: '37'
     },
     38: {
       label: 'Update Recurring Contribution Billing Details',
       name: 'Update Recurring Contribution Billing Details',
-      is_active: '1'
+      is_active: '1',
+      value: '38'
     },
     39: {
       label: 'Update Recurring Contribution',
       name: 'Update Recurring Contribution',
-      is_active: '1'
+      is_active: '1',
+      value: '39'
     },
     40: {
       label: 'Reminder Sent',
       name: 'Reminder Sent',
-      is_active: '1'
+      is_active: '1',
+      value: '40'
     },
     41: {
       label: 'Export Accounting Batch',
       name: 'Export Accounting Batch',
-      is_active: '1'
+      is_active: '1',
+      value: '41'
     },
     42: {
       label: 'Create Batch',
       name: 'Create Batch',
-      is_active: '1'
+      is_active: '1',
+      value: '42'
     },
     43: {
       label: 'Edit Batch',
       name: 'Edit Batch',
-      is_active: '1'
+      is_active: '1',
+      value: '43'
     },
     44: {
       label: 'SMS delivery',
       name: 'SMS delivery',
-      is_active: '1'
+      is_active: '1',
+      value: '44'
     },
     45: {
       label: 'Inbound SMS',
       name: 'Inbound SMS',
-      is_active: '1'
+      is_active: '1',
+      value: '45'
     },
     46: {
       label: 'Payment',
       name: 'Payment',
-      is_active: '1'
+      is_active: '1',
+      value: '46'
     },
     47: {
       label: 'Refund',
       name: 'Refund',
-      is_active: '1'
+      is_active: '1',
+      value: '47'
     },
     48: {
       label: 'Change Registration',
       name: 'Change Registration',
-      is_active: '1'
+      is_active: '1',
+      value: '48'
     },
     49: {
       label: 'Downloaded Invoice',
       name: 'Downloaded Invoice',
-      is_active: '1'
+      is_active: '1',
+      value: '49'
     },
     50: {
       label: 'Emailed Invoice',
       name: 'Emailed Invoice',
-      is_active: '1'
+      is_active: '1',
+      value: '50'
     },
     51: {
       label: 'Contact Merged',
       name: 'Contact Merged',
-      is_active: '1'
+      is_active: '1',
+      value: '51'
     },
     52: {
       label: 'Contact Deleted by Merge',
       name: 'Contact Deleted by Merge',
-      is_active: '1'
+      is_active: '1',
+      value: '52'
     },
     53: {
       label: 'Change Case Subject',
       icon: 'fa-pencil-square-o',
       name: 'Change Case Subject',
       grouping: 'system',
-      is_active: '1'
+      is_active: '1',
+      value: '53'
     },
     54: {
       label: 'Failed Payment',
       name: 'Failed Payment',
-      is_active: '1'
+      is_active: '1',
+      value: '54'
     },
     55: {
       label: 'Interview',
       icon: 'fa-comment-o',
       name: 'Interview',
-      is_active: '1'
+      is_active: '1',
+      value: '55'
     },
     56: {
       label: 'Medical evaluation',
       name: 'Medical evaluation',
       grouping: 'milestone',
-      is_active: '1'
+      is_active: '1',
+      value: '56'
     },
     58: {
       label: 'Mental health evaluation',
       name: 'Mental health evaluation',
       grouping: 'milestone',
-      is_active: '1'
+      is_active: '1',
+      value: '58'
     },
     60: {
       label: 'Secure temporary housing',
       name: 'Secure temporary housing',
       grouping: 'milestone',
-      is_active: '1'
+      is_active: '1',
+      value: '60'
     },
     62: {
       label: 'Income and benefits stabilization',
       name: 'Income and benefits stabilization',
-      is_active: '1'
+      is_active: '1',
+      value: '62'
     },
     64: {
       label: 'Long-term housing plan',
       name: 'Long-term housing plan',
       grouping: 'milestone',
-      is_active: '1'
+      is_active: '1',
+      value: '64'
     },
     66: {
       label: 'ADC referral',
       name: 'ADC referral',
-      is_active: '1'
+      is_active: '1',
+      value: '66'
     },
     68: {
       label: 'File Upload',
       icon: 'fa-file',
       name: 'File Upload',
-      is_active: '1'
+      is_active: '1',
+      value: '68'
     },
     69: {
       label: 'Remove Client From Case',
       icon: 'fa-user-times',
       name: 'Remove Client From Case',
       grouping: 'system',
-      is_active: '1'
+      is_active: '1',
+      value: '69'
     },
     70: {
       label: 'Case Task',
       name: 'Case Task',
       grouping: 'task',
-      is_active: '1'
+      is_active: '1',
+      value: '70'
     },
     72: {
       label: 'Communication Act',
       name: 'Communication Act',
       grouping: 'communication',
-      is_active: '1'
+      is_active: '1',
+      value: '72'
     },
     73: {
       label: 'Alert',
       icon: 'fa-exclamation',
       name: 'Alert',
       grouping: 'alert',
-      is_active: '0'
+      is_active: '0',
+      value: '73'
     }
   };
 

--- a/ang/test/mocks/data/cases.data.js
+++ b/ang/test/mocks/data/cases.data.js
@@ -189,6 +189,7 @@
             13: '1',
             15: '4',
             16: '1',
+            72: '1',
             53: '1'
           },
           'api.Case.getcaselist.relatedCasesByContact': { values: [] },


### PR DESCRIPTION
## Overview
The Activity Type filter inside Activity Feed was not working. This PR fixes the same.

## Before
![2021-05-13 at 3 49 PM](https://user-images.githubusercontent.com/5058867/118112536-c603bc80-b402-11eb-8a81-97bfe5ecbe16.png)

## After
![2021-05-13 at 3 48 PM](https://user-images.githubusercontent.com/5058867/118112502-b84e3700-b402-11eb-8034-14b83ee28193.png)

## Technical Details
This is a regression caused by - https://github.com/compucorp/uk.co.compucorp.civicase/pull/284.
Where we moved `CRM.civicase.activityTypes` to `CRM['civicase-base'].activityTypes`, but forgot to update `activity-filters.directive.js`.

In `ang/civicase/activity/filters/directives/activity-filters.directive.js`, replaced `CRM.civicase.activityTypes` with `ActivityType.getAll()`.

Also added unit tests.