### PR TITLE
MAE-966: Resolve issue with recording case activity on contact page

### DIFF
--- a/CRM/Civicase/Hook/ValidateForm/SaveActivityDraft.php
+++ b/CRM/Civicase/Hook/ValidateForm/SaveActivityDraft.php
@@ -34,7 +34,7 @@ class CRM_Civicase_Hook_ValidateForm_SaveActivityDraft {
       return;
     }
 
-    if (!array_key_exists($form->getButtonName('refresh'), $fields['buttons'])) {
+    if (empty($fields['buttons']) || !array_key_exists($form->getButtonName('refresh'), $fields['buttons'])) {
       return;
     }
 

--- a/api/v3/Activity/Getdayswithactivities.php
+++ b/api/v3/Activity/Getdayswithactivities.php
@@ -143,7 +143,7 @@ function _join_to_case(CRM_Utils_SQL_Select $query, $value) {
 function _get_case_ids(array $caseParams) {
   $results = civicrm_api3('Case', 'getcaselist', array_merge([
     'return' => 'id',
-    'options' => [limit => 0],
+    'options' => ['limit' => 0],
   ], $caseParams))['values'];
 
   return array_column($results, 'id');

--- a/api/v3/Activity/Getmonthswithactivities.php
+++ b/api/v3/Activity/Getmonthswithactivities.php
@@ -134,5 +134,5 @@ function get_records_from_activity_get_api(array $params) {
     $params['return'] = array_keys($options['return']);
   }
 
-  return _civicrm_api3_basic_get(CRM_Activity_BAO_Activity, $params, FALSE, 'Activity', $sql);
+  return _civicrm_api3_basic_get('CRM_Activity_BAO_Activity', $params, FALSE, 'Activity', $sql);
 }

--- a/api/v3/Activity/Getmonthswithactivities.php
+++ b/api/v3/Activity/Getmonthswithactivities.php
@@ -55,7 +55,7 @@ function civicrm_api3_activity_Getmonthswithactivities(array $params) {
   $grouped_activity_dates = [];
 
   foreach ($activities as $activity) {
-    list($activity_year, $activity_month) = explode('-', $activity['activity_date_time']);
+    [$activity_year, $activity_month] = explode('-', $activity['activity_date_time']);
 
     $activity_group_index = -1;
     foreach ($grouped_activity_dates as $key => $val) {
@@ -119,7 +119,7 @@ function get_records_from_activity_get_api(array $params) {
     $sort = explode(', ', $options['sort']);
 
     foreach ($sort as $index => &$sortString) {
-      list($sortField, $dir) = array_pad(explode(' ', $sortString), 2, 'ASC');
+      [$sortField, $dir] = array_pad(explode(' ', $sortString), 2, 'ASC');
       if ($sortField == 'is_overdue') {
         $incomplete = implode(',', array_keys(CRM_Activity_BAO_Activity::getStatusesByType(CRM_Activity_BAO_Activity::INCOMPLETE)));
         $sql->orderBy("IF((a.activity_date_time >= NOW() OR a.status_id NOT IN ($incomplete)), 0, 1) $dir", NULL, $index);


### PR DESCRIPTION
## Overview
This PR resolves the issue of not being able to record case activity on a contact page.

## Before
![MAE-966](https://user-images.githubusercontent.com/85277674/204299614-c3ce866c-ef22-4941-884f-628c1dcd642f.gif)


## After
![lov](https://user-images.githubusercontent.com/85277674/204300075-a6abd91e-a534-41fd-9778-251e9d6cc6d8.gif)


## Technical Details
In PHP 8.0 using array_key_exists with a non-array variable throws an error, we resolve this by ensuring the `$fields['buttons']` is not null.

likewise, in PHP 8.0 undefined constants are no longer interpreted as a string, we explicitly use `limit` index as a string https://github.com/compucorp/uk.co.compucorp.civicase/blob/b51d901649eb6f77b87033309f1fd426d9cc2481/api/v3/Activity/Getdayswithactivities.php#L146
