### PR TITLE
MAE-823: Fix bulk mail

### DIFF
--- a/CRM/Civicase/Hook/alterMailParams/SubjectCaseTypeCategoryProcessor.php
+++ b/CRM/Civicase/Hook/alterMailParams/SubjectCaseTypeCategoryProcessor.php
@@ -69,6 +69,9 @@ class CRM_Civicase_Hook_alterMailParams_SubjectCaseTypeCategoryProcessor {
    *   returns TRUE if hook should run, FALSE otherwise.
    */
   private function shouldRun(array $params, $context, $caseId) {
+    if (empty($params['subject'])) {
+      return FALSE;
+    }
     // If case id is set and email subject starts with '[case '.
     return $caseId && strpos($params['subject'], $this->toReplace) === 0;
   }

--- a/ang/civicase/activity/activity-forms/services/activity-form-services/add-custom-path-activity-form.service.js
+++ b/ang/civicase/activity/activity-forms/services/activity-form-services/add-custom-path-activity-form.service.js
@@ -10,7 +10,7 @@
    */
   function AddCustomPathActivityForm (civicaseCrmUrl) {
     var ACTIVITY_TYPES_CUSTOM_PATHS = {
-      Email: 'civicrm/activity/email/add',
+      Email: 'civicrm/case/email/add',
       'Print PDF Letter': 'civicrm/activity/pdf/add'
     };
 

--- a/ang/civicase/case/actions/services/email-case-action.service.js
+++ b/ang/civicase/case/actions/services/email-case-action.service.js
@@ -198,7 +198,7 @@
         }
 
         var popupPath = {
-          path: 'civicrm/activity/email/add',
+          path: 'civicrm/case/email/add',
           query: {
             action: 'add',
             hideDraftButton: 1,

--- a/ang/civicase/case/details/directives/case-details.directive.js
+++ b/ang/civicase/case/details/directives/case-details.directive.js
@@ -147,7 +147,7 @@
         }).join(',')
       };
 
-      civicaseCrmLoadForm(civicaseCrmUrl('civicrm/activity/email/add', createEmailURLParams))
+      civicaseCrmLoadForm(civicaseCrmUrl('civicrm/case/email/add', createEmailURLParams))
         .on('crmFormSuccess', function () {
           $rootScope.$broadcast('civicase::activity::updated');
         });

--- a/ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html
+++ b/ang/civicase/case/details/people-tab/directives/case-roles-tab.directive.html
@@ -175,7 +175,7 @@
         <td class="civicase__people-tab__table-column">
           <a
             class="crm-popup"
-            ng-href="{{ 'civicrm/activity/email/add' | civicaseCrmUrl:{ action: 'add', caseid: item.id, reset: 1, cid: role.contact_id } }}"
+            ng-href="{{ 'civicrm/case/email/add' | civicaseCrmUrl:{ action: 'add', caseid: item.id, reset: 1, cid: role.contact_id } }}"
           >
             {{ role.email }}
           </a>
@@ -214,7 +214,7 @@
               </li>
               <li role="separator" class="divider"></li>
               <li ng-if="role.email">
-                <a class="crm-popup" ng-href="{{ 'civicrm/activity/email/add' | civicaseCrmUrl:{ action: 'add', caseid: item.id, reset: 1, cid: role.contact_id } }}">{{ ts('Send Email') }}</a>
+                <a class="crm-popup" ng-href="{{ 'civicrm/case/email/add' | civicaseCrmUrl:{ action: 'add', caseid: item.id, reset: 1, cid: role.contact_id } }}">{{ ts('Send Email') }}</a>
               </li>
               <li>
                 <a class="crm-popup" ng-href="{{ 'civicrm/activity/pdf/add' | civicaseCrmUrl:{ action: 'add', caseid: item.id, reset: 1, cid: role.contact_id, context: 'standalone' } }}">{{ ts('Print/Merge Document') }}</a>

