### PR TITLE
BASWSPRT-308: Fix cases search with multiple options custom field

### DIFF
--- a/CRM/Civicase/APIHelpers/CaseDetails.php
+++ b/CRM/Civicase/APIHelpers/CaseDetails.php
@@ -1,6 +1,7 @@
 <?php
 
 use Civi\CCase\Utils as CiviCaseUtils;
+use CRM_Civicase_APIHelpers_CustomFieldFilter as CustomFieldFilter;
 
 /**
  * Case Details API Helper Class.
@@ -75,7 +76,7 @@ class CRM_Civicase_APIHelpers_CaseDetails {
       }
     }
 
-    self::handleCustomFieldFiltering($sql, $params);
+    CustomFieldFilter::filter($sql, $params);
 
     return [
       'resultMetadata' => $resultMetadata,
@@ -361,65 +362,6 @@ class CRM_Civicase_APIHelpers_CaseDetails {
         '=' => $params[$paramName],
       ];
     }
-  }
-
-  /**
-   * Handles filtering of case custom fields with multiple options.
-   *
-   * @param CRM_Utils_SQL_Select $sql
-   *   Reference to the SQL object.
-   * @param array $params
-   *   The list of params as provided by the action.
-   */
-  private static function handleCustomFieldFiltering(CRM_Utils_SQL_Select $sql, array &$params) {
-    foreach ($params as $key => $value) {
-      if (!empty(preg_match('/^custom_/i', $key))) {
-        $id = substr($key, 7);
-        $field = CRM_Core_BAO_CustomField::getFieldObject($id);
-        $isMultiple = CRM_Core_BAO_CustomField::hasOptions($field);
-
-        if (!$isMultiple) {
-          continue;
-        }
-
-        $columnGroup = CRM_Core_BAO_CustomField::getTableColumnGroup($id);
-
-        if (!empty($columnGroup)) {
-          // Remove this field,so the case API won't use it in filtering.
-          unset($params[$key]);
-
-          self::joinCustomFieldQuery($sql, $columnGroup, (array) $value);
-        }
-      }
-    }
-  }
-
-  /**
-   * Joins the custom fields table column with filter condition.
-   *
-   * @param CRM_Utils_SQL_Select $sql
-   *   Reference to the SQL object.
-   * @param array $columnGroup
-   *   Array containing details on the custom field to join.
-   * @param array $value
-   *   Array containing the custom field values to filter.
-   */
-  private static function joinCustomFieldQuery(CRM_Utils_SQL_Select $sql, array $columnGroup, array $value) {
-    // When the param is keyed by 'IN', transform back to normal.
-    $value = $value['IN'] ?? $value;
-    $table = $columnGroup[0];
-    $column = $columnGroup[1];
-
-    $conditions = array_map(function ($param) use ($table, $column) {
-      return "custom_case_to_{$table}.{$column} REGEXP '[[:<:]]" . $param . "[[:>:]]'";
-    }, $value);
-    $conditions = implode(" AND ", $conditions);
-
-    $sql->join(
-      "custom_case_to_{$table}", "LEFT JOIN {$table} AS custom_case_to_{$table}
-      ON custom_case_to_{$table}.entity_id = `a`.id"
-    );
-    $sql->where($conditions);
   }
 
 }

