### PR TITLE
NEUSPRT-25: Remove Disabled Case Tags and Sort Case Tags Alphabetical Order

### DIFF
--- a/ang/civicase/case/actions/services/edit-tags-case-action.service.js
+++ b/ang/civicase/case/actions/services/edit-tags-case-action.service.js
@@ -8,8 +8,9 @@
    * @param {Function} ts translation service
    * @param {object} dialogService dialog service
    * @param {object} civicaseCrmApi service to use civicrm api
+   * @param {Function} isTruthy service to check if value is truthy
    */
-  function EditTagsCaseAction (ts, dialogService, civicaseCrmApi) {
+  function EditTagsCaseAction (ts, dialogService, civicaseCrmApi, isTruthy) {
     /**
      * Click event handler for the Action
      *
@@ -96,11 +97,9 @@
      * @returns {Array} filtered tags array.
      */
     function filterTags (tags) {
-      _.remove(tags, function (tag) {
-        return tag.is_tagset === '0' && tag.is_selectable === '0';
+      return _.filter(tags, function (tag) {
+        return !(!isTruthy(tag.is_tagset) && !isTruthy(tag.is_selectable));
       });
-
-      return tags;
     }
 
     /**

--- a/ang/civicase/case/actions/services/edit-tags-case-action.service.js
+++ b/ang/civicase/case/actions/services/edit-tags-case-action.service.js
@@ -82,11 +82,25 @@
     function getTags () {
       return civicaseCrmApi('Tag', 'get', {
         sequential: 1,
-        used_for: { LIKE: '%civicrm_case%' },
-        options: { limit: 0 }
+        used_for: 'Cases',
+        options: { limit: 0, sort: 'name ASC' }
       }).then(function (data) {
-        return data.values;
+        return filterTags(data.values);
       });
+    }
+
+    /**
+     * Removes tags that are not selectable from the array.
+     *
+     * @param {Array} tags tags
+     * @returns {Array} filtered tags array.
+     */
+    function filterTags (tags) {
+      _.remove(tags, function (tag) {
+        return tag.is_tagset === '0' && tag.is_selectable === '0';
+      });
+
+      return tags;
     }
 
     /**

--- a/ang/test/civicase/case/actions/services/edit-tags-case-action.service.spec.js
+++ b/ang/test/civicase/case/actions/services/edit-tags-case-action.service.spec.js
@@ -49,8 +49,8 @@
       it('fetches the tags and shows on the UI', () => {
         expect(civicaseCrmApiMock).toHaveBeenCalledWith('Tag', 'get', {
           sequential: 1,
-          used_for: { LIKE: '%civicrm_case%' },
-          options: { limit: 0 }
+          used_for: 'Cases',
+          options: { limit: 0, sort: 'name ASC' }
         });
       });
 


### PR DESCRIPTION
## Overview
The Edit Tag form accessed on the manage cases page via the hamburger menu allows to select a tag that has been marked non selectable and the tag dropdown list also displays the tags in an unordered fashion. This PR fixes the issue by removing non selectable tags from the list and also sorting the tag names in alphabetical order. 

## Before
The issue described above exists.

The  tag dropdown list also displays the tags in an unordered fashion.
<img width="1280" alt="Manage Cases  CiviQA 2021-07-09 15-26-47" src="https://user-images.githubusercontent.com/6951813/125097123-b2589780-e0cd-11eb-9c7c-3d9c78c45c3b.png">

## After
The issues described above has been fixed
<img width="1266" alt="Manage Cases | CiviQA 2021-07-09 15-19-32" src="https://user-images.githubusercontent.com/6951813/125097260-dae09180-e0cd-11eb-9ffa-faeebf41d490.png">


## Technical Details
To fix the first issue, the tags fetched from the Tags api is simply sorted by the name. 
The second one is a bit tricky because we can't get the results from the API directly as Tagsets are created by default with the `is_selectable` property set to `0` as this property does not really apply to Tagset and is not exposed via the UI, so there is a need to only filter out tags that are not Tagsets and have the `is_selectable` property set to `0`. A `filterTags` function was added to filter out these non selectable/disabled tags 
