### PR TITLE
MAE-823: Fix UI not showing the right labels for other case_type_categories

### DIFF
--- a/CRM/Civicase/Event/Listener/AssetBuilder.php
+++ b/CRM/Civicase/Event/Listener/AssetBuilder.php
@@ -1,0 +1,29 @@
+<?php
+
+use Civi\Angular\Page\Modules;
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * Asset Builder Event Listener Class.
+ */
+class CRM_Civicase_Event_Listener_AssetBuilder {
+
+  /**
+   * Add word replacements to Angular asset.
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $event
+   *   AssetBuilder Event.
+   */
+  public static function addWordReplacements(GenericHookEvent $event) {
+    if ($event->asset == 'angular-modules.json') {
+      $caseCategoryName = \Civi::cache('metadata')->get('current_case_category');
+      CRM_Civicase_Hook_Helper_CaseTypeCategory::addWordReplacements($caseCategoryName);
+
+      // Rebuild the asset if it has been built.
+      if (!empty($event->content)) {
+        Modules::buildAngularModules($event);
+      }
+    }
+  }
+
+}

--- a/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
+++ b/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
@@ -68,11 +68,6 @@ class CRM_Civicase_Hook_Helper_CaseTypeCategory {
       return;
     }
 
-    $currentCaseCategory = \Civi::cache('metadata')->get('current_case_category');
-    if ($currentCaseCategory === $caseCategoryName) {
-      return;
-    }
-
     CRM_Core_Resources::singleton()->flushStrings()->resetCacheCode();
     \Civi::cache('metadata')->set('current_case_category', $caseCategoryName);
     $wordReplacements = CaseCategoryHelper::getWordReplacements($caseCategoryName);

--- a/civicase.php
+++ b/civicase.php
@@ -74,6 +74,11 @@ function civicase_civicrm_config(&$config) {
     ['CRM_Civicase_Event_Listener_CaseCustomFields', 'loadOnDemand'],
     10
   );
+
+  Civi::dispatcher()->addListener(
+    'hook_civicrm_buildAsset',
+    ['CRM_Civicase_Event_Listener_AssetBuilder', 'addWordReplacements']
+  );
 }
 
 /**


### PR DESCRIPTION
## Overview
This PP fixes the issue with awards, prospects and other `case_type_categories` showing the default case label. 

## Before
Other case-type categories(awards and prospects) show Case labels. 
![Case-bug](https://user-images.githubusercontent.com/85277674/211782819-c5e4a69d-45ca-4d22-af04-7ef64349361e.gif)

## After
Other case-type categories(awards and prospects) Dashboard showing their appropriate labels.
![Case](https://user-images.githubusercontent.com/85277674/211781889-8ff545fa-0eca-4b1c-b6d1-b43860cd63fc.gif)

## Technical Details
In CiviCRM, the Angular translation strings are loaded in a separate AJAX request `/civicrm/asset/builder?an=angular-modules.json` asset after the initial page request. and since the CiviCase word replacement implementation depends on the `case_type_category` URL param to load the translation strings, the replacement strings for the current case_type_category are not loaded.

To overcome this when the `angular-modules.json` asset is requested we call the `CRM_Civicase_Hook_Helper_CaseTypeCategory::addWordReplacement` with the cached `case_type_category`. 

The Cache value would always be set during the initial page request https://github.com/compucorp/uk.co.compucorp.civicase/blob/f2ac98e00edad590c7609c973915b22e071a3490/CRM/Civicase/Hook/Helper/CaseTypeCategory.php#L72.

The image below shows the translation/replacement strings in the angular-modules.json response.
<img width="1250" alt="Screenshot 2023-01-11 at 11 49 15" src="https://user-images.githubusercontent.com/85277674/211787968-f872bebc-d9f2-435b-8bdf-f3bcc4bfd42c.png">
