### PR TITLE
CPS-655: Fix new site deployments

### DIFF
--- a/CRM/Civicase/Setup/AddSingularLabels.php
+++ b/CRM/Civicase/Setup/AddSingularLabels.php
@@ -1,0 +1,36 @@
+<?php
+
+use CRM_Civicase_Service_CaseCategoryCustomFieldsSetting as CaseCategoryCustomFieldsSetting;
+
+/**
+ * Adds the singular label value for each case category.
+ *
+ * If the case category ends in an S, it will remove it.
+ */
+class CRM_Civicase_Setup_AddSingularLabels {
+
+  /**
+   * Adds the singular label value for each case category.
+   *
+   * If the case category ends in an S, it will remove it.
+   */
+  public function apply() {
+    $caseCategoryCustomFields = new CaseCategoryCustomFieldsSetting();
+    $caseTypeCategories = civicrm_api3('OptionValue', 'get', [
+      'sequential' => '1',
+      'option_group_id' => 'case_type_categories',
+    ]);
+
+    foreach ($caseTypeCategories['values'] as $caseTypeCategory) {
+      $isLabelLastCharacterS = substr(strtolower($caseTypeCategory['label']), -1) === 's';
+      $singularLabel = $isLabelLastCharacterS
+        ? substr($caseTypeCategory['label'], 0, -1)
+        : $caseTypeCategory['label'];
+
+      $caseCategoryCustomFields->save($caseTypeCategory['value'], [
+        'singular_label' => $singularLabel,
+      ]);
+    }
+  }
+
+}

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -12,6 +12,7 @@ use CRM_Civicase_Setup_AddChangeCaseRoleDateActivityTypes as AddChangeCaseRoleDa
 use CRM_Civicase_Setup_AddManageWorkflowMenu as AddManageWorkflowMenu;
 use CRM_Civicase_Service_CaseCategoryInstance as CaseCategoryInstance;
 use CRM_Civicase_Helper_CaseUrl as CaseUrlHelper;
+use CRM_Civicase_Setup_AddSingularLabels as AddSingularLabels;
 
 /**
  * Collection of upgrade steps.
@@ -79,6 +80,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
       new CreateSafeFileExtensionOptionValue(),
       new ProcessCaseCategoryForCustomGroupSupport(),
       new AddChangeCaseRoleDateActivityTypes(),
+      new AddSingularLabels(),
     ];
     foreach ($steps as $step) {
       $step->apply();

--- a/CRM/Civicase/Upgrader/Steps/Step0016.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0016.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_Civicase_Service_CaseCategoryCustomFieldsSetting as CaseCategoryCustomFieldsSetting;
+use CRM_Civicase_Setup_AddSingularLabels as AddSingularLabels;
 
 /**
  * Adds singular labels to case type categories.
@@ -14,33 +14,9 @@ class CRM_Civicase_Upgrader_Steps_Step0016 {
    *   True when the upgrader runs successfully.
    */
   public function apply() {
-    $this->addSingularLabelToCaseCategories();
+    (new AddSingularLabels())->apply();
 
     return TRUE;
-  }
-
-  /**
-   * Adds the singular label value for each case category.
-   *
-   * If the case category ends in an S, it will remove it.
-   */
-  private function addSingularLabelToCaseCategories() {
-    $caseCategoryCustomFields = new CaseCategoryCustomFieldsSetting();
-    $caseTypeCategories = civicrm_api3('OptionValue', 'get', [
-      'sequential' => '1',
-      'option_group_id' => 'case_type_categories',
-    ]);
-
-    foreach ($caseTypeCategories['values'] as $caseTypeCategory) {
-      $isLabelLastCharacterS = substr(strtolower($caseTypeCategory['label']), -1) === 's';
-      $singularLabel = $isLabelLastCharacterS
-        ? substr($caseTypeCategory['label'], 0, -1)
-        : $caseTypeCategory['label'];
-
-      $caseCategoryCustomFields->save($caseTypeCategory['value'], [
-        'singular_label' => $singularLabel,
-      ]);
-    }
   }
 
 }

--- a/tests/phpunit/CRM/Civicase/Service/CaseCategoryCustomFieldsSettingTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/CaseCategoryCustomFieldsSettingTest.php
@@ -15,18 +15,16 @@ class CRM_Civicase_Service_CaseCategoryCustomFieldsSettingTest extends BaseHeadl
   public function testSaveCustomFields() {
     $caseCategoryId = uniqid();
     $caseCategoryCustomFields = new CaseCategoryCustomFieldsSetting();
-
-    $caseCategoryCustomFields->save($caseCategoryId, [
-      'my_custom_field' => 'value',
-    ]);
-
-    $caseCategoryCustomFieldsValues = $this->getCaseCategoryCustomFieldsValues();
-    $expectedValues = [];
-    $expectedValues[$caseCategoryId] = [
+    $fieldData = [
       'my_custom_field' => 'value',
     ];
 
-    $this->assertEquals($expectedValues, $caseCategoryCustomFieldsValues);
+    $caseCategoryCustomFields->save($caseCategoryId, $fieldData);
+
+    $caseCategoryCustomFieldsValues = $this->getCaseCategoryCustomFieldsValues();
+
+    $this->assertArrayHasKey($caseCategoryId, $caseCategoryCustomFieldsValues);
+    $this->assertEquals($caseCategoryCustomFieldsValues[$caseCategoryId], $fieldData);
   }
 
   /**


### PR DESCRIPTION
## Overview
Some of the recently added upgrader logic was not applied when creating a new fresh site. This PR fixes the same.

## Before
Singular Labels were not created.

## After
Singular Labels are created.

## Technical Details
This is a regression of https://github.com/compucorp/uk.co.compucorp.civicase/pull/760. Where we forgot to mention apply the AddSingularLabels logic for creating a new site. This PR fixes that.

1. Code from `CRM/Civicase/Upgrader/Steps/Step0016.php` has been moved to `CRM/Civicase/Setup/AddSingularLabels.php`, and reused for upgrading and creating a new site.