### PR TITLE
MAE-956: Fix Manage cases and new case type cateogery pages on PHP 8

### DIFF
--- a/CRM/Civicase/Hook/alterAPIPermissions/CaseCategory.php
+++ b/CRM/Civicase/Hook/alterAPIPermissions/CaseCategory.php
@@ -204,7 +204,7 @@ class CRM_Civicase_Hook_alterAPIPermissions_CaseCategory {
     }
 
     $caseTypeCategoryParam = $params[$key];
-    if (array_key_exists('IN', $caseTypeCategoryParam)) {
+    if (is_array($caseTypeCategoryParam) && array_key_exists('IN', $caseTypeCategoryParam)) {
       foreach ($caseTypeCategoryParam['IN'] as $caseCategory) {
         return $this->getCaseTypeCategoryNameFromOptions($caseCategory);
       }


### PR DESCRIPTION
## Overview

Fixing some pages that do not load on PHP 8.

## Before

Neither "Manage Cases" page, or trying to create new case type category  are working:

![image](https://user-images.githubusercontent.com/6275540/200882674-abcbbd52-1ec6-4aed-8835-6241ff579678.png)


## After

Things are working fine as before:

![image](https://user-images.githubusercontent.com/6275540/200882864-fbf97222-0af2-478c-94b4-88694d9d237d.png)


## Technical Details

Case type category parameters that are passed to getCaseCategoryNameFromCaseTypeCategory() function are expected to be either an array or an integer, but the mentioned method tries to check if the "IN" key exist regardless, using array_key_exists() function.

This was not an issue before because on PHP 7.4  it will just throw a warning, but on PHP 8 it throws an error, resulting in issues with the above pages and for the following error in logs:

```
"Nov  9 11:13:29 php oddly-divine-kid_docker_cc-test_site-drupal: 1667992409|10.16.135.31|https://oddly-divine-kid.docker.cc-test.site|php|https://oddly-divine-kid.docker.cc-test.site/civicrm/ajax/rest|https://oddly-divine-kid.docker.cc-test.site/civicrm/case/a/?case_type_category=1&p=mg|1||TypeError: array_key_exists(): Argument #2 ($array) must be of type array, string given in CRM_Civicase_Hook_alterAPIPermissions_CaseCategory->getCaseCategoryNameFromCaseTypeCategory() (line 207 of /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/ext/uk.co.compucorp.civicase/CRM/Civicase/Hook/alterAPIPermissions/CaseCategory.php)."
```

here is how PHP 7.4 behavior differ from PHP 8: 

![Uploading 2022-11-09 18_33_51-PHP Sandbox - Execute PHP code online through your browser.png…]()


To fix the issue I here just updated the above method so it checks if case type category parameters are in array format before looking for the "IN" key in them.
