### PR TITLE
CPS-501: Fix files tab Activity Category filters

### DIFF
--- a/ang/civicase/case/details/file-tab/directives/file-filter.directive.js
+++ b/ang/civicase/case/details/file-tab/directives/file-filter.directive.js
@@ -52,6 +52,8 @@
       if ($scope.customFilters.tag_id) {
         applyTagsFilter();
       }
+
+      $scope.refresh();
     }
 
     /**

--- a/ang/test/civicase/case/details/file-tab/directives/file-filter.directive.spec.js
+++ b/ang/test/civicase/case/details/file-tab/directives/file-filter.directive.spec.js
@@ -22,6 +22,7 @@
 
         it('filters by the selected tags', () => {
           expect($scope.fileFilterParams.tag_id).toEqual('1');
+          expect($scope.refresh).toHaveBeenCalled();
         });
       });
 
@@ -33,6 +34,7 @@
 
         it('filters by all the selected tags', () => {
           expect($scope.fileFilterParams.tag_id).toEqual({ IN: ['1', '2'] });
+          expect($scope.refresh).toHaveBeenCalled();
         });
       });
 
@@ -44,6 +46,7 @@
 
         it('does not filter by tags', () => {
           expect($scope.fileFilterParams.tag_id).toBeUndefined();
+          expect($scope.refresh).toHaveBeenCalled();
         });
       });
     });
@@ -54,6 +57,7 @@
     function initController () {
       $scope = $rootScope.$new();
       $scope.fileFilterParams = {};
+      $scope.refresh = jasmine.createSpy('refresh');
 
       $controller('civicaseFileFilterController', {
         $scope: $scope


### PR DESCRIPTION
## Overview
In the Case Details Files tab, the activity category filter was not working. This PR fixes the same.

## Before
![before](https://user-images.githubusercontent.com/5058867/120170277-6e48bc00-c21e-11eb-89dd-e77b4318bbbc.gif)

## After
![after](https://user-images.githubusercontent.com/5058867/120170179-56713800-c21e-11eb-9e9a-d76af3fcc5ca.gif)

## Technical Details
In `ang/civicase/case/details/file-tab/directives/file-filter.directive.js`, the `$scope.refresh` function call was missing, and thats why the page was not getting refreshed.