### PR TITLE
NEUSPRT-102: Clear crm-entity stored data in cache

### DIFF
--- a/ang/civicase/case/list/directives/case-list-table.directive.js
+++ b/ang/civicase/case/list/directives/case-list-table.directive.js
@@ -188,6 +188,7 @@
       }
       setPageTitle();
       $($window).scrollTop(0); // Scrolls the window to top once new data loads
+      $('.crm-entity').removeData(); // Clear .crm-entity data in cache
     }
 
     /**


### PR DESCRIPTION
## Overview
This PR resolves the bug that happens when editing cases' subjects and details in the cases list view, if multiple case subjects and details are edited only the first case is changed and it takes the value of the last edited case.

## Before
![ll-before](https://user-images.githubusercontent.com/85277674/161779969-bf668203-47db-492a-a724-97513b89225b.gif)

## After
![aa](https://user-images.githubusercontent.com/85277674/161782528-ec1a8648-ed95-4cae-ab72-850dec60658b.gif)

## Technical details
The `crmEditable` function uses the data-id value of the closest element with class `.crm-entity` to know the id of the entity being edited, but `data-*` attributes are only pulled once from the DOM when the data property is first accessed, and subsequent read of the `data-*` returns the value from the cache, which is the value of the first case to be opened and not the currently opened case.
<img width="975" alt="Screenshot 2022-04-05 at 16 08 57" src="https://user-images.githubusercontent.com/85277674/161785814-76dccdf8-9eb9-4a0e-8997-e8941f8af1dd.png">

The solution is to clear the cache when a new case is opened.
