### PR TITLE
CPS-595: Add maxLength Attribute to Label Field

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/AddCaseCategoryCustomFields.php
+++ b/CRM/Civicase/Hook/BuildForm/AddCaseCategoryCustomFields.php
@@ -48,7 +48,7 @@ class CRM_Civicase_Hook_BuildForm_AddCaseCategoryCustomFields extends CRM_Civica
       'text',
       'singular_label',
       ts('Secondary Label'),
-      ['size' => 45],
+      ['size' => 45, 'maxLength' => 45],
       TRUE
     );
 

--- a/CRM/Civicase/Hook/BuildForm/AddCaseCategoryCustomFields.php
+++ b/CRM/Civicase/Hook/BuildForm/AddCaseCategoryCustomFields.php
@@ -85,6 +85,7 @@ class CRM_Civicase_Hook_BuildForm_AddCaseCategoryCustomFields extends CRM_Civica
   private function updatePrimaryLabelText(CRM_Core_Form $form) {
     $labelField = $form->getElement('label');
     $labelField->setLabel('Primary Label');
+    $labelField->setAttribute('maxlength', 45);
   }
 
 }


### PR DESCRIPTION
## Overview
The name of the Case Type Category is used also for creating a menu, that is displayed on the panel later. We need to limit the max possible length to assign to this name, since can cause visual problems if it is too long.

## Before
The field for the Category Name allowed a maximum of 512 characters. Assigning a big number (greater than 200 hundred) cause additional errors, but just with more than 50 characters it is possible to visually break the interface.

## After
The frontend is limiting the length to 45 characters (using the maxLength attribute)
![image](https://user-images.githubusercontent.com/74304572/118258929-a93ab800-b4da-11eb-8955-8fda2d8f3a48.png)

## Comments
The "Secondary label" is already limited to 45 characters. 
These changes only affects the Case Type Category options.
**Update:**  Secondary label was not limited to 45 characters, I have updated that now. The `size` attribute was 45, which is related to the input size not length of the text.