### PR TITLE
RSESPRT-55: Edit instance instead of creating if it already exists

### DIFF
--- a/CRM/Civicase/Service/CaseCategoryInstance.php
+++ b/CRM/Civicase/Service/CaseCategoryInstance.php
@@ -74,7 +74,7 @@ class CRM_Civicase_Service_CaseCategoryInstance {
   }
 
   /**
-   * Creates instance for the given case type category.
+   * Creates/Edits instance for the given case type category.
    *
    * @param mixed $categoryValue
    *   Case category value.
@@ -83,9 +83,15 @@ class CRM_Civicase_Service_CaseCategoryInstance {
    */
   public function createInstanceTypeFor($categoryValue, $instanceId) {
     $caseCategoryInstance = new CaseCategoryInstance();
-    $caseCategoryInstance->instance_id = $instanceId;
     $caseCategoryInstance->category_id = $categoryValue;
+    $caseCategoryInstance->find();
+    $existingInstance = $caseCategoryInstance->fetchAll();
 
+    if (!empty($existingInstance)) {
+      $caseCategoryInstance->id = $existingInstance[0]['id'];
+    }
+
+    $caseCategoryInstance->instance_id = $instanceId;
     $caseCategoryInstance->save();
   }
 


### PR DESCRIPTION
## Overview
When trying to Create a new Case Type Instance, if the Case Type already exists, error was thrown. This PR fixes that, and just edits the Instance with the new Instance ID.

## Before
Error was thrown.

## After
Error is not thrown. And record is updated.

## Technical Details
In `CRM/Civicase/Service/CaseCategoryInstance.php`, the `createInstanceTypeFor` was throwing error when trying to add instance for an Existing Case Type Category. Because Case Type Category is anunique field. But this is unexpected, instead now, we edit the case type category.