--- a/ang/civicase/case/details/people-tab/directives/other-relationships-tab.directive.html
+++ b/ang/civicase/case/details/people-tab/directives/other-relationships-tab.directive.html
@@ -122,7 +122,7 @@
         <td class="civicase__people-tab__table-column">
           <a
             class="crm-popup"
-            ng-href="{{ 'civicrm/activity/email/add' | civicaseCrmUrl:{ action: 'add', caseid: item.id, reset: 1, cid: contact.contact_id } }}">
+            ng-href="{{ 'civicrm/case/email/add' | civicaseCrmUrl:{ action: 'add', caseid: item.id, reset: 1, cid: contact.contact_id } }}">
             {{ contact.email }}
           </a>
         </td>
@@ -152,7 +152,7 @@
               <li ng-if="contact.email">
                 <a
                   class="crm-popup"
-                  ng-href="{{ 'civicrm/activity/email/add' | civicaseCrmUrl:{ action: 'add', caseid: item.id, reset: 1, cid: contact.id } }}">
+                  ng-href="{{ 'civicrm/case/email/add' | civicaseCrmUrl:{ action: 'add', caseid: item.id, reset: 1, cid: contact.id } }}">
                   {{ ts('Send Email') }}
                 </a>
               </li>

--- a/ang/civicase/contact/directives/contact-popover-content.directive.js
+++ b/ang/civicase/contact/directives/contact-popover-content.directive.js
@@ -40,7 +40,7 @@
         emailUrlParameters.caseid = $scope.caseId;
       }
 
-      return civicaseCrmUrl('civicrm/activity/email/add', emailUrlParameters);
+      return civicaseCrmUrl('civicrm/case/email/add', emailUrlParameters);
     }
   }
 })(angular);

