### PR TITLE
COMCL-168: Fix linters workflow

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,11 +13,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set Correct NodeJS version
-      shell: bash -l {0}
-      run: |
-        nvm install
-        nvm use
+    - name: Read .nvmrc
+      run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+      id: nvm
+
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '${{ steps.nvm.outputs.NVMRC }}'
 
     - name: Run npm install
       run: npm i

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -28,7 +28,7 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.35 --cms-ver 7.74 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.39.1 --cms-ver 7.85 --web-root $GITHUB_WORKSPACE/site
 
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## Overview
This PR fixes the failed linter workflow.

![Screenshot from 2022-01-13 18-48-06](https://user-images.githubusercontent.com/74309109/149372892-3265aff1-771c-4399-ad50-116bbe0b536b.png)

## Technical Details
The `Set Correct NodeJS version` step bootstraps the project with `nvm` so that `nvm` will install Node.js 14.16.0 which is specified in the file `.nvmrc`.
The issue is the `Run npm install` step didn't use the version 14.16.0 and instead used the version 16.3.1.

Here, I introduce the [setup-node action](https://github.com/actions/setup-node) which allows us to specify a Node.js version. It was created by the Github team.

Before using the action, we read the the version specified in the file `.nvmrc` and set an [output parameter](https://github.com/actions/setup-node/issues/32#issuecomment-539794249) so that the action can use it in the next step.
