### PR TITLE
CPS-577: Include Inactive RelationshipTypes on View

### DIFF
--- a/ang/civicase-base.ang.php
+++ b/ang/civicase-base.ang.php
@@ -147,7 +147,6 @@ function set_case_types_to_js_vars(&$options) {
  */
 function set_relationship_types_to_js_vars(&$options) {
   $result = civicrm_api3('RelationshipType', 'get', [
-    'is_active' => 1,
     'options' => ['limit' => 0],
   ]);
   $options['relationshipTypes'] = $result['values'];

--- a/ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html
+++ b/ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html
@@ -115,13 +115,13 @@
     <tbody class="civicase__people-tab__table-body">
       <tr
         class="contact--{{role.contact_id}}"
-        ng-class="{unassigned: !role.contact_id}"
+        ng-class="{unassigned: !role.contact_id, 'ui-state-disabled': role.relationship_is_active === '0'}"
         ng-form="roleForm"
         ng-if="!roles.isLoading"
         ng-repeat="role in roles.list track by $index"
       >
         <td class="civicase__people-tab__table-column civicase__people-tab__table-column--first">
-          <span ng-if="role.contact_id" class="civicase__checkbox" >
+          <span ng-if="role.contact_id && role.relationship_is_active !== '0'" class="civicase__checkbox" >
             <input
               id="select-role-{{ $index }}"
               class="civicase__people-tab__table-checkbox"
@@ -190,7 +190,7 @@
             <i class="fa fa-user-plus"></i>
           </button>
           <div
-            ng-if="(role.is_active === '1' || role.is_client === '1') && role.contact_id"
+            ng-if="(role.is_active === '1' || role.is_client === '1') && role.contact_id && role.relationship_is_active !== '0'"
             class="btn-group btn-group-sm">
             <button
               type="button"

--- a/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
+++ b/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
@@ -155,6 +155,7 @@
               relationship_type_id: caseTypeRole.relationship_type_id,
               role: caseTypeRole.role,
               relationship: caseRelation,
+              relationship_is_active: relTypes[caseTypeRole.relationship_type_id].is_active,
               previousValues: {
                 end_date: caseRelation.end_date,
                 start_date: caseRelation.start_date
@@ -166,7 +167,8 @@
           caseRoles.push({
             description: caseTypeRole.description,
             relationship_type_id: caseTypeRole.relationship_type_id,
-            role: caseTypeRole.role
+            role: caseTypeRole.role,
+            relationship_is_active: relTypes[caseTypeRole.relationship_type_id].is_active
           });
         }
       });


### PR DESCRIPTION
## Overview
This PR solves two problems observed on the Manage Cases screen, related to inactive Relationship Types on some of the listed cases.
The problem is visible while trying to send bulk emails on a selected group of cases, and also while accessing the People's tab.

### Steps for reproducing the error
We should have a `Case Type` with a RelationshipType assigned, like "MyRelationshipTest A B" on the screenshot:
![image](https://user-images.githubusercontent.com/74304572/118478217-d0db8b80-b739-11eb-821e-e807e8cf1653.png)

And that relationship should have been disabled:
![image](https://user-images.githubusercontent.com/74304572/118478428-113b0980-b73a-11eb-90ed-8e3a9d663d68.png)


## Before
When the action "Email - Send Now" is selected, this error is displayed:
![image](https://user-images.githubusercontent.com/74304572/118478919-a211e500-b73a-11eb-9a86-72a904b07b0b.png)

Also, accessing People's tab on a case of the specific Case Type display errors:
![image](https://user-images.githubusercontent.com/74304572/118479098-cff72980-b73a-11eb-9476-6b0b038afc72.png)


## After
After clicking on  "Email - Send Now" action, the expected windows is displayed:
![image](https://user-images.githubusercontent.com/74304572/118497062-ead39900-b74e-11eb-8bbd-d8e79d04e321.png)

Also, people's tab is accessible. The disabled relationship type is shown in a special way, indicating that is not available for being replaced or assigned (this was discussed and agreed with a PM).
![image](https://user-images.githubusercontent.com/74304572/118684584-8b4bbb00-b82c-11eb-9ee1-66340aed04a7.png)


## Technical Details
We are making available on the case roles array the status (`is_active`) of the related `RelationshipType`. 
We are interested in treating in a special way the types that were specifically made inactive, that's why we ask for `!=='0'`  later in the logic.