### PR TITLE
RSESPRT-140: Fix incorrect case types in advanced search

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/ModifyCaseTypesForAdvancedSearch.php
+++ b/CRM/Civicase/Hook/BuildForm/ModifyCaseTypesForAdvancedSearch.php
@@ -67,6 +67,7 @@ class CRM_Civicase_Hook_BuildForm_ModifyCaseTypesForAdvancedSearch {
     $result = civicrm_api3('CaseType', 'get', [
       'return' => ['id'],
       'case_type_category' => ['IN' => $this->accessibleCaseCategories],
+      'options' => ['limit' => 0],
     ]);
 
     return $result['values'];


### PR DESCRIPTION
## Overview

If the user who is accessing the system does not have access permission on every existing "case type category", then in the case advanced search page, the user will be only able to see the first 25 case type he has access to.

## Before

The user does not have access on every case type category, but he is still unable to see every case type that belongs to a case type category he has access to:
![22323](https://user-images.githubusercontent.com/6275540/201921903-75927e56-5908-4ae5-8564-cc99af9c8294.gif)


## After

The user now can see every case type to a case type category he has permission to see
![22222](https://user-images.githubusercontent.com/6275540/201921915-9a2fffc0-26c2-4e25-96d1-3e45be8a9e9f.gif)


## Technical Details

The buildForm hook that is implemented on advanced search to limit the case types to only the ones the user has access to, does not include the `limit` parameter in the API call, thus Civi Core by default will limit the result to the first 25, here I removed that limit by making it = 0 , which means no limit.
