### PR TITLE
MAE-969: Fix activities not loading on awards page

### DIFF
--- a/api/v3/Activity/Getall.php
+++ b/api/v3/Activity/Getall.php
@@ -35,6 +35,8 @@ function _civicrm_api3_activity_getall_spec(array &$spec) {
  */
 function civicrm_api3_activity_getall(array $params) {
   $contactTypesToReturn = [];
+  $params['return'] = is_string($params['return']) ? explode(',', $params['return']) : $params['return'];
+
   $targetContactParamIndex = array_search('target_contact_name', $params['return']);
   if ($targetContactParamIndex !== FALSE) {
     $contactTypesToReturn['target_contact_name'] = 1;
@@ -47,6 +49,7 @@ function civicrm_api3_activity_getall(array $params) {
     unset($params['return'][$assigneeContactParamIndex]);
   }
 
+  $params['return'] = implode(',', $params['return']);
   $result = civicrm_api3('Activity', 'get', $params);
 
   // These two activity types are known to often have a lot


### PR DESCRIPTION
## Overview
This PR fixes the issue with the award page not loading

## Before
The award page doesn't load
![image](https://user-images.githubusercontent.com/85277674/203321261-2274e205-a222-464c-8603-a780f37df7bb.png)

## After
The award page and Award activities tabs are loading
<img width="1213" alt="Screenshot 2022-11-22 at 13 54 07" src="https://user-images.githubusercontent.com/85277674/203319055-718eb990-a438-4fe1-b16f-5f7d5af87ca0.png">
<img width="1215" alt="Screenshot 2022-11-22 at 13 54 18" src="https://user-images.githubusercontent.com/85277674/203319085-9dc5410e-d68a-4c2d-8e20-b78b8da624a5.png">