### PR TITLE
MAE-985: Allow users to view an activity in a standalone page

### DIFF
--- a/api/v3/Activity/Getactionlinks.php
+++ b/api/v3/Activity/Getactionlinks.php
@@ -69,11 +69,14 @@ function _civicrm_api3_activity_getActivityActionLinks(array $params) {
     $seqLinks[] = $link;
   }
 
+  $caseId = (array) CRM_Utils_Array::value('case_id', $params);
+  $caseId = ((array) $caseId)[0] ?? NULL;
+
   $values = [
     'id' => $params['activity_id'],
     'cid' => CRM_Core_Session::getLoggedInContactID(),
     'cxt' => '',
-    'caseid' => CRM_Utils_Array::value('case_id', $params),
+    'caseid' => $caseId,
   ];
 
   // Invoke hook links for activity tab rows.

--- a/api/v3/Activity/Getactionlinks.php
+++ b/api/v3/Activity/Getactionlinks.php
@@ -86,7 +86,7 @@ function _civicrm_api3_activity_getActivityActionLinks(array $params) {
     $values
   );
 
-  return _civicrm_api3_activity_GetActionLinks_processLinks($seqLinks);
+  return _civicrm_api3_activity_GetActionLinks_processLinks($seqLinks, $values);
 }
 
 /**
@@ -94,11 +94,13 @@ function _civicrm_api3_activity_getActivityActionLinks(array $params) {
  *
  * @param array $activityActionLinks
  *   Activity Action Links.
+ * @param array $values
+ *   Placeholder values.
  *
  * @return array
  *   Activity Action Links.
  */
-function _civicrm_api3_activity_GetActionLinks_processLinks(array $activityActionLinks) {
+function _civicrm_api3_activity_GetActionLinks_processLinks(array $activityActionLinks, array $values) {
   foreach ($activityActionLinks as $id => $link) {
     // Remove action links already added by civicase.
     if (in_array($link['name'], ACTIONS_DEFINED_BY_CIVICASE)) {


### PR DESCRIPTION
## Overview
In PHP8  users are unable to access the standalone page, whereas in PHP7.4 the standalone page is displayed but with incorrect data.

## Before
On a site running PHP 7.4, The Activity data differs from what is shown on the standalone page.
<img width="1222" alt="Screenshot 2022-12-19 at 07 47 44" src="https://user-images.githubusercontent.com/85277674/208365991-f82d99b4-f11a-4dfd-89f7-c610f6d5b7d3.png">

<img width="1217" alt="Screenshot 2022-12-19 at 07 47 55" src="https://user-images.githubusercontent.com/85277674/208365963-f15595a1-6ef5-4b7e-a43b-200f6e0e02af.png">

<hr>
On a site running PHP 8.0+, The activity standalone page returns an error.
![screencast-php8-testing cc-staging site-2022 12 12-14_02_47](https://user-images.githubusercontent.com/85277674/208368061-4aa46776-8e9f-4b6e-8aed-9ebc5c2fb985.gif)


## After
The activity standalone displays the correct data with no error.
<img width="917" alt="Screenshot 2022-12-19 at 08 02 26" src="https://user-images.githubusercontent.com/85277674/208366883-bcba89dd-6907-426c-b9b4-16dfcf5d0fa4.png">

<img width="1212" alt="Screenshot 2022-12-19 at 08 00 24" src="https://user-images.githubusercontent.com/85277674/208366568-ccd6d51b-2340-4683-849b-3433cc866500.png">


## Technical Details
The error on the standalone page happened because the URL placeholders in the activity menu actions are not resolved to their actual value. e.g. `/civicrm/activity?atype=20&amp;action=view&amp;reset=1&amp;id=%%id%%&amp;cid=%%cid%%&amp;context=%%cxt%%&amp;searchContext=activity` therefore, there's no way for the activity page to know what activity to display.

Upon investigation, it was discovered that the activity.getActivityActionLinks API was returning the action URLs without the placeholder being replaced because it was trying to access a `values` array it hasn't declared in the function `_civicrm_api3_activity_GetActionLinks_processLinks`.