### PR TITLE
CPS-490: Close PDF popup after Download Document

### DIFF
--- a/ang/civicase/activity/actions/services/resume-draft-activity-action.service.js
+++ b/ang/civicase/activity/actions/services/resume-draft-activity-action.service.js
@@ -40,7 +40,7 @@
      */
     this.doAction = function ($scope) {
       viewInPopup(null, $scope.selectedActivities[0])
-        .on('crmFormSuccess', function () {
+        .on('crmFormSuccess crmPopupFormSuccess', function () {
           $rootScope.$broadcast('civicase::activity::updated');
         });
     };

--- a/ang/civicase/activity/actions/services/resume-draft-activity-action.service.js
+++ b/ang/civicase/activity/actions/services/resume-draft-activity-action.service.js
@@ -39,10 +39,7 @@
      * @param {object} $scope scope object
      */
     this.doAction = function ($scope) {
-      viewInPopup(null, $scope.selectedActivities[0])
-        .on('crmFormSuccess crmPopupFormSuccess', function () {
-          $rootScope.$broadcast('civicase::activity::updated');
-        });
+      viewInPopup(null, $scope.selectedActivities[0]);
     };
   }
 })(angular);

--- a/ang/civicase/activity/factories/view-in-popup.factory.js
+++ b/ang/civicase/activity/factories/view-in-popup.factory.js
@@ -1,7 +1,7 @@
 (function (angular, $, _, CRM) {
   var module = angular.module('civicase');
 
-  module.factory('viewInPopup', function (ActivityForms, civicaseCrmLoadForm) {
+  module.factory('viewInPopup', function ($rootScope, ActivityForms, civicaseCrmLoadForm) {
     /**
      * View activity in a popup
      *
@@ -25,7 +25,10 @@
         return;
       }
 
-      return civicaseCrmLoadForm(activityForm.getActivityFormUrl(activity, formOptions));
+      return civicaseCrmLoadForm(activityForm.getActivityFormUrl(activity, formOptions))
+        .on('crmFormSuccess crmPopupFormSuccess', function () {
+          $rootScope.$broadcast('civicase::activity::updated');
+        });
     }
 
     return viewInPopup;

--- a/ang/civicase/case/details/directives/case-details.directive.js
+++ b/ang/civicase/case/details/directives/case-details.directive.js
@@ -159,7 +159,10 @@
     function createPDFLetter () {
       PrintMergeCaseAction.doAction([$scope.item])
         .then(function (pdfLetter) {
-          civicaseCrmLoadForm(civicaseCrmUrl(pdfLetter.path, pdfLetter.query));
+          civicaseCrmLoadForm(civicaseCrmUrl(pdfLetter.path, pdfLetter.query))
+            .on('crmPopupFormSuccess', function () {
+              $rootScope.$broadcast('civicase::activity::updated');
+            });
         });
     }
 

--- a/civicase.php
+++ b/civicase.php
@@ -203,6 +203,15 @@ function civicase_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
 }
 
 /**
+ * Implements hook_civicrm_coreResourceList().
+ */
+function civicase_civicrm_coreResourceList(&$items, $region) {
+  if ($region == 'html-header') {
+    CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicase', 'js/close-pdf-form.js');
+  }
+}
+
+/**
  * Implements hook_civicrm_buildForm().
  */
 function civicase_civicrm_buildForm($formName, &$form) {

--- a/js/close-pdf-form.js
+++ b/js/close-pdf-form.js
@@ -23,8 +23,10 @@
 
     $('body')
       .off('submit', $form)
-      .on('submit', $form, function () {
-        CRM['civicase-base'].closePDFPopup();
+      .on('submit', $form, function (event) {
+        if (event.originalEvent.submitter.id === '_qf_PDF_upload-bottom') {
+          CRM['civicase-base'].closePDFPopup();
+        }
       });
   });
 })(CRM.$, CRM['civicase-base']);

--- a/js/close-pdf-form.js
+++ b/js/close-pdf-form.js
@@ -1,0 +1,30 @@
+(function ($, civicaseBase) {
+  if (!civicaseBase) {
+    return;
+  }
+  civicaseBase.shouldClosePDFPopup = true;
+
+  civicaseBase.closePDFPopup = function (forceClosePDFPopup) {
+    var $form = CRM.$('.CRM_Contact_Form_Task_PDF');
+    var popup = $form.closest('.ui-dialog-content');
+
+    if (!forceClosePDFPopup && !civicaseBase.shouldClosePDFPopup) {
+      return;
+    }
+
+    setTimeout(function () {
+      popup.trigger('crmPopupFormSuccess');
+      popup.dialog('close');
+    });
+  };
+
+  $(document).one('crmLoad', function () {
+    var $form = CRM.$('.CRM_Contact_Form_Task_PDF');
+
+    $('body')
+      .off('submit', $form)
+      .on('submit', $form, function () {
+        CRM['civicase-base'].closePDFPopup();
+      });
+  });
+})(CRM.$, CRM['civicase-base']);


### PR DESCRIPTION
## Overview
In PDF document Popup, after downloading the document, the popup did not close, and the user had to manually refresh the page to see latest activity. This PR fixes that, so that the popup closes and the activity feed refreshes.

## Before
The popup did not close, and the user had to manually refresh the page to see latest activity.

## After
![after](https://user-images.githubusercontent.com/5058867/118453037-66642480-b714-11eb-8e3c-9ba632feb78f.gif)

## Technical Details
Implemented `civicase_civicrm_coreResourceList` hook, which attaches a new JS file.
Added `js/close-pdf-form.js` to implement the feature.