--- a/CRM/Civicase/APIHelpers/CaseDetails.php
+++ b/CRM/Civicase/APIHelpers/CaseDetails.php
@@ -388,14 +388,14 @@ class CRM_Civicase_APIHelpers_CaseDetails {
           // Remove this field,so the case API won't use it in filtering.
           unset($params[$key]);
 
-          self::joinCustomFieldQuery($sql, $columnGroup, $value);
+          self::joinCustomFieldQuery($sql, $columnGroup, (array) $value);
         }
       }
     }
   }
 
   /**
-   * Joins the custom fields table column and adds a where condition to filter the result.
+   * Joins the custom fields table column with filter condition.
    *
    * @param CRM_Utils_SQL_Select $sql
    *   Reference to the SQL object.

--- a/CRM/Civicase/APIHelpers/CaseDetails.php
+++ b/CRM/Civicase/APIHelpers/CaseDetails.php
@@ -75,6 +75,8 @@ class CRM_Civicase_APIHelpers_CaseDetails {
       }
     }
 
+    self::handleCustomFieldFiltering($sql, $params);
+
     return [
       'resultMetadata' => $resultMetadata,
       'params' => $params,
@@ -359,6 +361,65 @@ class CRM_Civicase_APIHelpers_CaseDetails {
         '=' => $params[$paramName],
       ];
     }
+  }
+
+  /**
+   * Handles filtering of case custom fields with multiple options.
+   *
+   * @param CRM_Utils_SQL_Select $sql
+   *   Reference to the SQL object.
+   * @param array $params
+   *   The list of params as provided by the action.
+   */
+  private static function handleCustomFieldFiltering(CRM_Utils_SQL_Select $sql, array &$params) {
+    foreach ($params as $key => $value) {
+      if (!empty(preg_match('/^custom_/i', $key))) {
+        $id = substr($key, 7);
+        $field = CRM_Core_BAO_CustomField::getFieldObject($id);
+        $isMultiple = CRM_Core_BAO_CustomField::hasOptions($field);
+
+        if (!$isMultiple) {
+          continue;
+        }
+
+        $columnGroup = CRM_Core_BAO_CustomField::getTableColumnGroup($id);
+
+        if (!empty($columnGroup)) {
+          // Remove this field,so the case API won't use it in filtering.
+          unset($params[$key]);
+
+          self::joinCustomFieldQuery($sql, $columnGroup, $value);
+        }
+      }
+    }
+  }
+
+  /**
+   * Joins the custom fields table column and adds a where condition to filter the result.
+   *
+   * @param CRM_Utils_SQL_Select $sql
+   *   Reference to the SQL object.
+   * @param array $columnGroup
+   *   Array containing details on the custom field to join.
+   * @param array $value
+   *   Array containing the custom field values to filter.
+   */
+  private static function joinCustomFieldQuery(CRM_Utils_SQL_Select $sql, array $columnGroup, array $value) {
+    // When the param is keyed by 'IN', transform back to normal.
+    $value = $value['IN'] ?? $value;
+    $table = $columnGroup[0];
+    $column = $columnGroup[1];
+
+    $conditions = array_map(function ($param) use ($table, $column) {
+      return "custom_case_to_{$table}.{$column} REGEXP '[[:<:]]" . $param . "[[:>:]]'";
+    }, $value);
+    $conditions = implode(" AND ", $conditions);
+
+    $sql->join(
+      "custom_case_to_{$table}", "LEFT JOIN {$table} AS custom_case_to_{$table}
+      ON custom_case_to_{$table}.entity_id = `a`.id"
+    );
+    $sql->where($conditions);
   }
 
 }

--- a/CRM/Civicase/APIHelpers/CustomFieldFilter.php
+++ b/CRM/Civicase/APIHelpers/CustomFieldFilter.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Custom Field Options Filter class.
+ */
+class CRM_Civicase_APIHelpers_CustomFieldFilter {
+
+  /**
+   * Handles filtering of case custom fields with multiple options.
+   *
+   * @param CRM_Utils_SQL_Select $sql
+   *   Reference to the SQL object.
+   * @param array $params
+   *   The list of params as provided by the action.
+   */
+  public static function filter(CRM_Utils_SQL_Select $sql, array &$params) {
+    foreach ($params as $key => $value) {
+      if (!empty(preg_match('/^custom_/i', $key))) {
+        $id = substr($key, 7);
+        $field = CRM_Core_BAO_CustomField::getFieldObject($id);
+        $isMultiple = CRM_Core_BAO_CustomField::hasOptions($field);
+
+        if (!$isMultiple) {
+          continue;
+        }
+
+        $columnGroup = CRM_Core_BAO_CustomField::getTableColumnGroup($id);
+
+        if (!empty($columnGroup)) {
+          // Remove this field,so the case API won't use it in filtering.
+          unset($params[$key]);
+
+          self::joinCustomFieldQuery($sql, $columnGroup, (array) $value);
+        }
+      }
+    }
+  }
+
+  /**
+   * Joins the custom fields table column with filter condition.
+   *
+   * @param CRM_Utils_SQL_Select $sql
+   *   Reference to the SQL object.
+   * @param array $columnGroup
+   *   Array containing details on the custom field to join.
+   * @param array $value
+   *   Array containing the custom field values to filter.
+   */
+  private static function joinCustomFieldQuery(CRM_Utils_SQL_Select $sql, array $columnGroup, array $value) {
+    // When the param is keyed by 'IN', transform back to normal.
+    $value = $value['IN'] ?? $value;
+    $table = $columnGroup[0];
+    $column = $columnGroup[1];
+
+    $conditions = array_map(function ($param) use ($table, $column) {
+      return "custom_case_to_{$table}.{$column} REGEXP '[[:<:]]" . $param . "[[:>:]]'";
+    }, $value);
+    $conditions = implode(" AND ", $conditions);
+
+    $sql->join(
+      "custom_case_to_{$table}", "LEFT JOIN {$table} AS custom_case_to_{$table}
+      ON custom_case_to_{$table}.entity_id = `a`.id"
+    );
+    $sql->where($conditions);
+  }
+
+}

