### PR TITLE
MAE-976: Fix issue with Creating Case Activity and creating Case Activity reports.

### DIFF
--- a/CRM/Civicase/Form/Report/BaseExtendedReport.php
+++ b/CRM/Civicase/Form/Report/BaseExtendedReport.php
@@ -1173,23 +1173,9 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
    * of fields to be selected in the column header fields which is not
    * possible in the original function in base class.
    *
-   * @param array $specs
-   *   Specifications.
-   * @param string $tableName
-   *   Table name.
-   * @param string|null $daoName
-   *   DAO name.
-   * @param string|null $tableAlias
-   *   Table alias.
-   * @param array $defaults
-   *   Defaults.
-   * @param array $options
-   *   Options.
-   *
-   * @return array
-   *   Column lists.
+   * @inheritDoc
    */
-  protected function buildColumns(array $specs, $tableName, $daoName = NULL, $tableAlias = NULL, array $defaults = [], array $options = []) {
+  protected function buildColumns($specs, $tableName, $daoName = NULL, $tableAlias = NULL, $defaults = [], $options = []) {
 
     if (!$tableAlias) {
       $tableAlias = str_replace('civicrm_', '', $tableName);
@@ -1283,8 +1269,8 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
         }
       }
     }
-    $columns[$tableName]['prefix'] = isset($options['prefix']) ? $options['prefix'] : '';
-    $columns[$tableName]['prefix_label'] = isset($options['prefix_label']) ? $options['prefix_label'] : '';
+    $columns[$tableName]['prefix'] = $options['prefix'] ?? '';
+    $columns[$tableName]['prefix_label'] = $options['prefix_label'] ?? '';
     if (isset($options['group_title'])) {
       $groupTitle = $options['group_title'];
     }
@@ -1305,12 +1291,9 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
    * results for the row totals based on new Data aggregate functions
    * introduced.
    *
-   * @param array $rows
-   *   Result rows.
-   * @param bool $pager
-   *   Pager.
+   * @inheritDoc
    */
