### PR TITLE
ACU-594: Add Map and Select classes for exporting cases

### DIFF
--- a/CRM/Case/Export/Form/Map.php
+++ b/CRM/Case/Export/Form/Map.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * Class added for exporting cases.
+ *
+ * Added temporarily for solving an incompatibility issue while exporting
+ * cases in standalone window.
+ */
+class CRM_Case_Export_Form_Map extends CRM_Export_Form_Map {
+
+}

--- a/CRM/Case/Export/Form/Select.php
+++ b/CRM/Case/Export/Form/Select.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * Class added for exporting cases.
+ *
+ * Added temporarily for solving an incompatibility issue while exporting
+ * cases in standalone window.
+ */
+class CRM_Case_Export_Form_Select extends CRM_Export_Form_Select_Case {
+}

--- a/CRM/Civicase/Hook/PermissionCheck/CaseCategory.php
+++ b/CRM/Civicase/Hook/PermissionCheck/CaseCategory.php
@@ -6,7 +6,7 @@ use CRM_Case_BAO_CaseType as CaseType;
 use CRM_Civicase_Service_CaseCategoryFromUrl as CaseCategoryFromUrl;
 
 /**
- * Class CRM_Civicase_Hook_PermissionCheck_CaseCategory.
+ * Class for check permissions related to case categories.
  */
 class CRM_Civicase_Hook_PermissionCheck_CaseCategory {
 
@@ -42,7 +42,8 @@ class CRM_Civicase_Hook_PermissionCheck_CaseCategory {
     // will return true as the logic for equivalent case category permission
     // will be applied.
     $isAdvancedSearchPage = $url == 'civicrm/contact/search/advanced' && $permission != 'basic case information';
-    // We need to exclude Standalone page, since we can't precisely detect the category in it.
+    // We need to exclude Standalone page, since we can't precisely detect
+    // the category in it.
     $isStandalonePage = $url === 'civicrm/export/standalone';
 
     $caseCategoryName = $caseCategoryFromUrl->get($url);

--- a/CRM/Civicase/Hook/PermissionCheck/CaseCategory.php
+++ b/CRM/Civicase/Hook/PermissionCheck/CaseCategory.php
@@ -35,18 +35,21 @@ class CRM_Civicase_Hook_PermissionCheck_CaseCategory {
     }
 
     $url = CRM_Utils_System::currentPath();
+
     $caseCategoryFromUrl = new CaseCategoryFromUrl();
     $isAjaxRequest = $url == 'civicrm/ajax/rest';
     // We need to exclude this permission for this page because the permission
     // will return true as the logic for equivalent case category permission
     // will be applied.
     $isAdvancedSearchPage = $url == 'civicrm/contact/search/advanced' && $permission != 'basic case information';
-    $caseCategoryName = $caseCategoryFromUrl->get($url);
+    // We need to exclude Standalone page, since we can't precisely detect the category in it.
+    $isStandalonePage = $url === 'civicrm/export/standalone';
 
+    $caseCategoryName = $caseCategoryFromUrl->get($url);
     if ($caseCategoryName) {
       $this->modifyPermissionCheckForCategory($permission, $granted, $caseCategoryName);
     }
-    elseif (($isAjaxRequest && !$caseCategoryFromUrl->getIsCaseEntity()) || $isAdvancedSearchPage) {
+    elseif (($isAjaxRequest && !$caseCategoryFromUrl->getIsCaseEntity()) || $isAdvancedSearchPage || $isStandalonePage) {
       $this->checkForEquivalentCaseCategoryPermission($permission, $granted);
     }
   }


### PR DESCRIPTION
## Overview
This PR solves a problem experienced while trying to export Cases from the Manage Cases screen. Also this error is visible for any other case type.

## Before
In Manage Cases page, after selecting "Export Cases" action, an error is displayed:
![image](https://user-images.githubusercontent.com/74304572/120312006-62cec100-c302-11eb-9d31-3c2c85de1f30.png)
 
## After
The export action works correctly:
![image](https://user-images.githubusercontent.com/74304572/120312390-dbce1880-c302-11eb-8690-1e02bb9103c7.png)

## Technical Details
As can be seen [here](https://github.com/civicrm/civicrm-core/commit/f95d7a0876962829ba6aff1b9437bf1b4cfcbc74#diff-ca3d52925273a5d514259e5d7c95cdbc1e0b98ef642c33b5674ea68d8e85d26f) there was a recent change in civi-core that specifies a format for classes used in standalone mode.
This format is correctly followed by Activities, Contribution, Contacts, and other entities, but not for Cases. Then, these classes are not found when tried to be loaded: `CRM_Case_Export_Form_Map` and `CRM_Case_Export_Form_Select`
For solving the problem in our extension, we have added now the required classes. 
The general issue will be raised on the core to be evaluated.

**Edit**: Since now the standalone page is being handled by the CiviCase code, the hooks of it checked the Case Type Category received. In the case of the standalone page, it was not possible to detect the Category for all the situation (in particular, when selecting a custom set of fields), then the Category permission was not checked for that page.