### PR TITLE
RSESPRT-60: Fix Console Errors For Bulk Actions On Other Relationships Tab

### DIFF
--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
@@ -99,7 +99,7 @@
         .on('crmFormSuccess', function () {
           $scope.refresh();
           if (tab === 'relations') {
-            $scope.getRelations();
+            $scope.getRelations($scope.relationsFilter);
           }
         });
     }


### PR DESCRIPTION
## Overview
When a user tries to perform a bulk action such as adding contacts to a group on the other relationships tab on a case, the modal becomes unresponsive after and some console errors are logged. The bulk action is actually performed but the modal becomes unresponsive. 

## Before
<img width="1280" alt="Manage Cases | CiviQA 2021-06-25 15-44-16" src="https://user-images.githubusercontent.com/6951813/123445264-a352ef00-d5cf-11eb-9e81-5c678d8bc714.png">

## After
The issue is fixed and bulk actions can be performed and the modal can be closed or other actions performed.

<img width="1280" alt="Manage Cases  CiviQA 2021-06-25 16-14-46" src="https://user-images.githubusercontent.com/6951813/123446344-b1edd600-d5d0-11eb-8875-e0359c060224.png">


## Technical Details
The issue is a regression introduced in this PR: https://github.com/compucorp/uk.co.compucorp.civicase/pull/748, A new `filter` parameter was introduced to the `getRelations` function. There was a place missed in code that still calls the method (this causes an error [here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/daf2749c0a32987f85746a803f4bce06c894ef00/ang/civicase/case/details/people-tab/directives/other-relationships-tab.directive.js#L70)) the old way without passing the new expected parameter. This PR fixes that. 

