### PR TITLE
BASWSPRT-193: Change url of case from contact case tab

### DIFF
--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.js
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.js
@@ -40,7 +40,7 @@
       var caseTypeCategoryId = caseItem['case_type_id.case_type_category'];
 
       return civicaseCrmUrl('civicrm/case/a/', 'case_type_category=' + caseTypeCategoryId +
-        '#/case/list?caseId=' + caseItem.id + '&focus=1&all_statuses=1');
+        '#/case/list?caseId=' + caseItem.id + '&focus=1&cf={"id":' + caseItem.id + '}');
     }
   }
 })(angular, CRM.$, CRM._);

--- a/ang/civicase/case/list/directives/case-list-table.directive.js
+++ b/ang/civicase/case/list/directives/case-list-table.directive.js
@@ -194,7 +194,7 @@
      * Remove route params added by individual tabs
      */
     function removeExtraRouteParams () {
-      var allowedRouteParams = ['caseId', 'cf', 'all_statuses'];
+      var allowedRouteParams = ['caseId', 'cf'];
 
       $route.current.params = _.pick($route.current.params, function (value, key) {
         return allowedRouteParams.indexOf(key) !== -1;

--- a/ang/civicase/case/search/directives/search.directive.js
+++ b/ang/civicase/case/search/directives/search.directive.js
@@ -126,7 +126,6 @@
       $scope.$bindToRoute({ expr: 'expanded', param: 'sx', format: 'bool', default: false });
       $scope.$bindToRoute({ expr: 'filters', param: 'cf', default: {} });
       $scope.$bindToRoute({ expr: 'contactRoleFilter', param: 'crf', default: $scope.contactRoleFilter });
-      $scope.$bindToRoute({ expr: 'showCasesFromAllStatuses', param: 'all_statuses', format: 'bool' });
     }
 
     /**
@@ -347,7 +346,6 @@
       $window.location.href =
         'case_type_category=' + caseTypeCategory +
         '#/case/list?caseId=' + data.caseId +
-        '&all_statuses=1' +
         '&cf=%7B"case_type_category":"' + caseTypeCategory + '"%7D';
     }
 

--- a/ang/test/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.spec.js
+++ b/ang/test/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.spec.js
@@ -31,7 +31,7 @@
       it('returns the case details page url for the given case', () => {
         expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/case/a/',
           `case_type_category=${caseTypeCategory.value}` +
-          `#/case/list?caseId=${mockCase.id}&focus=1&all_statuses=1`);
+          `#/case/list?caseId=${mockCase.id}&focus=1&cf={"id":${mockCase.id}}`);
       });
     });
 

--- a/ang/test/civicase/case/search/directives/search.directive.spec.js
+++ b/ang/test/civicase/case/search/directives/search.directive.spec.js
@@ -217,7 +217,7 @@
 
         it('shows the cases', () => {
           const expectedURL = 'case_type_category=1#/case/list?' +
-            'caseId=10&all_statuses=1&cf=%7B"case_type_category":"1"%7D';
+            'caseId=10&cf=%7B"case_type_category":"1"%7D';
 
           expect($window.location.href)
             .toBe(expectedURL);


### PR DESCRIPTION
## Overview
When trying to access a case through the contact case tab and trying to open the case from "GO TO CASE"  button, the following error is thrown. 

"The case you are trying to view is not visible as your filters do not match.
Please click below to remove your filters"

This PR fixes that.

## Before
`/civicrm/case/a/?case_type_category=1#/case/list?caseId=55&focus=1&all_statuses=1`

## After
`/civicrm/case/a/?case_type_category=1&p=mg#/case/list?focus=1&cf={"id":55}&caseId=55`

## Technical Details
In the code, a api call is 1st made with `page_of_record: <case_id>`, which then returns the page number in which that case is part of(here page number refers to the pagination page number of manage case list). But looks like sometimes this page no is not getting generated correctly, and hence the issue.

Initially I thought that this is happening, because after the page number is sent from backend, we make another api call, to fetch the cases from that page. And if between these 2 api calls, more cases are created by other users, then the page number will change, and hence this issue might happen.

But I believe this theory is not correct for 2 reasons,

1. When this issues happens, it might happen for few hours straight. And it is unlikely that for few hours, many cases are created between those 2 api calls(it takes 1-2 seconds max between these 2 api calls).

2. Sometimes the cpn stays the same when refreshing the page. And if our theory was correct, the cpn should have updated when refreshing the page.

Because we did not have enough time to investigate this as this is a sporadic issue and it not easily reproducible.
We are changing the url itself. This way, we will make use of the Case ID search functionality, as we will pre populate it.