### PR TITLE
PHP fatal error fixes, issue #848

### DIFF
--- a/CRM/Civicase/BAO/Query/ContactLock.php
+++ b/CRM/Civicase/BAO/Query/ContactLock.php
@@ -18,7 +18,7 @@ class CRM_Civicase_BAO_Query_ContactLock extends CRM_Contact_BAO_Query_Interface
   /**
    * Alters from statement to include case locks.
    */
-  public function from($fieldName, $mode, $side) {
+  public static function from($fieldName, $mode, $side) {
     if ($fieldName == 'civicase_contactlock') {
       $loggedContactID = CRM_Core_Session::singleton()->getLoggedInContactID();
 
@@ -38,7 +38,7 @@ class CRM_Civicase_BAO_Query_ContactLock extends CRM_Contact_BAO_Query_Interface
   /**
    * Alters where statement to include case locks.
    */
-  public function where(&$query) {
+  public static function where(&$query) {
     if ($query->_mode == CRM_Contact_BAO_QUERY::MODE_ACTIVITY) {
 
       $query->_where[0][] = CRM_Contact_BAO_Query::buildClause("activity_lock", 'IS NULL');

--- a/CRM/Civicase/Page/MyActivities.php
+++ b/CRM/Civicase/Page/MyActivities.php
@@ -20,7 +20,7 @@ class CRM_Civicase_Page_MyActivities extends CRM_Core_Page {
   public function run() {
     $loader = new AngularLoader();
     $loader->setPageName('civicrm/case/my-activities');
-    $loader->setModules(['crmApp', 'my-activities']);
+    $loader->addModules(['crmApp', 'my-activities']);
     $loader->load();
 
     CRM_Core_Resources::singleton()


### PR DESCRIPTION
## Overview
These are the quick fixes for issue #848 . It also includes a quick fix to use addModules instead of setModules (due to a message we get from Core that setModules is deprecated).