### PR TITLE
NEUSPRT-84: Refactored the query for selecting case files into subquery

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -28,7 +28,7 @@ jobs:
       run: git fetch -n origin ${GITHUB_BASE_REF}
 
     - name: Run phpcs linter
-      run: git diff --diff-filter=d  origin/${GITHUB_BASE_REF} --name-only -- '*.php' | xargs -r ./bin/phpcs.phar --standard=phpcs-ruleset.xml
+      run: git diff --diff-filter=d  origin/${GITHUB_BASE_REF} --name-only -- '*.php' | xargs -r ./bin/drupal/coder/vendor/bin/phpcs --standard=phpcs-ruleset.xml
 
     - name: Run stylelint linter
       #This step will always run regardless of previous step's status

--- a/api/v3/Case/Getfiles.php
+++ b/api/v3/Case/Getfiles.php
@@ -81,7 +81,7 @@ function civicrm_api3_case_getfiles(array $params) {
 function _civicrm_api3_case_getfiles_format_params(array $params) {
   // Blerg, option value expansions don't seem to work in non-standard actions.
   if (isset($params['activity_type_id'])) {
-    $actTypes = CRM_Core_OptionGroup::values('activity_type', FALSE, FALSE, FALSE, NULL, 'name');;
+    $actTypes = CRM_Core_OptionGroup::values('activity_type', FALSE, FALSE, FALSE, NULL, 'name');
 
     if (isset($params['activity_type_id'][0]) && $params['activity_type_id'][0] === 'IN') {
       $params['activity_type_id'][1] = array_map(function ($type) use ($actTypes) {
@@ -119,7 +119,7 @@ function _civicrm_api3_case_getfiles_find(array $params, array $options) {
   $select = _civicrm_api3_case_getfiles_select($params);
 
   if (!empty($options['limit'])) {
-    $select->limit($options['limit'], isset($options['offset']) ? $options['offset'] : 0);
+    $select->limit($options['limit'], $options['offset'] ?? 0);
   }
 
   $dao = \CRM_Core_DAO::executeQuery($select->toSQL());

--- a/api/v3/Case/Getfiles.php
+++ b/api/v3/Case/Getfiles.php
@@ -143,29 +143,22 @@ function _civicrm_api3_case_getfiles_find(array $params, array $options) {
  *   Query select class.
  */
 function _civicrm_api3_case_getfiles_select(array $params) {
-  $select = CRM_Utils_SQL_Select::from('civicrm_case_activity caseact')
+  $activitySelect = CRM_Utils_SQL_Select::from('civicrm_activity act')
     ->strict()
-    ->join('ef', 'INNER JOIN civicrm_entity_file ef ON (ef.entity_table = "civicrm_activity" AND ef.entity_id = caseact.activity_id) ')
-    ->join('et', 'LEFT JOIN civicrm_entity_tag et ON (et.entity_table = "civicrm_activity" AND et.entity_id = caseact.activity_id) ')
+    ->join('ef', 'INNER JOIN civicrm_entity_file ef ON (ef.entity_table = "civicrm_activity" AND ef.entity_id = act.id) ')
+    ->join('et', 'LEFT JOIN civicrm_entity_tag et ON (et.entity_table = "civicrm_activity" AND et.entity_id = act.id) ')
     ->join('f', 'INNER JOIN civicrm_file f ON ef.file_id = f.id')
-    ->select('caseact.case_id as case_id, caseact.activity_id as activity_id, f.id as id, act.activity_date_time')
+    ->select('f.id as fid, act.activity_date_time, act.original_id, act.is_current_revision, act.id')
     ->distinct();
 
-  if (isset($params['case_id'])) {
-    $select->where('caseact.case_id = #caseIDs', [
-      'caseIDs' => $params['case_id'],
-    ]);
-  }
-
   if (isset($params['tag_id'])) {
-    $select->where(_civicase_get_tag_id_sql($params['tag_id']));
+    $activitySelect->where(_civicase_get_tag_id_sql($params['tag_id']));
   }
 
-  $select->join('act', 'INNER JOIN civicrm_activity act ON ((caseact.activity_id = act.id OR caseact.activity_id = act.original_id) AND act.is_current_revision=1)');
   if (isset($params['text'])) {
     // The end of the uri contains a hash which we want to ignore.
     // So we match from the start of the file uri as a cheap fix. CRM-20096.
-    $select->where('act.subject LIKE @q OR act.details LIKE @q OR f.description LIKE @q OR f.uri LIKE @q OR f.uri LIKE @s', [
+    $activitySelect->where('act.subject LIKE @q OR act.details LIKE @q OR f.description LIKE @q OR f.uri LIKE @q OR f.uri LIKE @s', [
       'q' => '%' . $params['text'] . '%',
       's' => $params['text'] . '%',
     ]
@@ -182,15 +175,15 @@ function _civicrm_api3_case_getfiles_select(array $params) {
     else {
       throw new \API_Exception("Field 'mime_type_cat' only supports string or IN values.");
     }
-    $select->where(CRM_Civicase_FileCategory::createSqlFilter('f.mime_type', $cats));
+    $activitySelect->where(CRM_Civicase_FileCategory::createSqlFilter('f.mime_type', $cats));
   }
 
   if (isset($params['mime_type'])) {
     if (is_array($params['mime_type'])) {
-      $select->where(CRM_Core_DAO::createSqlFilter('f.mime_type', $params['mime_type'], 'String'));
+      $activitySelect->where(CRM_Core_DAO::createSqlFilter('f.mime_type', $params['mime_type'], 'String'));
     }
     else {
-      $select->where('f.mime_type LIKE @type', [
+      $activitySelect->where('f.mime_type LIKE @type', [
         '@type' => $params['mime_type'],
       ]
       );
@@ -208,29 +201,43 @@ function _civicrm_api3_case_getfiles_select(array $params) {
       ->select('cov.value, cov.name');
     $actTypes = $selectActTypes->execute()->fetchMap('value', 'name');
     if ($actTypes) {
-      $select->where('act.activity_type_id IN (#type)', [
+      $activitySelect->where('act.activity_type_id IN (#type)', [
         '#type' => array_keys($actTypes),
       ]
       );
     }
     else {
-      $select->where('0 = 1');
+      $activitySelect->where('0 = 1');
     }
   }
 
   if (isset($params['activity_type_id'])) {
     if (is_array($params['activity_type_id'])) {
-      $select->where(CRM_Core_DAO::createSqlFilter('act.activity_type_id', $params['activity_type_id'], 'String'));
+      $activitySelect->where(CRM_Core_DAO::createSqlFilter('act.activity_type_id', $params['activity_type_id'], 'String'));
     }
     else {
-      $select->where('act.activity_type_id = #type', [
+      $activitySelect->where('act.activity_type_id = #type', [
         '#type' => $params['activity_type_id'],
       ]
       );
     }
   }
 
-  $select->orderBy(['act.activity_date_time DESC, act.id DESC, f.id DESC']);
+  $activitySelect->orderBy(['act.activity_date_time DESC, act.id DESC, f.id DESC']);
+
+  $select = CRM_Utils_SQL_Select::from('civicrm_case_activity caseact')
+    ->strict()
+    ->select('caseact.case_id as case_id, caseact.activity_id as activity_id, act.fid as id, act.activity_date_time')
+    ->distinct();
+
+  if (isset($params['case_id'])) {
+    $select->where('caseact.case_id = #caseIDs', [
+      'caseIDs' => $params['case_id'],
+    ]);
+  }
+
+  $select->join('act', "INNER JOIN (" . $activitySelect->toSql() . ") AS act ON ((caseact.activity_id = act.id OR caseact.activity_id = act.original_id) AND act.is_current_revision=1)");
+
   return $select;
 }
 

--- a/bin/install-php-linter
+++ b/bin/install-php-linter
@@ -1,14 +1,9 @@
 #!/bin/bash
 set -e
 
-# Download PHPCS if it already does not exist
-if [ ! -f phpcs.phar ]; then
-  curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
-fi
-# Give executable permission to PHPCS
-chmod +x phpcs.phar
-
 # Clone Drupal Coder repo
 if [ ! -d drupal/coder ]; then
   git clone --depth 1 https://git.drupalcode.org/project/coder.git drupal/coder
+  cd drupal/coder
+  composer install
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1427,8 +1427,8 @@
       }
     },
     "civicrm-scssroot": {
-      "version": "git://github.com/totten/civicrm-scssroot.git#3fc126e91ea503420daedc82425e9b85085707f6",
-      "from": "git://github.com/totten/civicrm-scssroot.git#v0.1.1",
+      "version": "github:totten/civicrm-scssroot#3fc126e91ea503420daedc82425e9b85085707f6",
+      "from": "github:totten/civicrm-scssroot#v0.1.1",
       "dev": true,
       "requires": {
         "civicrm-cv": "^0.1.2"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/compucorp/uk.co.compucorp.civicase#readme",
   "devDependencies": {
     "civicrm-cv": "^0.1.2",
-    "civicrm-scssroot": "git://github.com/totten/civicrm-scssroot.git#v0.1.1",
+    "civicrm-scssroot": "totten/civicrm-scssroot#v0.1.1",
     "eslint": "^6.5.1",
     "eslint-config-semistandard": "^15.0.0",
     "eslint-config-standard": "^14.1.0",


### PR DESCRIPTION
## Overview
This PR resolves the issue with files not appearing in the case file tabs for specific case IDs, as the server timeouts `HTTP 504` during the request before SQL could return a result. 

## Before
![image](https://user-images.githubusercontent.com/85277674/158952196-12ff6ad6-3eca-4cfd-8563-0c40eebbeb5a.png)

## After
![image](https://user-images.githubusercontent.com/85277674/158952216-5d0f97f1-ff2f-4d14-b13f-7367938625aa.png)

## Technical Details
The issue is caused by the number of files that are associated with the affected case IDs, and also the more the files the longer it takes for the SQL to execute, which in turn affects the server response time.

The simple approach taken to resolve this issue is to optimise the SQL query for selecting the files.

The query generated by `_civicrm_api3_case_getfiles_select()` for `case_id = 1` before update.

> SELECT DISTINCT caseact.case_id as case_id, caseact.activity_id as activity_id, f.id as id, act.activity_date_time
> FROM civicrm_case_activity caseact
> INNER JOIN civicrm_entity_file ef ON (ef.entity_table = "civicrm_activity" AND ef.entity_id = caseact.activity_id) 
> LEFT JOIN civicrm_entity_tag et ON (et.entity_table = "civicrm_activity" AND et.entity_id = caseact.activity_id)
> INNER JOIN civicrm_file f ON ef.file_id = f.id
> INNER JOIN civicrm_activity act ON ((caseact.activity_id = act.id OR caseact.activity_id = act.original_id) AND act.is_current_revision=1) 
> WHERE (caseact.case_id = 1) AND (act.subject LIKE "%%" OR act.details LIKE "%%" OR f.description LIKE "%%" OR f.uri LIKE "%%" OR f.uri LIKE "%") 
> ORDER BY act.activity_date_time DESC, act.id DESC, f.id DESC;

The query generated by `_civicrm_api3_case_getfiles_select()` for `case_id = 1` after refactoring the query to use subquery where neccessary.

> SELECT 
> DISTINCT caseact.case_id as case_id, caseact.activity_id as activity_id, act.file_id, act.adt
> FROM civicrm_case_activity caseact
> JOIN (
> SELECT act.id as act_id, f.id as file_id, act.activity_date_time as adt, act.original_id AS act_original_id FROM civicrm_activity act
> INNER JOIN civicrm_entity_file ef ON (ef.entity_table = "civicrm_activity" AND ef.entity_id = act.id) 
> INNER JOIN civicrm_file f ON ef.file_id = f.id
> LEFT JOIN civicrm_entity_tag et ON (et.entity_table = "civicrm_activity" AND et.entity_id = act.id) 
> ORDER BY act.activity_date_time DESC, act.id DESC, f.id DESC
> ) AS act on caseact.activity_id = act_id OR caseact.activity_id = act_original_id
> WHERE (caseact.case_id = 1);

Another solution would be to select the files in `chunks` using `offset` and `limit` but this would likely require a redesign of the current files tab to accommodate pagination buttons.

Or, instead of getting all files for a case, the frontend can instead get each activity for a case first, then fetch the files belonging to each activity, this would also require a frontend change.

## Additional Updates
This PR also fixes two separate ad-hoc issues
1. The phpcs linter action fails during installation.
```
ERROR: Referenced sniff "SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator" does not exist
```
This is caused by a new dependency introduced in the latest release of [Drupal coding standard project](https://www.drupal.org/project/coder), according to the updated [installation instruction ](https://www.drupal.org/node/1419988) it is required to install dependencies via composer. That's why in the bash script we now access the `drupal/coder` folder code and execute `composer install`. Also, since the `phpcs` is inside the `vendor` folder, we don't need to download it again (then we remove that part of the bash also).

2. The unit test action fails during npm installation
```
npm ERR! Error while executing:
npm ERR! /usr/bin/git ls-remote -h -t git://github.com/totten/civicrm-scssroot.git
npm ERR! 
npm ERR! fatal: remote error: 
npm ERR!   The unauthenticated git protocol on port 9418 is no longer supported.
```
This error is fixed by changing the `civicrm-scssroot` git URL to the newly supported [Github URL](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#github-urls).