### PR TITLE
BTHAB-20: Display enabled features menu

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/AddCaseCategoryFeaturesField.php
+++ b/CRM/Civicase/Hook/BuildForm/AddCaseCategoryFeaturesField.php
@@ -35,10 +35,10 @@ class CRM_Civicase_Hook_BuildForm_AddCaseCategoryFeaturesField extends CRM_Civic
     $features = [];
 
     foreach ($caseCategoryFeatures->getFeatures() as $feature) {
-      $features[] = 'case_category_feature_' . $feature['id'];
+      $features[] = 'case_category_feature_' . $feature['value'];
       $form->add(
         'checkbox',
-        'case_category_feature_' . $feature['id'],
+        'case_category_feature_' . $feature['value'],
         $feature['label']
       );
     }

--- a/CRM/Civicase/Hook/NavigationMenu/AbstractMenuAlter.php
+++ b/CRM/Civicase/Hook/NavigationMenu/AbstractMenuAlter.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Class AbstractMenuAlter.
+ */
+abstract class CRM_Civicase_Hook_NavigationMenu_AbstractMenuAlter {
+
+  /**
+   * Modifies the navigation menu.
+   *
+   * @param array $menu
+   *   Menu Array.
+   */
+  abstract public function run(array &$menu);
+
+  /**
+   * Allow a menu item to be inserted into the position of an existing item.
+   *
+   * @param array $menus
+   *   Array of menu items.
+   * @param string $menuBefore
+   *   Unique name of the menuitem to be moved down.
+   *
+   * @return int
+   *   Weight of the menu item that was moved down.
+   */
+  protected function moveMenuDown(array &$menus, string $menuBefore) {
+    $weight = $desiredWeight = 0;
+    $moveDown = FALSE;
+
+    foreach ($menus as $key => &$value) {
+      if ($value['attributes']['name'] === $menuBefore) {
+        $weight = $desiredWeight = (int) $value['attributes']['weight'];
+        $moveDown = TRUE;
+      }
+
+      if ($moveDown) {
+        $value['attributes']['weight'] = ++$weight;
+      }
+    }
+
+    return $desiredWeight;
+  }
+
+}

--- a/CRM/Civicase/Hook/NavigationMenu/AlterForCaseMenu.php
+++ b/CRM/Civicase/Hook/NavigationMenu/AlterForCaseMenu.php
@@ -7,7 +7,7 @@ use CRM_Civicase_Helper_CaseUrl as CaseUrlHelper;
 /**
  * Class CRM_Civicase_Hook_Navigation_AlterForCaseMenu.
  */
