### PR TITLE
Getmonthswithactivities: Fix PHP warning

### DIFF
--- a/api/v3/Activity/Getmonthswithactivities.php
+++ b/api/v3/Activity/Getmonthswithactivities.php
@@ -134,5 +134,5 @@ function get_records_from_activity_get_api(array $params) {
     $params['return'] = array_keys($options['return']);
   }
 
-  return _civicrm_api3_basic_get(CRM_Activity_BAO_Activity, $params, FALSE, 'Activity', $sql);
+  return _civicrm_api3_basic_get('CRM_Activity_BAO_Activity', $params, FALSE, 'Activity', $sql);
 }


### PR DESCRIPTION
## Overview

Fixes a PHP 7.3 warning.

## Technical Details

"PHP message: PHP Warning:  Use of undefined constant CRM_Activity_BAO_Activity - assumed 'CRM_Activity_BAO_Activity' (this will throw an Error in a future version of PHP) in `.../civicase/api/v3/Activity/Getmonthswithactivities.php on line 137

