### PR TITLE
NEUSPRT-35: Fix Case Statuses Order On Case Dashboard

### DIFF
--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -98,10 +98,9 @@
       getCaseTypes()
         .then(function () {
           caseStatusNames = getCaseStatusNamesBelongingToCaseTypes($scope.caseTypes);
-          $scope.caseStatuses = _.sortBy(
-            getStatusesByName(caseStatusNames),
-            'weight'
-          );
+          $scope.caseStatuses = _.sortBy(getStatusesByName(caseStatusNames), function (status) {
+            return parseInt(status.weight, 10);
+          });
           $scope.showBreakdown = $scope.caseTypes.length <=
             MAXIMUM_CASE_TYPES_TO_DISPLAY_BREAKDOWN;
           loadStatsData(caseFilters);

--- a/ang/test/civicase/case/directives/case-overview.directive.spec.js
+++ b/ang/test/civicase/case/directives/case-overview.directive.spec.js
@@ -104,15 +104,16 @@
 
       describe('when loading a subset of case types', () => {
         beforeEach(() => {
-          const sampleCaseStatuses = _.sample(CaseStatus.getAll(), 2);
           const sampleCaseTypes = _.sample(CaseType.getAll(), 3);
 
-          sampleCaseTypes[0].definition.statuses = [sampleCaseStatuses[0].name];
-          sampleCaseTypes[1].definition.statuses = [sampleCaseStatuses[1].name];
-          sampleCaseTypes[2].definition.statuses = [sampleCaseStatuses[1].name];
+          sampleCaseTypes[0].definition.statuses = _.map(CaseStatus.getAll(), 'name');
+          sampleCaseTypes[1].definition.statuses = _.map(CaseStatus.getAll(), 'name');
+          sampleCaseTypes[2].definition.statuses = _.map(CaseStatus.getAll(), 'name');
 
-          expectedCaseStatuses = _.chain(sampleCaseStatuses)
-            .sortBy('weight')
+          expectedCaseStatuses = _.chain(CaseStatus.getAll())
+            .sortBy(function (status) {
+              return parseInt(status.weight, 10);
+            })
             .value();
 
           CaseManagementWorkflow.getWorkflowsListForCaseOverview.and.returnValue($q.resolve({
@@ -138,7 +139,9 @@
           delete caseType.definition.statuses;
 
           expectedCaseStatuses = _.chain(allCaseStatuses)
-            .sortBy('weight')
+            .sortBy(function (status) {
+              return parseInt(status.weight, 10);
+            })
             .value();
 
           CaseManagementWorkflow.getWorkflowsListForCaseOverview.and.returnValue($q.resolve({

--- a/ang/test/mocks/data/cases-statuses.data.js
+++ b/ang/test/mocks/data/cases-statuses.data.js
@@ -2,31 +2,106 @@
   var module = angular.module('civicase.data');
   CRM['civicase-base'].caseStatuses = {
     1: {
-      value: '1',
-      label: 'Ongoing',
       color: '#42afcb',
-      name: 'Open',
+      filter: '0',
       grouping: 'Opened',
-      weight: '1',
-      is_active: '1'
+      is_active: '1',
+      label: 'Ongoing',
+      name: 'Open',
+      value: '1',
+      weight: '1'
     },
     2: {
-      value: '2',
-      label: 'Resolved',
       color: '#4d5663',
-      name: 'Closed',
+      filter: '0',
       grouping: 'Closed',
-      weight: '2',
-      is_active: '1'
+      is_active: '1',
+      label: 'Resolved',
+      name: 'Closed',
+      value: '2',
+      weight: '2'
     },
     3: {
-      value: '3',
-      label: 'Urgent',
       color: '#e6807f',
-      name: 'Urgent',
+      filter: '0',
       grouping: 'Opened',
-      weight: '3',
-      is_active: '1'
+      is_active: '1',
+      label: 'Urgent',
+      name: 'Urgent',
+      value: '3',
+      weight: '3'
+    },
+    4: {
+      filter: '0',
+      grouping: 'Opened',
+      is_active: '1',
+      label: 'Enquiry',
+      name: 'enquiry',
+      value: '4',
+      weight: '4'
+    },
+    5: {
+      filter: '0',
+      grouping: 'Opened',
+      is_active: '1',
+      label: 'Qualified',
+      name: 'qualified',
+      value: '5',
+      weight: '5'
+    },
+    6: {
+      filter: '0',
+      grouping: 'Opened',
+      is_active: '1',
+      label: 'In progress',
+      name: 'in_progress',
+      value: '6',
+      weight: '6'
+    },
+    7: {
+      filter: '0',
+      grouping: 'Opened',
+      is_active: '1',
+      label: 'Submitted',
+      name: 'submitted',
+      value: '7',
+      weight: '7'
+    },
+    8: {
+      filter: '0',
+      grouping: 'Closed',
+      is_active: '1',
+      label: 'Won',
+      name: 'won',
+      value: '8',
+      weight: '8'
+    },
+    9: {
+      filter: '0',
+      grouping: 'Closed',
+      is_active: '1',
+      label: 'Lost',
+      name: 'lost',
+      value: '9',
+      weight: '9'
+    },
+    10: {
+      filter: '0',
+      grouping: 'Opened',
+      is_active: '1',
+      label: 'Sample Status',
+      name: 'Sample Status',
+      value: '10',
+      weight: '10'
+    },
+    11: {
+      filter: '0',
+      grouping: 'Opened',
+      is_active: '1',
+      label: 'Sample Status 2',
+      name: 'Sample Status 2',
+      value: '11',
+      weight: '11'
     }
   };
 


### PR DESCRIPTION
## Overview
Case statuses are sorted in ascending order by weight on the case dashboard but this seems not to be consistent across sites.  

## Before
The issue described above exists. 
This issue is easily replicable. For example , on a site with 9 case statuses, if a 10th case status is added, instead of the new case status to be at the bottom of the list, it rather listed as the second case status on the list on the Case dashboard.

<img width="877" alt="Option Groups | CiviQA 2021-07-14 15-38-44" src="https://user-images.githubusercontent.com/6951813/125654866-1d1693bd-875c-4639-a00d-4cf3061b05cc.png">
<img width="881" alt="CiviCase Dashboard - All Cases | CiviQA 2021-07-14 15-34-23" src="https://user-images.githubusercontent.com/6951813/125654988-a55cd3bf-3b72-4ed9-9856-5e799772b467.png">


## After
The issue described above is fixed and case statuses are ordered by weight in ascending order. \
<img width="818" alt="CiviCase Dashboard - All Cases | CiviQA 2021-07-14 15-38-25" src="https://user-images.githubusercontent.com/6951813/125655106-6e08ac05-9888-42fa-bbd0-dd08625175f9.png">


## Technical Details
The weight property of the case status object is a string and when this is being sorted, the sorting is not consistent. E.g "2" > "10" will evaluate to TRUE. To fix the issue, the weight is parsed as an integer to be used for the sorting so that the case statuses are sorted properly.

This one got broken in https://github.com/compucorp/uk.co.compucorp.civicase/pull/763 - Connect to preview . 

Previously after sorting the statuses using weight, we were sorting them again using value , hence it worked. 

But after we removed the sorting by value(which was correct), this new issue got introduced. But this was not caught because in unit tests we had only 3 statuses as mock data. Now we have added more than 9 statuses as mock data.
