### PR TITLE
RSESPRT-45: Fix Limitation Between Custom Groups and Custom Types

### DIFF
--- a/CRM/Civicase/Helper/InstanceCustomGroupPostProcess.php
+++ b/CRM/Civicase/Helper/InstanceCustomGroupPostProcess.php
@@ -64,6 +64,7 @@ class CRM_Civicase_Helper_InstanceCustomGroupPostProcess {
       'extends' => 'Case',
       'extends_entity_column_id' => $caseCategoryId,
       'extends_entity_column_value' => ['NOT LIKE' => '%' . CRM_Core_DAO::VALUE_SEPARATOR . $caseTypeId . CRM_Core_DAO::VALUE_SEPARATOR . '%'],
+      'options' => ['limit' => 0],
     ]);
 
     // API above will not fetch results for when
@@ -72,6 +73,7 @@ class CRM_Civicase_Helper_InstanceCustomGroupPostProcess {
       'extends' => 'Case',
       'extends_entity_column_id' => $caseCategoryId,
       'extends_entity_column_value' => ['IS NULL' => 1],
+      'options' => ['limit' => 0],
     ]);
 
     return array_merge($customGroupsWithoutCurrentCaseType['values'], $customGroupsWithNullCaseType['values']);
@@ -102,6 +104,7 @@ class CRM_Civicase_Helper_InstanceCustomGroupPostProcess {
       'extends' => 'Case',
       'extends_entity_column_id' => ['NOT IN' => [$caseCategoryId]],
       'extends_entity_column_value' => ['LIKE' => '%' . CRM_Core_DAO::VALUE_SEPARATOR . $caseTypeId . CRM_Core_DAO::VALUE_SEPARATOR . '%'],
+      'options' => ['limit' => 0],
     ]);
 
     return $result['values'];

--- a/CRM/Civicase/Helper/InstanceCustomGroupPostProcess.php
+++ b/CRM/Civicase/Helper/InstanceCustomGroupPostProcess.php
@@ -19,6 +19,7 @@ class CRM_Civicase_Helper_InstanceCustomGroupPostProcess {
       'sequential' => 1,
       'return' => ['id'],
       'case_type_category' => $caseTypeCategoryId,
+      'options' => ['limit' => 0],
     ]);
 
     return array_column($result['values'], 'id');


### PR DESCRIPTION
## Overview
This PR solves a limitation between the number of Case Types and Custom Groups associations.

## Before
If you have more than 25 Case Types created:
![image](https://user-images.githubusercontent.com/74304572/119313785-249c2680-bc9e-11eb-96ef-12e5f3b99914.png)
only the first 25 appears associated to a Custom Group:
![image](https://user-images.githubusercontent.com/74304572/119313832-3251ac00-bc9e-11eb-84b7-b6de97079fb9.png)

Also, the inverse limitation existed: If you have more than 25 Custom Groups associated with Case Types, only the first 25 Groups get updated when a new Case Type is created.


## After
All the Case Types are associated with the given Group:
![image](https://user-images.githubusercontent.com/74304572/119314161-9bd1ba80-bc9e-11eb-9f2c-cb9ad1266544.png)

And also the inverse situation was fixed: when a new Case Type is added, all the groups are updated.

## Technical Details
The situation is solved by removing the limitation on the associated number of entities to return in the respective API call, for CustomGroups of CaseTypes.


