### PR TITLE
NEUSPRT-92: Filter out disabled case statuses in case overview

### DIFF
--- a/ang/civicase/case/directives/case-overview.directive.js
+++ b/ang/civicase/case/directives/case-overview.directive.js
@@ -48,10 +48,11 @@
    * @param {object} CaseTypeCategory the case type category service reference.
    * @param {Function} getServiceForInstance get service for a specific instance
    * @param {string} currentCaseCategory current case category
+   * @param {Function} isTruthy service to check if value is truthy
    */
   function civicaseCaseOverviewController ($scope, civicaseCrmApi, BrowserCache,
     CaseStatus, CaseType, CaseTypeCategory, getServiceForInstance,
-    currentCaseCategory) {
+    currentCaseCategory, isTruthy) {
     var BROWSER_CACHE_IDENTIFIER = 'civicase.CaseOverview.hiddenCaseStatuses';
     var MAXIMUM_CASE_TYPES_TO_DISPLAY_BREAKDOWN = 1;
     var allCaseStatusNames = _.map(CaseStatus.getAll(true), 'name');
@@ -100,6 +101,9 @@
           caseStatusNames = getCaseStatusNamesBelongingToCaseTypes($scope.caseTypes);
           $scope.caseStatuses = _.sortBy(getStatusesByName(caseStatusNames), function (status) {
             return parseInt(status.weight, 10);
+          });
+          $scope.caseStatuses = $scope.caseStatuses.filter(function (status) {
+            return isTruthy(status.is_active);
           });
           $scope.showBreakdown = $scope.caseTypes.length <=
             MAXIMUM_CASE_TYPES_TO_DISPLAY_BREAKDOWN;


### PR DESCRIPTION
## Overview
This PR resolves the issue with disabled case status appearing on the Case Status filter.

## Before
Disabled case statuses are still in the case status filter dropdown.
![case-b4](https://user-images.githubusercontent.com/85277674/156390739-8fd68404-26da-4408-b1eb-f0ec65758121.gif)

## After
Disabled case statuses are no longer visible in the case status filter dopdown.
![case](https://user-images.githubusercontent.com/85277674/156391152-a333a589-4d24-4dad-b39c-2bb9f972a749.gif)
