### PR TITLE
CATL-2256: Fix updating role/relationship date under certain configs

### DIFF
--- a/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
+++ b/ang/civicase/case/details/people-tab/services/people-tab-roles.service.js
@@ -248,6 +248,22 @@
     }
 
     /**
+     * Adds relationship_ids param to the
+     * case relationships.
+     *
+     * @param {object[]} relationships list of case relationships.
+     * @returns {object[]} a  list of case relationships with relationship_ids param.
+     */
+    function addRelationshipIdsParam (relationships) {
+      return _(relationships)
+        .map(function (relationship) {
+          relationship.relationship_ids = [relationship.id];
+          return relationship;
+        })
+        .value();
+    }
+
+    /**
      * Updates the list of roles to display the given page.
      *
      * @param {number} pageNumber the page number to navigate to.
@@ -279,7 +295,7 @@
      */
     function setCaseRelationships (newCaseRelationships) {
       caseRelationships = !allowMultipleCaseClients
-        ? newCaseRelationships
+        ? addRelationshipIdsParam(newCaseRelationships)
         : getUniqueCaseRelationships(newCaseRelationships);
     }
 


### PR DESCRIPTION
## Overview

Users cannot update any of the case roles/relationships start or end date when the "Allow multiple case clients" is set to "Single client per case".

_A brief description of the pull request. Try to keep it non-technical._

## Before

Neither of the case role/relationship start or end date could be set when "Single client per case" is set:

![image](https://user-images.githubusercontent.com/6275540/184696380-0f98adb6-e55d-4fc1-91bf-3181d3ad53da.png)


![11](https://user-images.githubusercontent.com/6275540/184696257-9e456e6d-e9da-4cb7-94ad-ba5210408321.gif)



## After

Both of the case role/relationship start and end dates can be changed:

![222](https://user-images.githubusercontent.com/6275540/184888524-1b1f36a3-f03c-4458-ae58-90733c962e49.gif)



## Technical Details


Due to the work done in this PR: https://github.com/compucorp/uk.co.compucorp.civicase/pull/732

when "Allow multiple case clients" is set to "Single client per case", the list of retuned relationships no longer has the `relationship_ids` parameter, which is used to construct the relationship API call that updates the relationship start and end dates (https://github.com/compucorp/uk.co.compucorp.civicase/blob/e284964303ba784be7f9f8514249b6b6a7646d3c/ang/civicase/case/details/people-tab/services/role-dates-updater.service.js#L123), the reason for no longer passing that parameter seems to have happened by mistake and not intentional, and thus to keep thing working the same whether  "Allow multiple case clients" is set to "Single client per case" or any other value, I updated `setCaseRelationships` to always pass the `relationship_ids`.