### PR TITLE
RSESPRT-70: Fix awards tab not loading

### DIFF
--- a/CRM/Civicase/Page/ContactCaseTab.php
+++ b/CRM/Civicase/Page/ContactCaseTab.php
@@ -55,7 +55,7 @@ class CRM_Civicase_Page_ContactCaseTab extends CRM_Core_Page {
     $angularManager = new Manager(CRM_Core_Resources::singleton());
     $moduleAndDependenciesNames = $angularManager->resolveDependencies([$mainModuleName]);
 
-    foreach ($angularManager->resolveDependencies(['civicase']) as $moduleName) {
+    foreach ($moduleAndDependenciesNames as $moduleName) {
       $module = $angularManager->getModule($moduleName);
       $translationDomainName = 'strings::' . $module['ext'];
       $moduleTranslations = $angularManager->getTranslatedStrings($moduleName);

--- a/CRM/Civicase/Page/ContactCaseTab.php
+++ b/CRM/Civicase/Page/ContactCaseTab.php
@@ -74,7 +74,7 @@ class CRM_Civicase_Page_ContactCaseTab extends CRM_Core_Page {
       );
     }
 
-    return $translations;
+    return $translations ?? [];
   }
 
 }


### PR DESCRIPTION
## Overview
This PR fixes the issue with the awards tab not loading from the contact page. 
Though not directly the cause of the bug here, this PR corrects the bug with the method `getModuleAndDependenciesTranslations($mainModuleName)` ignoring $mainModuleName and instead defaulting to 'civicase'

## Before
![contact_ct](https://user-images.githubusercontent.com/85277674/132643664-34b957b0-db7a-4aa1-a19b-d6071a778061.gif)


## After
![awards-after](https://user-images.githubusercontent.com/85277674/132643421-5a9fcac2-918a-47f3-8e1e-0709912b3ee8.gif)

## Technical Details
The error was caused by a NULL value being passed to the CIviCRM function CRM_Core_Resources::singleton()->addSetting() function.
