### PR TITLE
Pass missing $values to _processLinks

### DIFF
--- a/api/v3/Activity/Getactionlinks.php
+++ b/api/v3/Activity/Getactionlinks.php
@@ -86,7 +86,7 @@ function _civicrm_api3_activity_getActivityActionLinks(array $params) {
     $values
   );
 
-  return _civicrm_api3_activity_GetActionLinks_processLinks($seqLinks);
+  return _civicrm_api3_activity_GetActionLinks_processLinks($seqLinks, $values);
 }
 
 /**
@@ -98,7 +98,7 @@ function _civicrm_api3_activity_getActivityActionLinks(array $params) {
  * @return array
  *   Activity Action Links.
  */
-function _civicrm_api3_activity_GetActionLinks_processLinks(array $activityActionLinks) {
+function _civicrm_api3_activity_GetActionLinks_processLinks(array $activityActionLinks, array $values) {
   foreach ($activityActionLinks as $id => $link) {
     // Remove action links already added by civicase.
     if (in_array($link['name'], ACTIONS_DEFINED_BY_CIVICASE)) {


### PR DESCRIPTION
Correctly populate URL, also remove PHP Warnings #875


## Before
_"View activity"_ button in drop-down in activity tab contains `%%cid%%`, `%%cxt%%`… markers

Logs are full of `PHP Warning:  Invalid argument supplied for foreach() in civicrm/CRM/Core/Action.php on line 379`

## After
URL of _"View activity"_ is populated with variables.

Not more warnings

## Go further
`&amp;` still remain in URL


