### PR TITLE
NEUSPRT-98: Delete a case activity after moving to another case

### DIFF
--- a/api/v3/Activity/Movebyquery.php
+++ b/api/v3/Activity/Movebyquery.php
@@ -76,8 +76,25 @@ function civicrm_api3_activity_movebyquery(array $params) {
     $result = CRM_Activity_Page_AJAX::_convertToCaseActivity($caseActivityParams);
     if (empty($result['error_msg']) && !empty($result['newId'])) {
       $activityIds[] = $result['newId'];
+      delete_case_activity($activityId);
     }
   }
 
   return civicrm_api3_create_success($activityIds, $params, 'Activity', 'copybyquery');
+}
+
+/**
+ * Delete a case activity after moving to another case.
+ *
+ * @param int $activityId
+ *   Activity ID.
+ */
+function delete_case_activity($activityId) {
+  try {
+    civicrm_api3('Activity', 'deletebyquery', [
+      'id' => $activityId,
+    ]);
+  }
+  catch (Exception $e) {
+  }
 }


### PR DESCRIPTION
## Overview
This PR deletes a case activity after moving it to another case, so it doesn't appear in the Case it was moved from.

## Before
Move activity from case 1 -> case 2
Activity can still be seen in case 1 after the move.
![ls-b4](https://user-images.githubusercontent.com/85277674/162192663-3418be71-2d3e-4cd4-af32-8629c288167c.gif)


## After
Move activity from case 1 -> case 2
Activity can no longer be seen in case 1 after the move.
![ls-2](https://user-images.githubusercontent.com/85277674/162193629-7c5b0fc0-dc7d-4d5a-97fd-cedf8ae535fa.gif)
