### PR TITLE
Remove reference to undefined variable

### DIFF
--- a/ang/workflow.ang.php
+++ b/ang/workflow.ang.php
@@ -43,7 +43,6 @@ return [
     'css/*.css',
   ],
   'js' => get_workflow_js_files(),
-  'settings' => $options,
   'requires' => $requires,
   'partials' => [
     'ang/workflow',


### PR DESCRIPTION
## Overview
Removes reference to an undefined variable.

## Before
PHP Error

## After
Fixed

## Technical Details
`$options` variable is never defined and seems to have been introduced via copy/paste.

