### PR TITLE
WHF-329: Remove the use of sql keyword 'grouping' causing syntax error

### DIFF
--- a/CRM/Civicase/Helper/CaseCategory.php
+++ b/CRM/Civicase/Helper/CaseCategory.php
@@ -341,7 +341,7 @@ class CRM_Civicase_Helper_CaseCategory {
       return new CaseManagementUtils();
     }
 
-    $instanceClasses = CRM_Core_OptionGroup::values('case_category_instance_type', FALSE, FALSE, TRUE, NULL, 'grouping');
+    $instanceClasses = CRM_Core_OptionGroup::values('case_category_instance_type', TRUE, TRUE, TRUE, NULL);
     $instanceClass = $instanceClasses[$instanceValue];
 
     return new $instanceClass($caseCategoryInstance->id);

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -65,8 +65,8 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
         'option_group_id' => 'activity_type',
         'name' => ['IN' => $activityTypes],
         'api.OptionValue.setvalue' => [
-          'field' => 'grouping',
-          'value' => $grouping,
+          'option_group_id' => 'activity_type',
+          'grouping' => $grouping,
         ],
       ]);
     }
@@ -105,9 +105,9 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
         'option_group_id' => 'activity_status',
         'name' => $status,
         'return' => 'id',
-        'api.OptionValue.setvalue' => [
-          'field' => 'grouping',
-          'value' => $grouping,
+        'api.OptionValue.create' => [
+          'option_group_id' => 'activity_status',
+          'grouping' => $grouping,
         ],
       ]);
     }

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -64,7 +64,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
         'return' => 'id',
         'option_group_id' => 'activity_type',
         'name' => ['IN' => $activityTypes],
