### PR TITLE
CPS-609: Fix Case Custom Field Tokens Not Being Replaced In Emails

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/TokenTree.php
+++ b/CRM/Civicase/Hook/BuildForm/TokenTree.php
@@ -403,6 +403,7 @@ class CRM_Civicase_Hook_BuildForm_TokenTree {
         $this->addCustomTokens($newTokenTree, self::RECIPIENT_TOKEN_TEXT, $token);
       }
       elseif (strpos($token['id'], 'case.custom_') !== FALSE) {
+        $token['id'] = str_replace('case.custom_', 'case_cf.custom_', $token['id']);
         $this->addCustomTokens($newTokenTree, self::CASE_TOKEN_TEXT, $token);
       }
       else {

--- a/CRM/Civicase/Hook/Tokens/AddCaseCustomFieldsTokenValues.php
+++ b/CRM/Civicase/Hook/Tokens/AddCaseCustomFieldsTokenValues.php
@@ -89,7 +89,7 @@ class CRM_Civicase_Hook_Tokens_AddCaseCustomFieldsTokenValues {
     // so it can be evaluated for the case_cf category when token is replaced.
     $customValuesNew = [];
     foreach ($customValues as $key => $customValue) {
-      $customValuesNew['case_cf.' . $key] = $customValue;
+      $customValuesNew['case_cf.' . $key] = $this->caseTokenValuesHelper->getTokenReplacementValue($key, $customValues);
     }
 
     foreach ($cids as $cid) {

--- a/CRM/Civicase/Hook/Tokens/AddCaseCustomFieldsTokenValues.php
+++ b/CRM/Civicase/Hook/Tokens/AddCaseCustomFieldsTokenValues.php
@@ -1,0 +1,113 @@
+<?php
+
+use CRM_Civicase_Hook_Tokens_Helper_CaseTokenValues as CaseTokenValuesHelper;
+
+/**
+ * Class for adding case custom fields token values.
+ */
+class CRM_Civicase_Hook_Tokens_AddCaseCustomFieldsTokenValues {
+
+  /**
+   * Case Id.
+   *
+   * @var int|null
+   *   Case Id.
+   */
+  private $caseId;
+
+  /**
+   * Case Token Values helper.
+   *
+   * @var \CRM_Civicase_Hook_Tokens_Helper_CaseTokenValues
+   *   Case Custom field helper.
+   */
+  private $caseTokenValuesHelper;
+
+  /**
+   * Sets required class properties.
+   *
+   * @param \CRM_Civicase_Hook_Tokens_Helper_CaseTokenValues $caseTokenValuesHelper
+   *   Case token values helper.
+   */
+  public function __construct(CaseTokenValuesHelper $caseTokenValuesHelper) {
+    $this->caseTokenValuesHelper = $caseTokenValuesHelper;
+  }
+
+  /**
+   * Sets case custom field token values.
+   *
+   * @param array $values
+   *   Token values.
+   * @param array $cids
+   *   Contact ids.
+   * @param int $job
+   *   Job id.
+   * @param array $tokens
+   *   Available tokens.
+   * @param string $context
+   *   Context name.
+   */
+  public function run(array &$values, array $cids, $job, array $tokens, $context) {
+    $this->caseId = $this->caseTokenValuesHelper->getCaseId($values);
+    if (!$this->shouldRun($tokens)) {
+      return;
+    }
+
+    $this->setCaseCustomFieldTokenValues($values, $cids, $tokens);
+  }
+
+  /**
+   * Sets case custom field values.
+   *
+   * Normally we would not do this but there is an issue of a mysql max table
+   * join error on a site with a lot of case custom fields enabled.
+   * To fix that this class CRM_Civicase_Event_Listener_CaseCustomFields was
+   * created to prevent the loading of custom fields for cases without the
+   * specific custom fields being passed. However, when replacing tokens for
+   * sent emails, Civi expects the Case.get call to also return the case custom
+   * fields with the other case parameters when no return value is specified.
+   *
+   * This function replaces the case custom fields token values as civi is
+   * not able to do the values replacement because of the custom change we made
+   * to avoid the 61 max table join error.
+   *
+   * @param array $values
+   *   Token values.
+   * @param array $cids
+   *   Contact ids.
+   * @param array $tokens
+   *   Available tokens.
+   */
+  private function setCaseCustomFieldTokenValues(array &$values, array $cids, array $tokens) {
+    $customValues = $this->caseTokenValuesHelper->getCustomFieldValues($this->caseId, $tokens['case_cf']);
+    if (empty($customValues)) {
+      return;
+    }
+    unset($customValues['id']);
+
+    // We need to prepend the token category 'case_cf' to the custom field key
+    // so it can be evaluated for the case_cf category when token is replaced.
+    $customValuesNew = [];
+    foreach ($customValues as $key => $customValue) {
+      $customValuesNew['case_cf.' . $key] = $customValue;
+    }
+
+    foreach ($cids as $cid) {
+      $values[$cid] = array_merge($values[$cid], $customValuesNew);
+    }
+  }
+
+  /**
+   * Decides whether the hook should run or not.
+   *
+   * @param array $tokens
+   *   Available tokens.
+   *
+   * @return bool
+   *   Whether this hook should run or not.
+   */
+  private function shouldRun(array $tokens) {
+    return !empty($this->caseId) && !empty($tokens['case_cf']);
+  }
+
+}

--- a/CRM/Civicase/Hook/Tokens/AddCaseTokenCategory.php
+++ b/CRM/Civicase/Hook/Tokens/AddCaseTokenCategory.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Add Case token category class.
+ */
+class CRM_Civicase_Hook_Tokens_AddCaseTokenCategory {
+
+  /**
+   * Sets Case Token Category.
+   *
+   * @param array $tokens
+   *   Available tokens.
+   */
+  public function run(array &$tokens) {
+    if (!$this->shouldRun($tokens)) {
+      return;
+    }
+
+    $this->setCaseTokenCategory($tokens);
+  }
+
+  /**
+   * Sets Case Token Category.
+   *
+   * Without this function, the token values added in
+   * AddCaseCustomFieldsTokenValues class will not be replaced.
+   * Because the token values are added as part of the case category tokens
+   * included within contact tokens, Civi will fetch the array keys of
+   * the $tokens to use that to determine the token categories present, hence
+   * the reason why we are adding the case_cf token category. No need to set
+   * any tokens for this category, just the key is enough.
+   *
+   * @param array $tokens
+   *   Available tokens.
+   */
+  private function setCaseTokenCategory(array &$tokens) {
+    $tokens['case_cf'][''] = '';
+  }
+
+  /**
+   * Decides whether the hook should run or not.
+   *
+   * @param array $tokens
+   *   Available tokens.
+   *
+   * @return bool
+   *   Whether this hook should run or not.
+   */
+  private function shouldRun(array $tokens) {
+    return !isset($tokens['case_cf']);
+  }
+
+}

--- a/CRM/Civicase/Hook/Tokens/Helper/CaseTokenValues.php
+++ b/CRM/Civicase/Hook/Tokens/Helper/CaseTokenValues.php
@@ -24,6 +24,25 @@ class CRM_Civicase_Hook_Tokens_Helper_CaseTokenValues {
   }
 
   /**
+   * Returns the value for the custom field token.
+   *
+   * We are using the civicrm replacement function here because
+   * it takes care of complex replacement such as values for checkboxes,
+   * multi-selects and radio fields.
+   *
+   * @param string $token
+   *   Token to get replacement value for.
+   * @param array $customFieldValues
+   *   Array of custom field keys and values.
+   *
+   * @return string
+   *   Token replacement value.
+   */
+  public function getTokenReplacementValue($token, array $customFieldValues) {
+    return CRM_Utils_Token::getApiTokenReplacement('case', $token, $customFieldValues);
+  }
+
+  /**
    * Returns the case Id.
    *
    * Returns NULL if no case id is found. Means it is not a case related

--- a/CRM/Civicase/Hook/Tokens/Helper/CaseTokenValues.php
+++ b/CRM/Civicase/Hook/Tokens/Helper/CaseTokenValues.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * CaseCustomFieldValues helper class.
+ */
+class CRM_Civicase_Hook_Tokens_Helper_CaseTokenValues {
+
+  /**
+   * Get case custom field values.
+   *
+   * @param int $caseId
+   *   Case ID.
+   * @param array $customFieldNames
+   *   Custom field names.
+   *
+   * @return array
+   *   Case custom field values
+   */
+  public function getCustomFieldValues($caseId, array $customFieldNames) {
+    return civicrm_api3('Case', 'getsingle', [
+      'return' => $customFieldNames,
+      'id' => $caseId,
+    ]);
+  }
+
+  /**
+   * Returns the case Id.
+   *
+   * Returns NULL if no case id is found. Means it is not a case related
+   * form or page in that instance.
+   *
+   * @param array $contactTokenValues
+   *   Contact token values.
+   *
+   * @return int|null
+   *   Case Id.
+   */
+  public function getCaseId(array $contactTokenValues) {
+    $caseId = CRM_Utils_Request::retrieve('caseid', 'Positive');
+    if (!empty($caseId)) {
+      return $caseId;
+    }
+
+    if (!empty($_POST['entryURL'])) {
+      $urlParams = parse_url(htmlspecialchars_decode($_POST['entryURL']), PHP_URL_QUERY);
+      parse_str($urlParams, $urlParams);
+
+      if (!empty($urlParams['caseid'])) {
+        return $urlParams['caseid'];
+      }
+    }
+
+    if (!empty($contactTokenValues)) {
+      $caseContactData = current($contactTokenValues);
+      if (!empty($caseContactData['case.id'])) {
+        return $caseContactData['case.id'];
+      }
+    }
+
+    return NULL;
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -409,6 +409,7 @@ function civicase_civicrm_tokens(&$tokens) {
   $contactCustomFieldsService = new CRM_Civicase_Service_ContactCustomFieldsProvider();
   $hooks = [
     new CRM_Civicase_Hook_Tokens_AddContactTokens($contactFieldsService, $contactCustomFieldsService),
+    new CRM_Civicase_Hook_Tokens_AddCaseTokenCategory(),
   ];
   foreach ($hooks as &$hook) {
     $hook->run($tokens);
@@ -421,8 +422,10 @@ function civicase_civicrm_tokens(&$tokens) {
 function civicase_civicrm_tokenValues(&$values, $cids, $job = NULL, $tokens = [], $context = NULL) {
   $contactFieldsService = new CRM_Civicase_Service_ContactFieldsProvider();
   $contactCustomFieldsService = new CRM_Civicase_Service_ContactCustomFieldsProvider();
+  $caseTokenValuesHelper = new CRM_Civicase_Hook_Tokens_Helper_CaseTokenValues();
   $hooks = [
     new CRM_Civicase_Hook_Tokens_AddContactTokensValues($contactFieldsService, $contactCustomFieldsService),
+    new CRM_Civicase_Hook_Tokens_AddCaseCustomFieldsTokenValues($caseTokenValuesHelper),
   ];
   foreach ($hooks as &$hook) {
     $hook->run($values, $cids, $job, $tokens, $context);

--- a/tests/phpunit/CRM/Civicase/Hook/BuildForm/TokenTreeTest.php
+++ b/tests/phpunit/CRM/Civicase/Hook/BuildForm/TokenTreeTest.php
@@ -280,7 +280,7 @@ class CRM_Civicase_Hook_BuildForm_TokenTreeTest extends BaseHeadlessTest {
       $newTokenTree[TokenTree::CASE_TOKEN_TEXT]['children'][0]['children'][0]['text']
     );
     $this->assertEquals(
-      '{case.custom_' . $this->caseCustomField[0]['id'] . '}',
+      '{case_cf.custom_' . $this->caseCustomField[0]['id'] . '}',
       $newTokenTree[TokenTree::CASE_TOKEN_TEXT]['children'][1]['children'][0]['children'][0]['id']
     );
     $this->assertEquals(
@@ -288,7 +288,7 @@ class CRM_Civicase_Hook_BuildForm_TokenTreeTest extends BaseHeadlessTest {
       $newTokenTree[TokenTree::CASE_TOKEN_TEXT]['children'][1]['children'][0]['children'][0]['text']
     );
     $this->assertEquals(
-      '{case.custom_' . $this->caseCustomField[1]['id'] . '}',
+      '{case_cf.custom_' . $this->caseCustomField[1]['id'] . '}',
       $newTokenTree[TokenTree::CASE_TOKEN_TEXT]['children'][1]['children'][0]['children'][1]['id']
     );
     $this->assertEquals(

--- a/tests/phpunit/CRM/Civicase/Hook/Tokens/AddCaseCustomFieldsTokenValuesTest.php
+++ b/tests/phpunit/CRM/Civicase/Hook/Tokens/AddCaseCustomFieldsTokenValuesTest.php
@@ -78,10 +78,29 @@ class CRM_Civicase_Hook_Tokens_AddCaseCustomFieldsTokenValuesTest extends BaseHe
    */
   private function getCaseTokenValuesHelperHelperMock(array $customFieldValues, $caseId) {
     $caseCustomFieldValuesHelper = $this->getMockBuilder(CaseTokenValuesHelper::class)
-      ->setMethods(['getCustomFieldValues', 'getCaseId'])
+      ->setMethods(
+        [
+          'getCustomFieldValues',
+          'getCaseId',
+          'getTokenReplacementValue',
+        ]
+      )
       ->getMock();
     $caseCustomFieldValuesHelper->method('getCustomFieldValues')->willReturn($customFieldValues);
     $caseCustomFieldValuesHelper->method('getCaseId')->willReturn($caseId);
+    $returnValueMap = [];
+
+    foreach ($customFieldValues as $customField => $customFieldValue) {
+      $returnValueMap[] = [
+        $customField,
+        $customFieldValues,
+        $customFieldValues[$customField],
+      ];
+    }
+
+    $caseCustomFieldValuesHelper->method('getTokenReplacementValue')->will(
+      $this->returnValueMap($returnValueMap)
+    );
 
     return $caseCustomFieldValuesHelper;
   }

--- a/tests/phpunit/CRM/Civicase/Hook/Tokens/AddCaseCustomFieldsTokenValuesTest.php
+++ b/tests/phpunit/CRM/Civicase/Hook/Tokens/AddCaseCustomFieldsTokenValuesTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use CRM_Civicase_Hook_Tokens_Helper_CaseTokenValues as CaseTokenValuesHelper;
+use CRM_Civicase_Hook_Tokens_AddCaseCustomFieldsTokenValues as AddCaseCustomFieldsTokenValueHook;
+
+/**
+ * Add CaseCustomFieldsTokenValues Test class.
+ *
+ * @group headless
+ */
+class CRM_Civicase_Hook_Tokens_AddCaseCustomFieldsTokenValuesTest extends BaseHeadlessTest {
+
+  /**
+   * Test case custom field token values are added.
+   *
+   * @group headless
+   */
+  public function testCustomFieldTokenValuesAreAddedWhenCaseIdIsPresent() {
+    $caseCustomFieldValues = [
+      'custom_10' => 'This is it',
+      'custom_99' => 123,
+      'custom_50' => 'data',
+    ];
+    $customValuesNew = [];
+    foreach ($caseCustomFieldValues as $key => $customValue) {
+      $customValuesNew['case_cf.' . $key] = $customValue;
+    }
+
+    $caseId = 1;
+    $caseTokenValuesHelper = $this->getCaseTokenValuesHelperHelperMock($caseCustomFieldValues, $caseId);
+    $addCaseCustomFieldsTokenValueHook = new AddCaseCustomFieldsTokenValueHook($caseTokenValuesHelper);
+
+    $cid = 1;
+    $values[$cid] = ['contact_id' => 5, 'display_name' => 'Sample'];
+    $tokens['case_cf'] = array_merge(
+      array_keys($caseCustomFieldValues),
+      ['subject', 'name']
+    );
+    $expectedResult = array_merge($values[$cid], $customValuesNew);
+    $addCaseCustomFieldsTokenValueHook->run($values, [$cid], 0, $tokens, NULL);
+
+    $this->assertEquals($expectedResult, $values[$cid]);
+  }
+
+  /**
+   * Test the values array is not tampered with.
+   */
+  public function testValuesNotChangedWhenCaseIdNotFound() {
+    $caseCustomFieldValues = [
+      'custom_10' => 'This is it',
+    ];
+
+    $caseCustomFieldValuesHelper = $this->getCaseTokenValuesHelperHelperMock($caseCustomFieldValues, NULL);
+    $addCaseCustomFieldsTokenValueHook = new AddCaseCustomFieldsTokenValueHook($caseCustomFieldValuesHelper);
+
+    $cid = 1;
+    $expected = ['contact_id' => 5, 'display_name' => 'Sample'];
+    $values[$cid] = $expected;
+    $tokens['case'] = array_merge(
+      array_keys($caseCustomFieldValues),
+      ['subject', 'name']
+    );
+    $addCaseCustomFieldsTokenValueHook->run($values, [$cid], 0, $tokens, NULL);
+
+    $this->assertEquals($expected, $values[$cid]);
+  }
+
+  /**
+   * Get mock object for case token values helper.
+   *
+   * @param array $customFieldValues
+   *   Custom field values to return.
+   * @param int $caseId
+   *   Case ID.
+   *
+   * @return \PHPUnit_Framework_MockObject_MockObject
+   *   Mock object.
+   */
+  private function getCaseTokenValuesHelperHelperMock(array $customFieldValues, $caseId) {
+    $caseCustomFieldValuesHelper = $this->getMockBuilder(CaseTokenValuesHelper::class)
+      ->setMethods(['getCustomFieldValues', 'getCaseId'])
+      ->getMock();
+    $caseCustomFieldValuesHelper->method('getCustomFieldValues')->willReturn($customFieldValues);
+    $caseCustomFieldValuesHelper->method('getCaseId')->willReturn($caseId);
+
+    return $caseCustomFieldValuesHelper;
+  }
+
+}

--- a/tests/phpunit/CRM/Civicase/Hook/Tokens/Helper/CaseTokenValuesTest.php
+++ b/tests/phpunit/CRM/Civicase/Hook/Tokens/Helper/CaseTokenValuesTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use CRM_Civicase_Hook_Tokens_Helper_CaseTokenValues as CaseTokenValuesHelper;
+
+/**
+ * CaseTokenValues Test class.
+ *
+ * @group headless
+ */
+class CRM_Civicase_Hook_Tokens_Helper_CaseTokenValuesTest extends BaseHeadlessTest {
+
+  /**
+   * Test case id can be gotten from URL.
+   */
+  public function testGetCaseIdReturnsCorrectlyWhenPresentInUrl() {
+    $caseId = 1;
+    $_REQUEST['caseid'] = $caseId;
+    $caseTokenValuesHelper = new CaseTokenValuesHelper();
+    $this->assertEquals($caseId, $caseTokenValuesHelper->getCaseId([]));
+  }
+
+  /**
+   * Test case id can be gotten from entry URL.
+   */
+  public function testGetCaseIdReturnsCorrectlyWhenPresentInEntryUrl() {
+    $caseId = 1;
+    $_REQUEST['entryUrl'] = 'civicrm/test?caseid=' . $caseId;
+    $caseTokenValuesHelper = new CaseTokenValuesHelper();
+    $this->assertEquals($caseId, $caseTokenValuesHelper->getCaseId([]));
+  }
+
+  /**
+   * Test case Id can be gotten from token values.
+   */
+  public function testGetCaseIdReturnsCorrectlyWhenPresentInToken() {
+    $caseId = 1;
+    $tokenValues[] = ['case.id' => $caseId];
+    $caseTokenValuesHelper = new CaseTokenValuesHelper();
+    $this->assertEquals($caseId, $caseTokenValuesHelper->getCaseId($tokenValues));
+  }
+
+}


### PR DESCRIPTION
## Overview
When creating an Email activity for a case and case custom field tokens are selected, when the Email is sent, neither the actual token or replaced token values are present in the Email.  More like the token was replaced with an empty string.

## Before
The issue described above exists.

## After
The issue described no longer exists. Now when Emails are sent with case custom fields tokens present. The tokens are replaced properly with the appropriate values.

## Technical Details
This PR: https://github.com/compucorp/uk.co.compucorp.civicase/pull/749 fixes an issue that causes an error of Max table join on a site that has many Case custom fields enabled. The fix was to prevent default loading of all the custom fields for a Case and rather encourage on demand loading. However, when sending emails, Civi uses the [Case.getsingle function](https://github.com/civicrm/civicrm-core/blob/master/CRM/Utils/Token.php#L1627) to fetch a case data and expects that the case custom fields will be part of this data, since this data will not be returned based on the previous fix, the token values are replaced with an empty string. 

Since we don't want to revert the fix for the Max table join issue, this PR fixes this token replacement issue by [moving ](https://github.com/compucorp/uk.co.compucorp.civicase/blob/4c8f330ade2537621efa6cb0a14ac1345ef62460/CRM/Civicase/Hook/BuildForm/TokenTree.php#L406)case custom fields to a new token category `case_cf` (Short for Case Custom Fields). 

The `CRM_Civicase_Hook_Tokens_AddCaseCustomFieldsTokenValues` class was created to replace the provide the token values for the case custom fields under the new `case_cf` token category and the `CRM_Civicase_Hook_Tokens_AddCaseTokenCategory`  class  was created to inject the `case_cf` token category so that Civi recognises it as a token category and proper token replacement is done.

## Update
After testing the fix applied in this ticket, token values for case custom fields that are checkboxes, radio or select dropdowns were replaced with the values of these fields rather than the labels. To fix this, we use the same function that Civi uses for token value replacement, this function already takes care of cases like this and is able to replace fields with multivalues with appropriate labels. 
Ref [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Utils/Token.php#L1603-L1606).