### PR TITLE
CATL-2244: Order case webform action by title ASC

### DIFF
--- a/api/v3/Case/Getwebforms.php
+++ b/api/v3/Case/Getwebforms.php
@@ -47,9 +47,12 @@ function civicrm_api3_case_getwebforms(array $params) {
     return $out;
   }
 
+  $sort = htmlspecialchars($params['options']['sort'] ?? 'title');
+
   $query = "SELECT a.nid, a.data, n.title
           FROM webform_civicrm_forms a
-          INNER JOIN node n ON a.nid = n.nid";
+          INNER JOIN node n ON a.nid = n.nid
+          ORDER BY {$sort}";
 
   db_set_active('default');
   $daos = db_query($query);


### PR DESCRIPTION
## Overview
This PR orders the case webform actions by title ASC on default, or uses the sort order specified by the caller of `case.getwebforms` API action.

## Before
The order of returned results from `case.getwebforms` is not always guaranteed

## After
The order of returned results from `case.getwebforms` is now guaranteed
