### PR TITLE
BASWSPRT-275: Fix Missing Pivot Date Data

### DIFF
--- a/CRM/Civicase/Form/Report/BaseExtendedReport.php
+++ b/CRM/Civicase/Form/Report/BaseExtendedReport.php
@@ -805,8 +805,13 @@ abstract class CRM_Civicase_Form_Report_BaseExtendedReport extends CRM_Civicase_
       return $this->getContactColumnOptions($spec, $usedIds);
     }
 
+    $fieldOptions = $this->getCustomFieldOptions($spec);
+    if (CRM_Utils_Array::value('type', $spec) === CRM_Report_Form::OP_DATE) {
+      return $fieldOptions;
+    }
+
     return array_intersect_key(
-      $this->getCustomFieldOptions($spec),
+      $fieldOptions,
       $this->getUsedOptions($spec['dbAlias'], $fieldName)
     );
   }


### PR DESCRIPTION
## Overview
When a date related field such as Case start date is selected as the column in the case pivot report, the data for the dates column does not show up. 

## Before
<img width="1240" alt="Case with Activity Pivot Chart - Template  CiviQA 2021-06-09 17-13-47" src="https://user-images.githubusercontent.com/6951813/121391348-2c1e2980-c946-11eb-9229-a67db2b3c561.png">


## After
The issue is fixed and data now shows up when a date field is selected as a column. 

<img width="1269" alt="Case with Activity Pivot Chart - Template | CiviQA 2021-06-09 17-15-57" src="https://user-images.githubusercontent.com/6951813/121391542-64256c80-c946-11eb-8fda-ecb3ce7cbbd9.png">

## Technical Details
The regression was introduced in this PR: https://github.com/compucorp/uk.co.compucorp.civicase/pull/693. The date fields is a bit different from other report fields because it either gets grouped by date or year, the actual values are not used.  The array intersect [here](https://github.com/compucorp/uk.co.compucorp.civicase/pull/693/files#diff-ffc55342f1d0a39ba391eb4d70335b441e7dee676824ce3866b78dad65326b13R779-R780) will return an empty array for date related column fields because the `used options` will return the actual dates for cases while the grouped dates are returned by `getCustomFieldOptions`, hence the date field is [not included ](https://github.com/compucorp/uk.co.compucorp.civicase/blob/ab7eff9ee2866406e39c91c64befc2713137800b/CRM/Civicase/Form/Report/BaseExtendedReport.php#L884)in the final  SQL query. The fix was to exclude the date related fields from this logic entirely as it is not necessary.

