### PR TITLE
CPS-630: Fix syntax error on upgrader

### DIFF
--- a/CRM/Civicase/Setup/UpdateCategoryNavigationItems.php
+++ b/CRM/Civicase/Setup/UpdateCategoryNavigationItems.php
@@ -22,7 +22,7 @@ class CRM_Civicase_Setup_UpdateCategoryNavigationItems {
       $categoryInstance = CaseCategoryHelper::getInstanceObject($category['value']);
       $categoryMenu = $categoryInstance->getMenuObject();
       $categoryMenu->resetCaseCategorySubmenusUrl(
-        CategoryHelper::get($category['name']),
+        CategoryHelper::get($category['name'])
       );
     }
 


### PR DESCRIPTION
## Overview
This PR solves a syntax error on an upgrader method. 

## Before
Under some circumstances, the upgraders fail on that call. That does not happen always, probably depends on the PHP version.

## After
The error was fixed.

## Technical Details
As mentioned previously, probably the PHP interpreter was considering in some cases as a valid extra parameter, that's why the error passed undetected.
