### PR TITLE
RSESPRT-121: Change the custom_group extends_entity_column_value type to TEXT

### DIFF
--- a/CRM/Civicase/Upgrader/Steps/Step0018.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0018.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Changes custom_group entity_column_value column type to 'text'.
+ *
+ * Changes the type of civicrm_custom_group.extends_entity_column_value
+ * column to text from the default varchar(255).
+ * Because the column grows quickly as its used in CiviCase
+ * to store every case_category sub_types using the custom group.
+ */
+class CRM_Civicase_Upgrader_Steps_Step0018 {
+
+  /**
+   * Runs the upgrader changes.
+   *
+   * @return bool
+   *   True when the upgrader runs successfully.
+   */
+  public function apply() {
+    $tableName = CRM_Core_DAO_CustomGroup::$_tableName;
+    CRM_Core_DAO::executeQuery("ALTER TABLE $tableName MODIFY `extends_entity_column_value` TEXT DEFAULT NULL COMMENT 'linking custom group for dynamic object'", [], TRUE, NULL, FALSE, FALSE);
+
+    if (CRM_Core_Config::singleton()->logging) {
+      $logging = new CRM_Logging_Schema();
+      $logging->fixSchemaDifferencesFor($tableName, ['MODIFY' => 'extends_entity_column_value']);
+    }
+
+    return TRUE;
+  }
+
+}


### PR DESCRIPTION
## Overview
`Award` is a case_type_category, the  description below is applicable to other case_type_category like `Prospect`.
![image](https://user-images.githubusercontent.com/85277674/188462142-0f61db0a-2d2f-4c37-bcaa-53176135fc3a.png)

As we can see in the image above the custom group is used for Arts & Humanities Awards and other award types. if a new award type is created with Arts & Humanities Awards as its subtype, this new award type would also be added to the custom group used for i.e. `extends_entity_column_value`. this applies to all case sub-types. so the  extends_entity_column_value column keeps growing but according to the dB schema, it can only take 255 characters `VARCHAR(255)`, when it outgrows the current.

In this PR, we add an upgrader to change the custom_group extends_entity_column_value type to TEXT, so that it can accommodate more IDs.

## Before
_the custom_group extends_entity_column_value type is `VARCHAR(255)`_

## After
The `custom_group extends_entity_column_value` type is `TEXT`
![image](https://user-images.githubusercontent.com/85277674/188474031-0227c100-62d4-4a03-96ad-3fcb9059f626.png)

If the log is enabled on the server, the column is also updated and the `log_custom_group extends_entity_column_value type` is changed to `TEXT`
![image](https://user-images.githubusercontent.com/85277674/188474459-0a369e01-5e24-4337-b782-5a921d8a8762.png)

