### PR TITLE
Format Activity: avoid errors when some statuses are disabled

### DIFF
--- a/ang/civicase/activity/factories/format-activity.factory.js
+++ b/ang/civicase/activity/factories/format-activity.factory.js
@@ -4,7 +4,7 @@
   module.factory('formatActivity', function (CasesUtils, ActivityStatusType,
     ActivityStatus, ActivityType, CaseStatus, CaseType, isTruthy) {
     var activityTypes = ActivityType.getAll(true);
-    var activityStatuses = ActivityStatus.getAll();
+    var activityStatuses = ActivityStatus.getAll(true);
     var caseStatuses = CaseStatus.getAll();
 
     return function (act, caseId) {


### PR DESCRIPTION
## Overview

If some activity statuses are disabled, viewing old/existing data may cause Javascript errors, therefore causing the Contact Activity tab to fail to load.

To reproduce:

* Create a new Activity
* Save as Draft
* Then to go CiviCRM administration, and disable "Draft" as an activity status.
* Go back to the contact that had a draft activity - the tab fails to load.

## Technical Details

`getAll(true)` to load all activity statuses. This only impacts activity display.

### Core overrides

none
