### PR TITLE
NEUSPRT-108: Prevent deleting of copied activities

### DIFF
--- a/api/v3/Activity/Deletebyquery.php
+++ b/api/v3/Activity/Deletebyquery.php
@@ -51,16 +51,38 @@ function civicrm_api3_activity_deletebyquery(array $params) {
   }
 
   $activityIds = [];
+
+  unlink_from_other_activities($activities);
   foreach ($activities as $activityId) {
     try {
       civicrm_api3('Activity', 'delete', [
         'id' => $activityId,
       ]);
       $activityIds[] = $activityId;
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
     }
 
   }
 
   return civicrm_api3_create_success($activityIds, $params, 'Activity', 'copybyquery');
+}
+
+/**
+ * Unlink activities from other activity they are linked to.
+ *
+ * @param array $activities
+ *   Array of activity ids.
+ */
+function unlink_from_other_activities(array $activities) {
+  try {
+    civicrm_api3('Activity', 'get', [
+      'sequential' => 1,
+      'return' => ['id'],
+      'original_id' => ['IN' => $activities],
+      'api.Activity.update' => ['original_id' => ''],
+    ]);
+  }
+  catch (Exception $e) {
+  }
 }


### PR DESCRIPTION
## Overview
This PR resolves the issue with a copied activity being deleted when the activity it was copied from is deleted.

## Before
![hh-b4](https://user-images.githubusercontent.com/85277674/161971150-eb660420-c16f-401a-884e-68b0bbaf00d2.gif)

## After
![hh](https://user-images.githubusercontent.com/85277674/161971188-70f1ebaf-14ec-4b79-8b36-f486f56c385a.gif)

## Technical Details
When an activity is copied from one case to another, the duplicated activity is linked to the original activity in the DB by the column original_id.
![image](https://user-images.githubusercontent.com/85277674/161971361-0333f477-0ee0-4c58-b1d7-9ea0c022aa39.png)

hence, when an activity is deleted, activities linked to it via their original_id column are deleted also.
The solution is to unlink other activities from the activity before it is deleted. a new function `unlink_from_other_activities` is created to unlink other activities if any before it is deleted, note this function is only called in `civicrm_api3_activity_deletebyquery` so it only affects activities deleted in the CiviCase dashboard.