--- a/ang/test/civicase/activity/activity-forms/services/activity-forms-services/add-custom-path-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/activity-forms-services/add-custom-path-activity-form.service.spec.js
@@ -94,7 +94,7 @@
         });
 
         it('returns the form url to create a new activity', () => {
-          expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/activity/email/add', {
+          expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/case/email/add', {
             action: 'add',
             reset: 1,
             caseid: activity.case_id,

--- a/ang/test/civicase/case/actions/services/email-case-action.service.spec.js
+++ b/ang/test/civicase/case/actions/services/email-case-action.service.spec.js
@@ -96,7 +96,7 @@
 
             it('returns the path to open the send email popup and hides the draft button', () => {
               expect(returnValue).toEqual({
-                path: 'civicrm/activity/email/add',
+                path: 'civicrm/case/email/add',
                 query: {
                   action: 'add',
                   reset: 1,
@@ -167,7 +167,7 @@
 
         it('adds bulk email activitiy to all the selected cases', () => {
           expect(returnValue).toEqual({
-            path: 'civicrm/activity/email/add',
+            path: 'civicrm/case/email/add',
             query: {
               action: 'add',
               reset: 1,

--- a/ang/test/civicase/case/details/directives/case-details.directive.spec.js
+++ b/ang/test/civicase/case/details/directives/case-details.directive.spec.js
@@ -629,7 +629,7 @@
       });
 
       it('open a popup to create emails', function () {
-        expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/activity/email/add', {
+        expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/case/email/add', {
           action: 'add',
           caseid: $scope.item.id,
           atype: '3',

--- a/ang/test/civicase/contact/directives/contact-popover-content.directive.spec.js
+++ b/ang/test/civicase/contact/directives/contact-popover-content.directive.spec.js
@@ -44,7 +44,7 @@
         });
 
         it('returns the URL for sending a standalone email activity', () => {
-          expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/activity/email/add', {
+          expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/case/email/add', {
             action: 'add',
             cid: $scope.contactId,
             reset: 1
@@ -63,7 +63,7 @@
         });
 
         it('returns the URL for sending a case email activity', () => {
-          expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/activity/email/add', {
+          expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/case/email/add', {
             action: 'add',
             caseid: $scope.caseId,
             cid: $scope.contactId,

--- a/civicase.php
+++ b/civicase.php
@@ -185,6 +185,7 @@ function civicase_civicrm_alterMenu(&$items) {
   $items['civicrm/case/activity']['ids_arguments']['json'][] = 'civicase_reload';
   $items['civicrm/activity']['ids_arguments']['json'][] = 'civicase_reload';
   $items['civicrm/activity/email/add']['ids_arguments']['json'][] = 'civicase_reload';
+  $items['civicrm/case/email/add']['ids_arguments']['json'][] = 'civicase_reload';
   $items['civicrm/activity/pdf/add']['ids_arguments']['json'][] = 'civicase_reload';
   $items['civicrm/case/cd/edit']['ids_arguments']['json'][] = 'civicase_reload';
   $items['civicrm/export/standalone']['ids_arguments']['json'][] = 'civicase_reload';

--- a/tests/phpunit/CRM/Civicase/Hook/ValidateForm/SendBulkEmailTest.php
+++ b/tests/phpunit/CRM/Civicase/Hook/ValidateForm/SendBulkEmailTest.php
@@ -80,7 +80,7 @@ class CRM_Civicase_Hook_SendBulkEmailTest extends BaseHeadlessTest {
     );
     $this->assertEquals(0, count($emailsSent));
 
-    $this->form = new CRM_Contact_Form_Task_Email();
+    $this->form = new CRM_Case_Form_Task_Email();
     $this->runHook(
       'Test {case.id} for contact {contact.contact_id}',
       'Body for {contact.first_name} {case.id}',
@@ -148,7 +148,7 @@ class CRM_Civicase_Hook_SendBulkEmailTest extends BaseHeadlessTest {
     );
     $this->assertEquals(0, count($emailsSent));
 
-    $this->form = new CRM_Contact_Form_Task_Email();
+    $this->form = new CRM_Case_Form_Task_Email();
     $this->runHook(
       'Test {case.id} for contact {contact.contact_id}',
       'Body for {contact.first_name} {case.id}',
@@ -183,7 +183,7 @@ class CRM_Civicase_Hook_SendBulkEmailTest extends BaseHeadlessTest {
 
     $_REQUEST['caseRoles'] = $_GET['caseRoles'] = 'client';
 
-    $this->form = new CRM_Contact_Form_Task_Email();
+    $this->form = new CRM_Case_Form_Task_Email();
     $result = $this->runHook(
       '',
       '',
@@ -220,7 +220,7 @@ class CRM_Civicase_Hook_SendBulkEmailTest extends BaseHeadlessTest {
   public function testHookDoesNotRunWhenNoCasesAreSelected() {
     $_REQUEST['caseRoles'] = $_GET['caseRoles'] = '';
 
-    $this->form = new CRM_Contact_Form_Task_Email();
+    $this->form = new CRM_Case_Form_Task_Email();
     $result = $this->runHook('', '', [], []);
 
     $this->assertFalse($result);
@@ -335,7 +335,7 @@ class CRM_Civicase_Hook_SendBulkEmailTest extends BaseHeadlessTest {
         'contact_id' => $contact['id'],
         'preferred_mail_format' => 'HTML',
       ];
-      $formValues['to'][] = $contact['id'] . '::' . $contact['email'];
+      $formValues['to'][$contact['id']] = $contact['id'] . '::' . $contact['email'];
     }
     $formValues['to'] = implode(',', $formValues['to']);
 

--- a/tests/phpunit/CRM/Civicase/Hook/ValidateForm/SendBulkEmailTest.php
+++ b/tests/phpunit/CRM/Civicase/Hook/ValidateForm/SendBulkEmailTest.php
@@ -322,6 +322,7 @@ class CRM_Civicase_Hook_SendBulkEmailTest extends BaseHeadlessTest {
     $this->form->addElement('hidden', 'subject', $subject);
     $this->form->addElement('hidden', 'text_message', $body);
     $this->form->addElement('hidden', 'html_message', $body);
+    $this->form->addElement('hidden', 'from_email_address', 'example@mail.com');
 
     return (new SendBulkEmailHook())->run($formName, $fields, $files, $this->form, $errors);
   }

--- a/tests/phpunit/CRM/Civicase/Hook/ValidateForm/SendBulkEmailTest.php
+++ b/tests/phpunit/CRM/Civicase/Hook/ValidateForm/SendBulkEmailTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Civi\Test\Api3TestTrait;
 use CRM_Civicase_Hook_ValidateForm_SendBulkEmail as SendBulkEmailHook;
 
 /**
@@ -11,6 +12,7 @@ class CRM_Civicase_Hook_SendBulkEmailTest extends BaseHeadlessTest {
 
   use CRM_Civicase_Helpers_SessionTrait;
   use Helpers_MailHelpersTrait;
+  use Api3TestTrait;
 
   /**
    * Instance of the form sent on the hook.
@@ -27,13 +29,20 @@ class CRM_Civicase_Hook_SendBulkEmailTest extends BaseHeadlessTest {
   private $caseType;
 
   /**
+   * Currently logged in User.
+   *
+   * @var array
+   */
+  private $loggedInUser;
+
+  /**
    * {@inheritDoc}
    */
   public function setUp() {
     parent::setUp();
 
-    $loggedInUser = CRM_Civicase_Test_Fabricator_Contact::fabricateWithEmail();
-    $this->registerCurrentLoggedInContactInSession($loggedInUser['id']);
+    $this->loggedInUser = CRM_Civicase_Test_Fabricator_Contact::fabricateWithEmail();
+    $this->registerCurrentLoggedInContactInSession($this->loggedInUser['id']);
 
     $this->caseType = CRM_Civicase_Test_Fabricator_CaseType::fabricate()['id'];
   }
@@ -299,9 +308,20 @@ class CRM_Civicase_Hook_SendBulkEmailTest extends BaseHeadlessTest {
    *   Return the result of calling the hook.
    */
   private function runHook(string $subject, string $body, array $cases, array $contacts) {
+    $formName = $this->form->getName();
+    $senderEmail = $this->callAPISuccess('Email', 'getsingle', ['contact_id' => $this->loggedInUser['id']]);
+
+    $formValues = [
+      'to' => [],
+      'cc_id' => [],
+      'bcc_id' => [],
+      'subject' => $subject,
+      'text_message' => $body,
+      'html_message' => $body,
+      'from_email_address' => $senderEmail['id'],
+    ];
     $_REQUEST['allCaseIds'] = $_GET['allCaseIds'] = implode(',', $cases);
 
-    $formName = 'Test Form';
     $fields = $files = $errors = [];
 
     $this->form->_contactIds = [];
@@ -315,16 +335,34 @@ class CRM_Civicase_Hook_SendBulkEmailTest extends BaseHeadlessTest {
         'contact_id' => $contact['id'],
         'preferred_mail_format' => 'HTML',
       ];
+      $formValues['to'][] = $contact['id'] . '::' . $contact['email'];
     }
+    $formValues['to'] = implode(',', $formValues['to']);
+
+    $this->setFormSubmitValues($formName, $formValues);
+    return (new SendBulkEmailHook())->run($formName, $fields, $files, $this->form, $errors);
+  }
+
+  /**
+   * Sets the form submission values in Session and element.
+   *
+   * @param string $formName
+   *   The form name.
+   * @param array $formValues
+   *   The values of the form fields.
+   */
+  private function setFormSubmitValues(string $formName, array $formValues) {
+    $this->form->controller = new CRM_Core_Controller_Simple(get_class($this->form), $formName);
+    $_SESSION['_' . $this->form->controller->_name . '_container']['values'][$formName] = $formValues;
+    $_SESSION['_' . $this->form->controller->_name . '_container']['values']['Search'] = [];
 
     $this->form->addElement('hidden', 'cc_id', []);
     $this->form->addElement('hidden', 'bcc_id', []);
-    $this->form->addElement('hidden', 'subject', $subject);
-    $this->form->addElement('hidden', 'text_message', $body);
-    $this->form->addElement('hidden', 'html_message', $body);
-    $this->form->addElement('hidden', 'from_email_address', 'example@mail.com');
-
-    return (new SendBulkEmailHook())->run($formName, $fields, $files, $this->form, $errors);
+    $this->form->addElement('hidden', 'to', $formValues['to']);
+    $this->form->addElement('hidden', 'subject', $formValues['subject']);
+    $this->form->addElement('hidden', 'text_message', $formValues['text_message']);
+    $this->form->addElement('hidden', 'html_message', $formValues['html_message']);
+    $this->form->addElement('hidden', 'from_email_address', $formValues['from_email_address']);
   }
 
   /**

--- a/tests/phpunit/Helpers/MailHelpersTrait.php
+++ b/tests/phpunit/Helpers/MailHelpersTrait.php
@@ -40,7 +40,11 @@ trait Helpers_MailHelpersTrait {
       $headerValues = [];
       foreach ($allHeaders as $headerLine) {
         $tmp = explode(': ', $headerLine);
-        $headerValues[$tmp[0]] = $tmp[1];
+        // Not all headers are separated by `: ` some headers
+        // are separated by by `=`
+        // e.g. boundary="=_450418403cfd293a551c46b24aeb05c6"
+        // we simply ignore such header value.
+        $headerValues[$tmp[0]] = $tmp[1] ?? '';
       }
 
       $emails[$result->recipient_email][] = array_merge(


### PR DESCRIPTION
## Overview
CiviCRM only supports sending bulk mail to contacts on a single case, in a previous PR https://github.com/compucorp/uk.co.compucorp.civicase/pull/804 we bypassed this limitation and allowed sending of bulk mail to contacts on multiple cases, this feature worked until recently when we added support for CiviCRM version `5.51.3`. because of the following 
1. CiviCase uses this action form `CRM_Contact_Form_Task_Email` to send emails action, but in the recent version of CiviCRM some methods peculiar to case entity have been moved to a new child form `CRM_Case_Form_Task_Email` as seen in this commit https://github.com/civicrm/civicrm-core/commit/dcecc495e042dc45c45e23a0e02d1e02caef2341
2. In the hook `CRM_Civicase_Hook_ValidateForm_SendBulkEmail` we update the `_toContactEmails` form field to the email addresses we want to send the email to, but as seen in this commit https://github.com/civicrm/civicrm-core/commit/8335816a2edfd1b43d6243b9dbf9e3def34e248a CiviCRM now reads the value of the `to` field directly using the controller method `$this->getSubmittedValue('to')` to know which email addresses to send email to.

## Before
After sending an email, the email is sent multiple times and tokens are not resolved. the image below is the result of sending an email to two cases, with  1 client each.
<img width="1414" alt="Screenshot 2022-09-05 at 09 34 20" src="https://user-images.githubusercontent.com/85277674/188405677-279ca7b9-0d1a-4905-b917-3663dead8a17.png">

## After
![pro](https://user-images.githubusercontent.com/85277674/188408142-b8e57dd2-f866-4f43-aacc-308d7698ee92.gif)


## Technical Details
We resolved the _1._  by updating the form actions to use the `CRM_Case_Form_Task_Email` instead of `CRM_Contact_Form_Task_Email`.
We resolved _2._ by updating the `to` values in the form controller, so that `$this->getSubmittedValue('to')` will return the appropriate email addresses for the email to be sent.
```php
$data = &$form->controller->container();
$data['values']['Email']['to'] = implode(',', $toContactEmails);
```
For this to work as expected we had to clone the form object instance for each case ID `$emailForm = clone $this->form;`, because CiviCRM only reads from the container once and then saves to a cache and subsequent reads are from the cache, so to ensure each case gets their appropriate email addresses, we had to use a new form object.

Below is what the getSubmittedValue method looks like currently in CiviCRM:

```php
public function getSubmittedValue(string $fieldName) {
    if (empty($this->exportedValues)) {
      $this->exportedValues = $this->controller->exportValues($this->_name);
    }
    $value = $this->exportedValues[$fieldName] ?? NULL;
    ...
    return $value;
}
```

The other commits are ensuring the test now conforms to how the form values are now retrieved in the current CiviCRM version.