### PR TITLE
FDI-80: Improve activity tab performance

### DIFF
--- a/CRM/Civicase/Activity/ContactActivitiesSelector.php
+++ b/CRM/Civicase/Activity/ContactActivitiesSelector.php
@@ -26,7 +26,7 @@ class CRM_Civicase_Activity_ContactActivitiesSelector {
 
     $this->addAssigneeContactIdToReturnParams($newParams);
 
-    $activities = civicrm_api3('Activity', 'get', $newParams);
+    $activities = civicrm_api3('Activity', 'getall', $newParams);
 
     $this->filterOutActivitiesNotBelongingToContact($activities, $newParams);
 

--- a/CRM/Civicase/Activity/ContactActivitiesSelector.php
+++ b/CRM/Civicase/Activity/ContactActivitiesSelector.php
@@ -2,6 +2,8 @@
 
 /**
  * Class CRM_Civicase_Activity_ContactActivitiesSelector.
+ *
+ * Handle fetching activities for a given contact.
  */
 class CRM_Civicase_Activity_ContactActivitiesSelector {
 

--- a/api/v3/Activity/Getall.php
+++ b/api/v3/Activity/Getall.php
@@ -21,10 +21,10 @@ function _civicrm_api3_activity_getall_spec(array &$spec) {
  * When adding 'target_contact_name' or 'assignee_contact_name' to
  * civicrm “Activity.get” API, it will fetch all the target and assignee
  * contacts for each activity, but certain known type of activities such as
- * "Bulk Email" and "Bulk SMS" are known to have large number of target activities,
- * which results in slow queries.
+ * "Bulk Email" and "Bulk SMS" are known to have large number of target
+ * activities, which results in slow queries.
  * This API is similar to “Activity.get”, the difference
- * is that it does Not fetch the target and assignee contacts for
+ * is that it does not fetch the target and assignee contacts for
  * activity types that are known to have large number of contacts.
  *
  * @param array $params
@@ -49,8 +49,10 @@ function civicrm_api3_activity_getall(array $params) {
 
   $result = civicrm_api3('Activity', 'get', $params);
 
-  // These two activity types are known to often have a lot of contacts attached to them (mostly as target contacts),
-  // thus we ignore fetching contacts for them, since for example the user can just open the mailing report to see
+  // These two activity types are known to often have a lot
+  // of contacts attached to them (mostly as target contacts),
+  // thus we ignore fetching contacts for them, since for
+  // example the user can just open the mailing report to see
   // the contacts who received the email.
   $bulkEmailActivityId = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Bulk Email');
   $massSmsActivityId = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Mass SMS');
@@ -63,14 +65,14 @@ function civicrm_api3_activity_getall(array $params) {
     }
   }
 
-  // here we fetch the contacts separately, but only for
+  // Here we fetch the contacts separately, but only for
   // the activities that are not of the types defined above.
   if (!empty($activityIdsToFetchContactsFor)) {
     _civicrm_api3_activity_fill_activity_contact_names($activityIdsToFetchContactsFor, $params, $contactTypesToReturn);
   }
 
-  // merging the activity contacts back to the activities
-  // we fetched earlier
+  // Merging the activity contacts back to the activities
+  // we fetched earlier.
   foreach ($result['values'] as &$row) {
     if (!empty($activityIdsToFetchContactsFor[$row['id']])) {
       $row = array_merge($activityIdsToFetchContactsFor[$row['id']], $row);

--- a/api/v3/Activity/Getall.php
+++ b/api/v3/Activity/Getall.php
@@ -18,10 +18,14 @@ function _civicrm_api3_activity_getall_spec(array &$spec) {
 /**
  * Activity.GetAll API.
  *
- * This API is similar to “Activity.get”. But if the 'target_contact_id' are
- * more than 25, it returns first 25 only.
- * Also adds a parameter `total_target_contacts`,
- * which contains the total number of target contacts before hiding.
+ * When adding 'target_contact_name' or 'assignee_contact_name' to
+ * civicrm “Activity.get” API, it will fetch all the target and assignee
+ * contacts for each activity, but certain known type of activities such as
+ * "Bulk Email" and "Bulk SMS" are known to have large number of target activities,
+ * which results in slow queries.
+ * This API is similar to “Activity.get”, the difference
+ * is that it does Not fetch the target and assignee contacts for
+ * activity types that are known to have large number of contacts.
  *
  * @param array $params
  *   API parameters.
@@ -30,39 +34,48 @@ function _civicrm_api3_activity_getall_spec(array &$spec) {
  *   Activities
  */
 function civicrm_api3_activity_getall(array $params) {
+  $contactTypesToReturn = [];
+  $targetContactParamIndex = array_search('target_contact_name', $params['return']);
+  if ($targetContactParamIndex !== FALSE) {
+    $contactTypesToReturn['target_contact_name'] = 1;
+    unset($params['return'][$targetContactParamIndex]);
+  }
+
+  $assigneeContactParamIndex = array_search('assignee_contact_name', $params['return']);
+  if ($assigneeContactParamIndex !== FALSE) {
+    $contactTypesToReturn['assignee_contact_name'] = 1;
+    unset($params['return'][$assigneeContactParamIndex]);
+  }
+
   $result = civicrm_api3('Activity', 'get', $params);
 
-  if (!$result['is_error']) {
-    _civicrm_api3_activity_getall_limitContacts($result['values'], 'target_contact');
-    _civicrm_api3_activity_getall_limitContacts($result['values'], 'assignee_contact');
+  // These two activity types are known to often have a lot of contacts attached to them (mostly as target contacts),
+  // thus we ignore fetching contacts for them, since for example the user can just open the mailing report to see
+  // the contacts who received the email.
+  $bulkEmailActivityId = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Bulk Email');
+  $massSmsActivityId = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Mass SMS');
+  $activityTypesToIgnore = [$bulkEmailActivityId, $massSmsActivityId];
+
+  $activityIdsToFetchContactsFor = [];
+  foreach ($result['values'] as $row) {
+    if (!in_array($row['activity_type_id'], $activityTypesToIgnore)) {
+      $activityIdsToFetchContactsFor[$row['id']] = [];
+    }
+  }
+
+  // here we fetch the contacts separately, but only for
+  // the activities that are not of the types defined above.
+  if (!empty($activityIdsToFetchContactsFor)) {
+    _civicrm_api3_activity_fill_activity_contact_names($activityIdsToFetchContactsFor, $params, $contactTypesToReturn);
+  }
+
+  // merging the activity contacts back to the activities
+  // we fetched earlier
+  foreach ($result['values'] as &$row) {
+    if (!empty($activityIdsToFetchContactsFor[$row['id']])) {
+      $row = array_merge($activityIdsToFetchContactsFor[$row['id']], $row);
+    }
   }
 
   return $result;
-}
-
-/**
- * Limit contacts.
- *
- * @param array $result
- *   Results from which fields should be limited.
- * @param string $fieldName
- *   Name of the field to limit.
- */
-function _civicrm_api3_activity_getall_limitContacts(array &$result, string $fieldName) {
-  foreach ($result as &$record) {
-    if (empty($record[$fieldName . '_id'])) {
-      continue;
-    }
-
-    $contactIds = $record[$fieldName . '_id'];
-    $limitContactIdsTo = 25;
-
-    if (!empty($contactIds) && count($contactIds) > $limitContactIdsTo) {
-      $record['total_' . $fieldName . 's'] = count($contactIds);
-      $record[$fieldName . '_id'] = array_slice($record[$fieldName . '_id'], 0, $limitContactIdsTo, TRUE);
-      $record[$fieldName . '_name'] = array_slice($record[$fieldName . '_name'], 0, $limitContactIdsTo, TRUE);
-      $record[$fieldName . '_sort_name'] = array_slice($record[$fieldName . '_sort_name'], 0, $limitContactIdsTo, TRUE);
-    }
-  }
-
 }


### PR DESCRIPTION
## Overview

The activity tab loads very slowly  (and often does not load because it timeout) when the contact has a lot of Activities of certain types, mainly "Bulk Email" and "Mass SMS", this PR fixes that.

## Before

Activity tab is very slow (and in this case it timeout):
![bef](https://user-images.githubusercontent.com/6275540/181837496-ba4bce4a-492f-4fec-a606-e5af75c6b695.gif)

## After

activity tab loads fine:

![addada](https://user-images.githubusercontent.com/6275540/181839532-8c7055e1-8eb5-47de-8b66-053042fc6982.gif)

Though the difference is that "Bulk Emails" and "Mass SMS" activity types will no longer show the "To" and "From" parts:

![2022-07-29 23_37_17-191420552 191420552 _ fdi](https://user-images.githubusercontent.com/6275540/181839694-c5de912e-2618-4d8f-a0c3-cd0d0a62e8a1.png)


## Technical Details

When sending bulk emails, CiviCRM creates one activity that is shared between all the contacts that the email was sent to, these contacts will be stored as “target contact” inside the civicrm_activity_contact table.

In one of our client sites, most contacts  have around 33 activities, most of them are “Bulk Email” activities, but each of these activities are shared with another 30,000 something contacts, multiply that number by 33 = 990000 is the number of records that CiviCase tries to fetch when someone opens the activities tab for such contacts, which as you can see takes a lot of time.

If you disable CiviCase on that site, you will notice that activities will just load fine, that is because CiviCRM Core has special code for “Bulk Emails” activities that treat them differently from normal activities: https://github.com/civicrm/civicrm-core/blob/16fd31ae79d9ce630d8631d52f2ec1be1e51e1ef/CRM/Activity/BAO/Activity.php#L723 .

But CiviCase do things differently from CiviCRM core, CiviCase uses Activity.get API  to fetch all the contact activities, and passes the “target_contact_name” parameter to the API, which fetches all the target_contacts for each activity, which are a lot in bulk email cases as I explained above. The query that result from calling Activity.get API with “target_contact_name” as “return” parameter looks like this :

```
SELECT a.id as `id`, a.activity_id as `activity_id`, a.record_type_id as `record_type_id`, contact_id_to_civicrm_contact.display_name as `contact_id.display_name`,
contact_id_to_civicrm_contact.sort_name as `contact_id.sort_name`, a.contact_id as `contact_id`
FROM civicrm_activity_contact a
LEFT JOIN `civicrm_contact` `contact_id_to_civicrm_contact` ON a.contact_id = contact_id_to_civicrm_contact.id
WHERE (a.activity_id IN ("3285", "3277", "3276", "3274", "3272", "3269", "3245", "3240", "3230", "3227", "3217", "3206", "3198", "3184", "3172", "3168", "3160", "3157", "3155", "3080", "3078", "3075", "3073", "3074", "3065"));
```


But this issue is not new for CiviCase, it can be traced back to the work done here:

https://github.com/compucorp/uk.co.compucorp.civicase/pull/264 
https://github.com/compucorp/uk.co.compucorp.civicase/pull/265 
https://github.com/compucorp/uk.co.compucorp.civicase/pull/267 

In which all “Bulk Email” Activities where hidden from the Activities tab, but this work was replaced later by the work in BASWSPRT-166:

https://github.com/compucorp/uk.co.compucorp.civicase/pull/684 

In which the “Bulk Email” activities are brought back (by reverting all the work done in previous PRs) and then creating new API end point called Activity.getAll, which basically just do Activity.get , then on the output of Activity.get it will limit the number of target_contacts to 25 in case there are more contacts than that. The reason is we had another client who had similar issue with “Mass SMS” activity type , and thus it was decided that  it is just better to have "better" solution that covers all activity types instead of just hiding them.

The problem with the approach in the last PR,  is that it still gets the whole list of 990000 contacts, then it just gets the first 25 out of them for each activity, which is not really efficient.


When it came to solving the issue I had several ideas in mind:

1- To just hide the "To" field and unset "target_contact_name", which didn't seem to me that important, but after internal discussion and for business related reasons it was agreed to keep it.

2- To replace Activity.get call inside Activity.getall with a raw SQL query that fetch things properly, but the problem with this approach is we will loose the benefits that the API layer provides (pagination, filtering ..etc).


3- The 3rd idea I had was to unset the `target_contact_name` and `assignee_contact_name` which are the ones that force Activity.get call inside Activity.getall to fetch the contact ids, so by removing these parameters I force civi not to fetch the contacts, then with raw SQL I fetch only 25 contact for each activity, the query would look something like this:

```
    $contactRecordType = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_ActivityContact', 'record_type_id', 'Activity Targets');

    $fetchedActivityIdsFromActivityGetAPI = implode($activityIds, ',');
    $limitContactIdsTo = 25;
    $activityContacts = [];
    $query = "SELECT result.activity_id, result.contact_id, civicrm_contact.display_name, civicrm_contact.sort_name
              FROM (
	              SELECT activity_id, contact_id, record_type_id, @rank := CASE
			                  WHEN @partval = activity_id AND @rankval = contact_id THEN @rank
			                  WHEN @partval = activity_id AND (@rankval := contact_id) IS NOT NULL THEN @rank + 1
			                  WHEN (@partval := activity_id) IS NOT NULL AND (@rankval := contact_id) IS NOT NULL THEN 1
		                END AS rnk
	              FROM civicrm_activity_contact, (SELECT @rank := NULL, @partval := NULL, @rankval := NULL) AS x
	              WHERE activity_id IN ($fetchedActivityIdsFromActivityGetAPI ) AND record_type_id = $contactRecordType
	              ORDER BY activity_id, contact_id) AS result
              INNER JOIN civicrm_contact ON result.contact_id = civicrm_contact.id
              WHERE result.rnk <= $limitContactIdsTo";
    $targetContactResults = CRM_Core_DAO::executeQuery($query);
    while ($targetContactResults->fetch()) {
      $activityContacts[$targetContactResults->activity_id]['target_contact_id'][] = $targetContactResults->contact_id;
      $activityContacts[$targetContactResults->activity_id]['target_contact_name'][$targetContactResults->contact_id] =  $targetContactResults->display_name ?? '';
      $activityContacts[$targetContactResults->activity_id]['target_contact_sort_name'][$targetContactResults->contact_id] =  $targetContactResults->sort_name ?? '';
    }

// then merging the contacts with the activities.
```

In the above query I rank contacts from 1 to N separately for each activity, then for each fetch activity I limit the number of contacts to 25 by only getting contacts with rank <= 25 (thus it will fetch only the first 25 contacts for each activity).

Such query is not that fast, it takes around 2.5 seconds on the site we had the issue with. which is of course better than before, but not that great.

4- "This is the option I've implemented in this PR". Given that Civi core does not really show target contacts for "Bulk Email" and "Bulk SMS" activities to begin with (and that it has special code to handle them as I explained above), and given that it also does not make sense to show "to" and "from" fields for such kind of activities to begin with, since we can just go to Mailing or SMS reports to view the contacts who got them, I decided to ignore fetching contacts for such activities, also given that it would be rare to have other activity type that might be attached to large number of contacts other than these two.

The approach here is simple:

A- Unset "target_contact_name" and "assignee_contact_id" parameters inside Activity.getall API, this prevents the call to Activity.get inside Activity.getall from fetching the contacts for all activates.

B- Then I get the list of all activity ids from the Activity.get call in step 1, but  I ignore any activity of type "Bulk Email" or "Mass SMS".

C- Then I use the core function _civicrm_api3_activity_fill_activity_contact_names() to fetch the contacts for these activities (which will exclude the troublesome activities since we did not pass their ids to it).

D- Then I merge the contacts from step 3 with the activities from step 1 and return the result.


The last approach is much faster than the one in 3 since it ignores all the activity types that we don't care to get the contacts for, and even much simpler.  And in case in the future more similar problematic activity types appeared, we can just update the list in the code or even make them configurable through API, or alternatively we revert to the slower approach 3 if it really needed.


I also updated CRM_Civicase_Activity_ContactActivitiesSelector::getAllActivitiesForContact to use the improved Activity.getall API, since it was suffering form the same issue above, and affected the screen when the contact clicks on "My Activities" sub-tab. 


