### PR TITLE
CPS-720: Fix multiple popups on selecting an action

### DIFF
--- a/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
+++ b/ang/civicase/case/details/people-tab/directives/case-details-people-tab.directive.js
@@ -91,10 +91,12 @@
      */
     function doContactTask (tab) {
       var task = $scope.contactTasks[$scope[tab + 'SelectedTask']];
-      $scope[tab + 'SelectedTask'] = '';
       civicaseCrmLoadForm(civicaseCrmUrl(
         task.url, { cids: $scope.getSelectedContacts(tab).join(',') })
       )
+        .on('crmFormLoad', function () {
+          $scope[tab + 'SelectedTask'] = '';
+        })
         .on('crmFormSuccess', $scope.refresh)
         .on('crmFormSuccess', function () {
           $scope.refresh();


### PR DESCRIPTION
## Overview
This PR fixes the issue with multiple popups being shown when an action is selected in the `people` -> `other relationships` tab

## Before
Multiple popups are displayed to the user
![CPS-720 (1)](https://user-images.githubusercontent.com/85277674/189079596-bb6cb0a0-8ca9-49c2-a0e3-32d5457e231f.gif)


## After
A single popup is displayed to the user
![bnra](https://user-images.githubusercontent.com/85277674/189084140-1263ba6e-f610-4c2a-b87f-80628f17f8bf.gif)


## Technical Details
The `ng-change` directive in Angular is used to watch for changes in the model attached to an input. CiviCRM `crm-ui-select` fires events that change the model value more than once, causing the event handler `doContactTask` to be called twice, hence displaying multiple popups, this happens when the attached model value is programmatically updated, even though according to the [angularjs](https://docs.angularjs.org/api/ng/directive/ngChange) this should not happen.

A similar issue was mentioned as a part of this [PR](https://github.com/compucorp/uk.co.compucorp.civicase/pull/451), instead of following the approach in the PR where a dropdown was used in place of select input (probably because there was another issue that needed to be fixed). In this PR we wait for the popup to load first before updating the model value, that way it doesn't trigger the `ng-change` event.