### PR TITLE
CPS-537: Capitalise first letter of Contact Details Menu

### DIFF
--- a/CRM/Civicase/Hook/Tabset/CaseCategoryTabAdd.php
+++ b/CRM/Civicase/Hook/Tabset/CaseCategoryTabAdd.php
@@ -66,7 +66,7 @@ class CRM_Civicase_Hook_Tabset_CaseCategoryTabAdd {
           'cid' => $contactID,
           'case_type_category' => $caseCategory['value'],
         ]),
-        'title' => ts($caseCategory['label']),
+        'title' => ucfirst(strtolower($caseCategory['label'])),
         'weight' => $caseTabWeight,
         'count' => CaseCategoryHelper::getCaseCount($caseCategory['name'], $contactID),
         'class' => 'livePage',


### PR DESCRIPTION
## Overview
In the Contact Details page, the case type category menus are not capitalised, this PR fixes the same.

## Before
![2021-06-01 at 1 04 PM](https://user-images.githubusercontent.com/5058867/120284465-e58f5600-c2d9-11eb-869c-01c01fe7d7ed.png)

## After
![2021-06-01 at 1 03 PM](https://user-images.githubusercontent.com/5058867/120284403-d6a8a380-c2d9-11eb-9c95-4ae7676a646c.png)