-class CRM_Civicase_Hook_NavigationMenu_AlterForCaseMenu {
+class CRM_Civicase_Hook_NavigationMenu_AlterForCaseMenu extends CRM_Civicase_Hook_NavigationMenu_AbstractMenuAlter {
 
   /**
    * Case category Setting.
@@ -135,18 +135,7 @@ class CRM_Civicase_Hook_NavigationMenu_AlterForCaseMenu {
     $administerID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Administer', 'id', 'name');
     $civicaseSettings = &$menu[$administerID]['child'][$caseID];
 
-    $weight = $desiredWeight = 0;
-    $moveDown = FALSE;
-    foreach ($civicaseSettings['child'] as $key => &$value) {
-      if ($value['attributes']['name'] === 'Case Types') {
-        $weight = $desiredWeight = (int) $value['attributes']['weight'];
-        $moveDown = TRUE;
-      }
-
-      if ($moveDown) {
-        $value['attributes']['weight'] = ++$weight;
-      }
-    }
+    $desiredWeight = $this->moveMenuDown($civicaseSettings['child'], 'Case Types');
 
     $menu[$administerID]['child'][$caseID]['child'][] = [
       'attributes' => [

--- a/CRM/Civicase/Hook/NavigationMenu/CaseInstanceFeaturesMenu.php
+++ b/CRM/Civicase/Hook/NavigationMenu/CaseInstanceFeaturesMenu.php
@@ -1,0 +1,112 @@
+<?php
+
+use CRM_Certificate_ExtensionUtil as E;
+use Civi\Api4\CaseCategoryFeatures;
+use Civi\Api4\OptionGroup;
+
+/**
+ * Add menu for enabled features on Case instnace menus.
+ */
+class CRM_Civicase_Hook_NavigationMenu_CaseInstanceFeaturesMenu extends CRM_Civicase_Hook_NavigationMenu_AbstractMenuAlter {
+
+  /**
+   * Features menu should be created for.
+   *
+   * @var array
+   */
+  const FEATURES_WITH_MENU = [
+    'quotations',
+  ];
+
+  /**
+   * Modifies the navigation menu.
+   *
+   * @param array $menu
+   *   Menu Array.
+   */
+  public function run(array &$menu) {
+    $this->addFeaturesMenu($menu);
+  }
+
+  /**
+   * Adds enabled features menu to menu.
+   *
+   * @param array $menu
+   *   Tree of menu items, per hook_civicrm_navigationMenu.
+   */
+  private function addFeaturesMenu(array &$menu) {
+    try {
+
+      $caseInstancesGroup = $this->retrieveCaseInstanceWithEnabledFeatures();
+
+      foreach ($caseInstancesGroup as $caseInstances) {
+        $separator = 0;
+        $caseInstanceMenu = &$menu[$caseInstances['navigation_id']];
+        $caseInstanceName = $caseInstances['name'];
+        $caseInstanceName = ($caseInstanceName === 'Prospecting') ? 'prospect' : $caseInstanceName;
+        $desiredWeight = $this->moveMenuDown($caseInstanceMenu['child'], "manage_{$caseInstanceName}_workflows");
+
+        foreach ($caseInstances['items'] as $caseInstance) {
+          $caseInstanceMenu['child'][] = [
+            'attributes' => [
+              'label' => ts('Manage ' . $caseInstance['feature_id:label']),
+              'name' => 'Manage ' . $caseInstance['feature_id:label'],
+              'url' => "civicrm/case-features/a?case_type_category={$caseInstance['category_id']}#/{$caseInstance['feature_id:name']}",
+              'permission' => $caseInstanceMenu['attributes']['permission'],
+              'operator' => 'OR',
+              'parentID' => $caseInstanceMenu['attributes']['navID'],
+              'active' => 1,
+              'separator' => $separator++,
+              'weight' => $desiredWeight,
+            ],
+          ];
+        }
+      }
+    }
+    catch (\Throwable $th) {
+      \Civi::log()->error(E::ts("Error adding case instance features menu"), [
+        'context' => [
+          'backtrace' => $th->getTraceAsString(),
+          'message' => $th->getMessage(),
+        ],
+      ]);
+    }
+  }
+
+  /**
+   * Retrieves case instance that has the defined features enabled.
+   *
+   * @return array
+   *   Array of Key\Pair value grouped by case instance id.
+   */
+  private function retrieveCaseInstanceWithEnabledFeatures() {
+    $caseInstanceGroup = OptionGroup::get()->addWhere('name', '=', 'case_type_categories')->execute()[0] ?? NULL;
+
+    if (empty($caseInstanceGroup)) {
+      return [];
+    }
+
+    $result = CaseCategoryFeatures::get()
+      ->addSelect('*', 'option_value.label', 'option_value.name', 'feature_id:name', 'feature_id:label', 'navigation.id')
+      ->addJoin('OptionValue AS option_value', 'LEFT',
+      ['option_value.value', '=', 'category_id']
+    )
+      ->addJoin('Navigation AS navigation', 'LEFT',
+      ['navigation.name', '=', 'option_value.name']
+    )
+      ->addWhere('option_value.option_group_id', '=', $caseInstanceGroup['id'])
+      ->addWhere('feature_id:name', 'IN', self::FEATURES_WITH_MENU)
+      ->execute();
+
+    $caseCategoriesGroup = array_reduce((array) $result, function (array $accumulator, array $element) {
+      $accumulator[$element['category_id']]['items'][] = $element;
+      $accumulator[$element['category_id']]['navigation_id'] = $element['navigation.id'];
+      $accumulator[$element['category_id']]['name'] = $element['option_value.name'];
+
+      return $accumulator;
+    }, []);
+
+    return $caseCategoriesGroup;
+  }
+
+}

--- a/CRM/Civicase/Hook/PostProcess/SaveCaseCategoryFeature.php
+++ b/CRM/Civicase/Hook/PostProcess/SaveCaseCategoryFeature.php
@@ -47,10 +47,10 @@ class CRM_Civicase_Hook_PostProcess_SaveCaseCategoryFeature extends CRM_Civicase
     // Create new features link.
     $caseCategoryFeatures = new CRM_Civicase_Service_CaseTypeCategoryFeatures();
     foreach ($caseCategoryFeatures->getFeatures() as $feature) {
-      if (!empty($submittedValues['case_category_feature_' . $feature['id']])) {
+      if (!empty($submittedValues['case_category_feature_' . $feature['value']])) {
         CaseCategoryFeatures::create()
           ->addValue('category_id', $categoryId)
-          ->addValue('feature_id', $feature['id'])
+          ->addValue('feature_id', $feature['value'])
           ->execute();
       }
     }

--- a/CRM/Civicase/Service/CaseTypeCategoryFeatures.php
+++ b/CRM/Civicase/Service/CaseTypeCategoryFeatures.php
@@ -16,7 +16,6 @@ class CRM_Civicase_Service_CaseTypeCategoryFeatures {
     $optionValues = OptionValue::get()
       ->addSelect('id', 'label', 'value', 'name', 'option_group_id')
       ->addWhere('option_group_id:name', '=', self::NAME)
-      ->setLimit(25)
       ->execute();
 
     return $optionValues;

--- a/civicase.php
+++ b/civicase.php
@@ -408,6 +408,7 @@ function civicase_civicrm_check(&$messages) {
 function civicase_civicrm_navigationMenu(&$menu) {
   $hooks = [
     new CRM_Civicase_Hook_NavigationMenu_AlterForCaseMenu(),
+    new CRM_Civicase_Hook_NavigationMenu_CaseInstanceFeaturesMenu(),
   ];
 
   foreach ($hooks as $hook) {

--- a/sql/auto_install.sql
+++ b/sql/auto_install.sql
@@ -53,7 +53,7 @@ CREATE TABLE IF NOT EXISTS `civicrm_case_category_features` (
 -- * Sales order that represents quotations
 -- *
 -- *******************************************************/
-CREATE TABLE `civicase_sales_order` (
+CREATE TABLE IF NOT EXISTS `civicase_sales_order` (
   `id` int unsigned NOT NULL AUTO_INCREMENT COMMENT 'Unique CaseSalesOrder ID',
   `client_id` int unsigned COMMENT 'FK to Contact',
   `owner_id` int unsigned COMMENT 'FK to Contact',
@@ -81,7 +81,7 @@ ENGINE=InnoDB;
 -- * Sales order line items
 -- *
 -- *******************************************************/
-CREATE TABLE `civicase_sales_order_line` (
+CREATE TABLE IF NOT EXISTS `civicase_sales_order_line` (
   `id` int unsigned NOT NULL AUTO_INCREMENT COMMENT 'Unique CaseSalesOrderLine ID',
   `sales_order_id` int unsigned COMMENT 'FK to CaseSalesOrder',
   `financial_type_id` int unsigned COMMENT 'FK to CiviCRM Financial Type',


### PR DESCRIPTION
## Overview
In this PR we add the functionality to display the enabled extra features menu, under their respective CiviCase instance.

## Before
No menu support for extra features.

## After
If an extra feature is enabled for a CiviCase instance and the extra feature has support for menu, the menu will be displayed under the instance menu.
![aqqqqq](https://user-images.githubusercontent.com/85277674/220061301-aa89934a-3ae5-4552-987f-55afeebd2829.gif)


## Technical Details

This `the extra feature has support for menu` is currently hardcoded and only the `Quotations` feature is supported.
https://github.com/compucorp/uk.co.compucorp.civicase/blob/31d275c5516e348d92fdd386cd65ef298992df90/CRM/Civicase/Hook/NavigationMenu/CaseInstanceFeaturesMenu.php#L12-L19
In the future when adding menu support for other features we can add an input in the option value form, but that is beyond our current scope of work.
