### PR TITLE
BTHAB-37: Add direct link to CiviCase Instances

### DIFF
--- a/CRM/Civicase/Hook/NavigationMenu/AlterForCaseMenu.php
+++ b/CRM/Civicase/Hook/NavigationMenu/AlterForCaseMenu.php
@@ -1,5 +1,6 @@
 <?php
 
+use Civi\Api4\OptionGroup;
 use CRM_Civicase_Service_CaseCategorySetting as CaseCategorySetting;
 use CRM_Civicase_Helper_CaseUrl as CaseUrlHelper;
 
@@ -29,6 +30,7 @@ class CRM_Civicase_Hook_NavigationMenu_AlterForCaseMenu {
     $this->caseCategorySetting = new CaseCategorySetting();
     $this->rewriteCaseUrls($menu);
     $this->addCaseWebformUrl($menu);
+    $this->addCiviCaseInstanceMenu($menu);
   }
 
   /**
@@ -114,6 +116,64 @@ class CRM_Civicase_Hook_NavigationMenu_AlterForCaseMenu {
         $this->menuWalk($menu[$key]['child'], $callback);
       }
     }
+  }
+
+  /**
+   * Adds the civicase instance menu to the Adminsiter Civicase Menu.
+   *
+   * @param array $menu
+   *   Tree of menu items, per hook_civicrm_navigationMenu.
+   */
+  private function addCiviCaseInstanceMenu(array &$menu) {
+    $groupId = $this->getCaseTypeCategoryGroupId();
+    if (empty($groupId)) {
+      return;
+    }
+
+    // Find the Civicase menu.
+    $caseID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'CiviCase', 'id', 'name');
+    $administerID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Administer', 'id', 'name');
+    $civicaseSettings = &$menu[$administerID]['child'][$caseID];
+
+    $weight = $desiredWeight = 0;
+    $moveDown = FALSE;
+    foreach ($civicaseSettings['child'] as $key => &$value) {
+      if ($value['attributes']['name'] === 'Case Types') {
+        $weight = $desiredWeight = (int) $value['attributes']['weight'];
+        $moveDown = TRUE;
+      }
+
+      if ($moveDown) {
+        $value['attributes']['weight'] = ++$weight;
+      }
+    }
+
+    $menu[$administerID]['child'][$caseID]['child'][] = [
+      'attributes' => [
+        'label' => ts('CiviCase Instances'),
+        'name' => 'CiviCase Instances',
+        'url' => "civicrm/admin/options?gid=$groupId&reset=1",
+        'permission' => 'access all cases and activities',
+        'operator' => 'OR',
+        'separator' => 1,
+        'parentID' => $caseID,
+        'active' => 1,
+        'weight' => $desiredWeight,
+      ],
+    ];
+  }
+
+  /**
+   * Returnd the ID of the case type category option group.
+   */
+  private function getCaseTypeCategoryGroupId() {
+    $optionGroups = OptionGroup::get()
+      ->addSelect('id')
+      ->addWhere('name', '=', 'case_type_categories')
+      ->setLimit(25)
+      ->execute();
+
+    return $optionGroups[0]["id"] ?? NULL;
   }
 
 }


### PR DESCRIPTION
## Overview
This PR adds a direct Menu Link to create/edit CiviCase Instances in between CiviCase settings and Case Types.

## Before
The menu item doesn't exist.


## After
The menu item now exists.
![aaaaq](https://user-images.githubusercontent.com/85277674/216094328-80697a5f-720f-45cc-82b1-bc1e896b04e1.gif)


