### PR TITLE
CPS-432: Fix ts function usage

### DIFF
--- a/CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+++ b/CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_Civicase_ExtensionUtil as E;
+
 /**
  * Trait CRM_Extendedreport_Form_Report_ColumnDefinitionTrait.
  *
@@ -38,17 +40,17 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
     $spec = [
       'id' => [
         'name' => 'id',
-        'title' => ts('Activity ID'),
+        'title' => E::ts('Activity ID'),
         'is_group_bys' => $options['group_by'],
         'is_fields' => TRUE,
       ],
       'source_record_id' => [
         'name' => 'source_record_id',
-        'title' => ts('Source Record ID'),
+        'title' => E::ts('Source Record ID'),
         'is_fields' => TRUE,
       ],
       'activity_type_id' => [
-        'title' => ts('Activity Type'),
+        'title' => E::ts('Activity Type'),
         'alter_display' => 'alterActivityType',
         'is_fields' => TRUE,
         'is_filters' => TRUE,
@@ -59,7 +61,7 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
         'type' => CRM_Utils_Type::T_INT,
       ],
       'subject' => [
-        'title' => ts('Subject'),
+        'title' => E::ts('Subject'),
         'name' => 'subject',
         'is_fields' => TRUE,
         'is_filters' => TRUE,
@@ -71,7 +73,7 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
 
       ],
       'activity_date_time' => [
-        'title' => ts('Activity Date'),
+        'title' => E::ts('Activity Date'),
         'default' => TRUE,
         'name' => 'activity_date_time',
         'operatorType' => CRM_Report_Form::OP_DATE,
@@ -81,7 +83,7 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
         'is_order_bys' => TRUE,
       ],
       'status_id' => [
-        'title' => ts('Activity Status'),
+        'title' => E::ts('Activity Status'),
         'name' => 'status_id',
         'type' => CRM_Utils_Type::T_STRING,
         'alter_display' => 'alterPseudoConstant',
@@ -98,13 +100,13 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
         ],
       ],
       'duration' => [
-        'title' => ts('Activity Duration'),
+        'title' => E::ts('Activity Duration'),
         'name' => 'duration',
         'is_fields' => TRUE,
         'is_filters' => TRUE,
       ],
       'details' => [
-        'title' => ts('Activity Details'),
+        'title' => E::ts('Activity Details'),
         'is_fields' => TRUE,
         'is_filters' => TRUE,
         'type' => CRM_Utils_Type::T_TEXT,
@@ -116,7 +118,7 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
 
       ],
       'result' => [
-        'title' => ts('Activity Result'),
+        'title' => E::ts('Activity Result'),
         'is_fields' => TRUE,
         'is_filters' => TRUE,
         'type' => CRM_Utils_Type::T_TEXT,
@@ -129,7 +131,7 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       'is_current_revision' => [
         'type' => CRM_Utils_Type::T_BOOLEAN,
         'operatorType' => CRM_Report_Form::OP_SELECT,
-        'title' => ts("Current Revision"),
+        'title' => E::ts("Current Revision"),
         'name' => 'is_current_revision',
         'options' => ['' => '- select -', '1' => 'Yes', '0' => 'No'],
         'is_filters' => TRUE,
@@ -137,7 +139,7 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       'is_deleted' => [
         'type' => CRM_Report_Form::OP_INT,
         'operatorType' => CRM_Report_Form::OP_SELECT,
-        'title' => ts("Is activity deleted"),
+        'title' => E::ts("Is activity deleted"),
         'name' => 'is_deleted',
         'options' => ['' => '- select -', '0' => 'No', '1' => 'Yes'],
         'is_filters' => TRUE,
@@ -166,19 +168,19 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       'civicrm_case' => [
         'fields' => [
           'id' => [
-            'title' => ts('Case ID'),
+            'title' => E::ts('Case ID'),
             'name' => 'id',
             'is_fields' => TRUE,
             'is_filters' => TRUE,
           ],
           'subject' => [
-            'title' => ts('Case Subject'),
+            'title' => E::ts('Case Subject'),
             'default' => TRUE,
             'is_fields' => TRUE,
             'is_filters' => TRUE,
           ],
           'status_id' => [
-            'title' => ts('Case Status'),
+            'title' => E::ts('Case Status'),
             'default' => TRUE,
             'name' => 'status_id',
             'is_fields' => TRUE,
@@ -189,7 +191,7 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
             'type' => CRM_Utils_Type::T_INT,
           ],
           'case_type_id' => [
-            'title' => ts('Case Type'),
+            'title' => E::ts('Case Type'),
             'is_fields' => TRUE,
             'is_filters' => TRUE,
             'alter_display' => 'alterGenericSelect',
@@ -199,7 +201,7 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
             'type' => CRM_Utils_Type::T_INT,
           ],
           'start_date' => [
-            'title' => ts('Case Start Date'),
+            'title' => E::ts('Case Start Date'),
             'name' => 'start_date',
             'operatorType' => CRM_Report_Form::OP_DATE,
             'type' => CRM_Utils_Type::T_DATE,
@@ -207,7 +209,7 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
             'is_filters' => TRUE,
           ],
           'end_date' => [
-            'title' => ts('Case End Date'),
+            'title' => E::ts('Case End Date'),
             'name' => 'end_date',
             'is_fields' => TRUE,
             'is_filters' => TRUE,
@@ -216,7 +218,7 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
           ],
           'created_date' => [
             'name' => 'created_date',
-            'title' => ts('Case Created Date'),
+            'title' => E::ts('Case Created Date'),
             'operatorType' => CRM_Report_Form::OP_DATE,
             'type' => CRM_Utils_Type::T_DATE,
             'is_fields' => TRUE,
@@ -224,7 +226,7 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
           ],
           'modified_date' => [
             'name' => 'created_date',
-            'title' => ts('Case Modified Date'),
+            'title' => E::ts('Case Modified Date'),
             'operatorType' => CRM_Report_Form::OP_DATE,
             'type' => CRM_Utils_Type::T_DATE,
             'is_fields' => TRUE,
@@ -232,7 +234,7 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
           ],
           'is_deleted' => [
             'name' => 'is_deleted',
-            'title' => ts('Case is in the Trash?'),
+            'title' => E::ts('Case is in the Trash?'),
             'type' => CRM_Utils_Type::T_BOOLEAN,
             'is_fields' => TRUE,
             'is_filters' => TRUE,
@@ -283,16 +285,16 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
     $spec = [
       $options['prefix'] . 'display_name' => [
         'name' => 'display_name',
-        'title' => ts($options['prefix_label'] . 'Contact Name'),
-        'label' => ts('Contact Name'),
+        'title' => $options['prefix_label'] . E::ts('Contact Name'),
+        'label' => E::ts('Contact Name'),
         'is_fields' => TRUE,
         'is_filters' => TRUE,
         'is_order_bys' => TRUE,
       ],
       $options['prefix'] . 'contact_id' => [
         'name' => 'id',
-        'title' => ts($options['prefix_label'] . 'Contact ID'),
-        'label' => ts('Contact ID'),
+        'title' => $options['prefix_label'] . E::ts('Contact ID'),
+        'label' => E::ts('Contact ID'),
         'alter_display' => 'alterContactID',
         'type' => CRM_Utils_Type::T_INT,
         'is_order_bys' => TRUE,
@@ -303,22 +305,22 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       ],
       $options['prefix'] . 'external_identifier' => [
         'name' => 'external_identifier',
-        'title' => ts($options['prefix_label'] . 'External ID'),
-        'label' => ts('External ID'),
+        'title' => $options['prefix_label'] . E::ts('External ID'),
+        'label' => E::ts('External ID'),
         'type' => CRM_Utils_Type::T_INT,
         'is_fields' => TRUE,
       ],
       $options['prefix'] . 'sort_name' => [
         'name' => 'sort_name',
-        'title' => ts($options['prefix_label'] . 'Contact Name (in sort format)'),
-        'label' => ts('Contact Name (in sort format)'),
+        'title' => $options['prefix_label'] . E::ts('Contact Name (in sort format)'),
+        'label' => E::ts('Contact Name (in sort format)'),
         'is_fields' => TRUE,
         'is_filters' => TRUE,
         'is_order_bys' => TRUE,
       ],
       $options['prefix'] . 'contact_type' => [
-        'title' => ts($options['prefix_label'] . 'Contact Type'),
-        'label' => ts('Contact Type'),
+        'title' => $options['prefix_label'] . E::ts('Contact Type'),
+        'label' => E::ts('Contact Type'),
         'name' => 'contact_type',
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'options' => CRM_Contact_BAO_Contact::buildOptions('contact_type'),
@@ -327,8 +329,8 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
         'is_group_bys' => TRUE,
       ],
       $options['prefix'] . 'contact_sub_type' => [
-        'title' => ts($options['prefix_label'] . 'Contact Sub Type'),
-        'label' => ts('Contact Sub Type'),
+        'title' => $options['prefix_label'] . E::ts('Contact Sub Type'),
+        'label' => E::ts('Contact Sub Type'),
         'name' => 'contact_sub_type',
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'options' => CRM_Contact_BAO_Contact::buildOptions('contact_sub_type'),
@@ -340,38 +342,38 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
     $individualFields = [
       $options['prefix'] . 'first_name' => [
         'name' => 'first_name',
-        'title' => ts($options['prefix_label'] . 'First Name'),
-        'label' => ts('First Name'),
+        'title' => $options['prefix_label'] . E::ts('First Name'),
+        'label' => E::ts('First Name'),
         'is_fields' => TRUE,
         'is_filters' => TRUE,
         'is_order_bys' => TRUE,
       ],
       $options['prefix'] . 'middle_name' => [
         'name' => 'middle_name',
-        'title' => ts($options['prefix_label'] . 'Middle Name'),
-        'label' => ts('Middle Name'),
+        'title' => $options['prefix_label'] . E::ts('Middle Name'),
+        'label' => E::ts('Middle Name'),
         'is_fields' => TRUE,
       ],
       $options['prefix'] . 'last_name' => [
         'name' => 'last_name',
-        'title' => ts($options['prefix_label'] . 'Last Name'),
-        'label' => ts('Last Name'),
+        'title' => $options['prefix_label'] . E::ts('Last Name'),
+        'label' => E::ts('Last Name'),
         'is_fields' => TRUE,
         'is_filters' => TRUE,
         'is_order_bys' => TRUE,
       ],
       $options['prefix'] . 'nick_name' => [
         'name' => 'nick_name',
-        'title' => ts($options['prefix_label'] . 'Nick Name'),
-        'label' => ts('Nick Name'),
+        'title' => $options['prefix_label'] . E::ts('Nick Name'),
+        'label' => E::ts('Nick Name'),
         'is_fields' => TRUE,
         'is_filters' => TRUE,
         'is_order_bys' => TRUE,
       ],
       $options['prefix'] . 'gender_id' => [
         'name' => 'gender_id',
-        'title' => ts($options['prefix_label'] . 'Gender'),
-        'label' => ts('Gender'),
+        'title' => $options['prefix_label'] . E::ts('Gender'),
+        'label' => E::ts('Gender'),
         'options' => CRM_Contact_BAO_Contact::buildOptions('gender_id'),
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'alter_display' => 'alterGenderID',
@@ -380,8 +382,8 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       ],
       $options['prefix'] . 'birth_date' => [
         'name' => 'birth_date',
-        'title' => ts($options['prefix_label'] . 'Birth Date'),
-        'label' => ts('Birth Date'),
+        'title' => $options['prefix_label'] . E::ts('Birth Date'),
+        'label' => E::ts('Birth Date'),
         'operatorType' => CRM_Report_Form::OP_DATE,
         'type' => CRM_Utils_Type::T_DATE,
         'is_fields' => TRUE,
@@ -389,16 +391,16 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       ],
       $options['prefix'] . 'age' => [
         'name' => 'age',
-        'title' => ts($options['prefix_label'] . 'Age'),
-        'label' => ts('Age'),
+        'title' => $options['prefix_label'] . E::ts('Age'),
+        'label' => E::ts('Age'),
         'dbAlias' => 'TIMESTAMPDIFF(YEAR, ' . $tableAlias . '.birth_date, CURDATE())',
         'type' => CRM_Utils_Type::T_INT,
         'is_fields' => TRUE,
       ],
       $options['prefix'] . 'do_not_email' => [
         'name' => 'do_not_email',
-        'title' => ts($options['prefix_label'] . 'Do Not Email'),
-        'label' => ts('Do Not Email'),
+        'title' => $options['prefix_label'] . E::ts('Do Not Email'),
+        'label' => E::ts('Do Not Email'),
         'type' => CRM_Utils_Type::T_BOOLEAN,
         'operatorType' => CRM_Report_Form::OP_SELECT,
         'options' => ['' => '- select -', '1' => 'Yes', '0' => 'No'],
@@ -407,8 +409,8 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       ],
       $options['prefix'] . 'do_not_phone' => [
         'name' => 'do_not_phone',
-        'title' => ts($options['prefix_label'] . 'Do Not Phone'),
-        'label' => ts('Do Not Phone'),
+        'title' => $options['prefix_label'] . E::ts('Do Not Phone'),
+        'label' => E::ts('Do Not Phone'),
         'type' => CRM_Utils_Type::T_BOOLEAN,
         'operatorType' => CRM_Report_Form::OP_SELECT,
         'options' => ['' => '- select -', '1' => 'Yes', '0' => 'No'],
@@ -417,8 +419,8 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       ],
       $options['prefix'] . 'do_not_mail' => [
         'name' => 'do_not_mail',
-        'title' => ts($options['prefix_label'] . 'Do Not Mail'),
-        'label' => ts('Do Not Mail'),
+        'title' => $options['prefix_label'] . E::ts('Do Not Mail'),
+        'label' => E::ts('Do Not Mail'),
         'type' => CRM_Utils_Type::T_BOOLEAN,
         'operatorType' => CRM_Report_Form::OP_SELECT,
         'options' => ['' => '- select -', '1' => 'Yes', '0' => 'No'],
@@ -427,8 +429,8 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       ],
       $options['prefix'] . 'do_not_sms' => [
         'name' => 'do_not_sms',
-        'title' => ts($options['prefix_label'] . 'Do Not SMS'),
-        'label' => ts('Do Not SMS'),
+        'title' => $options['prefix_label'] . E::ts('Do Not SMS'),
+        'label' => E::ts('Do Not SMS'),
         'type' => CRM_Utils_Type::T_BOOLEAN,
         'operatorType' => CRM_Report_Form::OP_SELECT,
         'options' => ['' => '- select -', '1' => 'Yes', '0' => 'No'],
@@ -437,8 +439,8 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       ],
       $options['prefix'] . 'do_not_trade' => [
         'name' => 'do_not_trade',
-        'title' => ts($options['prefix_label'] . 'Do Not Trade'),
-        'label' => ts('Do Not Trade'),
+        'title' => $options['prefix_label'] . E::ts('Do Not Trade'),
+        'label' => E::ts('Do Not Trade'),
         'type' => CRM_Utils_Type::T_BOOLEAN,
         'operatorType' => CRM_Report_Form::OP_SELECT,
         'options' => ['' => '- select -', '1' => 'Yes', '0' => 'No'],
@@ -447,8 +449,8 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       ],
       $options['prefix'] . 'is_opt_out' => [
         'name' => 'is_opt_out',
-        'title' => ts($options['prefix_label'] . 'No Bulk Emails (User Opt Out)'),
-        'label' => ts('No Bulk Emails (User Opt Out)'),
+        'title' => $options['prefix_label'] . E::ts('No Bulk Emails (User Opt Out)'),
+        'label' => E::ts('No Bulk Emails (User Opt Out)'),
         'type' => CRM_Utils_Type::T_BOOLEAN,
         'operatorType' => CRM_Report_Form::OP_SELECT,
         'options' => ['' => '- select -', '1' => 'Yes', '0' => 'No'],
@@ -457,8 +459,8 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       ],
       $options['prefix'] . 'preferred_communication_method' => [
         'name' => 'preferred_communication_method',
-        'title' => ts($options['prefix_label'] . 'Preferred Communication Method'),
-        'label' => ts('Preferred Communication Method'),
+        'title' => $options['prefix_label'] . E::ts('Preferred Communication Method'),
+        'label' => E::ts('Preferred Communication Method'),
         'options' => CRM_Contact_BAO_Contact::buildOptions('preferred_communication_method'),
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'alter_display' => 'alterGenericSelect',
@@ -468,8 +470,8 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       ],
       $options['prefix'] . 'preferred_language' => [
         'name' => 'preferred_language',
-        'title' => ts($options['prefix_label'] . 'Preferred Language'),
-        'label' => ts('Preferred Language'),
+        'title' => $options['prefix_label'] . E::ts('Preferred Language'),
+        'label' => E::ts('Preferred Language'),
         'options' => CRM_Contact_BAO_Contact::buildOptions('preferred_language'),
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'alter_display' => 'alterGenericSelect',
@@ -479,8 +481,8 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       ],
       $options['prefix'] . 'preferred_mail_format' => [
         'name' => 'preferred_mail_format',
-        'title' => ts($options['prefix_label'] . 'Preferred Mail Format'),
-        'label' => ts('Preferred Mail Format'),
+        'title' => $options['prefix_label'] . E::ts('Preferred Mail Format'),
+        'label' => E::ts('Preferred Mail Format'),
         'options' => CRM_Contact_BAO_Contact::buildOptions('preferred_mail_format'),
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'alter_display' => 'alterGenericSelect',
@@ -490,8 +492,8 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       ],
       $options['prefix'] . 'prefix_id' => [
         'name' => 'prefix_id',
-        'title' => ts($options['prefix_label'] . 'Individual Prefix'),
-        'label' => ts('Individual Prefix'),
+        'title' => $options['prefix_label'] . E::ts('Individual Prefix'),
+        'label' => E::ts('Individual Prefix'),
         'options' => CRM_Contact_BAO_Contact::buildOptions('prefix_id'),
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'alter_display' => 'alterGenericSelect',
@@ -501,8 +503,8 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       ],
       $options['prefix'] . 'suffix_id' => [
         'name' => 'preferred_mail_format',
-        'title' => ts($options['prefix_label'] . 'Individual Suffix'),
-        'label' => ts('Individual Suffix'),
+        'title' => $options['prefix_label'] . E::ts('Individual Suffix'),
+        'label' => E::ts('Individual Suffix'),
         'options' => CRM_Contact_BAO_Contact::buildOptions('suffix_id'),
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'alter_display' => 'alterGenericSelect',
@@ -512,8 +514,8 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       ],
       $options['prefix'] . 'communication_style_id' => [
         'name' => 'communication_style_id',
-        'title' => ts($options['prefix_label'] . 'Communication Style'),
-        'label' => ts('Communication Style'),
+        'title' => $options['prefix_label'] . E::ts('Communication Style'),
+        'label' => E::ts('Communication Style'),
         'options' => CRM_Contact_BAO_Contact::buildOptions('communication_style_id'),
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'alter_display' => 'alterGenericSelect',
@@ -523,8 +525,8 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       ],
       $options['prefix'] . 'is_deceased' => [
         'name' => 'is_deceased',
-        'title' => ts($options['prefix_label'] . 'Deceased'),
-        'label' => ts('Deceased'),
+        'title' => $options['prefix_label'] . E::ts('Deceased'),
+        'label' => E::ts('Deceased'),
         'type' => CRM_Utils_Type::T_BOOLEAN,
         'operatorType' => CRM_Report_Form::OP_SELECT,
         'options' => ['' => '- select -', '1' => 'Yes', '0' => 'No'],
@@ -533,8 +535,8 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       ],
       $options['prefix'] . 'deceased_date' => [
         'name' => 'deceased_date',
-        'title' => ts($options['prefix_label'] . 'Deceased Date'),
-        'label' => ts('Deceased Date'),
+        'title' => $options['prefix_label'] . E::ts('Deceased Date'),
+        'label' => E::ts('Deceased Date'),
         'operatorType' => CRM_Report_Form::OP_DATE,
         'type' => CRM_Utils_Type::T_DATE,
         'is_fields' => TRUE,
@@ -542,15 +544,15 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       ],
       $options['prefix'] . 'primary_contact_id' => [
         'name' => 'primary_contact_id',
-        'title' => ts($options['prefix_label'] . 'Household Primary Contact ID'),
-        'label' => ts('Household Primary Contact ID'),
+        'title' => $options['prefix_label'] . E::ts('Household Primary Contact ID'),
+        'label' => E::ts('Household Primary Contact ID'),
         'is_fields' => TRUE,
         'is_filters' => TRUE,
       ],
       $options['prefix'] . 'is_deleted' => [
         'name' => 'is_deleted',
-        'title' => ts($options['prefix_label'] . 'Contact is in Trash'),
-        'label' => ts('Contact is in Trash'),
+        'title' => $options['prefix_label'] . E::ts('Contact is in Trash'),
+        'label' => E::ts('Contact is in Trash'),
         'type' => CRM_Utils_Type::T_BOOLEAN,
         'operatorType' => CRM_Report_Form::OP_SELECT,
         'options' => ['' => '- select -', '0' => 'No', '1' => 'Yes'],
@@ -559,8 +561,8 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       ],
       $options['prefix'] . 'created_date' => [
         'name' => 'created_date',
-        'title' => ts($options['prefix_label'] . 'Created Date'),
-        'label' => ts('Created Date'),
+        'title' => $options['prefix_label'] . E::ts('Created Date'),
+        'label' => E::ts('Created Date'),
         'operatorType' => CRM_Report_Form::OP_DATE,
         'type' => CRM_Utils_Type::T_DATE,
         'is_fields' => TRUE,
@@ -568,8 +570,8 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
       ],
       $options['prefix'] . 'modified_date' => [
         'name' => 'modified_date',
-        'title' => ts($options['prefix_label'] . 'Modified Date'),
-        'label' => ts('Modified Date'),
+        'title' => $options['prefix_label'] . E::ts('Modified Date'),
+        'label' => E::ts('Modified Date'),
         'operatorType' => CRM_Report_Form::OP_DATE,
         'type' => CRM_Utils_Type::T_DATE,
         'is_fields' => TRUE,
@@ -618,14 +620,14 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
     $options = array_merge($defaultOptions, $options);
     $activityFields['civicrm_activity']['fields'] = [
       'activity_type_id' => [
-        'title' => ts('Latest Activity Type'),
+        'title' => E::ts('Latest Activity Type'),
         'default' => FALSE,
         'type' => CRM_Utils_Type::T_STRING,
         'alter_display' => 'alterActivityType',
         'is_fields' => TRUE,
       ],
       'activity_date_time' => [
-        'title' => ts('Latest Activity Date'),
+        'title' => E::ts('Latest Activity Date'),
         'default' => FALSE,
         'is_fields' => TRUE,
       ],
@@ -654,7 +656,7 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
     $options = array_merge($defaultOptions, $options);
     $caseTagFields['civicrm_entity_tag']['fields'] = [
       'tag_id' => [
-        'title' => ts('Case Tag'),
+        'title' => E::ts('Case Tag'),
         'is_fields' => TRUE,
         'is_filters' => TRUE,
         'alter_display' => 'alterGenericSelect',

--- a/CRM/Civicase/Form/Report/ExtendedReport.php
+++ b/CRM/Civicase/Form/Report/ExtendedReport.php
@@ -283,20 +283,20 @@ class CRM_Civicase_Form_Report_ExtendedReport extends CRM_Report_Form {
     if ($this->isSupportsContactTab) {
       $this->_options = [
         'contact_dashboard_tab' => [
-          'title' => ts('Display as tab on contact record'),
+          'title' => E::ts('Display as tab on contact record'),
           'type' => 'checkbox',
         ],
         'contact_reportlet' => [
-          'title' => ts('Make available for contact summary page (requires contact layout editor extension)'),
+          'title' => E::ts('Make available for contact summary page (requires contact layout editor extension)'),
           'type' => 'checkbox',
         ],
         'contact_id_filter_field' => [
-          'title' => ts('Select field to use as contact filter'),
+          'title' => E::ts('Select field to use as contact filter'),
           'type' => 'select',
           'options' => $this->getContactFilterFieldOptions(),
         ],
         'number_of_rows_to_render' => [
-          'title' => ts('Override default number of rows with'),
+          'title' => E::ts('Override default number of rows with'),
           'type' => 'text',
         ],
       ];
@@ -351,7 +351,7 @@ class CRM_Civicase_Form_Report_ExtendedReport extends CRM_Report_Form {
       $this->_columns += $this->buildColumns([
         'tagid' => [
           'name' => 'tag_id',
-          'title' => ts('Tag'),
+          'title' => E::ts('Tag'),
           'type' => CRM_Utils_Type::T_INT,
           'tag' => TRUE,
           'operatorType' => CRM_Report_Form::OP_MULTISELECT,
@@ -366,7 +366,7 @@ class CRM_Civicase_Form_Report_ExtendedReport extends CRM_Report_Form {
         ],
       ], 'civicrm_tag', 'CRM_Core_DAO_Tag', 'tag', [], ['no_field_disambiguation' => TRUE]);
     }
-    $this->_columns['civicrm_tag']['group_title'] = ts('Tags');
+    $this->_columns['civicrm_tag']['group_title'] = E::ts('Tags');
   }
 
   /**
@@ -386,7 +386,7 @@ class CRM_Civicase_Form_Report_ExtendedReport extends CRM_Report_Form {
       [
         'gid' => [
           'name' => 'group_id',
-          'title' => ts('Group'),
+          'title' => E::ts('Group'),
           'type' => CRM_Utils_Type::T_INT,
           'operatorType' => CRM_Report_Form::OP_MULTISELECT,
           'group' => TRUE,
@@ -884,7 +884,7 @@ class CRM_Civicase_Form_Report_ExtendedReport extends CRM_Report_Form {
     if ($this->_aggregatesIncludeNULL && !empty($this->_params['fields']['include_null'])) {
       $fieldAlias = "{$fieldName}_null";
       $this->_columnHeaders[$fieldAlias] = [
-        'title' => ts('Unknown'),
+        'title' => E::ts('Unknown'),
         'type' => CRM_Utils_Type::T_INT,
       ];
       $this->_select .= " , SUM( IF (({$dbAlias} IS NULL OR {$dbAlias} = ''), 1, 0)) AS $fieldAlias ";
@@ -935,7 +935,7 @@ class CRM_Civicase_Form_Report_ExtendedReport extends CRM_Report_Form {
   function addAggregateTotal($fieldName) {
     $fieldAlias = "{$fieldName}_total";
     $this->_columnHeaders[$fieldAlias] = [
-      'title' => ts('Total'),
+      'title' => E::ts('Total'),
       'type' => CRM_Utils_Type::T_INT,
     ];
     $this->_select .= " , SUM( IF (1 = 1, 1, 0)) AS $fieldAlias ";
@@ -1262,7 +1262,7 @@ class CRM_Civicase_Form_Report_ExtendedReport extends CRM_Report_Form {
 
       if (!empty($filters) && $filterString == 'filters') {
         $this->tabs['Filters'] = [
-          'title' => ts('Filters'),
+          'title' => E::ts('Filters'),
           'tpl' => 'Filters',
           'div_label' => 'set-filters',
         ];
@@ -1319,12 +1319,12 @@ class CRM_Civicase_Form_Report_ExtendedReport extends CRM_Report_Form {
 
     }
 
-    $this->addCheckBox("fields", ts('Select Columns'), $options, NULL,
+    $this->addCheckBox("fields", E::ts('Select Columns'), $options, NULL,
       NULL, NULL, NULL, $this->_fourColumnAttribute, TRUE
     );
     if (!empty($colGroups)) {
       $this->tabs['FieldSelection'] = [
-        'title' => ts('Columns'),
+        'title' => E::ts('Columns'),
         'tpl' => 'FieldSelection',
         'div_label' => 'col-groups',
       ];
@@ -1366,7 +1366,7 @@ class CRM_Civicase_Form_Report_ExtendedReport extends CRM_Report_Form {
     }
     if (!empty($this->_options)) {
       $this->tabs['ReportOptions'] = [
-        'title' => ts('Display Options'),
+        'title' => E::ts('Display Options'),
         'tpl' => 'ReportOptions',
         'div_label' => 'other-options',
       ];
@@ -1390,7 +1390,7 @@ class CRM_Civicase_Form_Report_ExtendedReport extends CRM_Report_Form {
     $this->assign('orderByOptions', $options);
     if (!empty($options)) {
       $this->tabs['OrderBy'] = [
-        'title' => ts('Sorting'),
+        'title' => E::ts('Sorting'),
         'tpl' => 'OrderBy',
         'div_label' => 'order-by-elements',
       ];
@@ -1401,13 +1401,13 @@ class CRM_Civicase_Form_Report_ExtendedReport extends CRM_Report_Form {
           '-' => ' - none - ',
         ] + $options;
       for ($i = 1; $i <= 5; $i++) {
-        $this->addElement('select', "order_bys[{$i}][column]", ts('Order by Column'), $options);
-        $this->addElement('select', "order_bys[{$i}][order]", ts('Order by Order'), [
+        $this->addElement('select', "order_bys[{$i}][column]", E::ts('Order by Column'), $options);
+        $this->addElement('select', "order_bys[{$i}][order]", E::ts('Order by Order'), [
           'ASC' => 'Ascending',
           'DESC' => 'Descending',
         ]);
-        $this->addElement('checkbox', "order_bys[{$i}][section]", ts('Order by Section'), FALSE, ['id' => "order_by_section_$i"]);
-        $this->addElement('checkbox', "order_bys[{$i}][pageBreak]", ts('Page Break'), FALSE, ['id' => "order_by_pagebreak_$i"]);
+        $this->addElement('checkbox', "order_bys[{$i}][section]", E::ts('Order by Section'), FALSE, ['id' => "order_by_section_$i"]);
+        $this->addElement('checkbox', "order_bys[{$i}][pageBreak]", E::ts('Page Break'), FALSE, ['id' => "order_by_pagebreak_$i"]);
       }
     }
     $this->assignTabs();
@@ -1572,21 +1572,21 @@ class CRM_Civicase_Form_Report_ExtendedReport extends CRM_Report_Form {
   function getOperationPair($type = "string", $fieldName = NULL) {
     if ($type == self::OP_SINGLEDATE) {
       return [
-        'to' => ts('Until Date'),
-        'from' => ts('From Date'),
+        'to' => E::ts('Until Date'),
+        'from' => E::ts('From Date'),
       ];
     }
     if ($type === self::OP_STRING) {
       return [
-        'has' => ts('Contains'),
-        'sw' => ts('Starts with'),
-        'ew' => ts('Ends with'),
-        'nhas' => ts('Does not contain'),
-        'eq' => ts('Is equal to'),
-        'neq' => ts('Is not equal to'),
-        'nll' => ts('Is empty (Null)'),
-        'nnll' => ts('Is not empty (Null)'),
-        'rlike' => ts('Regex is true'),
+        'has' => E::ts('Contains'),
+        'sw' => E::ts('Starts with'),
+        'ew' => E::ts('Ends with'),
+        'nhas' => E::ts('Does not contain'),
+        'eq' => E::ts('Is equal to'),
+        'neq' => E::ts('Is not equal to'),
+        'nll' => E::ts('Is empty (Null)'),
+        'nnll' => E::ts('Is not empty (Null)'),
+        'rlike' => E::ts('Regex is true'),
       ];
     }
     return parent::getOperationPair($type, $fieldName);
@@ -1969,12 +1969,12 @@ class CRM_Civicase_Form_Report_ExtendedReport extends CRM_Report_Form {
     if (!empty($this->_templates)) {
 
       //$templatesDir = str_replace('CRM/Extendedreport', 'templates/CRM/Extendedreport', __DIR__);
-      $this->add('select', 'templates', ts('Select Alternate Template'), $this->_templates, FALSE,
-        ['id' => 'templates', 'title' => ts('- select -'),]
+      $this->add('select', 'templates', E::ts('Select Alternate Template'), $this->_templates, FALSE,
+        ['id' => 'templates', 'title' => E::ts('- select -'),]
       );
 
       $this->tabs['Template'] = [
-        'title' => ts('Template'),
+        'title' => E::ts('Template'),
         'tpl' => 'Template',
         'div_label' => 'set-template',
       ];
@@ -2032,9 +2032,9 @@ class CRM_Civicase_Form_Report_ExtendedReport extends CRM_Report_Form {
         $filter['operatorType'] = CRM_Report_Form::OP_SELECT;
         // filters
         $filter['options'] = [
-          '' => ts('- select -'),
-          1 => ts('Yes'),
-          0 => ts('No'),
+          '' => E::ts('- select -'),
+          1 => E::ts('Yes'),
+          0 => E::ts('No'),
         ];
         $filter['type'] = CRM_Utils_Type::T_INT;
         break;
@@ -2821,10 +2821,10 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
     switch ($customField['data_type']) {
       case 'Boolean':
         if ($value == '1') {
-          $retValue = ts('Yes');
+          $retValue = E::ts('Yes');
         }
         else {
-          $retValue = ts('No');
+          $retValue = E::ts('No');
         }
         break;
 
@@ -3109,7 +3109,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       if (!empty($spec['is_filters']) && !empty($spec['statistics']) && !empty($options) && !empty($options['group_by'])) {
         foreach ($spec['statistics'] as $statisticName => $statisticLabel) {
           $columns[$tableName]['filters'][$fieldAlias . '_' . $statisticName] = array_merge($spec, [
-            'title' => E::ts('Aggregate filter : ') . $statisticLabel,
+            'title' => E::E::ts('Aggregate filter : ') . $statisticLabel,
             'having' => TRUE,
             'dbAlias' => $tableName . '_' . $fieldAlias . '_' . $statisticName,
             'selectAlias' => "{$statisticName}({$tableAlias}.{$spec['name']})",
@@ -3174,7 +3174,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
 
     $specs = [
       'financial_type_id' => [
-        'title' => ts('Line Item Financial Type'),
+        'title' => E::ts('Line Item Financial Type'),
         'type' => CRM_Utils_Type::T_INT,
         'alter_display' => 'alterFinancialType',
         'is_fields' => TRUE,
@@ -3185,86 +3185,86 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'options' => CRM_Contribute_PseudoConstant::financialType(),
       ],
       'id' => [
-        'title' => ts('Individual Line Item'),
+        'title' => E::ts('Individual Line Item'),
         'type' => CRM_Utils_Type::T_INT,
         'is_order_bys' => TRUE,
         'is_group_bys' => TRUE,
       ],
       'participant_count' => [
-        'title' => ts('Participant Count'),
+        'title' => E::ts('Participant Count'),
         'type' => CRM_Utils_Type::T_INT,
         'statistics' => [
-          'sum' => ts('Total Participants'),
+          'sum' => E::ts('Total Participants'),
         ],
         'is_fields' => TRUE,
       ],
       'price_field_id' => [
-        'title' => ts('Price Field (line item)'),
+        'title' => E::ts('Price Field (line item)'),
         'type' => CRM_Utils_Type::T_INT,
         'is_order_bys' => TRUE,
         'is_group_bys' => TRUE,
       ],
       'price_field_value_id' => [
-        'title' => ts('Price Field Option (line item)'),
+        'title' => E::ts('Price Field Option (line item)'),
         'type' => CRM_Utils_Type::T_INT,
         'is_order_bys' => TRUE,
         'is_group_bys' => TRUE,
       ],
       'qty' => [
-        'title' => ts('Quantity'),
+        'title' => E::ts('Quantity'),
         'type' => CRM_Utils_Type::T_INT,
         'operator' => CRM_Report_Form::OP_INT,
         'statistics' => [
-          'sum' => ts('Total Quantity Selected'),
+          'sum' => E::ts('Total Quantity Selected'),
         ],
         'is_fields' => TRUE,
         'is_filters' => TRUE,
         'is_order_bys' => TRUE,
       ],
       'unit_price' => [
-        'title' => ts('Unit Price'),
+        'title' => E::ts('Unit Price'),
         'type' => CRM_Utils_Type::T_MONEY,
         'is_fields' => TRUE,
         'is_filters' => TRUE,
       ],
       'contribution_id' => [
-        'title' => ts('Contribution Count'),
+        'title' => E::ts('Contribution Count'),
         'type' => CRM_Utils_Type::T_INT,
         'statistics' => [
-          'count' => ts('Count of Contributions'),
+          'count' => E::ts('Count of Contributions'),
         ],
         'is_fields' => TRUE,
         'is_filters' => TRUE,
       ],
       'line_total' => [
-        'title' => ts('Line Total'),
+        'title' => E::ts('Line Total'),
         'type' => CRM_Utils_Type::T_MONEY,
         'statistics' => [
-          'sum' => ts('Total of Line Items'),
+          'sum' => E::ts('Total of Line Items'),
         ],
         'is_fields' => TRUE,
         'is_filters' => TRUE,
       ],
       'label' => [
-        'title' => ts('Line Label'),
+        'title' => E::ts('Line Label'),
         'type' => CRM_Utils_Type::T_STRING,
         'is_fields' => TRUE,
         'is_filters' => TRUE,
       ],
       'tax_amount' => [
-        'title' => ts('Tax Amount'),
+        'title' => E::ts('Tax Amount'),
         'type' => CRM_Utils_Type::T_MONEY,
         'statistics' => [
-          'sum' => ts('Tax Total of Line Items'),
+          'sum' => E::ts('Tax Total of Line Items'),
         ],
         'is_fields' => TRUE,
         'is_filters' => TRUE,
       ],
       'non_deductible_amount' => [
-        'title' => ts('Non Deductible Amount'),
+        'title' => E::ts('Non Deductible Amount'),
         'type' => CRM_Utils_Type::T_MONEY,
         'statistics' => [
-          'sum' => ts('Non Deductible Total of Line Items'),
+          'sum' => E::ts('Non Deductible Total of Line Items'),
         ],
         'is_fields' => TRUE,
         'is_filters' => TRUE,
@@ -3283,7 +3283,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
     $pseudoMethod = $this->financialTypePseudoConstant;
     $specs = [
       'label' => [
-        'title' => ts('Price Field Value Label'),
+        'title' => E::ts('Price Field Value Label'),
         'type' => CRM_Utils_Type::T_STRING,
         'is_filters' => TRUE,
         'is_order_bys' => TRUE,
@@ -3315,7 +3315,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
   protected function getPriceFieldColumns() {
     $specs = [
       'price_field_label' => [
-        'title' => ts('Price Field Label'),
+        'title' => E::ts('Price Field Label'),
         'type' => CRM_Utils_Type::T_STRING,
         'name' => 'label',
         'is_fields' => TRUE,
@@ -3357,7 +3357,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'alter_display' => 'alterRegisteredName',
       ],
       'participant_event_id' => [
-        'title' => ts('Event ID'),
+        'title' => E::ts('Event ID'),
         'name' => 'event_id',
         'type' => CRM_Utils_Type::T_STRING,
         'alter_display' => 'alterEventID',
@@ -3370,7 +3370,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       ],
       'participant_status_id' => [
         'name' => 'status_id',
-        'title' => ts('Event Participant Status'),
+        'title' => E::ts('Event Participant Status'),
         'alter_display' => 'alterParticipantStatus',
         'is_fields' => TRUE,
         'is_filters' => TRUE,
@@ -3380,7 +3380,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       ],
       'participant_role_id' => [
         'name' => 'role_id',
-        'title' => ts('Participant Role'),
+        'title' => E::ts('Participant Role'),
         'operatorType' => CRM_Report_Form::OP_MULTISELECT_SEPARATOR,
         'options' => CRM_Event_PseudoConstant::participantRole(),
         'alter_display' => 'alterParticipantRole',
@@ -3391,7 +3391,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'name' => 'fee_level',
         'type' => CRM_Utils_Type::T_STRING,
         'operator' => 'like',
-        'title' => ts('Participant Fee Level'),
+        'title' => E::ts('Participant Fee Level'),
         'is_fields' => TRUE,
       ],
       'participant_fee_amount' => NULL,
@@ -3445,14 +3445,14 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'name' => 'start_date',
         'is_fields' => TRUE,
         'is_filters' => TRUE,
-        'title' => ts('Current Cycle Start Date'),
+        'title' => E::ts('Current Cycle Start Date'),
         'type' => CRM_Utils_Type::T_DATE,
         'operatorType' => CRM_Report_Form::OP_DATE,
       ],
       'end_date' => [
         'name' => 'end_date',
         'is_fields' => TRUE,
-        'title' => ts('Current Membership Cycle End Date'),
+        'title' => E::ts('Current Membership Cycle End Date'),
         'include_null' => TRUE,
         'is_group_bys' => TRUE,
         'type' => CRM_Utils_Type::T_DATE,
@@ -3461,7 +3461,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       'id' => [
         'title' => 'Membership ID / Count',
         'name' => 'id',
-        'statistics' => ['count' => ts('Number of Memberships')],
+        'statistics' => ['count' => E::ts('Number of Memberships')],
       ],
       'contact_id' => [
         'title' => 'Membership Contact ID',
@@ -3485,7 +3485,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'grouping' => 'member-fields',
         'fields' => [
           'membership_type_id' => [
-            'title' => ts($options['prefix_label'] . 'Membership Type'),
+            'title' => $options['prefix_label'] . E::ts('Membership Type'),
             'alter_display' => 'alterMembershipTypeID',
             'options' => $this->_getOptions('membership', 'membership_type_id', $action = 'get'),
             'is_fields' => TRUE,
@@ -3497,7 +3497,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
           ],
           'membership_status_id' => [
             'name' => 'status_id',
-            'title' => ts($options['prefix_label'] . 'Membership Status'),
+            'title' => $options['prefix_label'] . E::ts('Membership Status'),
             'alter_display' => 'alterMembershipStatusID',
             'options' => $this->_getOptions('membership', 'status_id', $action = 'get'),
             'is_fields' => TRUE,
@@ -3510,14 +3510,14 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
             'name' => 'start_date',
             'is_fields' => TRUE,
             'is_filters' => TRUE,
-            'title' => ts($options['prefix_label'] . ' Start Date'),
+            'title' => $options['prefix_label'] . E::ts(' Start Date'),
             'type' => CRM_Utils_Type::T_DATE,
             'operatorType' => CRM_Report_Form::OP_DATE,
           ],
           'end_date' => [
             'name' => 'end_date',
             'is_fields' => TRUE,
-            'title' => ts($options['prefix_label'] . ' Membership Cycle End Date'),
+            'title' => $options['prefix_label'] . E::ts(' Membership Cycle End Date'),
             'include_null' => TRUE,
             'is_group_bys' => TRUE,
             'type' => CRM_Utils_Type::T_DATE,
@@ -3549,7 +3549,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
     $defaults = $this->getDefaultsFromOptions($options);
     $spec = [
       'accounting_code' => [
-        'title' => ts($options['prefix_label'] . 'Financial Account Code'),
+        'title' => $options['prefix_label'] . E::ts('Financial Account Code'),
         'name' => 'accounting_code',
         'type' => CRM_Utils_Type::T_STRING,
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
@@ -3558,7 +3558,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_filters' => TRUE,
       ],
       'name' => [
-        'title' => ts($options['prefix_label'] . 'Financial Account Name'),
+        'title' => $options['prefix_label'] . E::ts('Financial Account Name'),
         'name' => 'name',
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'options' => CRM_Contribute_PseudoConstant::financialAccount(),
@@ -3573,12 +3573,12 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
   protected function getFinancialTrxnColumns() {
     $specs = [
       'check_number' => [
-        'title' => ts('Cheque #'),
+        'title' => E::ts('Cheque #'),
         'default' => TRUE,
         'type' => CRM_Utils_Type::T_STRING,
       ],
       'payment_instrument_id' => [
-        'title' => ts('Payment Instrument'),
+        'title' => E::ts('Payment Instrument'),
         'default' => TRUE,
         'alter_display' => 'alterPaymentType',
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
@@ -3592,14 +3592,14 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'required' => TRUE,
         'no_display' => FALSE,
         'type' => CRM_Utils_Type::T_STRING,
-        'title' => ts('Currency'),
+        'title' => E::ts('Currency'),
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'options' => CRM_Core_OptionGroup::values('currencies_enabled'),
         'is_fields' => TRUE,
         'is_filters' => TRUE,
       ],
       'trxn_date' => [
-        'title' => ts('Transaction Date'),
+        'title' => E::ts('Transaction Date'),
         'default' => TRUE,
         'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
         'operatorType' => CRM_Report_Form::OP_DATE,
@@ -3607,7 +3607,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_filters' => TRUE,
       ],
       'trxn_id' => [
-        'title' => ts('Transaction #'),
+        'title' => E::ts('Transaction #'),
         'default' => TRUE,
         'is_fields' => TRUE,
         'is_filters' => TRUE,
@@ -3617,7 +3617,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'name' => 'status_id',
         'is_fields' => TRUE,
         'is_filters' => TRUE,
-        'title' => ts('Transaction Status'),
+        'title' => E::ts('Transaction Status'),
         'filters_default' => [1],
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'type' => CRM_Utils_Type::T_INT,
@@ -3633,15 +3633,15 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
   protected function getFinancialTypeColumns() {
     $specs = [
       'name' => [
-        'title' => ts('Financial_type'),
+        'title' => E::ts('Financial_type'),
         'type' => CRM_Utils_Type::T_STRING,
       ],
       'accounting_code' => [
-        'title' => ts('Accounting Code'),
+        'title' => E::ts('Accounting Code'),
         'type' => CRM_Utils_Type::T_STRING,
       ],
       'is_deductible' => [
-        'title' => ts('Tax Deductible'),
+        'title' => E::ts('Tax Deductible'),
         'type' => CRM_Utils_Type::T_BOOLEAN,
       ],
     ];
@@ -3658,14 +3658,14 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
   protected function getPledgePaymentColumns($options) {
     $specs = [
       $options['prefix'] . 'actual_amount' => [
-        'title' => ts($options['prefix'] . 'Amount Paid'),
+        'title' => $options['prefix'] . E::ts('Amount Paid'),
         'type' => CRM_Utils_Type::T_MONEY,
-        'statistics' => ['sum' => ts('Total Amount Paid')],
+        'statistics' => ['sum' => E::ts('Total Amount Paid')],
         'is_fields' => TRUE,
       ],
       $options['prefix'] . 'scheduled_date' => [
         'type' => CRM_Utils_Type::T_DATE,
-        'title' => ts($options['prefix'] . 'Scheduled Payment Due'),
+        'title' => $options['prefix'] . E::ts('Scheduled Payment Due'),
         'is_fields' => TRUE,
         'is_filters' => TRUE,
         'is_group_bys' => TRUE,
@@ -3674,16 +3674,16 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       ],
       $options['prefix'] . 'scheduled_amount' => [
         'type' => CRM_Utils_Type::T_MONEY,
-        'title' => ts($options['prefix_label'] . 'Amount to be paid'),
+        'title' => $options['prefix_label'] . E::ts('Amount to be paid'),
         'is_fields' => TRUE,
         'statistics' => [
-          'sum' => ts('Amount to be paid'),
-          'cumulative' => ts('Cumulative to be paid'),
+          'sum' => E::ts('Amount to be paid'),
+          'cumulative' => E::ts('Cumulative to be paid'),
         ],
       ],
       $options['prefix'] . 'status_id' => [
         'type' => CRM_Utils_Type::T_INT,
-        'title' => ts($options['prefix_label'] . 'Payment Status'),
+        'title' => $options['prefix_label'] . E::ts('Payment Status'),
         'is_fields' => FALSE,
         'is_filters' => TRUE,
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
@@ -3710,7 +3710,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
     $specs = [
       $options['prefix'] . 'scheduled_date' => [
         'type' => CRM_Utils_Type::T_DATE,
-        'title' => ts('Next Payment Due'),
+        'title' => E::ts('Next Payment Due'),
         'is_fields' => TRUE,
         'is_filters' => TRUE,
         'is_group_bys' => TRUE,
@@ -3719,7 +3719,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       ],
       $options['prefix'] . 'scheduled_amount' => [
         'type' => CRM_Utils_Type::T_MONEY,
-        'title' => ts('Next payment Amount'),
+        'title' => E::ts('Next payment Amount'),
         'is_fields' => TRUE,
         'is_filters' => TRUE,
       ],
@@ -3739,7 +3739,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
     $actions = [
       'add_payment' => [
         'type' => CRM_Utils_Type::T_INT,
-        'title' => ts('Payment Link'),
+        'title' => E::ts('Payment Link'),
         'name' => 'id',
         'alter_display' => 'alterPledgePaymentLink',
         // Otherwise it will be supressed. We retrieve & alter.
@@ -3757,7 +3757,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
     $spec = [
       'membership_type_id' => [
         'name' => 'id',
-        'title' => ts('Membership Types'),
+        'title' => E::ts('Membership Types'),
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'type' => CRM_Utils_Type::T_INT,
         'options' => CRM_Member_PseudoConstant::membershipType(),
@@ -3798,11 +3798,11 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       'event_id' => [
         'name' => 'id',
         'is_fields' => TRUE,
-        'title' => ts('Event ID'),
+        'title' => E::ts('Event ID'),
         'type' => CRM_Utils_Type::T_INT,
       ],
       'title' => [
-        'title' => ts('Event Title'),
+        'title' => E::ts('Event Title'),
         'is_fields' => TRUE,
         'is_filters' => TRUE,
         'crm_editable' => [
@@ -3815,7 +3815,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'operatorType' => CRM_Report_Form::OP_STRING,
       ],
       'event_type_id' => [
-        'title' => ts('Event Type'),
+        'title' => E::ts('Event Type'),
         'alter_display' => 'alterEventType',
         'name' => 'event_type_id',
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
@@ -3828,11 +3828,11 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
 
       ],
       'fee_label' => [
-        'title' => ts('Fee Label'),
+        'title' => E::ts('Fee Label'),
         'is_fields' => TRUE,
       ],
       'event_start_date' => [
-        'title' => ts('Event Start Date'),
+        'title' => E::ts('Event Start Date'),
         'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
         'operatorType' => CRM_Report_Form::OP_DATE,
         'name' => 'start_date',
@@ -3840,12 +3840,12 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_filters' => TRUE,
       ],
       'event_end_date' => [
-        'title' => ts('Event End Date'),
+        'title' => E::ts('Event End Date'),
         'is_fields' => TRUE,
         'name' => 'end_date',
       ],
       'max_participants' => [
-        'title' => ts('Capacity'),
+        'title' => E::ts('Capacity'),
         'type' => CRM_Utils_Type::T_INT,
         'is_fields' => TRUE,
         'crm_editable' => [
@@ -3855,7 +3855,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         ],
       ],
       'is_active' => [
-        'title' => ts('Is Active'),
+        'title' => E::ts('Is Active'),
         'is_fields' => TRUE,
         'type' => CRM_Utils_Type::T_INT,
         'crm_editable' => [
@@ -3866,7 +3866,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         ],
       ],
       'is_public' => [
-        'title' => ts('Is Publicly Visible'),
+        'title' => E::ts('Is Publicly Visible'),
         'type' => CRM_Utils_Type::T_INT,
         'is_fields' => TRUE,
         'crm_editable' => [
@@ -3903,45 +3903,45 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
     // $fields['civicrm_event_summary' . $options['prefix']]['fields'] =
     $specs = [
       'registered_amount' . $options['prefix'] => [
-        'title' => $options['prefix_label'] . ts('Total Income'),
+        'title' => $options['prefix_label'] . E::ts('Total Income'),
         'default' => TRUE,
         'type' => CRM_Utils_Type::T_MONEY,
-        'statistics' => ['sum' => ts('Total Income')],
+        'statistics' => ['sum' => E::ts('Total Income')],
         'is_fields' => TRUE,
       ],
       'paid_amount' . $options['prefix'] => [
-        'title' => $options['prefix_label'] . ts('Paid Up Income'),
+        'title' => $options['prefix_label'] . E::ts('Paid Up Income'),
         'default' => TRUE,
         'type' => CRM_Utils_Type::T_MONEY,
-        'statistics' => ['sum' => ts('Total Paid Up Income')],
+        'statistics' => ['sum' => E::ts('Total Paid Up Income')],
         'is_fields' => TRUE,
       ],
       'pending_amount' . $options['prefix'] => [
-        'title' => $options['prefix_label'] . ts('Pending Income'),
+        'title' => $options['prefix_label'] . E::ts('Pending Income'),
         'default' => TRUE,
         'type' => CRM_Utils_Type::T_MONEY,
-        'statistics' => ['sum' => ts('Total Pending Income')],
+        'statistics' => ['sum' => E::ts('Total Pending Income')],
         'is_fields' => TRUE,
       ],
       'registered_count' . $options['prefix'] => [
-        'title' => $options['prefix_label'] . ts('No. Participants'),
+        'title' => $options['prefix_label'] . E::ts('No. Participants'),
         'default' => TRUE,
         'type' => CRM_Utils_Type::T_INT,
-        'statistics' => ['sum' => ts('Total No. Participants')],
+        'statistics' => ['sum' => E::ts('Total No. Participants')],
         'is_fields' => TRUE,
       ],
       'paid_count' . $options['prefix'] => [
-        'title' => $options['prefix_label'] . ts('Paid Up Participants'),
+        'title' => $options['prefix_label'] . E::ts('Paid Up Participants'),
         'default' => TRUE,
         'type' => CRM_Utils_Type::T_INT,
-        'statistics' => ['sum' => ts('Total No,. Paid Up Participants')],
+        'statistics' => ['sum' => E::ts('Total No,. Paid Up Participants')],
         'is_fields' => TRUE,
       ],
       'pending_count' . $options['prefix'] => [
-        'title' => $options['prefix_label'] . ts('Pending Participants'),
+        'title' => $options['prefix_label'] . E::ts('Pending Participants'),
         'default' => TRUE,
         'type' => CRM_Utils_Type::T_INT,
-        'statistics' => ['sum' => ts('Total Pending Participants')],
+        'statistics' => ['sum' => E::ts('Total Pending Participants')],
         'is_fields' => TRUE,
       ],
     ];
@@ -3961,7 +3961,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
     }
     $specs = [
       'campaign_type_id' => [
-        'title' => ts('Campaign Type'),
+        'title' => E::ts('Campaign Type'),
         'is_filters' => TRUE,
         'is_order_bys' => TRUE,
         'is_fields' => TRUE,
@@ -3971,7 +3971,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'alter_display' => 'alterCampaignType',
       ],
       'id' => [
-        'title' => ts('Campaign'),
+        'title' => E::ts('Campaign'),
         'is_filters' => TRUE,
         'is_order_bys' => TRUE,
         'is_fields' => TRUE,
@@ -3981,7 +3981,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'alter_display' => 'alterCampaign',
       ],
       'goal_revenue' => [
-        'title' => ts('Revenue goal'),
+        'title' => E::ts('Revenue goal'),
         'is_filters' => TRUE,
         'is_order_bys' => TRUE,
         'is_fields' => TRUE,
@@ -3999,17 +3999,17 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
    */
   function getContributionColumns($options) {
 
-    $options = array_merge(['group_title' => E::ts('Contributions')], $options);
+    $options = array_merge(['group_title' => E::E::ts('Contributions')], $options);
     $specs = [
       'id' => [
-        'title' => ts('Contribution ID'),
+        'title' => E::ts('Contribution ID'),
         'is_filters' => TRUE,
         'is_order_bys' => TRUE,
         'is_fields' => TRUE,
         'is_group_bys' => TRUE,
       ],
       'financial_type_id' => [
-        'title' => ts('Contribution Type (Financial)'),
+        'title' => E::ts('Contribution Type (Financial)'),
         'type' => CRM_Utils_Type::T_INT,
         'alter_display' => 'alterFinancialType',
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
@@ -4020,7 +4020,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_group_bys' => TRUE,
       ],
       'payment_instrument_id' => [
-        'title' => ts('Payment Instrument'),
+        'title' => E::ts('Payment Instrument'),
         'type' => CRM_Utils_Type::T_INT,
         'alter_display' => 'alterPaymentType',
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
@@ -4031,7 +4031,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_group_bys' => TRUE,
       ],
       'contribution_status_id' => [
-        'title' => ts('Contribution Status'),
+        'title' => E::ts('Contribution Status'),
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'options' => CRM_Contribute_PseudoConstant::contributionStatus(),
         'alter_display' => 'alterContributionStatus',
@@ -4042,7 +4042,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_group_bys' => TRUE,
       ],
       'campaign_id' => [
-        'title' => ts('Campaign'),
+        'title' => E::ts('Campaign'),
         'type' => CRM_Utils_Type::T_INT,
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'options' => CRM_Campaign_BAO_Campaign::getCampaigns(),
@@ -4068,10 +4068,10 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       ],
       'receipt_date' => ['is_fields' => TRUE, 'is_order_bys' => TRUE,],
       'total_amount' => [
-        'title' => ts('Contribution Amount'),
+        'title' => E::ts('Contribution Amount'),
         'statistics' => [
-          'count' => ts('No. Contributions'),
-          'sum' => ts('Total Amount'),
+          'count' => E::ts('No. Contributions'),
+          'sum' => E::ts('Total Amount'),
         ],
         'type' => CRM_Utils_Type::T_MONEY,
         'is_fields' => TRUE,
@@ -4086,7 +4086,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_fields' => TRUE,
         'is_filters' => TRUE,
         'is_group_bys' => TRUE,
-        'title' => ts('Contribution Page'),
+        'title' => E::ts('Contribution Page'),
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'options' => $this->_getOptions('Contribution', 'contribution_page_id'),
         'type' => CRM_Utils_Type::T_INT,
@@ -4112,7 +4112,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'type' => CRM_Utils_Type::T_STRING,
       ],
       'contact_id' => [
-        'title' => ts('Contribution Contact ID'),
+        'title' => E::ts('Contribution Contact ID'),
         'name' => 'contact_id',
         'is_filters' => TRUE,
       ],
@@ -4146,7 +4146,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
     $spec =
       [
         'contributionsummary' . $options['prefix'] => [
-          'title' => $options['prefix_label'] . ts('Contribution Details'),
+          'title' => $options['prefix_label'] . E::ts('Contribution Details'),
           'default' => TRUE,
           'required' => TRUE,
           'alter_display' => 'alterDisplaytable2csv',
@@ -4168,7 +4168,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
     }
     $specs = [
       'title' => [
-        'title' => ts('Batch Title'),
+        'title' => E::ts('Batch Title'),
         'is_filters' => TRUE,
         'is_order_bys' => TRUE,
         'is_fields' => TRUE,
@@ -4178,7 +4178,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'type' => CRM_Utils_Type::T_STRING,
       ],
       'status_id' => [
-        'title' => ts('Batch Status'),
+        'title' => E::ts('Batch Status'),
         'is_filters' => TRUE,
         'is_order_bys' => FALSE,
         'is_fields' => TRUE,
@@ -4223,7 +4223,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
 
     $spec = [
       $options['prefix'] . 'phone' => [
-        'title' => ts($options['prefix_label'] . 'Phone'),
+        'title' => $options['prefix_label'] . E::ts('Phone'),
         'name' => 'phone',
         'is_fields' => TRUE,
       ],
@@ -4255,15 +4255,15 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'required' => TRUE,
       ],
       'amount' => [
-        'title' => ts('Pledged Amount'),
-        'statistics' => ['sum' => ts('Total Pledge Amount')],
+        'title' => E::ts('Pledged Amount'),
+        'statistics' => ['sum' => E::ts('Total Pledge Amount')],
         'type' => CRM_Utils_Type::T_MONEY,
         'name' => 'amount',
         'operatorType' => CRM_Report_Form::OP_INT,
         'is_fields' => TRUE,
       ],
       'financial_type_id' => [
-        'title' => ts('Financial Type'),
+        'title' => E::ts('Financial Type'),
         'type' => CRM_Utils_Type::T_INT,
         'alter_display' => 'alterFinancialType',
         'is_fields' => TRUE,
@@ -4274,35 +4274,35 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'options' => CRM_Contribute_PseudoConstant::financialType(),
       ],
       'frequency_unit' => [
-        'title' => ts('Frequency Unit'),
+        'title' => E::ts('Frequency Unit'),
         'is_fields' => TRUE,
         'type' => CRM_Utils_Type::T_STRING,
       ],
       'installments' => [
-        'title' => ts('Installments'),
+        'title' => E::ts('Installments'),
         'is_fields' => TRUE,
       ],
       'create_date' => [
-        'title' => ts('Pledge Made Date'),
+        'title' => E::ts('Pledge Made Date'),
         'operatorType' => CRM_Report_Form::OP_DATE,
         'is_fields' => TRUE,
         'is_filters' => TRUE,
       ],
       'start_date' => [
-        'title' => ts('Pledge Start Date'),
+        'title' => E::ts('Pledge Start Date'),
         'type' => CRM_Utils_Type::T_DATE,
         'is_fields' => TRUE,
         'is_filters' => TRUE,
       ],
       'end_date' => [
-        'title' => ts('Pledge End Date'),
+        'title' => E::ts('Pledge End Date'),
         'type' => CRM_Utils_Type::T_DATE,
         'is_fields' => TRUE,
         'is_filters' => TRUE,
       ],
       'status_id' => [
         'name' => 'status_id',
-        'title' => ts('Pledge Status'),
+        'title' => E::ts('Pledge Status'),
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'options' => CRM_Core_OptionGroup::values('contribution_status'),
         'is_fields' => TRUE,
@@ -4310,7 +4310,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'type' => CRM_Utils_Type::T_INT,
       ],
       'campaign_id' => [
-        'title' => ts('Campaign'),
+        'title' => E::ts('Campaign'),
         'type' => CRM_Utils_Type::T_INT,
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'options' => CRM_Campaign_BAO_Campaign::getCampaigns(),
@@ -4350,7 +4350,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
 
     $fields = [
       'email' => [
-        'title' => ts($options['prefix_label'] . 'Email'),
+        'title' => $options['prefix_label'] . E::ts('Email'),
         'name' => 'email',
         'is_fields' => TRUE,
         'is_filters' => TRUE,
@@ -4388,7 +4388,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
 
     $fields = [
       'url' => [
-        'title' => $options['prefix_label'] . ts('Website'),
+        'title' => $options['prefix_label'] . E::ts('Website'),
         'name' => 'url',
         'is_fields' => TRUE,
         'is_filters' => TRUE,
@@ -4398,7 +4398,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'operatorType' => CRM_Report_Form::OP_STRING,
       ],
       'website_type_id' => [
-        'title' => $options['prefix_label'] . ts('Website Type'),
+        'title' => $options['prefix_label'] . E::ts('Website Type'),
         'name' => 'website_type_id',
         'is_fields' => TRUE,
         'is_filters' => TRUE,
@@ -4435,7 +4435,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
 
     $fields = [
       'note' => [
-        'title' => ts($options['prefix_label'] . 'Note'),
+        'title' => $options['prefix_label'] . E::ts('Note'),
         'name' => 'note',
         'is_fields' => TRUE,
       ],
@@ -4469,12 +4469,12 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
     $specs = [
       $prefix . 'id' => [
         'name' => 'id',
-        'title' => ts('Relationship ID'),
+        'title' => E::ts('Relationship ID'),
         'is_fields' => TRUE,
         'type' => CRM_Utils_Type::T_STRING,
       ],
       $prefix . 'relationship_start_date' => [
-        'title' => ts('Relationship Start Date'),
+        'title' => E::ts('Relationship Start Date'),
         'name' => 'start_date',
         'type' => CRM_Utils_Type::T_DATE,
         'is_fields' => TRUE,
@@ -4482,7 +4482,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_join_filters' => TRUE,
       ],
       $prefix . 'relationship_end_date' => [
-        'title' => ts('Relationship End Date'),
+        'title' => E::ts('Relationship End Date'),
         'name' => 'end_date',
         'is_fields' => TRUE,
         'type' => CRM_Utils_Type::T_DATE,
@@ -4490,14 +4490,14 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_join_filters' => TRUE,
       ],
       $prefix . 'relationship_description' => [
-        'title' => ts('Description'),
+        'title' => E::ts('Description'),
         'name' => 'description',
         'type' => CRM_Utils_Type::T_STRING,
         'is_fields' => TRUE,
         'is_filters' => TRUE,
       ],
       $prefix . 'relationship_is_active' => [
-        'title' => ts('Relationship Status'),
+        'title' => E::ts('Relationship Status'),
         'name' => 'is_active',
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'options' => [
@@ -4512,7 +4512,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       ],
       $prefix . 'relationship_type_id' => [
         'name' => 'relationship_type_id',
-        'title' => ts('Relationship Type'),
+        'title' => E::ts('Relationship Type'),
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'options' => [
             '' => '- any relationship type -',
@@ -4525,7 +4525,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       // For the join filters we will use a one-way option list to make our life easier.
       $prefix . 'join_relationship_type_id' => [
         'name' => 'relationship_type_id',
-        'title' => ts('Relationship Type'),
+        'title' => E::ts('Relationship Type'),
         'operatorType' => CRM_Report_Form::OP_SELECT,
         'options' => [
             '' => '- any relationship type -',
@@ -4558,19 +4558,19 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
     $defaults = $this->getDefaultsFromOptions($options);
     $specs = [
       'label_a_b' => [
-        'title' => ts('Relationship A-B '),
+        'title' => E::ts('Relationship A-B '),
         'type' => CRM_Utils_Type::T_STRING,
         'is_fields' => 1,
         'is_filters' => 1,
       ],
       'label_b_a' => [
-        'title' => ts('Relationship B-A '),
+        'title' => E::ts('Relationship B-A '),
         'type' => CRM_Utils_Type::T_STRING,
         'is_fields' => 1,
         'is_filters' => 1,
       ],
       'contact_type_a' => [
-        'title' => ts('Contact Type  A'),
+        'title' => E::ts('Contact Type  A'),
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'options' => CRM_Contact_BAO_Contact::buildOptions('contact_type'),
         'type' => CRM_Utils_Type::T_STRING,
@@ -4578,7 +4578,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_filters' => 1,
       ],
       'contact_type_b' => [
-        'title' => ts('Contact Type  B'),
+        'title' => E::ts('Contact Type  B'),
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'options' => CRM_Contact_BAO_Contact::buildOptions('contact_type'),
         'type' => CRM_Utils_Type::T_STRING,
@@ -4613,7 +4613,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
    */
   protected function addJoinFiltersTab() {
     $this->tabs['Relationships'] = [
-      'title' => ts('Join Filters'),
+      'title' => E::ts('Join Filters'),
       'tpl' => 'Relationships',
       'div_label' => 'set-relationships',
     ];
@@ -4630,7 +4630,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
     }
     foreach ($this->getSelectedJoinFilters() as $fieldName => $field) {
       $join = $this->getQillForField($field, $fieldName, 'join_filter_');
-      $join['title'] = E::ts('%1 only included based on filter ', [$field['entity']]) . $join['title'];
+      $join['title'] = E::E::ts('%1 only included based on filter ', [$field['entity']]) . $join['title'];
       $statistics['filters'][] = $join;
     }
   }
@@ -4674,13 +4674,13 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
 
     $spec = [
       $options['prefix'] . 'name' => [
-        'title' => ts($options['prefix_label'] . 'Address Name'),
+        'title' => $options['prefix_label'] . E::ts('Address Name'),
         'name' => 'name',
         'is_fields' => TRUE,
         'type' => CRM_Utils_Type::T_STRING,
       ],
       $options['prefix'] . 'display_address' => [
-        'title' => ts($options['prefix_label'] . 'Display Address'),
+        'title' => $options['prefix_label'] . E::ts('Display Address'),
         'pseudofield' => TRUE,
         'is_fields' => TRUE,
         'type' => CRM_Utils_Type::T_STRING,
@@ -4703,7 +4703,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       ],
       $options['prefix'] . 'street_number' => [
         'name' => 'street_number',
-        'title' => ts($options['prefix_label'] . 'Street Number'),
+        'title' => $options['prefix_label'] . E::ts('Street Number'),
         'type' => 1,
         'crm_editable' => [
           'id_table' => 'civicrm_address',
@@ -4714,7 +4714,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       ],
       $options['prefix'] . 'street_name' => [
         'name' => 'street_name',
-        'title' => ts($options['prefix_label'] . 'Street Name'),
+        'title' => $options['prefix_label'] . E::ts('Street Name'),
         'type' => 1,
         'crm_editable' => [
           'id_table' => 'civicrm_address',
@@ -4727,7 +4727,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_order_bys' => TRUE,
       ],
       $options['prefix'] . 'street_address' => [
-        'title' => ts($options['prefix_label'] . 'Street Address'),
+        'title' => $options['prefix_label'] . E::ts('Street Address'),
         'name' => 'street_address',
         'is_fields' => TRUE,
         'is_filters' => TRUE,
@@ -4735,7 +4735,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
 
       ],
       $options['prefix'] . 'supplemental_address_1' => [
-        'title' => ts($options['prefix_label'] . 'Supplementary Address Field 1'),
+        'title' => $options['prefix_label'] . E::ts('Supplementary Address Field 1'),
         'name' => 'supplemental_address_1',
         'crm_editable' => [
           'id_table' => 'civicrm_address',
@@ -4745,7 +4745,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_fields' => TRUE,
       ],
       $options['prefix'] . 'supplemental_address_2' => [
-        'title' => ts($options['prefix_label'] . 'Supplementary Address Field 2'),
+        'title' => $options['prefix_label'] . E::ts('Supplementary Address Field 2'),
         'name' => 'supplemental_address_2',
         'crm_editable' => [
           'id_table' => 'civicrm_address',
@@ -4755,7 +4755,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_fields' => TRUE,
       ],
       $options['prefix'] . 'supplemental_address_3' => [
-        'title' => ts($options['prefix_label'] . 'Supplementary Address Field 3'),
+        'title' => $options['prefix_label'] . E::ts('Supplementary Address Field 3'),
         'name' => 'supplemental_address_3',
         'crm_editable' => [
           'id_table' => 'civicrm_address',
@@ -4766,7 +4766,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       ],
       $options['prefix'] . 'street_number' => [
         'name' => 'street_number',
-        'title' => ts($options['prefix_label'] . 'Street Number'),
+        'title' => $options['prefix_label'] . E::ts('Street Number'),
         'type' => 1,
         'is_order_bys' => TRUE,
         'is_filters' => TRUE,
@@ -4774,18 +4774,18 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       ],
       $options['prefix'] . 'street_name' => [
         'name' => 'street_name',
-        'title' => ts($options['prefix_label'] . 'Street Name'),
+        'title' => $options['prefix_label'] . E::ts('Street Name'),
         'type' => 1,
         'is_fields' => TRUE,
       ],
       $options['prefix'] . 'street_unit' => [
         'name' => 'street_unit',
-        'title' => ts($options['prefix_label'] . 'Street Unit'),
+        'title' => $options['prefix_label'] . E::ts('Street Unit'),
         'type' => 1,
         'is_fields' => TRUE,
       ],
       $options['prefix'] . 'city' => [
-        'title' => ts($options['prefix_label'] . 'City'),
+        'title' => $options['prefix_label'] . E::ts('City'),
         'name' => 'city',
         'operator' => 'like',
         'crm_editable' => [
@@ -4799,7 +4799,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_order_bys' => TRUE,
       ],
       $options['prefix'] . 'postal_code' => [
-        'title' => ts($options['prefix_label'] . 'Postal Code'),
+        'title' => $options['prefix_label'] . E::ts('Postal Code'),
         'name' => 'postal_code',
         'type' => 1,
         'is_fields' => TRUE,
@@ -4808,7 +4808,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_order_bys' => TRUE,
       ],
       $options['prefix'] . 'postal_code_suffix' => [
-        'title' => ts($options['prefix_label'] . 'Postal Code Suffix'),
+        'title' => $options['prefix_label'] . E::ts('Postal Code Suffix'),
         'name' => 'postal_code',
         'type' => 1,
         'is_fields' => TRUE,
@@ -4817,7 +4817,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_order_bys' => TRUE,
       ],
       $options['prefix'] . 'county_id' => [
-        'title' => ts($options['prefix_label'] . 'County'),
+        'title' => $options['prefix_label'] . E::ts('County'),
         'alter_display' => 'alterCountyID',
         'name' => 'county_id',
         'type' => CRM_Utils_Type::T_INT,
@@ -4828,7 +4828,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_group_bys' => TRUE,
       ],
       $options['prefix'] . 'state_province_id' => [
-        'title' => ts($options['prefix_label'] . 'State/Province'),
+        'title' => $options['prefix_label'] . E::ts('State/Province'),
         'alter_display' => 'alterStateProvinceID',
         'name' => 'state_province_id',
         'type' => CRM_Utils_Type::T_INT,
@@ -4839,7 +4839,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
         'is_group_bys' => TRUE,
       ],
       $options['prefix'] . 'country_id' => [
-        'title' => ts($options['prefix_label'] . 'Country'),
+        'title' => $options['prefix_label'] . E::ts('Country'),
         'alter_display' => 'alterCountryID',
         'name' => 'country_id',
         'is_fields' => TRUE,
@@ -4851,20 +4851,20 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
       ],
       $options['prefix'] . 'location_type_id' => [
         'name' => 'is_primary',
-        'title' => ts($options['prefix_label'] . 'Location Type'),
+        'title' => $options['prefix_label'] . E::ts('Location Type'),
         'type' => CRM_Utils_Type::T_INT,
         'is_fields' => TRUE,
         'alter_display' => 'alterLocationTypeID',
       ],
       $options['prefix'] . 'id' => [
-        'title' => ts($options['prefix_label'] . ' Address ID'),
+        'title' => $options['prefix_label'] . E::ts(' Address ID'),
         'name' => 'id',
         'is_fields' => TRUE,
         'type' => CRM_Utils_Type::T_INT,
       ],
       $options['prefix'] . 'is_primary' => [
         'name' => 'is_primary',
-        'title' => ts($options['prefix_label'] . 'Primary Address?'),
+        'title' => $options['prefix_label'] . E::ts('Primary Address?'),
         'type' => CRM_Utils_Type::T_BOOLEAN,
         'is_fields' => TRUE,
       ],
@@ -5995,7 +5995,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
 
     $registeredByContactId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $value, 'contact_id', 'id');
     $row[$selectedField . '_link'] = CRM_Utils_System::url('civicrm/contact/view', 'reset=1&cid=' . $registeredByContactId);
-    $row[$selectedField . '_hover']  = ts('View Contact Summary for Contact that registered the participant.');
+    $row[$selectedField . '_hover']  = E::ts('View Contact Summary for Contact that registered the participant.');
 
     return CRM_Contact_BAO_Contact::displayName($registeredByContactId);
   }
@@ -6018,7 +6018,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
         $this->_absoluteUrl, $this->_id, $this->_drilldownReport
       );
       $row[$selectedField . '_link'] = $url;
-      $row[$selectedField . '_hover'] = ts(implode(',', $this->_drilldownReport));
+      $row[$selectedField . '_hover'] = implode(',', $this->_drilldownReport);
     }
     return is_string(CRM_Event_PseudoConstant::event($value, FALSE)) ? CRM_Event_PseudoConstant::event($value, FALSE) : '';
   }
@@ -6066,7 +6066,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
   function alterCountryID($value, &$row, $selectedField, $criteriaFieldName) {
     $url = CRM_Utils_System::url(CRM_Utils_System::currentPath(), "reset=1&force=1&{$criteriaFieldName}_op=in&{$criteriaFieldName}_value={$value}", $this->_absoluteUrl);
     $row[$selectedField . '_link'] = $url;
-    $row[$selectedField . '_hover'] = ts("%1 for this country.", [
+    $row[$selectedField . '_hover'] = E::ts("%1 for this country.", [
       1 => $value,
     ]);
     $countries = CRM_Core_PseudoConstant::country($value, FALSE);
@@ -6086,7 +6086,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
   function alterCountyID($value, &$row, $selectedfield, $criteriaFieldName) {
     $url = CRM_Utils_System::url(CRM_Utils_System::currentPath(), "reset=1&force=1&{$criteriaFieldName}_op=in&{$criteriaFieldName}_value={$value}", $this->_absoluteUrl);
     $row[$selectedfield . '_link'] = $url;
-    $row[$selectedfield . '_hover'] = ts("%1 for this county.", [
+    $row[$selectedfield . '_hover'] = E::ts("%1 for this county.", [
       1 => $value,
     ]);
     $counties = CRM_Core_PseudoConstant::county($value);
@@ -6152,7 +6152,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
   function alterStateProvinceID($value, &$row, $selectedfield, $criteriaFieldName) {
     $url = CRM_Utils_System::url(CRM_Utils_System::currentPath(), "reset=1&force=1&{$criteriaFieldName}_op=in&{$criteriaFieldName}_value={$value}", $this->_absoluteUrl);
     $row[$selectedfield . '_link'] = $url;
-    $row[$selectedfield . '_hover'] = ts("%1 for this state.", [
+    $row[$selectedfield . '_hover'] = E::ts("%1 for this state.", [
       1 => $value,
     ]);
 
@@ -6242,7 +6242,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
     if ($this->_groupByArray !== ['civicrm_pledge_payment_id' => 'pledge_payment.id']
       && $this->_groupByArray !== ['civicrm_pledge_payment_id' => 'civicrm_pledge_payment.id']
     ) {
-      CRM_Core_Session::setStatus(ts('Pledge payment link not added'), ts('The pledge payment link cannot be added if the grouping options on the report make it ambiguous'));
+      CRM_Core_Session::setStatus(E::ts('Pledge payment link not added'), E::ts('The pledge payment link cannot be added if the grouping options on the report make it ambiguous'));
       return '';
     }
     if (empty($value)) {
@@ -6259,9 +6259,9 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
       );
     }
     $row[$selectedField . '_link'] = CRM_Utils_System::url('civicrm/contact/view/contribution', 'reset=1&action=add&cid=' . $contactID . '&context=pledge&ppid=' . $value);
-    $row[$selectedField . '_hover'] = ts('Record a payment received for this pledged payment');
+    $row[$selectedField . '_hover'] = E::ts('Record a payment received for this pledged payment');
     $row[$selectedField . '_class'] = "action-item crm-hover-button crm-popup";
-    return ts('Record Payment');
+    return E::ts('Record Payment');
   }
 
   /**
@@ -6281,7 +6281,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
    */
   function alterBatchStatus($value) {
     if (!$value) {
-      return ts("N/A");
+      return E::ts("N/A");
     }
     $values = CRM_Batch_BAO_Batch::buildOptions('status_id');
     return $values[$value];
@@ -6293,7 +6293,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
    * @return mixed
    */
   function alterBoolean($value) {
-    $options = [0 => ts('No'), 1 => ts('Yes')];
+    $options = [0 => E::ts('No'), 1 => E::ts('Yes')];
     if (isset($options[$value])) {
       return $options[$value];
     }
@@ -6486,18 +6486,18 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
         ) {
           // If there's no option list for this filter, define one.
           $field['options'] = [
-            1 => ts('January'),
-            2 => ts('February'),
-            3 => ts('March'),
-            4 => ts('April'),
-            5 => ts('May'),
-            6 => ts('June'),
-            7 => ts('July'),
-            8 => ts('August'),
-            9 => ts('September'),
-            10 => ts('October'),
-            11 => ts('November'),
-            12 => ts('December'),
+            1 => E::ts('January'),
+            2 => E::ts('February'),
+            3 => E::ts('March'),
+            4 => E::ts('April'),
+            5 => E::ts('May'),
+            6 => E::ts('June'),
+            7 => E::ts('July'),
+            8 => E::ts('August'),
+            9 => E::ts('September'),
+            10 => E::ts('October'),
+            11 => E::ts('November'),
+            12 => E::ts('December'),
           ];
           // Add this option list to this column _columns. This is
           // required so that filter statistics show properly.
@@ -6509,7 +6509,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
         if (!empty($field['options']) ||
           $fieldName == 'state_province_id' || $fieldName == 'county_id'
         ) {
-          $element = $this->addElement('select', "{$prefix}{$fieldName}_op", ts('Operator:'), $operations);
+          $element = $this->addElement('select', "{$prefix}{$fieldName}_op", E::ts('Operator:'), $operations);
           if (count($operations) <= 1) {
             $element->freeze();
           }
@@ -6527,7 +6527,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
               'style' => 'min-width:250px',
               'class' => 'crm-select2 huge',
               'multiple' => TRUE,
-              'placeholder' => ts('- select -'),
+              'placeholder' => E::ts('- select -'),
             ]);
           }
         }
@@ -6535,14 +6535,14 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
 
       case CRM_Report_Form::OP_SELECT:
         // assume a select field
-        $this->addElement('select', "{$prefix}{$fieldName}_op", ts('Operator:'), $operations);
+        $this->addElement('select', "{$prefix}{$fieldName}_op", E::ts('Operator:'), $operations);
         if (!empty($field['options'])) {
           $this->addElement('select', "{$prefix}{$fieldName}_value", NULL, $field['options']);
         }
         break;
 
       case 256:
-        $this->addElement('select', "{$prefix}{$fieldName}_op", ts('Operator:'), $operations);
+        $this->addElement('select', "{$prefix}{$fieldName}_op", E::ts('Operator:'), $operations);
         $this->setEntityRefDefaults($field, $table);
         $this->addEntityRef("{$prefix}{$fieldName}_value", NULL, $field['attributes']);
         break;
@@ -6558,18 +6558,18 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
         break;
       case self::OP_SINGLEDATE:
         // build single datetime field
-        $this->addElement('select', "{$prefix}{$fieldName}_op", ts('Operator:'), $operations);
-        $this->add('datepicker', "{$prefix}{$fieldName}_value", ts(''), FALSE, FALSE, ['time' => FALSE]);
+        $this->addElement('select', "{$prefix}{$fieldName}_op", E::ts('Operator:'), $operations);
+        $this->add('datepicker', "{$prefix}{$fieldName}_value", E::ts(''), FALSE, FALSE, ['time' => FALSE]);
         break;
       case CRM_Report_Form::OP_INT:
       case CRM_Report_Form::OP_FLOAT:
         // and a min value input box
-        $this->add('text', "{$prefix}{$fieldName}_min", ts('Min'));
+        $this->add('text', "{$prefix}{$fieldName}_min", E::ts('Min'));
         // and a max value input box
-        $this->add('text', "{$prefix}{$fieldName}_max", ts('Max'));
+        $this->add('text', "{$prefix}{$fieldName}_max", E::ts('Max'));
       default:
         // default type is string
-        $this->addElement('select', "{$prefix}{$fieldName}_op", ts('Operator:'), $operations,
+        $this->addElement('select', "{$prefix}{$fieldName}_op", E::ts('Operator:'), $operations,
           ['onchange' => "return showHideMaxMinVal( '" . $prefix . $fieldName . "', this.value );"]
         );
         // we need text box for value input
@@ -6727,11 +6727,11 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
       }
 
     }
-    $this->add('select', 'aggregate_column_headers', ts('Aggregate Report Column Headers'), $aggregateColumnHeaderFields, FALSE,
-      ['id' => 'aggregate_column_headers', 'title' => ts('- select -')]
+    $this->add('select', 'aggregate_column_headers', E::ts('Aggregate Report Column Headers'), $aggregateColumnHeaderFields, FALSE,
+      ['id' => 'aggregate_column_headers', 'title' => E::ts('- select -')]
     );
-    $this->add('select', 'aggregate_row_headers', ts('Row Fields'), $aggregateRowHeaderFields, FALSE,
-      ['id' => 'aggregate_row_headers', 'title' => ts('- select -')]
+    $this->add('select', 'aggregate_row_headers', E::ts('Row Fields'), $aggregateRowHeaderFields, FALSE,
+      ['id' => 'aggregate_row_headers', 'title' => E::ts('- select -')]
     );
     $this->_columns[$this->_baseTable]['fields']['include_null'] = [
       'title' => 'Show column for unknown',
@@ -6739,7 +6739,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
       'default' => TRUE,
     ];
     $this->tabs['Aggregate'] = [
-      'title' => ts('Pivot table'),
+      'title' => E::ts('Pivot table'),
       'tpl' => 'Aggregate',
       'div_label' => 'set-aggregate',
     ];
@@ -7132,7 +7132,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
         // Perhaps later we should find a way to support them not being the same but for now....
         if (CRM_Utils_Array::value('field_on_null', $orderBys[$fieldName], [])
           !== CRM_Utils_Array::value('field_on_null', $selectedFields[$fieldName], [])) {
-          CRM_Core_Session::setStatus(E::ts('Selected field fallback altered to match order by fallback. Currently different configurations are not supported if both are selected'));
+          CRM_Core_Session::setStatus(E::E::ts('Selected field fallback altered to match order by fallback. Currently different configurations are not supported if both are selected'));
           $selectedFields[$fieldName]['field_on_null'] = CRM_Utils_Array::value('field_on_null', $orderBys[$fieldName], []);
           $this->_formValues['extended_fields'][$fieldName] = $selectedFields[$fieldName];
         }
@@ -7292,7 +7292,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
       $this->_columns[$tableKey]['metadata'][$fieldName . '_qty'] = array_merge(
         $field, [
           'title' => "$prefixLabel{$field['label']} Quantity",
-          'statistics' => ['count' => ts("Quantity Selected")],
+          'statistics' => ['count' => E::ts("Quantity Selected")],
         ]
       );
     }
@@ -7558,9 +7558,9 @@ WHERE cg.extends IN ('" . $extendsString . "') AND
 
     if ($field['type'] === CRM_Utils_Type::T_BOOLEAN) {
       $field['options'] = [
-        '' => ts('- select -'),
-        1 => ts('Yes'),
-        0 => ts('No'),
+        '' => E::ts('- select -'),
+        1 => E::ts('Yes'),
+        0 => E::ts('No'),
       ];
     }
     return $field;
@@ -7694,7 +7694,7 @@ WHERE cg.extends IN ('" . $extendsString . "') AND
       if ($from || $to) {
         return [
           'title' => $field['title'],
-          'value' => ts("Between %1 and %2", [1 => $from, 2 => $to]),
+          'value' => E::ts("Between %1 and %2", [1 => $from, 2 => $to]),
         ];
       }
       elseif (in_array($rel = CRM_Utils_Array::value("{$prefix}{$fieldName}_relative", $this->_params),
@@ -7719,7 +7719,7 @@ WHERE cg.extends IN ('" . $extendsString . "') AND
         $max = CRM_Utils_Array::value("{$prefix}{$fieldName}_max", $this->_params);
         $val = CRM_Utils_Array::value("{$prefix}{$fieldName}_value", $this->_params);
         if (in_array($op, ['bw', 'nbw']) && ($min || $max)) {
-          $value = "{$pair[$op]} $min " . ts('and') . " $max";
+          $value = "{$pair[$op]} $min " . E::ts('and') . " $max";
         }
         elseif ($val && CRM_Utils_Array::value('operatorType', $field) & self::OP_ENTITYREF) {
           $this->setEntityRefDefaults($field, $field['table_name']);
@@ -7743,7 +7743,7 @@ WHERE cg.extends IN ('" . $extendsString . "') AND
             }
           }
           $pair[$op] = (count($val) == 1) ? (($op == 'notin' || $op ==
-            'mnot') ? ts('Is Not') : ts('Is')) : CRM_Utils_Array::value($op, $pair);
+            'mnot') ? E::ts('Is Not') : E::ts('Is')) : CRM_Utils_Array::value($op, $pair);
           $val = implode(', ', $val);
           $value = "{$pair[$op]} " . $val;
         }
@@ -8020,7 +8020,7 @@ WHERE cg.extends IN ('" . $extendsString . "') AND
    */
   protected function getAggregateColumnFields() {
     $fields = $this->getMetadataByType('aggregate_columns');
-    $aggregateColumns = ['' => ts('--Select--')];
+    $aggregateColumns = ['' => E::ts('--Select--')];
     foreach ($fields as $key => $spec) {
       $tooCrazyManyOptionsForHeaders = ['county_id', 'country_id', 'state_province_id'];
       if (in_array($spec['name'], $tooCrazyManyOptionsForHeaders)) {
@@ -8041,7 +8041,7 @@ WHERE cg.extends IN ('" . $extendsString . "') AND
     // else it gets REALLLLLYYYYY WIDE - but for rows not sure what limits if
     // any there should be
     $fields = $this->getMetadataByType('metadata');
-    $aggregateRows = ['' => ts('--Select--')];
+    $aggregateRows = ['' => E::ts('--Select--')];
     foreach ($fields as $key => $spec) {
       $aggregateRows[$key] = $spec['title'];
     }

--- a/CRM/Civicase/Hook/BuildForm/CaseCategoryFormLabelTranslationForChangeCase.php
+++ b/CRM/Civicase/Hook/BuildForm/CaseCategoryFormLabelTranslationForChangeCase.php
@@ -57,7 +57,7 @@ class CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslationForChangeCase 
    *   For Elements array.
    */
   private function translateLabel($element) {
-    $label = ts($element->getLabel());
+    $label = $element->getLabel();
     $element->setLabel($label);
   }
 

--- a/CRM/Civicase/Hook/BuildForm/CaseCategoryFormLabelTranslationForChangeCase.php
+++ b/CRM/Civicase/Hook/BuildForm/CaseCategoryFormLabelTranslationForChangeCase.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
+
 /**
  * Class CaseCategoryFormLabelTranslationForChangeCase.
  */
@@ -57,7 +59,7 @@ class CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslationForChangeCase 
    *   For Elements array.
    */
   private function translateLabel($element) {
-    $label = $element->getLabel();
+    $label = CaseTypeCategoryHelper::translate($element->getLabel());
     $element->setLabel($label);
   }
 

--- a/CRM/Civicase/Hook/BuildForm/CaseCategoryFormLabelTranslationForNewCase.php
+++ b/CRM/Civicase/Hook/BuildForm/CaseCategoryFormLabelTranslationForNewCase.php
@@ -52,7 +52,7 @@ class CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslationForNewCase {
    */
   private function translateLabel(array $elements) {
     foreach ($elements as $element) {
-      $label = ts($element->getLabel());
+      $label = $element->getLabel();
       $element->setLabel($label);
     }
   }

--- a/CRM/Civicase/Hook/BuildForm/CaseCategoryFormLabelTranslationForNewCase.php
+++ b/CRM/Civicase/Hook/BuildForm/CaseCategoryFormLabelTranslationForNewCase.php
@@ -52,7 +52,7 @@ class CRM_Civicase_Hook_BuildForm_CaseCategoryFormLabelTranslationForNewCase {
    */
   private function translateLabel(array $elements) {
     foreach ($elements as $element) {
-      $label = $element->getLabel();
+      $label = CaseTypeCategoryHelper::translate($element->getLabel());
       $element->setLabel($label);
     }
   }

--- a/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
+++ b/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
@@ -1,5 +1,6 @@
 <?php
 
+use CRM_Civicase_ExtensionUtil as E;
 use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 use CRM_Civicase_Service_CaseCategorySetting as CaseCategorySetting;
 
@@ -120,6 +121,25 @@ class CRM_Civicase_Hook_Helper_CaseTypeCategory {
     $allowCaseCategoryWebform = Civi::settings()->get($allowCaseCategoryWebform);
 
     return $allowCaseCategoryWebform ? Civi::settings()->get($caseCategoryWebformUrl) : NULL;
+  }
+
+  /**
+   * This is wrapper for "E::ts" function.
+   *
+   * CiviCRM does not recomment to use this to translate variables.
+   * But in CiviCase, we have used this function in few places with variables
+   * to achieve certain results.
+   * Hence this new function has been created, so that it can be only used in
+   * the places where it is absolutely necessary.
+   *
+   * @param string $value
+   *   Value to be translated.
+   *
+   * @return string
+   *   Translated value.
+   */
+  public static function translate($value) {
+    return E::ts($value);
   }
 
 }

--- a/CRM/Civicase/Hook/Permissions/CaseCategory.php
+++ b/CRM/Civicase/Hook/Permissions/CaseCategory.php
@@ -5,7 +5,7 @@ use CRM_Case_BAO_CaseType as CaseType;
 use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 
 /**
- * Class CRM_Civicase_Hook_Permissions_CaseCategory.
+ * Case Category Permissions hook.
  */
 class CRM_Civicase_Hook_Permissions_CaseCategory {
 
@@ -27,6 +27,7 @@ class CRM_Civicase_Hook_Permissions_CaseCategory {
    * CRM_Civicase_Hook_Permissions_CaseCategory constructor.
    *
    * @param array $permissions
+   *   Permissions.
    */
   public function __construct(array &$permissions) {
     $this->permissions = &$permissions;
@@ -55,7 +56,7 @@ class CRM_Civicase_Hook_Permissions_CaseCategory {
     $caseCategoryPermissions = $this->permissionService->get();
     $this->permissions[$caseCategoryPermissions['BASIC_CASE_CATEGORY_INFO']['name']] = [
       $caseCategoryPermissions['BASIC_CASE_CATEGORY_INFO']['label'],
-      ts($caseCategoryPermissions['BASIC_CASE_CATEGORY_INFO']['description']),
+      $caseCategoryPermissions['BASIC_CASE_CATEGORY_INFO']['description'],
     ];
   }
 
@@ -76,7 +77,7 @@ class CRM_Civicase_Hook_Permissions_CaseCategory {
       foreach ($caseCategoryPermissions as $caseCategoryPermission) {
         $this->permissions[$caseCategoryPermission['name']] = [
           $caseCategoryPermission['label'],
-          ts($caseCategoryPermission['description']),
+          $caseCategoryPermission['description'],
         ];
       }
     }

--- a/CRM/Civicase/Hook/PreProcess/CaseCategoryWordReplacementsForChangeCase.php
+++ b/CRM/Civicase/Hook/PreProcess/CaseCategoryWordReplacementsForChangeCase.php
@@ -50,7 +50,7 @@ class CRM_Civicase_Hook_PreProcess_CaseCategoryWordReplacementsForChangeCase {
    *   Form Object.
    */
   private function setPageTitle(CRM_Core_Form $form) {
-    $pageTitle = ts($form->get_template_vars('activityTypeName'));
+    $pageTitle = $form->get_template_vars('activityTypeName');
     $displayName = $this->getContactDisplayName($form);
     if ($displayName) {
       CRM_Utils_System::setTitle($displayName . ' - ' . $pageTitle);

--- a/CRM/Civicase/Hook/PreProcess/CaseCategoryWordReplacementsForChangeCase.php
+++ b/CRM/Civicase/Hook/PreProcess/CaseCategoryWordReplacementsForChangeCase.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
 
 /**
  * Class CaseCategoryWordReplacementsForChangeCase.
@@ -50,7 +51,7 @@ class CRM_Civicase_Hook_PreProcess_CaseCategoryWordReplacementsForChangeCase {
    *   Form Object.
    */
   private function setPageTitle(CRM_Core_Form $form) {
-    $pageTitle = $form->get_template_vars('activityTypeName');
+    $pageTitle = CaseTypeCategoryHelper::translate($form->get_template_vars('activityTypeName'));
     $displayName = $this->getContactDisplayName($form);
     if ($displayName) {
       CRM_Utils_System::setTitle($displayName . ' - ' . $pageTitle);

--- a/CRM/Civicase/Hook/PreProcess/CaseCategoryWordReplacementsForNewCase.php
+++ b/CRM/Civicase/Hook/PreProcess/CaseCategoryWordReplacementsForNewCase.php
@@ -47,7 +47,7 @@ class CRM_Civicase_Hook_PreProcess_CaseCategoryWordReplacementsForNewCase {
     // We need to translate this manually as Civi does not the page title
     // through the ts function.
     $pageTitle = $form->get_template_vars('activityType');
-    CRM_Utils_System::setTitle(ts($pageTitle));
+    CRM_Utils_System::setTitle($pageTitle);
     CaseCategoryHelper::updateBreadcrumbs($caseCategoryId);
   }
 

--- a/CRM/Civicase/Hook/PreProcess/CaseCategoryWordReplacementsForNewCase.php
+++ b/CRM/Civicase/Hook/PreProcess/CaseCategoryWordReplacementsForNewCase.php
@@ -47,7 +47,7 @@ class CRM_Civicase_Hook_PreProcess_CaseCategoryWordReplacementsForNewCase {
     // We need to translate this manually as Civi does not the page title
     // through the ts function.
     $pageTitle = $form->get_template_vars('activityType');
-    CRM_Utils_System::setTitle($pageTitle);
+    CRM_Utils_System::setTitle(CaseTypeCategoryHelper::translate($pageTitle));
     CaseCategoryHelper::updateBreadcrumbs($caseCategoryId);
   }
 

--- a/CRM/Civicase/Hook/Tokens/AddContactTokens.php
+++ b/CRM/Civicase/Hook/Tokens/AddContactTokens.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_Civicase_ExtensionUtil as E;
+
 /**
  * Add current user tokens.
  */
@@ -50,11 +52,11 @@ class CRM_Civicase_Hook_Tokens_AddContactTokens {
   public function run(array &$tokens) {
     foreach ($this->contactFieldsService->get() as $field) {
       $tokens[self::TOKEN_KEY]['current_user.contact_' . $field] =
-        ts('Current User ' . ucwords(str_replace("_", " ", $field)));
+        E::ts('Current User ') . ucwords(str_replace("_", " ", $field));
     }
     foreach ($this->contactCustomFieldsService->get() as $key => $field) {
       $tokens[self::TOKEN_KEY]['current_user.contact_' . $key] =
-        ts('Current User ' . ucwords(str_replace("_", " ", $field)));
+        E::ts('Current User ') . ucwords(str_replace("_", " ", $field));
     }
   }
 

--- a/CRM/Civicase/Hook/Tokens/AddContactTokens.php
+++ b/CRM/Civicase/Hook/Tokens/AddContactTokens.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_Civicase_ExtensionUtil as E;
+use CRM_Civicase_Hook_Helper_CaseTypeCategory as CaseTypeCategoryHelper;
 
 /**
  * Add current user tokens.
@@ -52,11 +52,11 @@ class CRM_Civicase_Hook_Tokens_AddContactTokens {
   public function run(array &$tokens) {
     foreach ($this->contactFieldsService->get() as $field) {
       $tokens[self::TOKEN_KEY]['current_user.contact_' . $field] =
-        E::ts('Current User ') . ucwords(str_replace("_", " ", $field));
+        CaseTypeCategoryHelper::translate('Current User ' . ucwords(str_replace("_", " ", $field)));
     }
     foreach ($this->contactCustomFieldsService->get() as $key => $field) {
       $tokens[self::TOKEN_KEY]['current_user.contact_' . $key] =
-        E::ts('Current User ') . ucwords(str_replace("_", " ", $field));
+        CaseTypeCategoryHelper::translate('Current User ' . ucwords(str_replace("_", " ", $field)));
     }
   }
 

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -13,6 +13,7 @@ use CRM_Civicase_Setup_AddManageWorkflowMenu as AddManageWorkflowMenu;
 use CRM_Civicase_Service_CaseCategoryInstance as CaseCategoryInstance;
 use CRM_Civicase_Helper_CaseUrl as CaseUrlHelper;
 use CRM_Civicase_Setup_AddSingularLabels as AddSingularLabels;
+use CRM_Civicase_ExtensionUtil as E;
 
 /**
  * Collection of upgrade steps.
@@ -152,7 +153,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
    */
   private function createManageCasesMenuItem() {
     $this->addNav([
-      'label' => ts('Manage Cases', ['domain' => 'uk.co.compucorp.civicase']),
+      'label' => E::ts('Manage Cases'),
       'name' => 'Manage Cases',
       'url' => CaseUrlHelper::getUrlByRouteType('all'),
       'permission' => 'access my cases and activities,access all cases and activities',
@@ -301,31 +302,31 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     // Create activity types.
     $this->addOptionValue([
       'option_group_id' => 'activity_type',
-      'label' => ts('Alert'),
+      'label' => E::ts('Alert'),
       'name' => 'Alert',
       'grouping' => 'alert',
       'is_reserved' => 0,
-      'description' => ts('Alerts to display in cases'),
+      'description' => E::ts('Alerts to display in cases'),
       'component_id' => 'CiviCase',
       'icon' => 'fa-exclamation',
     ]);
     $this->addOptionValue([
       'option_group_id' => 'activity_type',
-      'label' => ts('File Upload'),
+      'label' => E::ts('File Upload'),
       'name' => 'File Upload',
       'grouping' => 'file',
       'is_reserved' => 0,
-      'description' => ts('Add files to a case'),
+      'description' => E::ts('Add files to a case'),
       'component_id' => 'CiviCase',
       'icon' => 'fa-file',
     ]);
     $this->addOptionValue([
       'option_group_id' => 'activity_type',
-      'label' => ts('Remove Client From Case'),
+      'label' => E::ts('Remove Client From Case'),
       'name' => 'Remove Client From Case',
       'grouping' => 'system',
       'is_reserved' => 0,
-      'description' => ts('Client removed from multi-client case'),
+      'description' => E::ts('Client removed from multi-client case'),
       'component_id' => 'CiviCase',
       'icon' => 'fa-user-times',
     ]);
@@ -333,7 +334,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     // Create activity statuses.
     $this->addOptionValue([
       'option_group_id' => 'activity_status',
-      'label' => ts('Unread'),
+      'label' => E::ts('Unread'),
       'name' => 'Unread',
       'grouping' => 'communication',
       'is_reserved' => 0,
@@ -341,7 +342,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     ]);
     $this->addOptionValue([
       'option_group_id' => 'activity_status',
-      'label' => ts('Draft'),
+      'label' => E::ts('Draft'),
       'name' => 'Draft',
       'grouping' => 'communication',
       'is_reserved' => 0,
@@ -500,8 +501,10 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
       if ($revisionNum <= $currentRevisionNum) {
         continue;
       }
-      $tsParams = [1 => $this->extensionName, 2 => $revisionNum];
-      $title = ts('Upgrade %1 to revision %2', $tsParams);
+      $title = E::ts('Upgrade %1 to revision %2', [
+        1 => $this->extensionName,
+        2 => $revisionNum,
+      ]);
       $upgradeTask = new CRM_Queue_Task(
         [get_class($this), 'runStepUpgrade'],
         [(new $revisionClass())],

--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ Link to extension: https://github.com/civicrm/org.civicrm.casetokens
 * Case status now has a ‘Status class’ field to show cases which are incomplete, completed, or cancelled.
 
 # Technical Requirements
-* CiviCRM: version >= v5.8, preferably the latest version.
+* CiviCRM: CiviCase is designed and tested with a [patched version of CiviCRM v5.35.2](https://github.com/compucorp/civicrm-core/releases/download/5.35.2%2Bpatch.f58e72/civicrm-5.35.2+patch.f58e72.tar.gz) and may have unforeseen issues with newer versions of CiviCRM and hence we would recommend only using it with that version of CiviCRM. Compucorp normally undertakes to update these extensions shortly after a new CiviCRM security release.
 * [Shoreditch](https://github.com/civicrm/org.civicrm.shoreditch): version >= v0.1-alpha32, preferably the latest version.
+* [Usermenu](https://github.com/compucorp/uk.co.compucorp.usermenu).
 * (Recommended) Migrate from embedded activity revisions to full system logging ([CRM-21051](https://issues.civicrm.org/jira/browse/CRM-21051))
 
 # Installation (git/cli)
@@ -137,6 +138,6 @@ To install the extension on an existing CiviCRM site:
 mkdir sites/all/modules/civicrm/ext
 cd sites/all/modules/civicrm/ext
 git clone https://github.com/civicrm/org.civicrm.shoreditch shoreditch
+git clone https://github.com/compucorp/uk.co.compucorp.usermenu usermenu
 git clone https://github.com/compucorp/uk.co.compucorp.civicase civicase
-cv en shoreditch civicase
-
+cv en shoreditch usermenu civicase

--- a/gulp-tasks/generate-translations.js
+++ b/gulp-tasks/generate-translations.js
@@ -1,0 +1,14 @@
+/**
+ * @file
+ * Exports Gulp task to generate translation files.
+ */
+
+'use strict';
+
+var execSync = require('child_process').execSync;
+
+module.exports = function (done) {
+  execSync('civistrings -o "l10n/civicase.pot" ./ang/ ./api/ ./Civi/ ./CRM/ ./settings/');
+
+  done();
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,7 @@ var sassTask = require('./gulp-tasks/sass.js');
 var sassSyncTask = require('./gulp-tasks/sass-sync.js');
 var testTask = require('./gulp-tasks/karma-unit-test.js');
 var watchTask = require('./gulp-tasks/watch.js');
+var generateTranslationsTask = require('./gulp-tasks/generate-translations.js');
 
 /**
  * Updates and sync the scssRoot paths
@@ -44,3 +45,5 @@ gulp.task('watch', watchTask);
  * Runs sass and test task
  */
 gulp.task('default', gulp.series('sass', 'test'));
+
+gulp.task('generate-translations', generateTranslationsTask);

--- a/l10n/civicase.pot
+++ b/l10n/civicase.pot
@@ -1,0 +1,2364 @@
+#: ./CRM/Civicase/Api/Wrapper/CaseList.php ./ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html ./ang/civicase/case/list/directives/case-list-table-first-column-header.html
+msgid "Next Activity"
+msgstr ""
+
+#: ./CRM/Civicase/Api/Wrapper/CaseList.php ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php ./ang/civicase/case/list/directives/case-list-table-first-column-header.html
+msgid "Subject"
+msgstr ""
+
+#: ./CRM/Civicase/Api/Wrapper/CaseList.php ./ang/civicase/activity/filters/directives/activity-filters.directive.js ./ang/civicase/case/list/directives/case-list-table-first-column-header.html
+msgid "Status"
+msgstr ""
+
+#: ./CRM/Civicase/Api/Wrapper/CaseList.php ./ang/civicase/case/list/directives/case-list-table-first-column-header.html
+msgid "Type"
+msgstr ""
+
+#: ./CRM/Civicase/Api/Wrapper/CaseList.php ./ang/civicase/case/list/directives/case-list-table-first-column-header.html ./ang/civicase/case/search/directives/search.directive.js
+msgid "Case Manager"
+msgstr ""
+
+#: ./CRM/Civicase/Api/Wrapper/CaseList.php ./ang/civicase/case/list/directives/case-list-table-first-column-header.html ./ang/civicase/case/search/directives/search.directive.js
+msgid "Start Date"
+msgstr ""
+
+#: ./CRM/Civicase/Api/Wrapper/CaseList.php ./ang/civicase/case/list/directives/case-list-table-first-column-header.html
+msgid "Last Updated"
+msgstr ""
+
+#: ./CRM/Civicase/Api/Wrapper/CaseList.php ./ang/civicase/case/list/directives/case-list-table-first-column-header.html
+msgid "My Role"
+msgstr ""
+
+#: ./CRM/Civicase/Check.php
+msgid "This system uses embedded activity revisions. This feature should be <em>disabled</em> for CiviCase 5. See <a href=\"%1\">CiviCase Settings</a>."
+msgstr ""
+
+#: ./CRM/Civicase/Check.php
+msgid "CiviCase: Disable old-style logging"
+msgstr ""
+
+#: ./CRM/Civicase/Check.php
+msgid "This system does <em>not</em> use data logging. This feature should be <em>enabled</em> for CiviCase 5. See <a href=\"%1\">Misc Settings</a>."
+msgstr ""
+
+#: ./CRM/Civicase/Check.php
+msgid "CiviCase: Enable new-style logging"
+msgstr ""
+
+#: ./CRM/Civicase/Check.php
+msgid "This database includes ~%1 historical activity revisions based on the legacy format. This may not work correctly with some filters or reports. Consider migrating or archiving this data."
+msgstr ""
+
+#: ./CRM/Civicase/Check.php
+msgid "CiviCase: Migrate historical logs"
+msgstr ""
+
+#: ./CRM/Civicase/FileCategory.php
+msgid "Archive"
+msgstr ""
+
+#: ./CRM/Civicase/FileCategory.php
+msgid "Document"
+msgstr ""
+
+#: ./CRM/Civicase/FileCategory.php
+msgid "Media"
+msgstr ""
+
+#: ./CRM/Civicase/FileCategory.php
+msgid "Presentation"
+msgstr ""
+
+#: ./CRM/Civicase/FileCategory.php
+msgid "Spreadsheet"
+msgstr ""
+
+#: ./CRM/Civicase/FileCategory.php
+msgid "Other"
+msgstr ""
+
+#: ./CRM/Civicase/Form/CaseCategoryTypeCustomField.php
+msgid "Administer %1"
+msgstr ""
+
+#: ./CRM/Civicase/Form/CaseCategoryTypeCustomField.php ./CRM/Civicase/Form/CaseWebforms.php ./ang/civicase/activity/actions/services/move-copy-activity-action.service.js ./ang/civicase/case/actions/services/edit-tags-case-action.service.js ./ang/test/workflow/action-links/controllers/workflow-duplicate.controller.spec.js ./ang/workflow/action-links/controllers/workflow-duplicate.controller.js
+msgid "Save"
+msgstr ""
+
+#: ./CRM/Civicase/Form/CaseCategoryTypeCustomField.php ./CRM/Civicase/Form/CaseWebforms.php ./CRM/Civicase/Form/LockedContacts.php ./ang/civicase/shared/directives/file-uploader.directive.html
+msgid "Cancel"
+msgstr ""
+
+#: ./CRM/Civicase/Form/CaseWebforms.php
+msgid "No Webforms with cases exists!"
+msgstr ""
+
+#: ./CRM/Civicase/Form/CaseWebforms.php
+msgid "Your changes have been saved successfully."
+msgstr ""
+
+#: ./CRM/Civicase/Form/LockedContacts.php
+msgid "Locked Contacts"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/BaseExtendedReport.php
+msgid "Results"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/BaseExtendedReport.php ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Aggregate Report Column Headers"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/BaseExtendedReport.php ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "- select -"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/BaseExtendedReport.php ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Row Fields"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/BaseExtendedReport.php
+msgid "Date Grouping"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/BaseExtendedReport.php
+msgid "Data Function Fields"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/BaseExtendedReport.php
+msgid "Data Functions"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/BaseExtendedReport.php ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Pivot table"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/BaseExtendedReport.php ./CRM/Civicase/Form/Report/ExtendedReport.php ./ang/civicase/case/search/directives/search.directive.js ./ang/workflow/columns/directives/workflow-list-column-is-enabled.html
+msgid "Yes"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/BaseExtendedReport.php ./CRM/Civicase/Form/Report/ExtendedReport.php ./ang/civicase/case/search/directives/search.directive.js ./ang/workflow/columns/directives/workflow-list-column-is-enabled.html
+msgid "No"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/BaseExtendedReport.php ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Total"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/BaseExtendedReport.php
+msgid "Aggregate filter : "
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/BaseExtendedReport.php ./CRM/Civicase/Form/Report/ExtendedReport.php ./ang/civicase/case/list/directives/case-list.html
+msgid "Filters"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/Case/CaseWithActivityPivot.php
+msgid "Case"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/Case/CaseWithActivityPivot.php
+msgid "Activity"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/Case/CaseWithActivityPivot.php
+msgid "As At Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Activity ID"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Source Record ID"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Activity Type"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Activity Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Activity Status"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Activity Duration"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Activity Details"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Activity Result"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Current Revision"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Is activity deleted"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php ./ang/civicase/case/card/directives/case-card-dashboard.directive.html ./ang/civicase/case/list/directives/case-list-table-first-column-header.html ./ang/civicase/case/search/directives/search.directive.html ./ang/civicase/case/search/directives/search.directive.js
+msgid "Case ID"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Case Subject"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Case Status"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Case Type"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php ./ang/civicase/case/search/directives/search.directive.html
+msgid "Case Start Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php ./ang/civicase/case/search/directives/search.directive.html
+msgid "Case End Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Case Created Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Case Modified Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Case is in the Trash?"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Contact Name"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Contact ID"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "External ID"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Contact Name (in sort format)"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Contact Type"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Contact Sub Type"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "First Name"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Middle Name"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Last Name"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Nick Name"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Gender"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Birth Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Age"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Do Not Email"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Do Not Phone"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Do Not Mail"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Do Not SMS"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Do Not Trade"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "No Bulk Emails (User Opt Out)"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Preferred Communication Method"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Preferred Language"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Preferred Mail Format"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Individual Prefix"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Individual Suffix"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Communication Style"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Deceased"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Deceased Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Household Primary Contact ID"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Contact is in Trash"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Created Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Modified Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Latest Activity Type"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Latest Activity Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+msgid "Case Tag"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Display as tab on contact record"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Make available for contact summary page (requires contact layout editor extension)"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Select field to use as contact filter"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Override default number of rows with"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Tag"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php ./ang/civicase/case/search/directives/search.directive.js
+msgid "Tags"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Group"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Unknown"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Select Columns"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Columns"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Display Options"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Sorting"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Order by Column"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Order by Order"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Order by Section"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Page Break"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Until Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "From Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Contains"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Starts with"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Ends with"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Does not contain"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Is equal to"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Is not equal to"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Is empty (Null)"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Is not empty (Null)"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Regex is true"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Select Alternate Template"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Template"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Line Item Financial Type"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Individual Line Item"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Participant Count"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Total Participants"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Price Field (line item)"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Price Field Option (line item)"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Quantity"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Total Quantity Selected"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Unit Price"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Contribution Count"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Count of Contributions"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Line Total"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Total of Line Items"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Line Label"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Tax Amount"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Tax Total of Line Items"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Non Deductible Amount"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Non Deductible Total of Line Items"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Price Field Value Label"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Price Field Label"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Event ID"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Event Participant Status"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Participant Role"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Participant Fee Level"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Current Cycle Start Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Current Membership Cycle End Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Number of Memberships"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Membership Type"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Membership Status"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid " Start Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid " Membership Cycle End Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Financial Account Code"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Financial Account Name"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Cheque #"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Payment Instrument"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Currency"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Transaction Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Transaction #"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Transaction Status"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Financial_type"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Accounting Code"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Tax Deductible"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Amount Paid"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Total Amount Paid"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Scheduled Payment Due"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Amount to be paid"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Cumulative to be paid"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Payment Status"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Next Payment Due"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Next payment Amount"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Payment Link"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Membership Types"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Event Title"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Event Type"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Fee Label"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Event Start Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Event End Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Capacity"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Is Active"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Is Publicly Visible"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Total Income"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Paid Up Income"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Total Paid Up Income"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Pending Income"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Total Pending Income"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "No. Participants"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Total No. Participants"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Paid Up Participants"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Total No,. Paid Up Participants"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Pending Participants"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Total Pending Participants"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Campaign Type"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php ./ang/civicase/activity/filters/directives/activity-filters.directive.js
+msgid "Campaign"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Revenue goal"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Contribution ID"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Contribution Type (Financial)"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Contribution Status"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Contribution Amount"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "No. Contributions"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Total Amount"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Contribution Page"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Contribution Contact ID"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Contribution Details"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Batch Title"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Batch Status"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html ./ang/civicase/case/details/people-tab/directives/other-relationships-tab.directive.html
+msgid "Phone"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Pledged Amount"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Total Pledge Amount"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Financial Type"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Frequency Unit"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Installments"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Pledge Made Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Pledge Start Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Pledge End Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Pledge Status"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html ./ang/civicase/case/details/people-tab/directives/other-relationships-tab.directive.html
+msgid "Email"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Website"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Website Type"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Note"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Relationship ID"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Relationship Start Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Relationship End Date"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php ./ang/civicase/case/details/people-tab/directives/contact-prompt-dialog.html ./ang/civicase/case/details/people-tab/directives/other-relationships-tab.directive.html ./ang/workflow/configs/workflow-list-columns.config.js
+msgid "Description"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Relationship Status"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Relationship Type"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Relationship A-B "
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Relationship B-A "
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Contact Type  A"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Contact Type  B"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Join Filters"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Address Name"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Display Address"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Street Number"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Street Name"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Street Address"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Supplementary Address Field 1"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Supplementary Address Field 2"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Supplementary Address Field 3"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Street Unit"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "City"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Postal Code"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Postal Code Suffix"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "County"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "State/Province"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Country"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Location Type"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid " Address ID"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Primary Address?"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "View Contact Summary for Contact that registered the participant."
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "%1 for this country."
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "%1 for this county."
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "%1 for this state."
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Pledge payment link not added"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "The pledge payment link cannot be added if the grouping options on the report make it ambiguous"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Record a payment received for this pledged payment"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Record Payment"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "N/A"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "January"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "February"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "March"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "April"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "May"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "June"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "July"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "August"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "September"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "October"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "November"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "December"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Operator:"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Min"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Max"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Quantity Selected"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Between %1 and %2"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "and"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Is Not"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "Is"
+msgstr ""
+
+#: ./CRM/Civicase/Form/Report/ExtendedReport.php
+msgid "--Select--"
+msgstr ""
+
+#: ./CRM/Civicase/Helper/CaseCategory.php
+msgid "Home"
+msgstr ""
+
+#: ./CRM/Civicase/Helper/CaseCategory.php
+msgid "CiviCRM"
+msgstr ""
+
+#: ./CRM/Civicase/Helper/CaseCategory.php
+msgid "Case Dashboard"
+msgstr ""
+
+#: ./CRM/Civicase/Hook/BuildForm/AddCaseCategoryCustomFields.php
+msgid "Secondary Label"
+msgstr ""
+
+#: ./CRM/Civicase/Hook/BuildForm/AddCaseCategoryInstanceField.php
+msgid "Instance Type"
+msgstr ""
+
+#: ./CRM/Civicase/Hook/BuildForm/EnableCaseCategoryIconField.php
+msgid "Icon"
+msgstr ""
+
+#: ./CRM/Civicase/Hook/BuildForm/EnableCaseCategoryIconField.php
+msgid "Choose Icon"
+msgstr ""
+
+#: ./CRM/Civicase/Hook/BuildForm/HandleDraftActivities.php
+msgid "Save Draft"
+msgstr ""
+
+#: ./CRM/Civicase/Hook/BuildForm/HandleDraftActivities.php
+msgid "Continue Editing"
+msgstr ""
+
+#: ./CRM/Civicase/Hook/BuildForm/HandleDraftActivities.php
+msgid "Saved as a Draft"
+msgstr ""
+
+#: ./CRM/Civicase/Hook/NavigationMenu/AlterForCaseMenu.php
+msgid "CiviCase Webforms"
+msgstr ""
+
+#: ./CRM/Civicase/Hook/Permissions/ExportCasesAndReports.php
+msgid "Access export action in manage cases and reports"
+msgstr ""
+
+#: ./CRM/Civicase/Hook/PostProcess/ActivityFormStatusWordReplacement.php
+msgid "%1 Saved"
+msgstr ""
+
+#: ./CRM/Civicase/Hook/PreProcess/CaseCategoryWordReplacementsForChangeCase.php
+msgid "%1 Activity"
+msgstr ""
+
+#: ./CRM/Civicase/Hook/Tabset/CaseTabModifier.php ./ang/civicase/case/search/directives/search.directive.js
+msgid "Cases"
+msgstr ""
+
+#: ./CRM/Civicase/Hook/Tokens/AddContactTokens.php
+msgid "Current User "
+msgstr ""
+
+#: ./CRM/Civicase/Hook/ValidateForm/SaveActivityDraft.php
+msgid "Saved"
+msgstr ""
+
+#: ./CRM/Civicase/Hook/ValidateForm/SaveCaseTypeCategory.php
+msgid "Allowed characters: letters (a-z), numbers and hyphen."
+msgstr ""
+
+#: ./CRM/Civicase/Page/ContactActivityTab.php
+msgid "Activity Links"
+msgstr ""
+
+#: ./CRM/Civicase/Service/CaseCategoryMenu.php ./ang/civicase/dashboard/directives/dashboard.directive.html
+msgid "Dashboard"
+msgstr ""
+
+#: ./CRM/Civicase/Service/CaseCategoryMenu.php
+msgid "New %1"
+msgstr ""
+
+#: ./CRM/Civicase/Service/CaseCategoryMenu.php
+msgid "My %1"
+msgstr ""
+
+#: ./CRM/Civicase/Service/CaseCategoryMenu.php
+msgid "My %1 activities"
+msgstr ""
+
+#: ./CRM/Civicase/Service/CaseCategoryMenu.php
+msgid "All %1"
+msgstr ""
+
+#: ./CRM/Civicase/Service/CaseCategoryMenu.php
+msgid "Manage %1 Types"
+msgstr ""
+
+#: ./CRM/Civicase/Setup/AddCaseCategoryWordReplacementOptionGroup.php
+msgid "Case Type Category Word Replacements"
+msgstr ""
+
+#: ./CRM/Civicase/Setup/AddChangeCaseRoleDateActivityTypes.php
+msgid "Change Case Role Start Date"
+msgstr ""
+
+#: ./CRM/Civicase/Setup/AddChangeCaseRoleDateActivityTypes.php
+msgid "Change Case Role End Date"
+msgstr ""
+
+#: ./CRM/Civicase/Setup/CaseCategoryInstanceSupport.php
+msgid "Case Category Instance Type"
+msgstr ""
+
+#: ./CRM/Civicase/Setup/CaseTypeCategorySupport.php ./ang/civicase/activity/filters/directives/activity-filters.directive.html
+msgid "Case Type Categories"
+msgstr ""
+
+#: ./CRM/Civicase/Upgrader/Base.php ./CRM/Civicase/Upgrader.php
+msgid "Upgrade %1 to revision %2"
+msgstr ""
+
+#: ./CRM/Civicase/Upgrader.php ./ang/civicase/case/list/directives/case-list.html
+msgid "Manage Cases"
+msgstr ""
+
+#: ./CRM/Civicase/Upgrader.php
+msgid "Alert"
+msgstr ""
+
+#: ./CRM/Civicase/Upgrader.php
+msgid "Alerts to display in cases"
+msgstr ""
+
+#: ./CRM/Civicase/Upgrader.php
+msgid "File Upload"
+msgstr ""
+
+#: ./CRM/Civicase/Upgrader.php
+msgid "Add files to a case"
+msgstr ""
+
+#: ./CRM/Civicase/Upgrader.php ./ang/civicase-base/replaceable-db-strings/activity-types.js
+msgid "Remove Client From Case"
+msgstr ""
+
+#: ./CRM/Civicase/Upgrader.php
+msgid "Client removed from multi-client case"
+msgstr ""
+
+#: ./CRM/Civicase/Upgrader.php
+msgid "Unread"
+msgstr ""
+
+#: ./CRM/Civicase/Upgrader.php
+msgid "Draft"
+msgstr ""
+
+#: ./ang/civicase/activity/actions/services/delete-activity-action.service.js ./ang/civicase/activity/panel/directives/activity-panel.directive.js
+msgid "Delete Activity"
+msgstr ""
+
+#: ./ang/civicase/activity/actions/services/delete-activity-action.service.js
+msgid "Permanently delete %1 activit%2?"
+msgstr ""
+
+#: ./ang/civicase/activity/actions/services/move-copy-activity-action.html
+msgid "Select Case"
+msgstr ""
+
+#: ./ang/civicase/activity/actions/services/move-copy-activity-action.html ./ang/civicase/shared/directives/file-uploader.directive.html
+msgid "Activity Subject"
+msgstr ""
+
+#: ./ang/civicase/activity/actions/services/move-copy-activity-action.service.js
+msgid " %1Activity"
+msgstr ""
+
+#: ./ang/civicase/activity/actions/services/move-copy-activity-action.service.js
+msgid " %1 Activities"
+msgstr ""
+
+#: ./ang/civicase/activity/card/directives/activity-card-big.directive.html ./ang/civicase/activity/card/directives/activity-card-long.directive.html ./ang/civicase/activity/card/directives/activity-card-short.directive.html
+msgid "Loading..."
+msgstr ""
+
+#: ./ang/civicase/activity/card/directives/activity-card-big.directive.html ./ang/civicase/activity/card/directives/activity-card-long.directive.html ./ang/civicase/activity/card/directives/activity-card-short.directive.html
+msgid "Download File"
+msgstr ""
+
+#: ./ang/civicase/activity/card/directives/activity-card-big.directive.html ./ang/civicase/activity/card/directives/activity-card-long.directive.html ./ang/civicase/activity/card/directives/activity-card-short.directive.html ./ang/civicase/activity/panel/directives/activity-panel.directive.html
+msgid "Add star"
+msgstr ""
+
+#: ./ang/civicase/activity/card/directives/activity-card-big.directive.html ./ang/civicase/activity/card/directives/activity-card-long.directive.html ./ang/civicase/activity/card/directives/activity-card-short.directive.html ./ang/civicase/activity/panel/directives/activity-panel.directive.html
+msgid "Unstar"
+msgstr ""
+
+#: ./ang/civicase/activity/card/directives/activity-card-big.directive.html ./ang/civicase/activity/card/directives/activity-card-long.directive.html ./ang/civicase/activity/card/directives/activity-card-short.directive.html
+msgid "Mark incomplete"
+msgstr ""
+
+#: ./ang/civicase/activity/card/directives/activity-card-big.directive.html ./ang/civicase/activity/card/directives/activity-card-long.directive.html ./ang/civicase/activity/card/directives/activity-card-short.directive.html
+msgid "Mark complete"
+msgstr ""
+
+#: ./ang/civicase/activity/card/directives/activity-card-big.directive.html
+msgid "Click on the button below to add a milestone to this case"
+msgstr ""
+
+#: ./ang/civicase/activity/card/directives/activity-card-big.directive.html
+msgid "ADD ACTIVITY"
+msgstr ""
+
+#: ./ang/civicase/activity/card/directives/activity-card-long.directive.html ./ang/civicase/activity/card/directives/activity-card-short.directive.html ./ang/civicase/case/card/directives/case-card-case-list.directive.html ./ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html ./ang/civicase/case/details/directives/case-details-header.directive.html
+msgid "Case ID:"
+msgstr ""
+
+#: ./ang/civicase/activity/card/directives/activity-card-menu-file.html ./ang/civicase/activity/filters/directives/activity-filters.directive.html ./ang/civicase/case/details/file-tab/directives/case-details-file-tab.directive.html ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html ./ang/civicase/case/details/people-tab/directives/other-relationships-tab.directive.html ./ang/civicase/case/list/directives/case-list-table-first-column-header.html ./ang/workflow/directives/workflow-list.directive.html
+msgid "Actions"
+msgstr ""
+
+#: ./ang/civicase/activity/card/directives/activity-card-menu-file.html
+msgid "Download"
+msgstr ""
+
+#: ./ang/civicase/activity/card/directives/activity-card-menu-file.html ./ang/civicase-base/providers/activity-actions.provider.js
+msgid "Delete"
+msgstr ""
+
+#: ./ang/civicase/activity/card/directives/activity-card.directive.js
+msgid "Deleting..."
+msgstr ""
+
+#: ./ang/civicase/activity/card/directives/activity-card.directive.js ./ang/civicase/activity/filters/directives/activity-filters.directive.js
+msgid "Deleted"
+msgstr ""
+
+#: ./ang/civicase/activity/feed/directives/activity-feed.directive.html
+msgid "Click for more"
+msgstr ""
+
+#: ./ang/civicase/activity/feed/directives/activity-feed.directive.html ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html ./ang/civicase/case/details/people-tab/directives/other-relationships-tab.directive.html
+msgid "None Found"
+msgstr ""
+
+#: ./ang/civicase/activity/feed/directives/activity-feed.directive.html
+msgid "Showing all %1"
+msgstr ""
+
+#: ./ang/civicase/activity/feed/directives/activity-feed.directive.js ./ang/civicase/activity/filters/directives/activity-filters-contact.directive.js ./ang/civicase/case/actions/directives/case-actions.directive.js ./ang/civicase/case/actions/services/change-status-case-action.service.js ./ang/civicase/case/actions/services/delete-cases-case-action.service.js ./ang/civicase/case/details/file-tab/directives/file-filter.directive.js ./ang/civicase/case/search/controllers/search.controller.js ./ang/civicase/shared/directives/crm-ui-number-range.directive.js ./ang/civicase/shared/directives/file-uploader.directive.js
+msgid "civicase"
+msgstr ""
+
+#: ./ang/civicase/activity/feed/directives/activity-feed.directive.js
+msgid "Overdue Activities"
+msgstr ""
+
+#: ./ang/civicase/activity/feed/directives/activity-feed.directive.js
+msgid "Future Activities"
+msgstr ""
+
+#: ./ang/civicase/activity/feed/directives/activity-feed.directive.js
+msgid "Past Activities - Prior to Today"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters-contact.directive.html
+msgid "Show only activities created by, involving or assigned to me"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters-contact.directive.html
+msgid "My Activities"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters-contact.directive.html
+msgid "Show only activities created by me but assigned to someone other than me"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters-contact.directive.html
+msgid "Delegated"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters-contact.directive.html
+msgid "Show all activities regardless of who created them, who they are assigned to or who they are with"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters-contact.directive.html
+msgid "All"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters.directive.html
+msgid "Show overdue activities first"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters.directive.html
+msgid "Show case activities"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters.directive.html
+msgid "Select timeline"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters.directive.html ./ang/civicase/case/details/file-tab/directives/file-filter.directive.html
+msgid "All Activity Categories"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters.directive.html
+msgid "Show only activities with attachments"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters.directive.html
+msgid "Show only starred items"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters.directive.html
+msgid "Click to view More Filters"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters.directive.html
+msgid "Clear Filters"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters.directive.html
+msgid "Add Filter"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters.directive.js
+msgid "Activity type"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters.directive.js ./ang/test/civicase/activity/filters/directives/activity-filters.directive.spec.js
+msgid "With"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters.directive.js ./ang/test/civicase/activity/filters/directives/activity-filters.directive.spec.js
+msgid "Assigned to"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters.directive.js ./ang/civicase/case/details/file-tab/directives/file-filter.directive.html ./ang/civicase/case/search/directives/search.directive.html ./ang/test/civicase/activity/filters/directives/activity-filters.directive.spec.js
+msgid "Tagged"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters.directive.js ./ang/civicase/case/details/file-tab/directives/file-filter.directive.html ./ang/test/civicase/activity/filters/directives/activity-filters.directive.spec.js
+msgid "Contains text"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters.directive.js ./ang/test/civicase/activity/filters/directives/activity-filters.directive.spec.js
+msgid "Activity date"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters.directive.js
+msgid "Deleted Activities"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters.directive.js
+msgid "Normal"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters.directive.js
+msgid "Test Activities"
+msgstr ""
+
+#: ./ang/civicase/activity/filters/directives/activity-filters.directive.js
+msgid "Test"
+msgstr ""
+
+#: ./ang/civicase/activity/panel/directives/activity-panel.directive.html
+msgid "Change activity status"
+msgstr ""
+
+#: ./ang/civicase/activity/panel/directives/activity-panel.directive.html ./ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html ./ang/civicase/case/details/directives/case-details-header.directive.html
+msgid "Change status to:"
+msgstr ""
+
+#: ./ang/civicase/activity/panel/directives/activity-panel.directive.html
+msgid "Change activity priority"
+msgstr ""
+
+#: ./ang/civicase/activity/panel/directives/activity-panel.directive.html
+msgid "Change priority to:"
+msgstr ""
+
+#: ./ang/civicase/activity/panel/directives/activity-panel.directive.js
+msgid "Permanently delete this %1 activity?"
+msgstr ""
+
+#: ./ang/civicase/case/actions/directives/case-actions.directive.js
+msgid "Delete Permanently"
+msgstr ""
+
+#: ./ang/civicase/case/actions/directives/case-actions.directive.js
+msgid "Restore from Trash"
+msgstr ""
+
+#: ./ang/civicase/case/actions/services/change-status-case-action.service.js
+msgid "Select New Status"
+msgstr ""
+
+#: ./ang/civicase/case/actions/services/change-status-case-action.service.js
+msgid "Notes"
+msgstr ""
+
+#: ./ang/civicase/case/actions/services/change-status-case-action.service.js
+msgid "Case status changed from %1 to %2"
+msgstr ""
+
+#: ./ang/civicase/case/actions/services/delete-cases-case-action.service.js
+msgid "Permanently delete selected case? This cannot be undone."
+msgstr ""
+
+#: ./ang/civicase/case/actions/services/delete-cases-case-action.service.js
+msgid "Permanently delete %1 cases? This cannot be undone."
+msgstr ""
+
+#: ./ang/civicase/case/actions/services/delete-cases-case-action.service.js
+msgid "Undelete selected case?"
+msgstr ""
+
+#: ./ang/civicase/case/actions/services/delete-cases-case-action.service.js
+msgid "Undelete %1 cases?"
+msgstr ""
+
+#: ./ang/civicase/case/actions/services/delete-cases-case-action.service.js
+msgid "This case and all associated activities will be moved to the trash."
+msgstr ""
+
+#: ./ang/civicase/case/actions/services/delete-cases-case-action.service.js
+msgid "%1 cases and all associated activities will be moved to the trash."
+msgstr ""
+
+#: ./ang/civicase/case/actions/services/email-case-action.service.js ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.js ./ang/civicase/case/details/people-tab/directives/other-relationships-tab.directive.html ./ang/civicase/case/details/people-tab/services/people-tab-roles.service.js ./ang/civicase/case/search/directives/search.directive.js ./ang/test/civicase/case/details/people-tab/services/people-tab-roles.service.spec.js
+msgid "Client"
+msgstr ""
+
+#: ./ang/civicase/case/actions/services/email-case-action.service.js ./ang/test/civicase/case/actions/services/email-case-action.service.spec.js
+msgid "Draft Email"
+msgstr ""
+
+#: ./ang/civicase/case/actions/services/email-case-action.service.js
+msgid "Select case role(s)."
+msgstr ""
+
+#: ./ang/civicase/case/actions/services/email-case-action.service.js
+msgid "No case roles are selected"
+msgstr ""
+
+#: ./ang/civicase/case/actions/services/email-case-action.service.js
+msgid "Please add a contact for the selected role(s)."
+msgstr ""
+
+#: ./ang/civicase/case/actions/services/email-case-action.service.js
+msgid "No contacts available for selected role(s)"
+msgstr ""
+
+#: ./ang/civicase/case/actions/services/go-to-webform-case-action.service.js ./ang/test/civicase/case/actions/services/go-to-webforms-case-action.service.spec.js
+msgid "Please refresh this page to view updates from the webform submission."
+msgstr ""
+
+#: ./ang/civicase/case/actions/services/go-to-webform-case-action.service.js ./ang/test/civicase/case/actions/services/go-to-webforms-case-action.service.spec.js
+msgid "Refresh"
+msgstr ""
+
+#: ./ang/civicase/case/actions/services/merge-cases-case-action.service.js
+msgid "Merge all activity records into a single case?"
+msgstr ""
+
+#: ./ang/civicase/case/actions/services/merge-cases-case-action.service.js
+msgid "Warning: selected cases are of different types."
+msgstr ""
+
+#: ./ang/civicase/case/actions/services/merge-cases-case-action.service.js
+msgid "Warning: selected cases belong to different clients."
+msgstr ""
+
+#: ./ang/civicase/case/card/directives/case-card-contact-record.directive.html
+msgid "Case ID :"
+msgstr ""
+
+#: ./ang/civicase/case/card/directives/case-card-other-cases.directive.html
+msgid "Case is for the same client(s)"
+msgstr ""
+
+#: ./ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
+msgid "Go To Case"
+msgstr ""
+
+#: ./ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html ./ang/civicase/case/details/directives/case-details-header.directive.html
+msgid "Change case status"
+msgstr ""
+
+#: ./ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html ./ang/civicase/case/details/summary-tab/directives/case-summary.directive.html
+msgid "This case doesn't currently have a description. Click here to add now."
+msgstr ""
+
+#: ./ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html ./ang/civicase/case/details/directives/case-details-header.directive.html ./ang/civicase-base/replaceable-db-strings/activity-types.js
+msgid "Change Case Type"
+msgstr ""
+
+#: ./ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html ./ang/civicase/case/details/directives/case-details-header.directive.html
+msgid "Ongoing"
+msgstr ""
+
+#: ./ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html ./ang/civicase/case/details/directives/case-details-header.directive.html
+msgid "Case Manager:"
+msgstr ""
+
+#: ./ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html ./ang/civicase/case/details/configs/add-case-details-tabs.config.js ./ang/test/civicase/case/details/configs/add-case-details-tabs.config.spec.js
+msgid "Summary"
+msgstr ""
+
+#: ./ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
+msgid "Last Activity"
+msgstr ""
+
+#: ./ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
+msgid "Contact Role"
+msgstr ""
+
+#: ./ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
+msgid "Last Modified"
+msgstr ""
+
+#: ./ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-list.directive.html
+msgid "Load More Cases"
+msgstr ""
+
+#: ./ang/civicase/case/details/configs/add-case-details-tabs.config.js ./ang/civicase/dashboard/directives/dashboard.directive.html ./ang/test/civicase/case/details/configs/add-case-details-tabs.config.spec.js
+msgid "Activities"
+msgstr ""
+
+#: ./ang/civicase/case/details/configs/add-case-details-tabs.config.js ./ang/test/civicase/case/details/configs/add-case-details-tabs.config.spec.js
+msgid "People"
+msgstr ""
+
+#: ./ang/civicase/case/details/configs/add-case-details-tabs.config.js ./ang/test/civicase/case/details/configs/add-case-details-tabs.config.spec.js
+msgid "Files"
+msgstr ""
+
+#: ./ang/civicase/case/details/configs/add-case-details-tabs.config.js ./ang/test/civicase/case/details/configs/add-case-details-tabs.config.spec.js
+msgid "Linked Cases"
+msgstr ""
+
+#: ./ang/civicase/case/details/directives/case-details-header.directive.html
+msgid "Case is in Trash"
+msgstr ""
+
+#: ./ang/civicase/case/details/directives/case-details-tabs.directive.html
+msgid "Current"
+msgstr ""
+
+#: ./ang/civicase/case/details/directives/case-details-tabs.directive.html
+msgid "Add new"
+msgstr ""
+
+#: ./ang/civicase/case/details/directives/case-details-tabs.directive.html
+msgid "Create email"
+msgstr ""
+
+#: ./ang/civicase/case/details/directives/case-details-tabs.directive.html
+msgid "Create PDF letter"
+msgstr ""
+
+#: ./ang/civicase/case/details/directives/case-details-tabs.directive.html
+msgid "Add activity"
+msgstr ""
+
+#: ./ang/civicase/case/details/directives/case-details-tabs.directive.html
+msgid "Add timeline"
+msgstr ""
+
+#: ./ang/civicase/case/details/directives/case-details-tabs.directive.html
+msgid "Add all activities from %1 to this case?"
+msgstr ""
+
+#: ./ang/civicase/case/details/directives/case-details.directive.js ./ang/test/civicase/case/details/directives/case-details.directive.spec.js
+msgid "Details"
+msgstr ""
+
+#: ./ang/civicase/case/details/file-tab/directives/file-filter.directive.html
+msgid "File Types..."
+msgstr ""
+
+#: ./ang/civicase/case/details/file-tab/directives/file-list.directive.html
+msgid "No files found"
+msgstr ""
+
+#: ./ang/civicase/case/details/linked-cases-tab/directives/case-details-linked-cases-tab--placeholder.directive.html ./ang/civicase/case/details/linked-cases-tab/directives/case-details-linked-cases-tab.directive.html ./ang/civicase-base/replaceable-db-strings/activity-types.js ./ang/civicase.ang.php
+msgid "Link Cases"
+msgstr ""
+
+#: ./ang/civicase/case/details/linked-cases-tab/directives/case-details-linked-cases-tab--placeholder.directive.html ./ang/civicase/case/details/summary-tab/directives/case-summary-other-cases.directive.html
+msgid "Other Cases"
+msgstr ""
+
+#: ./ang/civicase/case/details/linked-cases-tab/directives/case-details-linked-cases-tab.directive.html
+msgid "No linked cases"
+msgstr ""
+
+#: ./ang/civicase/case/details/linked-cases-tab/directives/case-details-linked-cases-tab.directive.html
+msgid "Click the button below to create a new link for this case"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.html
+msgid "Case Roles"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.html
+msgid "Other Relationships"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html
+msgid "Add Case Role"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html ./ang/civicase/case/details/people-tab/directives/other-relationships-tab.directive.html
+msgid "%1 Contacts"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html ./ang/civicase/case/details/people-tab/directives/other-relationships-tab.directive.html
+msgid "Select Records:"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html
+msgid "All %1 records"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html
+msgid "Display previous case role assignments"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html
+msgid "All Roles"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html
+msgid "Role"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html ./ang/civicase/case/details/people-tab/directives/other-relationships-tab.directive.html ./ang/civicase/shared/directives/file-uploader.directive.html
+msgid "Name"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html
+msgid "Start date"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html
+msgid "End date"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html
+msgid "Unassigned"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html
+msgid "Reassign %1"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html
+msgid "Add Another %1"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.js
+msgid "Remove %1"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html ./ang/civicase/case/details/people-tab/directives/other-relationships-tab.directive.html
+msgid "Send Email"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html ./ang/civicase/case/details/people-tab/directives/other-relationships-tab.directive.html ./ang/civicase.ang.php
+msgid "Print/Merge Document"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html ./ang/civicase/case/details/people-tab/directives/other-relationships-tab.directive.html
+msgid "Page %1 of %2"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.js
+msgid "Replace %1"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.js
+msgid "Remove %1 as %2?"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.js
+msgid "%1 removed as %2"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.js
+msgid "Add Client"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.js
+msgid "Add %1"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.js
+msgid "%1 replaced %2 as %3"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.js
+msgid "%1 added as Client"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.js
+msgid "Continue"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/contact-prompt-dialog.html
+msgid "Select Contact"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/other-relationships-tab.directive.html
+msgid "Relationship"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/other-relationships-tab.directive.html
+msgid "All %1 Contacts"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/other-relationships-tab.directive.html
+msgid "%1 Selected"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/directives/other-relationships-tab.directive.html
+msgid "Edit Relationship"
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/messages.constants.js
+msgid "Case clients cannot be selected for a case role. Please select another contact."
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/messages.constants.js
+msgid "Case clients cannot be same as other case roles. Please select another contact."
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/messages.constants.js
+msgid "Please select a contact."
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/messages.constants.js
+msgid "End date cannot be before start date of the relationship."
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/messages.constants.js
+msgid "Reassignment date cannot be before start date of the relationship."
+msgstr ""
+
+#: ./ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
+msgid "Case Manager."
+msgstr ""
+
+#: ./ang/civicase/case/details/summary-tab/directives/case-summary-other-cases.directive.html ./ang/civicase/dashboard/directives/dashboard-tab.directive.html ./ang/civicase/dashboard/directives/dashboard-tab.directive.js
+msgid "cases"
+msgstr ""
+
+#: ./ang/civicase/case/details/summary-tab/directives/case-summary-recent-communications.directive.html
+msgid "Recent Communications"
+msgstr ""
+
+#: ./ang/civicase/case/details/summary-tab/directives/case-summary-recent-communications.directive.html ./ang/civicase/case/details/summary-tab/directives/case-summary-tasks.directive.html
+msgid "View All"
+msgstr ""
+
+#: ./ang/civicase/case/details/summary-tab/directives/case-summary-recent-communications.directive.html
+msgid "Click on the button below to add a\n      communication to this case"
+msgstr ""
+
+#: ./ang/civicase/case/details/summary-tab/directives/case-summary-recent-communications.directive.html
+msgid "Create new communication"
+msgstr ""
+
+#: ./ang/civicase/case/details/summary-tab/directives/case-summary-tasks.directive.html
+msgid "Tasks"
+msgstr ""
+
+#: ./ang/civicase/case/details/summary-tab/directives/case-summary-tasks.directive.html
+msgid "Click on the button below to add a task to this case"
+msgstr ""
+
+#: ./ang/civicase/case/details/summary-tab/directives/case-summary-tasks.directive.html
+msgid "Create new tasks"
+msgstr ""
+
+#: ./ang/civicase/case/details/summary-tab/directives/case-summary.directive.html
+msgid "Case last updated: "
+msgstr ""
+
+#: ./ang/civicase/case/list/directives/case-list-table-first-column-header.html
+msgid "Case Client"
+msgstr ""
+
+#: ./ang/civicase/case/list/directives/case-list-table-first-column-header.html ./ang/civicase/case/search/directives/search.directive.js
+msgid "End Date"
+msgstr ""
+
+#: ./ang/civicase/case/list/directives/case-list-table-first-column-header.html
+msgid "Date Created"
+msgstr ""
+
+#: ./ang/civicase/case/list/directives/case-list-table-first-column-header.html
+msgid "Next Milestone"
+msgstr ""
+
+#: ./ang/civicase/case/list/directives/case-list-table-first-column-header.html
+msgid "Next Task"
+msgstr ""
+
+#: ./ang/civicase/case/list/directives/case-list-table-first-column-header.html
+msgid "Next Communication"
+msgstr ""
+
+#: ./ang/civicase/case/list/directives/case-list-table.directive.html
+msgid "No cases found matching the search criteria."
+msgstr ""
+
+#: ./ang/civicase/case/search/directives/search.directive.html
+msgid "Case Type: Any"
+msgstr ""
+
+#: ./ang/civicase/case/search/directives/search.directive.html
+msgid "Status: All cases"
+msgstr ""
+
+#: ./ang/civicase/case/search/directives/search.directive.html
+msgid "Status: All open cases"
+msgstr ""
+
+#: ./ang/civicase/case/search/directives/search.directive.html
+msgid "Relationship Type: All"
+msgstr ""
+
+#: ./ang/civicase/case/search/directives/search.directive.html
+msgid "Edit Search"
+msgstr ""
+
+#: ./ang/civicase/case/search/directives/search.directive.html
+msgid "Other Criteria"
+msgstr ""
+
+#: ./ang/civicase/case/search/directives/search.directive.html
+msgid "Search"
+msgstr ""
+
+#: ./ang/civicase/case/search/directives/search.directive.html ./ang/civicase/case/search/directives/search.directive.js
+msgid "Contact Search"
+msgstr ""
+
+#: ./ang/civicase/case/search/directives/search.directive.html ./ang/civicase/case/search/directives/search.directive.js
+msgid "Deleted Cases"
+msgstr ""
+
+#: ./ang/civicase/case/search/directives/search.directive.html
+msgid "Only Show Disabled Cases"
+msgstr ""
+
+#: ./ang/civicase/case/search/directives/search.directive.html
+msgid "Clear Search"
+msgstr ""
+
+#: ./ang/civicase/case/search/directives/search.directive.js ./ang/civicase/dashboard/directives/dashboard.directive.js ./ang/test/civicase/case/search/directives/search.directive.spec.js
+msgid "My Cases"
+msgstr ""
+
+#: ./ang/civicase/case/search/directives/search.directive.js ./ang/civicase/dashboard/directives/dashboard.directive.js ./ang/test/civicase/case/search/directives/search.directive.spec.js
+msgid "Cases I am involved in"
+msgstr ""
+
+#: ./ang/civicase/case/search/directives/search.directive.js ./ang/civicase/dashboard/directives/dashboard.directive.js ./ang/test/civicase/case/search/directives/search.directive.spec.js
+msgid "All Cases"
+msgstr ""
+
+#: ./ang/civicase/case/search/directives/search.directive.js
+msgid "All Case Roles"
+msgstr ""
+
+#: ./ang/civicase/case/search/directives/search.directive.js
+msgid "Me"
+msgstr ""
+
+#: ./ang/civicase/case/search/directives/search.directive.js
+msgid "%1 selected"
+msgstr ""
+
+#: ./ang/civicase/case/search/directives/search.directive.js
+msgid "Case Search Results"
+msgstr ""
+
+#: ./ang/civicase/case/search/directives/search.directive.js
+msgid "All Open"
+msgstr ""
+
+#: ./ang/civicase/contact/directives/contact-card.directive.html
+msgid "View Contact"
+msgstr ""
+
+#: ./ang/civicase/contact/directives/contact-card.directive.html
+msgid "Click the Activity to view all Contacts."
+msgstr ""
+
+#: ./ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
+msgid "Related cases to the user"
+msgstr ""
+
+#: ./ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
+msgid "Add case"
+msgstr ""
+
+#: ./ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
+msgid "This contact has no cases"
+msgstr ""
+
+#: ./ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
+msgid "Click the button below to create a new case for this contact"
+msgstr ""
+
+#: ./ang/civicase/contact-case-tab/directives/contact-case-tab.directive.html
+msgid "Add new case"
+msgstr ""
+
+#: ./ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+msgid "Open Cases"
+msgstr ""
+
+#: ./ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+msgid "Resolved cases"
+msgstr ""
+
+#: ./ang/civicase/contact-case-tab/directives/contact-case-tab.directive.js
+msgid "Other cases for this contact"
+msgstr ""
+
+#: ./ang/civicase/dashboard/directives/add-case-dashboard-action-button.html
+msgid "Add Case"
+msgstr ""
+
+#: ./ang/civicase/dashboard/directives/dashboard.directive.html
+msgid "CiviCase Dashboard - My Cases"
+msgstr ""
+
+#: ./ang/civicase/dashboard/directives/dashboard.directive.html
+msgid "CiviCase Dashboard - All Cases"
+msgstr ""
+
+#: ./ang/civicase/shared/directives/crm-ui-number-range.directive.js
+msgid "From"
+msgstr ""
+
+#: ./ang/civicase/shared/directives/crm-ui-number-range.directive.js
+msgid "To"
+msgstr ""
+
+#: ./ang/civicase/shared/directives/file-uploader.directive.html
+msgid "Drop file here"
+msgstr ""
+
+#: ./ang/civicase/shared/directives/file-uploader.directive.html
+msgid "or click here to browse"
+msgstr ""
+
+#: ./ang/civicase/shared/directives/file-uploader.directive.html
+msgid "Size"
+msgstr ""
+
+#: ./ang/civicase/shared/directives/file-uploader.directive.html
+msgid "Remove"
+msgstr ""
+
+#: ./ang/civicase/shared/directives/file-uploader.directive.html
+msgid "File Description"
+msgstr ""
+
+#: ./ang/civicase/shared/directives/file-uploader.directive.html
+msgid "Add file description"
+msgstr ""
+
+#: ./ang/civicase/shared/directives/file-uploader.directive.html
+msgid "Upload File(s)"
+msgstr ""
+
+#: ./ang/civicase/shared/directives/file-uploader.directive.js
+msgid "Unknown error"
+msgstr ""
+
+#: ./ang/civicase/shared/directives/file-uploader.directive.js
+msgid "Attachment failed"
+msgstr ""
+
+#: ./ang/civicase/shared/directives/file-uploader.directive.js
+msgid "Uploading..."
+msgstr ""
+
+#: ./ang/civicase/shared/directives/file-uploader.directive.js
+msgid "Uploaded"
+msgstr ""
+
+#: ./ang/civicase-base/decorators/root-scope.decorator.js
+msgid "string"
+msgstr ""
+
+#: ./ang/civicase-base/providers/activity-actions.provider.js
+msgid "Resume Draft"
+msgstr ""
+
+#: ./ang/civicase-base/providers/activity-actions.provider.js
+msgid "View in Feed"
+msgstr ""
+
+#: ./ang/civicase-base/providers/activity-actions.provider.js ./ang/workflow/action-links/directives/workflow-list-edit-action.html
+msgid "Edit"
+msgstr ""
+
+#: ./ang/civicase-base/providers/activity-actions.provider.js
+msgid "Print Report"
+msgstr ""
+
+#: ./ang/civicase-base/providers/activity-actions.provider.js
+msgid "Move to Case"
+msgstr ""
+
+#: ./ang/civicase-base/providers/activity-actions.provider.js
+msgid "Copy to Case"
+msgstr ""
+
+#: ./ang/civicase-base/providers/activity-actions.provider.js
+msgid "Tag - add to activities"
+msgstr ""
+
+#: ./ang/civicase-base/providers/activity-actions.provider.js
+msgid "Tag - remove from activities"
+msgstr ""
+
+#: ./ang/civicase-base/providers/activity-actions.provider.js
+msgid "Download All"
+msgstr ""
+
+#: ./ang/civicase-base/replaceable-db-strings/activity-types.js
+msgid "Open Case"
+msgstr ""
+
+#: ./ang/civicase-base/replaceable-db-strings/activity-types.js ./ang/civicase.ang.php
+msgid "Change Case Status"
+msgstr ""
+
+#: ./ang/civicase-base/replaceable-db-strings/activity-types.js
+msgid "Change Case Subject"
+msgstr ""
+
+#: ./ang/civicase-base/replaceable-db-strings/activity-types.js
+msgid "Change Case Start Date"
+msgstr ""
+
+#: ./ang/civicase-base/replaceable-db-strings/activity-types.js
+msgid "Assign Case Role"
+msgstr ""
+
+#: ./ang/civicase-base/replaceable-db-strings/activity-types.js
+msgid "Remove Case Role"
+msgstr ""
+
+#: ./ang/civicase-base/replaceable-db-strings/activity-types.js
+msgid "Merge Case"
+msgstr ""
+
+#: ./ang/civicase-base/replaceable-db-strings/activity-types.js
+msgid "Reassigned Case"
+msgstr ""
+
+#: ./ang/civicase-base/replaceable-db-strings/activity-types.js
+msgid "Change Case Tags"
+msgstr ""
+
+#: ./ang/civicase-base/replaceable-db-strings/activity-types.js
+msgid "Add Client To Case"
+msgstr ""
+
+#: ./ang/civicase.ang.php
+msgid "Edit Tags"
+msgstr ""
+
+#: ./ang/civicase.ang.php
+msgid "Print Case"
+msgstr ""
+
+#: ./ang/civicase.ang.php
+msgid "Email - send now"
+msgstr ""
+
+#: ./ang/civicase.ang.php
+msgid "Link 2 Cases"
+msgstr ""
+
+#: ./ang/civicase.ang.php
+msgid "Merge 2 Cases"
+msgstr ""
+
+#: ./ang/civicase.ang.php
+msgid "Lock Case"
+msgstr ""
+
+#: ./ang/civicase.ang.php
+msgid "Delete Case"
+msgstr ""
+
+#: ./ang/civicase.ang.php
+msgid "Export Cases"
+msgstr ""
+
+#: ./ang/civicase.ang.php
+msgid "Webforms"
+msgstr ""
+
+#: ./ang/test/civicase/case/details/directives/case-details.directive.spec.js
+msgid "Custom Tab"
+msgstr ""
+
+#: ./ang/workflow/action-links/controllers/workflow-duplicate.controller.js
+msgid "This title is already in use. Please choose another"
+msgstr ""
+
+#: ./ang/workflow/action-links/controllers/workflow-duplicate.controller.js
+msgid "Duplicating Workflow..."
+msgstr ""
+
+#: ./ang/workflow/action-links/controllers/workflow-duplicate.controller.js
+msgid "Duplicate created successfully"
+msgstr ""
+
+#: ./ang/workflow/action-links/directives/workflow-list-duplicate-action.html
+msgid "Duplicate"
+msgstr ""
+
+#: ./ang/workflow/configs/workflow-list-columns.config.js
+msgid "Title"
+msgstr ""
+
+#: ./ang/workflow/configs/workflow-list-columns.config.js
+msgid "Enabled?"
+msgstr ""
+
+#: ./ang/workflow/directives/workflow-list.directive.html
+msgid "Manage %1 types"
+msgstr ""
+
+#: ./ang/workflow/directives/workflow-list.directive.html
+msgid "New %1 type"
+msgstr ""
+
+#: ./ang/workflow/directives/workflow-list.directive.html
+msgid "Filter"
+msgstr ""
+
+#: ./ang/workflow/directives/workflow-list.directive.html
+msgid "No %1 types are available."
+msgstr ""
+
+#: ./settings/CiviCase.setting.php
+msgid "Allow cases to be locked"
+msgstr ""
+
+#: ./settings/CiviCase.setting.php
+msgid "This will allow cases to be locked for certain contacts."
+msgstr ""
+
+#: ./settings/CiviCase.setting.php
+msgid "Show \"Coming Soon\" section on Case Summary"
+msgstr ""
+
+#: ./settings/CiviCase.setting.php
+msgid "This configuration controls the visibility of the coming soon section on the case summary screen which has Next Milestone, Next Activity and the Case Calendar."
+msgstr ""
+
+#: ./settings/CiviCase.setting.php
+msgid "Allow linked cases tab"
+msgstr ""
+
+#: ./settings/CiviCase.setting.php
+msgid "This will allow linked cases to be viewed on a separate tab."
+msgstr ""
+
+#: ./settings/CiviCase.setting.php
+msgid "Show Webforms list in a separate dropdown"
+msgstr ""
+
+#: ./settings/CiviCase.setting.php
+msgid "This will show the webforms list in a separate dropdown."
+msgstr ""
+
+#: ./settings/CiviCase.setting.php
+msgid "Label for the Webforms dropdown button"
+msgstr ""
+
+#: ./settings/CiviCase.setting.php
+msgid "Show full name on Case activity feed"
+msgstr ""
+
+#: ./settings/CiviCase.setting.php
+msgid "This configuration determines whether or not the full name of the activity creator is displayed in the case activity feed."
+msgstr ""
+
+#: ./settings/CiviCase.setting.php
+msgid "Include activities I'm involved in"
+msgstr ""
+
+#: ./settings/CiviCase.setting.php
+msgid "Cases I'm involved in filter will include 'activities created by me' and 'activities assigned to me'."
+msgstr ""
+
+#: ./settings/CiviCase.setting.php
+msgid "One active case role"
+msgstr ""
+
+#: ./settings/CiviCase.setting.php
+msgid "This setting will only allow one active instance of each case role for all case types."
+msgstr ""
+
+#: ./settings/CiviCase.setting.php
+msgid "Limit recipients field on bulk email"
+msgstr ""
+
+#: ./settings/CiviCase.setting.php
+msgid "This setting will only allow selected contacts to be added to recipient and Cc/Bcc fields in bulk email."
+msgstr ""
+
+#: ./settings/CiviCase.setting.php
+msgid "Restrict email recipients to contacts involved with the case"
+msgstr ""
+
+#: ./settings/CiviCase.setting.php
+msgid "When this setting is enabled users will only be able to add existing contacts who are either the case clients or people currently involved with the case as recipients of new emails."
+msgstr ""
+


### PR DESCRIPTION
## Overview
The PR implements proper usage of the `ts` or translation function. 

## Technical Details
1. Used `E::ts` instead of `ts`.
2. `ts` function should only be used with string values, so applied the same.
3. A new Gulp task, `generate-translations` has been added, which will generate the translation file(`.pot`).

**New function created for translation**
Under `CRM_Civicase_Hook_Helper_CaseTypeCategory` class a new function `translate` has been created. 
This is wrapper for "E::ts" function.
CiviCRM does not recommend to use this to translate variables. But in CiviCase, we have used this function in few places with variables to achieve certain results. Hence this new function has been created, so that it can be only used in the places where it is absolutely necessary.


The Backstop Tests were run in https://github.com/compucorp/cases-product-suite-backstopjs/actions/runs/1081871388.