--- a/CRM/Civicase/Test/Fabricator/CustomField.php
+++ b/CRM/Civicase/Test/Fabricator/CustomField.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Fabricates custom field.
+ */
+class CRM_Civicase_Test_Fabricator_CustomField {
+
+  /**
+   * Fabricates a custom field.
+   *
+   * @param array $params
+   *   Parameters.
+   *
+   * @return array
+   *   Results.
+   */
+  public static function fabricate(array $params = []) {
+    $params = array_merge(static::getDefaultParams(), $params);
+
+    if (empty($params['custom_group_id'])) {
+      $params['custom_group_id'] = CRM_Civicase_Test_Fabricator_CustomGroup::fabricate()['id'];
+    }
+
+    $field = civicrm_api3('CustomField', 'create', $params);
+
+    return array_shift($field['values']);
+  }
+
+  /**
+   * Initialiazes Default parameters.
+   *
+   * @return array
+   *   Default parameters.
+   */
+  public static function getDefaultParams() {
+    return [
+      'name' => md5(mt_rand()),
+      'label' => md5(mt_rand()),
+      'html_type' => 'Text',
+    ];
+  }
+
+}

--- a/CRM/Civicase/Test/Fabricator/CustomGroup.php
+++ b/CRM/Civicase/Test/Fabricator/CustomGroup.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Fabricates custom group.
+ */
+class CRM_Civicase_Test_Fabricator_CustomGroup {
+
+  /**
+   * Fabricates a custom group.
+   *
+   * @param array $params
+   *   Parameters.
+   *
+   * @return array
+   *   Results.
+   */
+  public static function fabricate(array $params = []) {
+    $params = array_merge(static::getDefaultParams(), $params);
+    $group = civicrm_api3('CustomGroup', 'create', [
+      'title' => $params['title'],
+      'extends' => $params['extends'],
+    ]);
+
+    return array_shift($group['values']);
+  }
+
+  /**
+   * Initialiazes Default parameters.
+   *
+   * @return array
+   *   Default parameters.
+   */
+  public static function getDefaultParams() {
+    return ['title' => md5(mt_rand()), 'extends' => ['0' => 'Case']];
+  }
+
+}

--- a/tests/phpunit/api/v3/Case/GetcaselistTest.php
+++ b/tests/phpunit/api/v3/Case/GetcaselistTest.php
@@ -5,6 +5,7 @@ use CRM_Civicase_Test_Fabricator_RelationshipType as RelationshipTypeFabricator;
 use CRM_Civicase_Test_Fabricator_Relationship as RelationshipFabricator;
 use CRM_Civicase_Test_Fabricator_CaseType as CaseTypeFabricator;
 use CRM_Civicase_Test_Fabricator_Case as CaseFabricator;
