### PR TITLE
COMCL-167: Accept multiple types argument

### DIFF
--- a/CRM/Civicase/Api/Wrapper/CaseGetList.php
+++ b/CRM/Civicase/Api/Wrapper/CaseGetList.php
@@ -71,13 +71,13 @@ class CRM_Civicase_Api_Wrapper_CaseGetList implements API_Wrapper {
   /**
    * Handles request coming from Case.getlist API.
    *
-   * @param array $apiRequest
+   * @param array|Civi\Api4\Generic\AbstractAction $apiRequest
    *   API Request.
    *
    * @return bool
    *   If request can be handled.
    */
-  private function canHandleTheRequest(array $apiRequest) {
+  private function canHandleTheRequest($apiRequest) {
     return $apiRequest['entity'] == 'Case' && $apiRequest['action'] == 'getlist';
   }
 

--- a/CRM/Civicase/Api/Wrapper/CaseGetList.php
+++ b/CRM/Civicase/Api/Wrapper/CaseGetList.php
@@ -64,7 +64,11 @@ class CRM_Civicase_Api_Wrapper_CaseGetList implements API_Wrapper {
     $excludedCaseIds = !empty($apiRequest['params']['params']['case_id']['NOT IN']) ? $apiRequest['params']['params']['case_id']['NOT IN'] : [];
     if (!in_array($input, $excludedCaseIds)) {
       $apiRequest['params']['params']['case_id'] = $input;
-      $apiRequest['params']['params']['options'] = ['or' => [['case_id', 'contact_id.sort_name']]];
+      $apiRequest['params']['params']['options'] = [
+        'or' => [
+          ['case_id', 'contact_id.sort_name'],
+        ],
+      ];
     }
   }
 


### PR DESCRIPTION
## Overview

This PR fixes the issue when the site throws an error when accessing SearchKit menu. 

## Before

![Peek 2022-01-12 13-07](https://user-images.githubusercontent.com/208713/149145983-1eca7f31-2546-4843-ae3c-b141bbfe35fb.gif)

## After

![Peek 2022-01-12 13-01](https://user-images.githubusercontent.com/208713/149145249-dacd9d35-1a63-48f8-aa89-e535f4cf5c9f.gif)

## Technical Details

When using SearchKit function, the APIWrapper hook get called and API v4 object is passed to $apiRequest, and CiviCase implements apiWrappers [hook](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_apiWrappers/), and the implementation only accept a parameter as an array, hence, PHP throws the error.

According to https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_apiWrappers/   $apiRequest parameter can be passed as array or Civi\Api4\Generic\AbstractAction therefore the function must be able to handle multiple types argument. 

Note on the CiviCase's API Wrapper hook, the implementation mainly handle an array and this should not be any issue as the Civi\Api4\Generic\AbstractAction class has implemented [ArrayAccess](https://www.php.net/manual/en/class.arrayaccess.php) interface that allow to access object's properties as an array. 

See https://github.com/civicrm/civicrm-core/blob/5.39/Civi/Api4/Generic/AbstractAction.php#L43
 
## Comment

Note that there is an issue when installing NODE JS, so the linter is not running probably which should be dealt with separately as it is not relevant to this PR. 