-        'api.OptionValue.setvalue' => [
+        'api.OptionValue.create' => [
           'option_group_id' => 'activity_type',
           'grouping' => $grouping,
         ],

--- a/tests/phpunit/api/v3/Case/GetfilesTest.php
+++ b/tests/phpunit/api/v3/Case/GetfilesTest.php
@@ -1,8 +1,10 @@
 <?php
 
+use Civi\Test;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
+use CRM_Civicase_Test_Fabricator_Contact as ContactFabricator;
 
 require_once 'BaseTestCase.php';
 
@@ -10,180 +12,214 @@ require_once 'BaseTestCase.php';
  * Test the "Case.getfiles" API.
  *
  * Tips:
- *  - With HookInterface, you may implement CiviCRM hooks directly in the test class.
- *    Simply create corresponding functions (e.g. "hook_civicrm_post(...)" or similar).
- *  - With TransactionalInterface, any data changes made by setUp() or test****() functions will
- *    rollback automatically -- as long as you don't manipulate schema or truncate tables.
- *    If this test needs to manipulate schema or truncate tables, then either:
+ *  - With HookInterface, you may implement CiviCRM hooks directly
+ *    in the test class.
+ *    Simply create corresponding functions
+ *     (e.g. "hook_civicrm_post(...)" or similar).
+ *  - With TransactionalInterface, any data changes made by setUp()
+ *    or test****() functions will
+ *    rollback automatically -- as long as you don't manipulate schema
+ *    or truncate tables.
+ *    If this test needs to manipulate schema or truncate tables,
+ *    then either:
  *       a. Do all that using setupHeadless() and Civi\Test.
- *       b. Disable TransactionalInterface, and handle all setup/teardown yourself.
+ *       b. Disable TransactionalInterface,
+ *          and handle all setup/teardown yourself.
  *
  * @group headless
  */
 class api_v3_Case_GetfilesTest extends api_v3_Case_BaseTestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
 
+  /**
+   * Holds logged in case creator id.
+   *
+   * @var int
+   */
+  private $creator;
+
+  /**
+   * Holds logged in case client id.
+   *
+   * @var int
+   */
+  private $client;
+
+  /**
+   * Setup headless test.
+   */
   public function setUpHeadless() {
-    // Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+    // Civi\Test has many helpers, like install(),
+    // uninstall(), sql(), and sqlFile().
     // See: https://github.com/civicrm/org.civicrm.testapalooza/blob/master/civi-test.md
-    return \Civi\Test::headless()->installMe(__DIR__)->apply();
+    return Test::headless()->installMe(__DIR__)->apply();
   }
 
+  /**
+   * Setup data before tests run.
+   */
   public function setUp() {
     parent::setUp();
-    CRM_Core_DAO::executeQuery('UPDATE civicrm_option_value SET grouping = "milestone" WHERE option_group_id = 2 AND name = "Medical evaluation"');
+    $this->creator = ContactFabricator::fabricate();
+    $this->client = ContactFabricator::fabricate();
+    CRM_Core_DAO::executeQuery('UPDATE civicrm_option_value SET `grouping` = "milestone" WHERE option_group_id = 2 AND `name` = "Medical evaluation"');
     $this->cleanupFiles();
   }
 
+  /**
+   * Cleanup test files.
+   */
   public function tearDown() {
     parent::tearDown();
     $this->cleanupFiles();
   }
 
+  /**
+   * Provide data for testing get files.
+   */
   public function getExamples() {
-    $cases = array();
+    $cases = [];
 
     // $cases[] = array(
-    //   0 => 'actSubject',
-    //   1 => 'actDetails',
-    //   2 => 'fileName',
-    //   3 => 'searchText',
-    //   4 => expectMatch,
+    // 0 => 'actSubject',
+    // 1 => 'actDetails',
+    // 2 => 'fileName',
+    // 3 => 'searchText',
+    // 4 => expectMatch,
     // );
-
-    $cases[0] = array(
+    $cases[0] = [
       // Match any file if there's no filter.
       0 => 'Give bread a chance',
       1 => 'With a little butter and jam',
       2 => self::getFilePrefix() . 'theStuff.txt',
-      3 => array(),
+      3 => [],
       4 => TRUE,
-    );
-    $cases[1] = array(
+    ];
+    $cases[1] = [
       // Match any file if the text filter is blank.
       0 => 'Give bread a chance',
       1 => 'With a little butter and jam',
       2 => self::getFilePrefix() . 'theStuff.txt',
-      3 => array('text' => ''),
+      3 => ['text' => ''],
       4 => TRUE,
-    );
-    $cases[2] = array(
+    ];
+    $cases[2] = [
       // This doesn't match "cheese" to anything.
       0 => 'Give bread a chance',
       1 => 'With a little butter and jam',
       2 => self::getFilePrefix() . 'theStuff.txt',
-      3 => array('text' => 'cheese'),
+      3 => ['text' => 'cheese'],
       4 => FALSE,
-    );
-    $cases[3] = array(
+    ];
+    $cases[3] = [
       // Match on subject.
       0 => 'Give cheese a chance',
       1 => '',
       2 => self::getFilePrefix() . 'theStuff.txt',
-      3 => array('text' => 'cheese'),
+      3 => ['text' => 'cheese'],
       4 => TRUE,
-    );
-    $cases[4] = array(
+    ];
+    $cases[4] = [
       // Match on details.
       0 => 'Give bread a chance',
       1 => 'But make it with cheesey goodness',
       2 => self::getFilePrefix() . 'theStuff.txt',
-      3 => array('text' => 'cheese'),
+      3 => ['text' => 'cheese'],
       4 => TRUE,
-    );
-    $cases[5] = array(
+    ];
+    $cases[5] = [
       // Match on file name.
       0 => 'Give bread a chance',
       1 => '',
       2 => self::getFilePrefix() . 'theCheeseIsGoodForYou.txt',
-      3 => array('text' => 'cheese'),
+      3 => ['text' => 'cheese'],
       4 => TRUE,
-    );
-    $cases[6] = array(
+    ];
+    $cases[6] = [
       // Match on file type (miss).
       0 => 'Give bread a chance',
       1 => '',
       2 => self::getFilePrefix() . 'theCheeseIsGoodForYou.txt',
-      3 => array('mime_type' => 'text/html'),
+      3 => ['mime_type' => 'text/html'],
       4 => FALSE,
-    );
-    $cases[7] = array(
+    ];
+    $cases[7] = [
       // Match on file type.
       0 => 'Give bread a chance',
       1 => '',
       2 => self::getFilePrefix() . 'theCheeseIsGoodForYou.txt',
-      3 => array('mime_type' => 'text/plain'),
+      3 => ['mime_type' => 'text/plain'],
       4 => TRUE,
-    );
-    $cases[8] = array(
+    ];
+    $cases[8] = [
       // Match on file category.
       0 => 'Give bread a chance',
       1 => '',
       2 => self::getFilePrefix() . 'theCheeseIsGoodForYou.txt',
-      3 => array('mime_type_cat' => 'doc'),
+      3 => ['mime_type_cat' => 'doc'],
       4 => TRUE,
-    );
-    $cases[9] = array(
+    ];
+    $cases[9] = [
       // Match on file category (miss).
       0 => 'Give bread a chance',
       1 => '',
       2 => self::getFilePrefix() . 'theCheeseIsGoodForYou.txt',
-      3 => array('mime_type_cat' => 'sheet'),
+      3 => ['mime_type_cat' => 'sheet'],
       4 => FALSE,
-    );
-    $cases[10] = array(
+    ];
+    $cases[10] = [
       // Match on activity type (existing record).
       0 => 'Give bread a chance',
       1 => '',
       2 => self::getFilePrefix() . 'theCheeseIsGoodForYou.txt',
-      3 => array('activity_type_id' => 'Medical evaluation'),
+      3 => ['activity_type_id' => 'Medical evaluation'],
       4 => TRUE,
-    );
-    $cases[11] = array(
+    ];
+    $cases[11] = [
       // Match on multiple activity types (existing record).
       0 => 'Give bread a chance',
       1 => '',
       2 => self::getFilePrefix() . 'theCheeseIsGoodForYou.txt',
-      3 => array(
-        'activity_type_id' => array(
+      3 => [
+        'activity_type_id' => [
           'IN',
-          array('Medical evaluation', 'Incoming Email'),
-        ),
-      ),
+          ['Medical evaluation', 'Incoming Email'],
+        ],
+      ],
       4 => TRUE,
-    );
-    $cases[12] = array(
+    ];
+    $cases[12] = [
       // Match on activity type (existent but unused type name).
       0 => 'Give bread a chance',
       1 => '',
       2 => self::getFilePrefix() . 'theCheeseIsGoodForYou.txt',
-      3 => array('activity_type_id' => 'Incoming Email'),
+      3 => ['activity_type_id' => 'Incoming Email'],
       4 => FALSE,
-    );
-    $cases[13] = array(
+    ];
+    $cases[13] = [
       // Match on activity type (non-existent type name).
       0 => 'Give bread a chance',
       1 => '',
       2 => self::getFilePrefix() . 'theCheeseIsGoodForYou.txt',
-      3 => array('activity_type_id' => 'Federated republic of blergistan'),
+      3 => ['activity_type_id' => 'Federated republic of blergistan'],
       4 => FALSE,
-    );
+    ];
 
-    $cases[14] = array(
+    $cases[14] = [
       // Match on activity type grouping (existing record)
       0 => 'Give bread a chance',
       1 => '',
       2 => self::getFilePrefix() . 'theCheeseIsGoodForYou.txt',
-      3 => array('activity_type_id.grouping' => array('LIKE' => '%milestone%')),
+      3 => ['activity_type_id.grouping' => ['LIKE' => '%milestone%']],
       4 => TRUE,
-    );
-    $cases[15] = array(
+    ];
+    $cases[15] = [
       // Match on activity type grouping (no match)
       0 => 'Give bread a chance',
       1 => '',
       2 => self::getFilePrefix() . 'theCheeseIsGoodForYou.txt',
-      3 => array('activity_type_id.grouping' => array('LIKE' => '%document%')),
+      3 => ['activity_type_id.grouping' => ['LIKE' => '%document%']],
       4 => FALSE,
-    );
+    ];
 
     return $cases;
   }
@@ -192,7 +228,7 @@ class api_v3_Case_GetfilesTest extends api_v3_Case_BaseTestCase implements Headl
    * Create an activity with an attachment. Run a search. See if it matches.
    *
    * @param string $actSubject
-   *   Set the activity's subject
+   *   Set the activity's subject.
    * @param string $actDetails
    *   Set the activity's details.
    * @param string $fileName
@@ -202,42 +238,43 @@ class api_v3_Case_GetfilesTest extends api_v3_Case_BaseTestCase implements Headl
    *   Ex: array('text' => 'hello').
    * @param bool $expectMatch
    *   Whether the $searchText matches the activity.
+   *
    * @dataProvider getExamples
    */
-  public function testSearch($actSubject, $actDetails, $fileName, $searchParams, $expectMatch) {
-    $cases[0] = $this->callAPISuccess('Case', 'create', array(
-      'contact_id' => 1,
-      'creator_id' => 1,
+  public function testSearch($actSubject, $actDetails, $fileName, array $searchParams, $expectMatch) {
+    $cases[0] = $this->callAPISuccess('Case', 'create', [
+      'contact_id' => $this->client['id'],
+      'creator_id' => $this->creator['id'],
       'case_type_id' => 'housing_support',
       'subject' => 'Hello world',
-    ));
-    $cases[1] = $this->callAPISuccess('Case', 'create', array(
-      'contact_id' => 2,
-      'creator_id' => 2,
+    ]);
+    $cases[1] = $this->callAPISuccess('Case', 'create', [
+      'contact_id' => $this->client['id'],
+      'creator_id' => $this->creator['id'],
       'case_type_id' => 'housing_support',
       'subject' => 'Hello world',
-    ));
+    ]);
 
-    $medEval = $this->callAPISuccess('Activity', 'getsingle', array(
+    $medEval = $this->callAPISuccess('Activity', 'getsingle', [
       'case_id' => $cases[0]['id'],
       'activity_type_id' => 'Medical evaluation',
-    ));
-    CRM_Core_DAO::executeQuery('UPDATE civicrm_activity SET subject = %2, details = %3 WHERE id = %1', array(
-      1 => array($medEval['id'], 'Integer'),
-      2 => array($actSubject, 'String'),
-      3 => array($actDetails, 'String'),
-    ));
-    $attachment = $this->callAPISuccess('Attachment', 'create', array(
+    ]);
+    CRM_Core_DAO::executeQuery('UPDATE civicrm_activity SET subject = %2, details = %3 WHERE id = %1', [
+      1 => [$medEval['id'], 'Integer'],
+      2 => [$actSubject, 'String'],
+      3 => [$actDetails, 'String'],
+    ]);
+    $attachment = $this->callAPISuccess('Attachment', 'create', [
       'name' => $fileName,
       'mime_type' => 'text/plain',
       'content' => 'My test content',
       'entity_table' => 'civicrm_activity',
       'entity_id' => $medEval['id'],
-    ));
+    ]);
 
-    $getfiles = $this->callAPISuccess('Case', 'getfiles', $searchParams + array(
+    $getfiles = $this->callAPISuccess('Case', 'getfiles', $searchParams + [
       'case_id' => $cases[0]['id'],
-    ));
+    ]);
     if ($expectMatch) {
       $attId = $attachment['id'];
       $this->assertEquals(1, $getfiles['count']);
@@ -256,7 +293,7 @@ class api_v3_Case_GetfilesTest extends api_v3_Case_BaseTestCase implements Headl
    * Create an activity with an attachment. Run a search. See if it matches.
    *
    * @param string $actSubject
-   *   Set the activity's subject
+   *   Set the activity's subject.
    * @param string $actDetails
    *   Set the activity's details.
    * @param string $fileName
@@ -266,42 +303,43 @@ class api_v3_Case_GetfilesTest extends api_v3_Case_BaseTestCase implements Headl
    *   Ex: array('text' => 'hello').
    * @param bool $expectMatch
    *   Whether the $searchText matches the activity.
+   *
    * @dataProvider getExamples
    */
-  public function testReviseThenAttachThenSearch($actSubject, $actDetails, $fileName, $searchParams, $expectMatch) {
-    $cases[0] = $this->callAPISuccess('Case', 'create', array(
-      'contact_id' => 1,
-      'creator_id' => 1,
+  public function testReviseThenAttachThenSearch($actSubject, $actDetails, $fileName, array $searchParams, $expectMatch) {
+    $cases[0] = $this->callAPISuccess('Case', 'create', [
+      'contact_id' => $this->client['id'],
+      'creator_id' => $this->creator['id'],
       'case_type_id' => 'housing_support',
       'subject' => 'Hello world',
-    ));
-    $cases[1] = $this->callAPISuccess('Case', 'create', array(
-      'contact_id' => 2,
-      'creator_id' => 2,
+    ]);
+    $cases[1] = $this->callAPISuccess('Case', 'create', [
+      'contact_id' => $this->client['id'],
+      'creator_id' => $this->creator['id'],
       'case_type_id' => 'housing_support',
       'subject' => 'Hello world',
-    ));
+    ]);
 
-    $medEval = $this->callAPISuccess('Activity', 'getsingle', array(
+    $medEval = $this->callAPISuccess('Activity', 'getsingle', [
       'case_id' => $cases[0]['id'],
       'activity_type_id' => 'Medical evaluation',
-    ));
-    $update = $this->callAPISuccess('Activity', 'create', array(
+    ]);
+    $update = $this->callAPISuccess('Activity', 'create', [
       'activity_id' => $medEval['id'],
       'subject' => $actSubject,
       'details' => $actDetails,
-    ));
-    $attachment = $this->callAPISuccess('Attachment', 'create', array(
+    ]);
+    $attachment = $this->callAPISuccess('Attachment', 'create', [
       'name' => $fileName,
       'mime_type' => 'text/plain',
       'content' => 'My test content',
       'entity_table' => 'civicrm_activity',
       'entity_id' => $update['id'],
-    ));
+    ]);
 
-    $getfiles = $this->callAPISuccess('Case', 'getfiles', $searchParams + array(
+    $getfiles = $this->callAPISuccess('Case', 'getfiles', $searchParams + [
       'case_id' => $cases[0]['id'],
-    ));
+    ]);
     if ($expectMatch) {
       $attId = $attachment['id'];
       $this->assertEquals(1, $getfiles['count']);
@@ -320,7 +358,7 @@ class api_v3_Case_GetfilesTest extends api_v3_Case_BaseTestCase implements Headl
    * Create an activity with an attachment. Run a search. See if it matches.
    *
    * @param string $actSubject
-   *   Set the activity's subject
+   *   Set the activity's subject.
    * @param string $actDetails
    *   Set the activity's details.
    * @param string $fileName
@@ -330,42 +368,43 @@ class api_v3_Case_GetfilesTest extends api_v3_Case_BaseTestCase implements Headl
    *   Ex: array('text' => 'hello').
    * @param bool $expectMatch
    *   Whether the $searchText matches the activity.
+   *
    * @dataProvider getExamples
    */
-  public function testAttachThenReviseThenSearch($actSubject, $actDetails, $fileName, $searchParams, $expectMatch) {
-    $cases[0] = $this->callAPISuccess('Case', 'create', array(
-      'contact_id' => 1,
-      'creator_id' => 1,
+  public function testAttachThenReviseThenSearch($actSubject, $actDetails, $fileName, array $searchParams, $expectMatch) {
+    $cases[0] = $this->callAPISuccess('Case', 'create', [
+      'contact_id' => $this->client['id'],
+      'creator_id' => $this->creator['id'],
       'case_type_id' => 'housing_support',
       'subject' => 'Hello world',
-    ));
-    $cases[1] = $this->callAPISuccess('Case', 'create', array(
-      'contact_id' => 2,
-      'creator_id' => 2,
+    ]);
+    $cases[1] = $this->callAPISuccess('Case', 'create', [
+      'contact_id' => $this->client['id'],
+      'creator_id' => $this->creator['id'],
       'case_type_id' => 'housing_support',
       'subject' => 'Hello world',
-    ));
+    ]);
 
-    $medEval = $this->callAPISuccess('Activity', 'getsingle', array(
+    $medEval = $this->callAPISuccess('Activity', 'getsingle', [
       'case_id' => $cases[0]['id'],
       'activity_type_id' => 'Medical evaluation',
-    ));
-    $attachment = $this->callAPISuccess('Attachment', 'create', array(
+    ]);
+    $attachment = $this->callAPISuccess('Attachment', 'create', [
       'name' => $fileName,
       'mime_type' => 'text/plain',
       'content' => 'My test content',
       'entity_table' => 'civicrm_activity',
       'entity_id' => $medEval['id'],
-    ));
-    $update = $this->callAPISuccess('Activity', 'create', array(
+    ]);
+    $update = $this->callAPISuccess('Activity', 'create', [
       'activity_id' => $medEval['id'],
       'subject' => $actSubject,
       'details' => $actDetails,
-    ));
+    ]);
 
-    $getfiles = $this->callAPISuccess('Case', 'getfiles', $searchParams + array(
+    $getfiles = $this->callAPISuccess('Case', 'getfiles', $searchParams + [
       'case_id' => $cases[0]['id'],
-    ));
+    ]);
     if ($expectMatch) {
       $attId = $attachment['id'];
       $this->assertEquals(1, $getfiles['count']);
@@ -384,36 +423,36 @@ class api_v3_Case_GetfilesTest extends api_v3_Case_BaseTestCase implements Headl
    * Test that `options.xref==1` causes lookups for all related records.
    */
   public function testXref() {
-    $cases[0] = $this->callAPISuccess('Case', 'create', array(
-      'contact_id' => 1,
-      'creator_id' => 1,
+    $cases[0] = $this->callAPISuccess('Case', 'create', [
+      'contact_id' => $this->client['id'],
+      'creator_id' => $this->creator['id'],
       'case_type_id' => 'housing_support',
       'subject' => 'Hello world',
-    ));
+    ]);
 
-    $medEval = $this->callAPISuccess('Activity', 'getsingle', array(
+    $medEval = $this->callAPISuccess('Activity', 'getsingle', [
       'case_id' => $cases[0]['id'],
       'activity_type_id' => 'Medical evaluation',
-    ));
-    CRM_Core_DAO::executeQuery('UPDATE civicrm_activity SET subject = %2, details = %3 WHERE id = %1', array(
-      1 => array($medEval['id'], 'Integer'),
-      2 => array('The subject', 'String'),
-      3 => array('The details', 'String'),
-    ));
-    $attachment = $this->callAPISuccess('Attachment', 'create', array(
+    ]);
+    CRM_Core_DAO::executeQuery('UPDATE civicrm_activity SET subject = %2, details = %3 WHERE id = %1', [
+      1 => [$medEval['id'], 'Integer'],
+      2 => ['The subject', 'String'],
+      3 => ['The details', 'String'],
+    ]);
+    $attachment = $this->callAPISuccess('Attachment', 'create', [
       'name' => self::getFilePrefix() . 'TheFile.txt',
       'mime_type' => 'text/plain',
       'content' => 'My test content',
       'entity_table' => 'civicrm_activity',
       'entity_id' => $medEval['id'],
-    ));
+    ]);
 
-    $getfiles = $this->callAPISuccess('Case', 'getfiles', array(
+    $getfiles = $this->callAPISuccess('Case', 'getfiles', [
       'case_id' => $cases[0]['id'],
-      'options' => array(
+      'options' => [
         'xref' => 1,
-      ),
-    ));
+      ],
+    ]);
     $this->assertEquals(1, $getfiles['count']);
     $attId = $attachment['id'];
     $this->assertEquals($cases[0]['id'], $getfiles['values'][$attId]['case_id']);
@@ -426,8 +465,11 @@ class api_v3_Case_GetfilesTest extends api_v3_Case_BaseTestCase implements Headl
     $this->assertEquals('Hello world', $getfiles['xref']['case'][$cases[0]['id']]['subject']);
   }
 
+  /**
+   * Test getting of empty files will fail.
+   */
   public function testEmpty() {
-    $this->callAPIFailure('Case', 'getfiles', array());
+    $this->callAPIFailure('Case', 'getfiles', []);
   }
 
 }


### PR DESCRIPTION
## Overview
This PR Resolves the SQL syntax error that occurs when creating a new case_category_instance_type type e.g. A new type of Awards application, and when installing the extension.
 
## Before
![awards-b4](https://user-images.githubusercontent.com/85277674/175882331-de32aaa3-1763-49e0-817d-e723300c1980.gif)


## After
![awards-affter](https://user-images.githubusercontent.com/85277674/175881823-582fa6f0-a40a-49db-909b-a46a95c2ce3f.gif)

## Technical Details
On a server with MySQL 8 and above the following error is thrown when trying to access some part of CiviCase(create a new case_category_instance_type type e.g. A new type of Awards application ) and option group settings page 
```
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'grouping ,v.value as value, v.grouping as `grouping` FROM civicrm_option_value v' at line 1
```
This error is caused by retrieving a column named `grouping` without having it surrounded by backticks `` ` ``,  because grouping is a reserved keyword, and rk's must be in backticks when used in a query in the latest MySQL version.

This can be traced to the call of CiviCRM `CRM_Core_OptionGroup::values()` function used to retrieve the values and labels of case_type_category option groups:
https://github.com/compucorp/uk.co.compucorp.civicase/blob/f815d9886bb8d34d8584b8245339e2cb0b9f3d80/CRM/Civicase/Helper/CaseCategory.php#L344

The [function](https://github.com/compucorp/civicrm-core/blob/8191e9834750f6ac016bb77b29234108f3f5a915/CRM/Core/OptionGroup.php#L102-L106) takes the following parameter 
```
CRM_Core_OptionGroup::values(
   $name - name of the option group.
   $flip - results are return in id => label format if false, or otherwise.
   $grouping - return the value in 'grouping' column.
   $localize - if true, localize the results before returning.
   $condition - add another condition to the sql query.
   $labelColumnName - the column to use for 'label'.
   $onlyActive - return only the action option values.
   $fresh - ignore cache entries and go back to DB.
   $keyColumnName - the column to use for 'key'.
   $orderBy - the column to use for ordering.
)
```
The keyColumnName and labelColumnName are included in the SQL used in the function and since the labelColumnName (`grouping`)specified in CiviCase is a reserved keyword and not surrounded in backticks it results in a syntax error.

**Solution:**
**The first approach** would be to propose a change in CiviCRM core such that labelColumnName and keyColumnName parameters are surrounded by backticks, so we have something like
```
    $query = "
SELECT  `v.{$labelColumnName}` as `{$labelColumnName}` , `v.{$keyColumnName} `as value, v.grouping as `grouping`
FROM   civicrm_option_value v,
       civicrm_option_group g
WHERE  v.option_group_id = g.id
  AND  g.name            = %1
  AND  g.is_active       = 1 ";
```
**The second approach** would be to change how we call the `CRM_Core_OptionGroup::values()` function, without having to specify the `grouping` word as the labelColumnName, and still have it return the values we want.


This PR goes with **the second approach** and we came up with this arguments list CRM_Core_OptionGroup::values('case_category_instance_type', TRUE, TRUE, TRUE, NULL);  which implies that grouping should be returned and the value used as id by passing flip as TRUE
```
{
   1: "CRM_Civicase_Service_CaseManagementUtils"
   2: "CRM_CiviAwards_Service_ApplicantManagementUtils"
}
```

In addition, a similar SQL syntax error was reported when installing the extension:
```
      [is_error] => 1
      [error_message] => Error in call to OptionValue_setvalue : DB Error: syntax error
```
This error happens in the upgrader post-install hook, where the `setValue` action is used to update some option values `grouping` column. Since the `setValue` action doesn't have a mechanism to handle reserved keywords in generated SQL, this results in an error.

The issue is simply resolved by using `create` action to update the column, instead
https://github.com/compucorp/uk.co.compucorp.civicase/blob/e8ab40e94a0c5de4034c216425af28db193cdfad/CRM/Civicase/Upgrader.php#L108

Also good to note that `setValue` action is deprecated in CiviCRM.


## Comment
I checked the codebase for any other similar use of `CRM_Core_OptionGroup::values` in the codebase, but currently couldn't find any, but if such exist we know what to do.