-  public function formatDisplay(array &$rows, $pager = TRUE) {
+  public function formatDisplay(&$rows, $pager = TRUE) {
     // Set pager based on if any limit was applied in the query.
     if ($pager) {
       $this->setPager();
@@ -1352,19 +1335,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
   /**
    * Use the options for the field to map the display value.
    *
-   * @param string $value
-   *   Value of the field.
-   * @param array $row
-   *   Row display values.
-   * @param string $selectedField
-   *   Selected field.
-   * @param string $criteriaFieldName
-   *   Criteria field name.
-   * @param array $specs
-   *   Specifications of the column.
-   *
-   * @return string
-   *   Label of the option ids.
+   * @inheritDoc
    */
   public function alterFromOptions($value, array &$row, $selectedField, $criteriaFieldName, array $specs) {
     if ($specs['data_type'] == 'ContactReference') {
@@ -1798,10 +1769,9 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
    * when next the report instance is opened, those panes are automatically
    * expanded.
    *
-   * @param array $params
-   *   Params.
+   * @inheritDoc
    */
-  public function setParams(array $params) {
+  public function setParams($params) {
     if (empty($params)) {
       $this->_params = $params;
       return;

--- a/CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
+++ b/CRM/Civicase/Form/Report/ColumnDefinitionTrait.php
@@ -253,13 +253,9 @@ trait CRM_Civicase_Form_Report_ColumnDefinitionTrait {
   /**
    * Get contact columns.
    *
-   * @param array $options
-   *   Options for generating the columns.
-   *
-   * @return array
-   *   Contact columns
+   * @inheritDoc
    */
-  public function getContactColumns(array $options = []) {
+  protected function getContactColumns($options = []) {
     $defaultOptions = [
       'prefix' => '',
       'prefix_label' => '',

--- a/CRM/Civicase/Form/Report/ExtendedReport.php
+++ b/CRM/Civicase/Form/Report/ExtendedReport.php
@@ -830,7 +830,7 @@ class CRM_Civicase_Form_Report_ExtendedReport extends CRM_Report_Form {
    *
    * @throws Exception
    */
-  function addColumnAggregateSelect($fieldName, $dbAlias, $spec) {
+  public function addColumnAggregateSelect($fieldName, $dbAlias, array $spec) {
     if (empty($fieldName)) {
       $this->addAggregateTotal($fieldName);
       return;
@@ -2314,7 +2314,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
    * @param string $fieldAlias
    * @param string $title
    */
-  protected function addRowHeader($tableAlias, $selectedField, $fieldAlias, $title = '') {
+  protected function addRowHeader($tableAlias, array $selectedField, $fieldAlias, $title = '') {
     if (empty($tableAlias)) {
       $this->_select = 'SELECT 1 '; // add a fake value just to save lots of code to calculate whether a comma is required later
       $this->_rollup = NULL;
@@ -2578,7 +2578,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
    *
    * @param $rows
    */
-  function alterRollupRows(&$rows) {
+  function alterRollupRows(array &$rows) {
     if (count($rows) === 1) {
       // If the report only returns one row there is no rollup.
       return;
@@ -2636,7 +2636,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
    *
    * @return string
    */
-  function alterFromOptions($value, &$row, $selectedField, $criteriaFieldName, $specs) {
+  public function alterFromOptions($value, array &$row, $selectedField, $criteriaFieldName, array $specs) {
     if ($specs['data_type'] == 'ContactReference') {
       if (!empty($row[$selectedField])) {
         return CRM_Contact_BAO_Contact::displayName($row[$selectedField]);
@@ -7488,7 +7488,7 @@ WHERE cg.extends IN ('" . $extendsString . "') AND
    * @param $prefixLabel
    * @param $tableKey
    */
-  protected function addCustomTableToColumns($field, $currentTable, $prefix, $prefixLabel, $tableKey) {
+  protected function addCustomTableToColumns(array $field, $currentTable, $prefix, $prefixLabel, $tableKey) {
     $entity = $field['extends'];
     if (in_array($entity, ['Individual', 'Organization', 'Household'])) {
       $entity = 'Contact';
@@ -7572,7 +7572,7 @@ WHERE cg.extends IN ('" . $extendsString . "') AND
    * @return array
    * @throws \Exception
    */
-  protected function getCustomFieldOptions($spec) {
+  protected function getCustomFieldOptions(array $spec) {
     $options = [];
     if (!empty($spec['options'])) {
       return $spec['options'];

--- a/CRM/Civicase/Hook/PostProcess/ActivityFormStatusWordReplacement.php
+++ b/CRM/Civicase/Hook/PostProcess/ActivityFormStatusWordReplacement.php
@@ -32,6 +32,7 @@ class CRM_Civicase_Hook_PostProcess_ActivityFormStatusWordReplacement {
       return;
     }
 
+    $caseId = ((array) $caseId)[0] ?? NULL;
     $caseCategoryName = CaseCategoryHelper::getCategoryName($caseId);
     CaseCategoryWordReplacementHelper::addWordReplacements($caseCategoryName);
     $translatedActivityTypeName = civicaseTs($form->getVar('_activityTypeName'));


### PR DESCRIPTION
## Overview
This PR resolves the following issues on the PHP8 site
- users cannot create new case activity reports.
- users cannot create case activities from the case dashboard.

## Before
Users are not able to create new case activity reports.
![screencast-php8-testing cc-staging site-2022 12 06-11_23_09](https://user-images.githubusercontent.com/85277674/206683941-61918dd1-abb9-48b9-8601-9be06ed809a9.gif)


## After
Users are able to create new case activity reports.
![ygiiui](https://user-images.githubusercontent.com/85277674/206644533-d8318e8b-b52a-4831-8936-c7ee26f3a5bc.gif)

## Before
Users are not able to create case activities from the case dashboard.
![screencast-php8-testing cc-staging site-2022 12 05-19_26_36 (1)](https://user-images.githubusercontent.com/85277674/206699898-45dff76a-60a6-4430-8055-cc497397017c.gif)


## After
Users can create case activities from the case dashboard.
![activviiviviv](https://user-images.githubusercontent.com/85277674/206700601-24b9d1f6-6bfb-43e2-bcf9-a86b8ee5c2fc.gif)


## Technical Details
- users cannot create new case activity reports: This issue was caused by an incompatibility in method definition between the child and parent classes.
- users cannot create case activities from the case dashboard: This happens because caseId returned from the `getVar` method is an array, whereas the caseId is expected as a string, we resolve this issue by getting the first element in the array as the caseid. https://github.com/compucorp/uk.co.compucorp.civicase/blob/a285a091e949a7e8dbb47890639bcc2a88b909fb/CRM/Civicase/Hook/PostProcess/ActivityFormStatusWordReplacement.php#L29
