### PR TITLE
RSESPRT-59: Fix Wrong Text In Case Management Case Category Email Subject 

### DIFF
--- a/CRM/Civicase/Hook/alterMailParams/SubjectCaseTypeCategoryProcessor.php
+++ b/CRM/Civicase/Hook/alterMailParams/SubjectCaseTypeCategoryProcessor.php
@@ -39,11 +39,20 @@ class CRM_Civicase_Hook_alterMailParams_SubjectCaseTypeCategoryProcessor {
 
     // Get replacement words and replace the word 'case' in subject.
     $wordReplacements = CaseCategoryHelper::getWordReplacements($caseTypeCategory);
+
     if (!empty($wordReplacements['case'])) {
-      // Make sure we make just 1 replacement.
-      $subject = explode($this->toReplace, $params['subject'], 2);
-      $params['subject'] = '[' . $wordReplacements['case'] . ' ' . $subject[1];
+      $replaceCaseWith = $wordReplacements['case'];
     }
+    if (!empty($wordReplacements['_singular_wildcard_'])) {
+      $replaceCaseWith = $wordReplacements['_singular_wildcard_'];
+    }
+
+    if (empty($replaceCaseWith)) {
+      return;
+    }
+    // Make sure we make just 1 replacement.
+    $subject = explode($this->toReplace, $params['subject'], 2);
+    $params['subject'] = '[' . $replaceCaseWith . ' ' . $subject[1];
   }
 
   /**

--- a/tests/phpunit/CRM/Civicase/Hook/alterMailParams/SubjectCaseTypeCategoryProcessorTest.php
+++ b/tests/phpunit/CRM/Civicase/Hook/alterMailParams/SubjectCaseTypeCategoryProcessorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use CRM_Civicase_Hook_alterMailParams_SubjectCaseTypeCategoryProcessor as SubjectCaseTypeCategoryProcessor;
+use CRM_Civicase_Test_Fabricator_CaseCategoryInstance as CaseCategoryInstanceFabricator;
+use CRM_Civicase_Test_Fabricator_CaseCategory as CaseCategoryFabricator;
+use CRM_Civicase_Test_Fabricator_CaseCategoryInstanceType as CaseCategoryInstanceTypeFabricator;
+use CRM_Civicase_Service_CaseCategoryCustomFieldsSetting as CaseCategoryCustomFieldsSetting;
+use CRM_Civicase_Test_Fabricator_CaseType as CaseTypeFabricator;
+use CRM_Civicase_Test_Fabricator_Case as CaseFabricator;
+use CRM_Civicase_Test_Fabricator_Contact as ContactFabricator;
+
+/**
+ * Test class for the SubjectCaseTypeCategoryProcessor.
+ *
+ * @group headless
+ */
+class CRM_Civicase_Hook_alterMailParams_SubjectCaseTypeCategoryProcessorTest extends BaseHeadlessTest {
+
+  /**
+   * Test first instance of case is replaced.
+   */
+  public function testRunReplacesTheFirstInstanceOfCaseInMailSubjectCorrectly() {
+    $categoryInstanceTypeOne = CaseCategoryInstanceTypeFabricator::fabricate();
+    $categoryParams = ['label' => 'Awards', 'singular_label' => 'Award'];
+    $caseCategory = $this->createCaseTypeCategory($categoryParams);
+    CaseCategoryInstanceFabricator::fabricate(
+      [
+        'category_id' => $caseCategory['value'],
+        'instance_id' => $categoryInstanceTypeOne['value'],
+      ]
+    );
+
+    $emailSubjectProcessor = new SubjectCaseTypeCategoryProcessor();
+    $_REQUEST['caseid'] = $this->getCase($caseCategory['value'])['id'];
+    $params['subject'] = "[case ] This is a test email subject case";
+    $emailSubjectProcessor->run($params, $context = '');
+    $replacedValue = strtolower($categoryParams['singular_label']);
+    $expectedSubject = "[{$replacedValue} ] This is a test email subject case";
+    $this->assertEquals($expectedSubject, $params['subject']);
+  }
+
+  /**
+   * Fabricates a case type category.
+   *
+   * @param array $caseTypeCategoryParams
+   *   Case type category params.
+   *
+   * @return array
+   *   Case category.
+   */
+  private function createCaseTypeCategory(array $caseTypeCategoryParams) {
+    $caseTypeCategory = CaseCategoryFabricator::fabricate($caseTypeCategoryParams);
+    (new CaseCategoryCustomFieldsSetting())->save(
+      $caseTypeCategory['value'], ['singular_label' => $caseTypeCategoryParams['singular_label']]
+    );
+
+    return $caseTypeCategory;
+  }
+
+  /**
+   * Fabricates a case with given case category.
+   *
+   * @param int $caseTypeCategory
+   *   Case type category value.
+   *
+   * @return array
+   *   Case data.
+   */
+  private function getCase($caseTypeCategory) {
+    $caseType = CaseTypeFabricator::fabricate(['case_type_category' => $caseTypeCategory]);
+    $client = ContactFabricator::fabricate();
+
+    return CaseFabricator::fabricate(
+      [
+        'case_type_id' => $caseType['id'],
+        'contact_id' => $client['id'],
+        'creator_id' => $client['id'],
+      ]
+    );
+  }
+
+}


### PR DESCRIPTION
## Overview
This issue was previously reported for the prospect category (Sales and opportunity tracking) but was also observed for case categories belonging to the case management instance. See details here: https://github.com/compucorp/uk.co.compucorp.civicrm.prospect/pull/93.

## Before
When an Email activity is created for a case category of the case management instance, the sent email subject contains the word _singular_wildcard_ instead of the appropriate case category name.

## After
The issue described above is fixed. 

## Technical Details
The word replacement for case management instance categories was using the word replacements for Case management instances [here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/5ad931596188b21a402a06b7430ac08447c88ed9/CRM/Civicase/Helper/CaseCategory.php#L147-L156) hence this logic [here](https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/Hook/alterMailParams/SubjectCaseTypeCategoryProcessor.php#L42-L45) was replacing the `[case ` in the email subject to `_singular_wildcard_`.
The logic was adjusted to cater for primary case categories which uses files for word replacements and a pre-set array for case management instance categories.

This issue is a regression introduced in this PR: https://github.com/compucorp/uk.co.compucorp.civicase/pull/782