### PR TITLE
MAE-992: Fix restrict email recipients to contact involved with case

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/HandleDraftActivities.php
+++ b/CRM/Civicase/Hook/BuildForm/HandleDraftActivities.php
@@ -13,7 +13,7 @@ class CRM_Civicase_Hook_BuildForm_HandleDraftActivities {
   ];
 
   const PDF_LETTER_FORM_NAME = 'CRM_Contact_Form_Task_PDF';
-  const EMAIL_FORM_NAME = 'CRM_Contact_Form_Task_Email';
+  const EMAIL_FORM_NAME = 'CRM_Case_Form_Task_Email';
   const SPECIAL_FORMS = [
     self::PDF_LETTER_FORM_NAME,
     self::EMAIL_FORM_NAME,
@@ -96,7 +96,7 @@ class CRM_Civicase_Hook_BuildForm_HandleDraftActivities {
             'id' => $id,
             'return' => 'case_id',
           ]);
-          $composeUrl = CRM_Utils_System::url("civicrm/activity/$atype/add", [
+          $composeUrl = CRM_Utils_System::url("civicrm/case/$atype/add", [
             'action' => 'add',
             'reset' => 1,
             'caseId' => $caseId['case_id'][0],

--- a/CRM/Civicase/Hook/BuildForm/LimitRecipientFieldsToOnlySelectedContacts.php
+++ b/CRM/Civicase/Hook/BuildForm/LimitRecipientFieldsToOnlySelectedContacts.php
@@ -57,7 +57,7 @@ class CRM_Civicase_Hook_BuildForm_LimitRecipientFieldsToOnlySelectedContacts {
    */
   private function shouldRun($formName) {
     return (
-      $formName === CRM_Contact_Form_Task_Email::class &&
+      $formName === CRM_Case_Form_Task_Email::class &&
       CRM_Utils_Array::value('caseRolesBulkEmail', $_GET, '0') === '1' &&
       CRM_Utils_Array::value('snippet', $_GET, '0') === CRM_Core_Smarty::PRINT_JSON &&
       CRM_Utils_Array::value('cid', $_GET, '0') &&

--- a/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
+++ b/CRM/Civicase/Hook/BuildForm/RestrictCaseEmailContacts.php
@@ -40,8 +40,8 @@ class CRM_Civicase_Hook_BuildForm_RestrictCaseEmailContacts {
    *   True when the hook can run.
    */
   private function shouldRun() {
-    $isEmailForm = get_class($this->form) === CRM_Contact_Form_Task_Email::class;
-    $isCaseEmail = !empty($this->form->getVar('_caseId'));
+    $isEmailForm = get_class($this->form) === CRM_Case_Form_Task_Email::class;
+    $isCaseEmail = !empty(CRM_Utils_Request::retrieve('caseid', 'Positive'));
     $shouldRestrictContacts = (bool) Civi::settings()->get('civicaseRestrictCaseEmailContacts');
     $isBulkEmail = CRM_Utils_Array::value('caseRolesBulkEmail', $_GET, '0') === '1';
 
@@ -56,7 +56,7 @@ class CRM_Civicase_Hook_BuildForm_RestrictCaseEmailContacts {
    * switching cases or updating the contacts for the existing one.
    */
   private function addListOfCaseContactsToSettings() {
-    $caseId = $this->form->getVar('_caseId');
+    $caseId = CRM_Utils_Request::retrieve('caseid', 'Positive');
 
     $caseDetailsResponse = civicrm_api3('Case', 'getdetails', [
       'id' => $caseId,

--- a/CRM/Civicase/Hook/BuildForm/TokenTree.php
+++ b/CRM/Civicase/Hook/BuildForm/TokenTree.php
@@ -56,7 +56,7 @@ class CRM_Civicase_Hook_BuildForm_TokenTree {
     if (!$this->shouldRun($formName)) {
       return;
     }
-    $this->isEmailForm = $form instanceof CRM_Contact_Form_Task_Email;
+    $this->isEmailForm = $form instanceof CRM_Case_Form_Task_Email;
     $this->setAllRelevantCustomFields();
     $this->attachNewTokenTreeToForm($form);
   }
@@ -479,7 +479,7 @@ class CRM_Civicase_Hook_BuildForm_TokenTree {
     return CRM_Utils_Request::retrieve('caseid', 'Integer') &&
       in_array(
         $formName,
-        [CRM_Contact_Form_Task_Email::class, CRM_Contact_Form_Task_PDF::class]
+        [CRM_Case_Form_Task_Email::class, CRM_Contact_Form_Task_PDF::class]
       );
   }
 

--- a/CRM/Civicase/Hook/PostProcess/AttachEmailActivityToAllCases.php
+++ b/CRM/Civicase/Hook/PostProcess/AttachEmailActivityToAllCases.php
@@ -67,7 +67,7 @@ class CRM_Civicase_Hook_PostProcess_AttachEmailActivityToAllCases {
    *   Whether the hook should run or not.
    */
   private function shouldRun($formName) {
-    return $formName === CRM_Contact_Form_Task_Email::class &&
+    return $formName === CRM_Case_Form_Task_Email::class &&
       !empty(CRM_Utils_Array::value('allCaseIds', $_GET, '0')) &&
       !empty(CRM_Utils_Array::value('caseid', $_GET, '0'));
   }

--- a/CRM/Civicase/Hook/PostProcess/HandleDraftActivity.php
+++ b/CRM/Civicase/Hook/PostProcess/HandleDraftActivity.php
@@ -82,7 +82,7 @@ class CRM_Civicase_Hook_PostProcess_HandleDraftActivity {
    *   Whether the hook should run or not.
    */
   private function shouldRun($formName, $urlParams) {
-    $specialForms = ['CRM_Contact_Form_Task_PDF', 'CRM_Contact_Form_Task_Email'];
+    $specialForms = ['CRM_Contact_Form_Task_PDF', 'CRM_Case_Form_Task_Email'];
 
     return in_array($formName, $specialForms) && !empty($urlParams['draft_id']);
   }

--- a/CRM/Civicase/Hook/ValidateForm/SaveActivityDraft.php
+++ b/CRM/Civicase/Hook/ValidateForm/SaveActivityDraft.php
@@ -12,7 +12,7 @@ class CRM_Civicase_Hook_ValidateForm_SaveActivityDraft {
    */
   private $specialForms = [
     'pdf' => 'CRM_Contact_Form_Task_PDF',
-    'email' => 'CRM_Contact_Form_Task_Email',
+    'email' => 'CRM_Case_Form_Task_Email',
   ];
 
   /**
@@ -56,7 +56,7 @@ class CRM_Civicase_Hook_ValidateForm_SaveActivityDraft {
     // The validate stage provides an opportunity to bypass normal
     // form processing, save the draft & return early.
     $activityType = $form->getVar('_activityTypeId');
-    $caseId = $form->getVar('_caseId');
+    $caseId = CRM_Utils_Request::retrieve('caseid', 'String');
     if (!$activityType) {
       $activityType = $formName == 'CRM_Contact_Form_Task_PDF' ? 'Print PDF Letter' : 'Email';
     }

--- a/ang/civicase/activity/activity-forms/services/activity-form-services/draft-email-activity-form.service.js
+++ b/ang/civicase/activity/activity-forms/services/activity-form-services/draft-email-activity-form.service.js
@@ -45,8 +45,12 @@
         draftFormParameters.caseid = activity.case_id;
       }
 
+      var viewUrl = 'civicrm/activity/email/';
+      var addUrl = 'civicrm/case/email/';
+      var url = action === 'view' ? viewUrl : addUrl;
+
       return civicaseCrmUrl(
-        'civicrm/activity/email/' + action,
+        url + action,
         draftFormParameters
       );
     }

--- a/ang/test/civicase/activity/activity-forms/services/activity-forms-services/draft-email-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/activity-forms-services/draft-email-activity-form.service.spec.js
@@ -67,7 +67,7 @@
         });
 
         it('returns the popup form URL for the draft activity in create mode by default', () => {
-          expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/activity/email/add',
+          expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/case/email/add',
             expectedActivityFormUrlParams);
         });
       });
@@ -83,7 +83,7 @@
         });
 
         it('returns the popup form URL for the draft activity in create mode by default', () => {
-          expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/activity/email/add',
+          expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/case/email/add',
             expectedActivityFormUrlParams);
         });
       });

--- a/tests/phpunit/CRM/Civicase/Hook/BuildForm/TokenTreeTest.php
+++ b/tests/phpunit/CRM/Civicase/Hook/BuildForm/TokenTreeTest.php
@@ -29,11 +29,11 @@ class CRM_Civicase_Hook_BuildForm_TokenTreeTest extends BaseHeadlessTest {
   public function testRun() {
     $this->setContactCustomFields();
     $this->setCaseCustomFields();
-    $form = new CRM_Contact_Form_Task_Email();
+    $form = new CRM_Case_Form_Task_Email();
     $form->assign('tokens', $this->getTokens());
     $_GET['caseid'] = $_REQUEST['caseid'] = 1;
     $hook = new TokenTree();
-    $hook->run($form, CRM_Contact_Form_Task_Email::class);
+    $hook->run($form, CRM_Case_Form_Task_Email::class);
     $setting = CRM_Core_Resources::singleton()->getSettings();
     $this->assertNotEmpty($setting['civicase-base']['custom_token_tree']);
     $newTokenTree = $this->format(json_decode($setting['civicase-base']['custom_token_tree'], TRUE));

--- a/tests/phpunit/CRM/Civicase/Hook/PostProcess/AttachEmailActivityToAllCasesTest.php
+++ b/tests/phpunit/CRM/Civicase/Hook/PostProcess/AttachEmailActivityToAllCasesTest.php
@@ -25,8 +25,8 @@ class CRM_Civicase_Hook_PostProcess_AttachEmailActivityToAllCasesTest extends Ba
     $_GET['allCaseIds'] = $_REQUEST['allCaseIds'] = $allCaseIds;
 
     (new AttachEmailActivityToAllCases())->run(
-      CRM_Contact_Form_Task_Email::class,
-      new CRM_Contact_Form_Task_Email()
+      CRM_Case_Form_Task_Email::class,
+      new CRM_Case_Form_Task_Email()
     );
 
     foreach ($cases as $caseId) {


### PR DESCRIPTION
## Overview
This PR solves the following:

1- Issues related to `Send Draft` button not visible and not working as expected when user `Send Email`
### Before
![before_wrong](https://user-images.githubusercontent.com/115652455/209395480-86dee86c-6f08-4581-844e-2b77bbb0337d.jpg)
### After
![Screenshot 2022-12-23 222310](https://user-images.githubusercontent.com/115652455/209396945-07b8a4ae-1411-4d7a-96b0-f85194521262.jpg)

2- Restrict email recipients only to contact involved with the case not working as expected.
### Before
![Screenshot 2022-12-23 221333](https://user-images.githubusercontent.com/115652455/209396121-1d32faa2-a794-4611-8b37-a2a0b286da01.jpg)
### After
![Screenshot 2022-12-23 222508](https://user-images.githubusercontent.com/115652455/209397097-599e6f63-144e-4285-abc1-70ef5a5d7e39.jpg)

3- When enable `Limit recipients field on bulk email` from settings and `Send bulk message` not working as expected
### Before
![Screenshot 2022-12-23 221812](https://user-images.githubusercontent.com/115652455/209396508-4b3023f6-d1c8-4bd1-8bda-a1913b7bca8c.jpg)
### After
![Screenshot 2022-12-23 222708](https://user-images.githubusercontent.com/115652455/209397397-04a2e35c-1820-48dc-aacf-fff26d2c7dac.jpg)


4- Token list when user `Send Email` is not working properly.
### Before
![Screenshot 2022-12-23 222051](https://user-images.githubusercontent.com/115652455/209396735-0d751927-f535-4360-8f21-f7744706f427.jpg)
### After
![Screenshot 2022-12-23 222831](https://user-images.githubusercontent.com/115652455/209398628-50d445dd-7a6b-4c0e-b468-2f46313675b7.jpg)

## Technical Details
These issues occurs because of the support for CiviCRM 5.51.3
CiviCRM uses `CRM_Contact_Form_Task_Email` to send Email, in recent version they moved to use `CRM_Case_Form_Task_Email`, more on this in here[PR](https://github.com/compucorp/uk.co.compucorp.civicase/pull/868) 
for issue 1: `Send Email` sent the user to this url `civicrm/case/email/add` which uses  `CRM_Case_Form_Task_Email ` form, the problem is that `Send Draft` button will not be visible because it depends on `CRM_Contact_Form_Task_Email` and will sent the user to this url `civicrm/activity/email/add` (CRM_Contact_Form_Task_Email)
for other issues:
changing `CRM_Contact_Form_Task_Email` to `CRM_Case_Form_Task_Email` and url `civicrm/activity/email/add` to `civicrm/activity/email/add` when add email will solve the issues.