+use CRM_Civicase_Test_Fabricator_CustomField as CustomFieldFabricator;
 
 /**
  * Runs tests for api_v3_Case_Getcaselist api class.
@@ -83,6 +84,84 @@ class api_v3_Case_GetcaselistTest extends BaseHeadlessTest {
     // Only Case A is expected to be returned because that is the only case a
     // relationship type manager was defined for with contact.
     $this->assertEquals($caseA['id'], $result['id']);
+  }
+
+  /**
+   * Test cases can be filtered by custom field with multiple options.
+   */
+  public function testFilterByCustomFieldWithMultipleOptions() {
+    $client = ContactFabricator::fabricate();
+    $caseType = CaseTypeFabricator::fabricate(['name' => md5(mt_rand())]);
+    $options = [['value' => 1], ['value' => 2]];
+    $optionGroupId = $this->createFieldOptions($options);
+    $customFieldParams = [
+      'html_type' => 'Select',
+      'option_group_id' => $optionGroupId,
+    ];
+    $customField = CustomFieldFabricator::fabricate($customFieldParams);
+    $customField = 'custom_' . $customField['id'];
+
+    $caseA = CaseFabricator::fabricate(
+      [
+        'subject' => md5(mt_rand()),
+        'case_type_id' => $caseType['id'],
+        'contact_id' => $client['id'],
+        'creator_id' => $this->creator,
+      ]
+    );
+
+    // Assign field with multiple options to the case.
+    civicrm_api3('CustomValue', 'create', [
+      $customField => [1, 2],
+      'entity_id' => $caseA['id'],
+    ]);
+
+    CaseFabricator::fabricate(
+      [
+        'case_type_id' => $caseType['id'],
+        'contact_id' => $client['id'],
+        'creator_id' => $this->creator,
+      ]
+    );
+
+    // Attempt to search by one of the assigned options.
+    $caseDetailsParams = [
+      $customField => 1,
+    ];
+
+    $result = civicrm_api3('Case', 'getdetails', $caseDetailsParams);
+
+    // Confirm that only caseA with the searched option is returned.
+    $this->assertCount(1, $result['values']);
+    $this->assertEquals($caseA['id'], $result['id']);
+  }
+
+  /**
+   * Create grouped custom field options.
+   *
+   * @param array $options
+   *   Array contaning values for the options.
+   *
+   * @return int
+   *   Returns the option group id.
+   */
+  private function createFieldOptions(array $options) {
+    $params = [
+      'name' => md5(mt_rand()),
+      'is_active' => 1,
+    ];
+    $result = civicrm_api3('OptionGroup', 'create', $params);
+
+    array_walk($options, function ($option) use ($result) {
+      civicrm_api3('OptionValue', 'create', [
+        'option_group_id' => $result['id'],
+        'label' => md5(mt_rand()),
+        'value' => $option['value'],
+        'is_active' => 1,
+      ]);
+    });
+
+    return $result['id'];
   }
 
 }


### PR DESCRIPTION
## Overview
The filters in the Manage Cases page don’t work correctly when searching by custom fields with multiple options, this is because of the way values for multiple options custom fields are stored by CiviCRM.

<img width="572" alt="Screenshot 2021-09-27 at 14 15 11" src="https://user-images.githubusercontent.com/85277674/134915932-cd5d4d84-3d47-4d76-8c49-1cd2b6934a9f.png">

As seen in the image above, the first row has two values, 12 and 13 respectively and these two values are stored in a single column delimited by space( ).
So a filter condition to get a case with the custom field that has the value `12` would only return the second row and exclude the first row.

since the where condition generated by civicrm would likely be in the form `where case_the_e_112 = 12`, or in some cases `where case_the_e_112 IN (12, 13)`, in any of the two, it is certain that the condition used by CiviCRM assumes the column `case_the_e_112` would always contain a single value, which is not the case.

This PR corrects that by creating a method to handle filtering of multiple options custom fields using REGEXP instead of `=` or `IN`.

## Before
Not all expected cases are returned even though they matched the search criteria
https://user-images.githubusercontent.com/85277674/134920115-55da4fc6-57f6-4403-973a-5d77ae49b8ed.mp4

## After
All cases that matched the search criteria are returned
https://user-images.githubusercontent.com/85277674/134920972-3c8cde6b-ce2f-401c-a484-0f6cab426056.mp4

## Technical Details
The solution proposed in this PR is to handle the filtering of cases with multiple options custom fields in a custom method separately, we specify the joins and where condition SQL statement to be used.

The major code is where the PR uses SQL REGEXP word boundary test `REGEXP '[[:<:]]" . $value . "[[:>:]]'"`   to get a value from a group of values separated by spaces.