### PR TITLE
NEUSPRT-169: Allow user to update file activity from the files tab

### DIFF
--- a/ang/civicase/activity/activity-forms/services/activity-form-services/update-activity-form.service.js
+++ b/ang/civicase/activity/activity-forms/services/activity-form-services/update-activity-form.service.js
@@ -38,8 +38,9 @@
       };
 
       if (activity.case_id) {
-        urlPath = 'civicrm/case/activity';
+        urlPath = 'civicrm/activity/add';
         urlParams.caseid = activity.case_id;
+        urlParams.context = 'case';
       }
 
       return civicaseCrmUrl(urlPath, urlParams);

--- a/ang/test/civicase/activity/activity-forms/services/activity-forms-services/update-activity-form.service.spec.js
+++ b/ang/test/civicase/activity/activity-forms/services/activity-forms-services/update-activity-form.service.spec.js
@@ -67,11 +67,12 @@
         });
 
         it('returns the update form url for the case activity', () => {
-          expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/case/activity', {
+          expect(civicaseCrmUrl).toHaveBeenCalledWith('civicrm/activity/add', {
             action: 'update',
             id: activity.id,
             reset: 1,
-            caseid: activity.case_id
+            caseid: activity.case_id,
+            context: 'case'
           });
         });
       });


### PR DESCRIPTION
## Overview
In this PR we fix the issue that prevents users from being able to edit a file activity via the files tab.

## Before
A file activity can not be updated from the `files tab`.
![aaaq](https://user-images.githubusercontent.com/85277674/217465120-bc2fd618-32a6-408f-8050-e423dba60dac.gif)

## After
A file activity can be updated from the `files tab`.
![aq](https://user-images.githubusercontent.com/85277674/217463709-7c95ce72-a6a7-4ce6-9081-babb3d3fbd85.gif)

## Technical Details
A user cannot update a file activity from the `files tab` even though the same activity can be updated from the `activities tab`. This difference happens because the `activity tab` uses the `CRM_Activity_Form_Activity` controller to update a form while the `files tab` uses `CRM_Case_Form_Activity`.

The reason the `CRM_Case_Form_Activity` fails while updating the activity is that it expects `target_contact_id` to be passed as a valid id, which is not always set in CiviCase. 

an approach to resolve this will be to make a PR to the core that allows the target_contact_id to be empty.
https://github.com/civicrm/civicrm-core/blob/1d5c596ceb4aa45f68bf54807082a3eb019a47dc/CRM/Case/Form/Activity.php#L407-L409

another approach will be to simply use the same controller as that used in the `activity tab`.

We decided to follow the latter in this PR since it's more straightforward.
