### PR TITLE
NEUSPRT-110: Transfer activity tags when moving or copying

### DIFF
--- a/CRM/Civicase/APIHelpers/ActivityQueryApi.php
+++ b/CRM/Civicase/APIHelpers/ActivityQueryApi.php
@@ -3,7 +3,7 @@
 use CRM_Civicase_APIHelpers_GenericApi as GenericApiHelper;
 
 /**
- * Class CRM_Civicase_APIHelpers_ActivityQueryApi.
+ * ActivityQueryApi API Helper Class.
  */
 class CRM_Civicase_APIHelpers_ActivityQueryApi {
 
@@ -45,6 +45,33 @@ class CRM_Civicase_APIHelpers_ActivityQueryApi {
     }
 
     return $apiParams;
+  }
+
+  /**
+   * Copy tags from one activity to another activity.
+   *
+   * @param int $activityId
+   *   ID of the activity that is being copied.
+   * @param int $newActivityId
+   *   ID of the new activity.
+   * @param string $mode
+   *   Mode can either be move or copy.
+   */
+  public function transferActivityTags($activityId, $newActivityId, $mode = 'copy') {
+    $result = civicrm_api3('EntityTag', 'get', [
+      'sequential' => 1,
+      'entity_table' => "civicrm_activity",
+      'entity_id' => $activityId,
+    ]);
+
+    array_walk($result['values'], function ($tag) use ($newActivityId, $mode) {
+      $tag['entity_id'] = $newActivityId;
+      if ($mode === 'copy') {
+        unset($tag['id']);
+      }
+
+      civicrm_api3('EntityTag', 'create', $tag);
+    });
   }
 
 }

--- a/api/v3/Activity/Copybyquery.php
+++ b/api/v3/Activity/Copybyquery.php
@@ -73,6 +73,7 @@ function civicrm_api3_activity_copybyquery(array $params) {
 
     $result = CRM_Activity_Page_AJAX::_convertToCaseActivity($caseActivityParams);
     if (empty($result['error_msg']) && !empty($result['newId'])) {
+      $activityQueryApiHelper->transferActivityTags($activityId, $result['newId']);
       $activityIds[] = $result['newId'];
     }
   }

--- a/api/v3/Activity/Movebyquery.php
+++ b/api/v3/Activity/Movebyquery.php
@@ -76,6 +76,7 @@ function civicrm_api3_activity_movebyquery(array $params) {
     $result = CRM_Activity_Page_AJAX::_convertToCaseActivity($caseActivityParams);
     if (empty($result['error_msg']) && !empty($result['newId'])) {
       $activityIds[] = $result['newId'];
+      $activityQueryApiHelper->transferActivityTags($activityId, $result['newId'], 'move');
       delete_case_activity($activityId);
     }
   }


### PR DESCRIPTION
## Overview
This PR transfer case activity tags along with the activity when the activity is been moved or copied from one case to another.

## Before
Activity tags are not moved to the new activity.
![lop-asasa](https://user-images.githubusercontent.com/85277674/163414677-00696c69-ed88-4e6d-953c-e153ef4097f6.gif)

## After
Activity tags are moved to the new activity.
![lop](https://user-images.githubusercontent.com/85277674/163412462-2948dc80-67ee-4b55-9e76-e4909bc31949.gif)
