### PR TITLE
CPS-575: Fix page level Permissions

### DIFF
--- a/ang/civicase-base.ang.php
+++ b/ang/civicase-base.ang.php
@@ -14,20 +14,10 @@ use CRM_Civicase_Helper_GlobRecursive as GlobRecursive;
 use CRM_Civicase_Helper_NewCaseWebform as NewCaseWebform;
 use CRM_Civicase_Service_CaseCategoryCustomFieldsSetting as CaseCategoryCustomFieldsSetting;
 use CRM_Civicase_Helper_CaseUrl as CaseUrlHelper;
-use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 
 [$caseCategoryId, $caseCategoryName] = CaseUrlHelper::getCategoryParamsFromUrl();
 
 $caseCategorySetting = new CRM_Civicase_Service_CaseCategorySetting();
-
-if (CRM_Utils_System::currentPath() !== 'civicrm/case/contact-case-tab') {
-  $notTranslationPath = $caseCategoryName == CaseCategoryHelper::CASE_TYPE_CATEGORY_NAME && CRM_Utils_System::currentPath() != 'civicrm/case/a';
-  if (!$notTranslationPath) {
-    if (!in_array($caseCategoryName, CaseCategoryHelper::getAccessibleCaseTypeCategories())) {
-      throw new Exception('Access denied! You are not authorized to access this page.');
-    }
-  }
-}
 
 $options = [
   'activityTypes' => 'activity_type',

--- a/ang/civicase-base.ang.php
+++ b/ang/civicase-base.ang.php
@@ -14,10 +14,20 @@ use CRM_Civicase_Helper_GlobRecursive as GlobRecursive;
 use CRM_Civicase_Helper_NewCaseWebform as NewCaseWebform;
 use CRM_Civicase_Service_CaseCategoryCustomFieldsSetting as CaseCategoryCustomFieldsSetting;
 use CRM_Civicase_Helper_CaseUrl as CaseUrlHelper;
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 
 [$caseCategoryId, $caseCategoryName] = CaseUrlHelper::getCategoryParamsFromUrl();
 
 $caseCategorySetting = new CRM_Civicase_Service_CaseCategorySetting();
+
+if (CRM_Utils_System::currentPath() !== 'civicrm/case/contact-case-tab') {
+  $notTranslationPath = $caseCategoryName == CaseCategoryHelper::CASE_TYPE_CATEGORY_NAME && CRM_Utils_System::currentPath() != 'civicrm/case/a';
+  if (!$notTranslationPath) {
+    if (!in_array($caseCategoryName, CaseCategoryHelper::getAccessibleCaseTypeCategories())) {
+      throw new Exception('Access denied! You are not authorized to access this page.');
+    }
+  }
+}
 
 $options = [
   'activityTypes' => 'activity_type',

--- a/ang/civicase-base/directives/access-denied.directive.html
+++ b/ang/civicase-base/directives/access-denied.directive.html
@@ -1,0 +1,9 @@
+<div id="bootstrap-theme">
+  <div class="panel">
+    <div class="panel-body">
+      <h1 crm-page-title>{{ ts('Access Denied') }}</h1>
+      <h3>Access Denied!</h3>
+      You are not authorized to access this page.
+    </div>
+  </div>
+</div>

--- a/ang/civicase-base/directives/acess-denied.directive.js
+++ b/ang/civicase-base/directives/acess-denied.directive.js
@@ -1,0 +1,10 @@
+(function (angular, _) {
+  var module = angular.module('civicase-base');
+
+  module.directive('civicaseAccessDenied', function () {
+    return {
+      restrict: 'E',
+      templateUrl: '~/civicase-base/directives/access-denied.directive.html'
+    };
+  });
+}(angular, CRM._));

--- a/ang/civicase.ang.php
+++ b/ang/civicase.ang.php
@@ -21,7 +21,12 @@ load_resources();
 // Word replacements are already loaded for the contact tab ContactCaseTab.
 if (CRM_Utils_System::currentPath() !== 'civicrm/case/contact-case-tab') {
   $notTranslationPath = $caseCategoryName == CaseCategoryHelper::CASE_TYPE_CATEGORY_NAME && CRM_Utils_System::currentPath() != 'civicrm/case/a';
+
   if (!$notTranslationPath) {
+    if (!in_array($caseCategoryName, CaseCategoryHelper::getAccessibleCaseTypeCategories())) {
+      throw new Exception('Access denied! You are not authorized to access this page.');
+    }
+
     CRM_Civicase_Hook_Helper_CaseTypeCategory::addWordReplacements($caseCategoryName);
   }
 }

--- a/ang/civicase/app.routes.js
+++ b/ang/civicase/app.routes.js
@@ -11,10 +11,19 @@
     });
   });
 
-  module.config(function ($routeProvider) {
+  module.config(function ($routeProvider, UrlParametersProvider) {
     $routeProvider.when('/case', {
       reloadOnSearch: false,
-      template: '<civicase-dashboard></civicase-dashboard>'
+      template: function () {
+        var urlParams = UrlParametersProvider.parse(window.location.search);
+        var urlHash = UrlParametersProvider.parse(window.location.hash);
+
+        if (urlParams.case_type_category === urlHash.case_type_category) {
+          return '<civicase-dashboard></civicase-dashboard>';
+        }
+
+        return '<civicase-access-denied></civicase-access-denied>';
+      }
     });
   });
 


### PR DESCRIPTION
## Overview
When trying to access the Dashboard/Manage <Case Type Category screen> for a user of different Case Type Category, the page was accessible, but Console Errors were seen. It has been fixed now, and Access Denied error is produced.

## Before
![2021-05-13 at 5 39 PM](https://user-images.githubusercontent.com/5058867/118123656-32d28300-b412-11eb-8de1-5723b91ce639.png)

## After
![2021-05-26 at 11 22 AM](https://user-images.githubusercontent.com/5058867/119609109-a6ae5b80-be14-11eb-94a7-435a78a578b5.png)

(when the `case_type_category` before and after the hash does not match.)
![2021-05-26 at 11 22 AM](https://user-images.githubusercontent.com/5058867/119609171-c2b1fd00-be14-11eb-9f08-ff59b6d5c8e7.png)

## Technical Details
In `ang/civicase-base.ang.php`, added logic to throw error if the user does not have access to current case type category.
Also added a new directive `acess-denied.directive` which is shown when the `case_type_category` before and after the hash does not match.