### PR TITLE
BTHAB-23: Add API/Screen to create new quotation

### DIFF
--- a/CRM/Civicase/BAO/CaseSalesOrder.php
+++ b/CRM/Civicase/BAO/CaseSalesOrder.php
@@ -28,4 +28,63 @@ class CRM_Civicase_BAO_CaseSalesOrder extends CRM_Civicase_DAO_CaseSalesOrder {
     return $instance;
   }
 
+  /**
+   * Computes the sales order line item total.
+   *
+   * @param array $items
+   *   Array of sales order line items.
+   *
+   * @return array
+   *   ['totalAfterTax' => <value>, 'totalBeforeTax' => <value>]
+   */
+  public static function computeTotal(array $items) {
+    $totalBeforeTax = round(array_reduce($items, fn ($a, $b) => $a + self::getSubTotal($b), 0), 2);
+    $totalAfterTax = round(array_reduce($items,
+      fn ($a, $b) => $a + (($b['tax_rate'] * self::getSubTotal($b)) / 100),
+      0
+    ) + $totalBeforeTax, 2);
+
+    return [
+      'taxRates' => self::computeTaxRates($items),
+      'totalAfterTax' => $totalAfterTax,
+      'totalBeforeTax' => $totalBeforeTax,
+    ];
+  }
+
+  /**
+   * Computes the sub total of a single line item.
+   *
+   * @param array $item
+   *   Single sales order line item.
+   *
+   * @return int
+   *   The line item subtotal.
+   */
+  public static function getSubTotal(array $item) {
+    return $item['unit_price'] * $item['quantity'] * ((100 - ($item['discounted_percentage'] ?? 0)) / 100) ?? 0;
+  }
+
+  /**
+   * Computes the tax rates of each line item.
+   *
+   * @param array $items
+   *   Single sales order line item.
+   *
+   * @return array
+   *   Returned sorted array of line items tax rates.
+   */
+  public static function computeTaxRates(array $items) {
+    $items = array_filter($items, fn ($a) => $a['tax_rate'] > 0);
+    usort($items, fn ($a, $b) => $a['tax_rate'] <=> $b['tax_rate']);
+
+    return array_map(
+      fn ($a) =>
+      [
+        'rate' => round($a['tax_rate'], 2),
+        'value' => round(($a['tax_rate'] * self::getSubTotal($a)) / 100, 2),
+      ],
+      $items
+    );
+  }
+
 }

--- a/CRM/Civicase/Hook/NavigationMenu/CaseInstanceFeaturesMenu.php
+++ b/CRM/Civicase/Hook/NavigationMenu/CaseInstanceFeaturesMenu.php
@@ -1,8 +1,7 @@
 <?php
 
 use CRM_Certificate_ExtensionUtil as E;
-use Civi\Api4\CaseCategoryFeatures;
-use Civi\Api4\OptionGroup;
+use CRM_Civicase_Service_CaseTypeCategoryFeatures as CaseTypeCategoryFeatures;
 
 /**
  * Add menu for enabled features on Case instnace menus.
@@ -36,8 +35,8 @@ class CRM_Civicase_Hook_NavigationMenu_CaseInstanceFeaturesMenu extends CRM_Civi
    */
   private function addFeaturesMenu(array &$menu) {
     try {
-
-      $caseInstancesGroup = $this->retrieveCaseInstanceWithEnabledFeatures();
+      $caseTypeCategoryFeatures = new CaseTypeCategoryFeatures();
+      $caseInstancesGroup = $caseTypeCategoryFeatures->retrieveCaseInstanceWithEnabledFeatures(self::FEATURES_WITH_MENU);
 
       foreach ($caseInstancesGroup as $caseInstances) {
         $separator = 0;
@@ -71,42 +70,6 @@ class CRM_Civicase_Hook_NavigationMenu_CaseInstanceFeaturesMenu extends CRM_Civi
         ],
       ]);
     }
-  }
-
-  /**
-   * Retrieves case instance that has the defined features enabled.
-   *
-   * @return array
-   *   Array of Key\Pair value grouped by case instance id.
-   */
-  private function retrieveCaseInstanceWithEnabledFeatures() {
-    $caseInstanceGroup = OptionGroup::get()->addWhere('name', '=', 'case_type_categories')->execute()[0] ?? NULL;
-
-    if (empty($caseInstanceGroup)) {
-      return [];
-    }
-
-    $result = CaseCategoryFeatures::get()
-      ->addSelect('*', 'option_value.label', 'option_value.name', 'feature_id:name', 'feature_id:label', 'navigation.id')
-      ->addJoin('OptionValue AS option_value', 'LEFT',
-      ['option_value.value', '=', 'category_id']
-    )
-      ->addJoin('Navigation AS navigation', 'LEFT',
-      ['navigation.name', '=', 'option_value.name']
-    )
-      ->addWhere('option_value.option_group_id', '=', $caseInstanceGroup['id'])
-      ->addWhere('feature_id:name', 'IN', self::FEATURES_WITH_MENU)
-      ->execute();
-
-    $caseCategoriesGroup = array_reduce((array) $result, function (array $accumulator, array $element) {
-      $accumulator[$element['category_id']]['items'][] = $element;
-      $accumulator[$element['category_id']]['navigation_id'] = $element['navigation.id'];
-      $accumulator[$element['category_id']]['name'] = $element['option_value.name'];
-
-      return $accumulator;
-    }, []);
-
-    return $caseCategoriesGroup;
   }
 
 }

--- a/CRM/Civicase/Service/CaseTypeCategoryFeatures.php
+++ b/CRM/Civicase/Service/CaseTypeCategoryFeatures.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Api4\OptionGroup;
+use Civi\Api4\CaseCategoryFeatures;
 use Civi\Api4\OptionValue as OptionValue;
 
 /**
@@ -19,6 +21,45 @@ class CRM_Civicase_Service_CaseTypeCategoryFeatures {
       ->execute();
 
     return $optionValues;
+  }
+
+  /**
+   * Retrieves case instance that has the defined features enabled.
+   *
+   * @param array $features
+   *   The features to retrieve case instances for.
+   *
+   * @return array
+   *   Array of Key\Pair value grouped by case instance id.
+   */
+  public function retrieveCaseInstanceWithEnabledFeatures(array $features) {
+    $caseInstanceGroup = OptionGroup::get()->addWhere('name', '=', 'case_type_categories')->execute()[0] ?? NULL;
+
+    if (empty($caseInstanceGroup)) {
+      return [];
+    }
+
+    $result = CaseCategoryFeatures::get()
+      ->addSelect('*', 'option_value.label', 'option_value.name', 'feature_id:name', 'feature_id:label', 'navigation.id')
+      ->addJoin('OptionValue AS option_value', 'LEFT',
+      ['option_value.value', '=', 'category_id']
+    )
+      ->addJoin('Navigation AS navigation', 'LEFT',
+      ['navigation.name', '=', 'option_value.name']
+    )
+      ->addWhere('option_value.option_group_id', '=', $caseInstanceGroup['id'])
+      ->addWhere('feature_id:name', 'IN', $features)
+      ->execute();
+
+    $caseCategoriesGroup = array_reduce((array) $result, function (array $accumulator, array $element) {
+      $accumulator[$element['category_id']]['items'][] = $element;
+      $accumulator[$element['category_id']]['navigation_id'] = $element['navigation.id'];
+      $accumulator[$element['category_id']]['name'] = $element['option_value.name'];
+
+      return $accumulator;
+    }, []);
+
+    return $caseCategoriesGroup;
   }
 
 }

--- a/CRM/Civicase/Test/Fabricator/Product.php
+++ b/CRM/Civicase/Test/Fabricator/Product.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Fabricates cases.
+ */
+class CRM_Civicase_Test_Fabricator_Product {
+
+  /**
+   * Default Parameters.
+   *
+   * @var array
+   */
+  private static $defaultParams = [
+    'name' => 'test',
+    'description' => 'test',
+    'sku' => 'test',
+    'price' => 20,
+  ];
+
+  /**
+   * Fabricate Case.
+   *
+   * @param array $params
+   *   Parameters.
+   *
+   * @return mixed
+   *   Api result.
+   */
+  public static function fabricate(array $params = []) {
+    $params = array_merge(self::$defaultParams, $params);
+    $result = civicrm_api4('Product', 'create', [
+      'values' => $params,
+    ])->jsonSerialize();
+
+    return array_shift($result);
+  }
+
+}

--- a/Civi/Api4/Action/CaseSalesOrder/ComputeTotalAction.php
+++ b/Civi/Api4/Action/CaseSalesOrder/ComputeTotalAction.php
@@ -8,13 +8,13 @@ use Civi\Api4\Generic\Traits\DAOActionTrait;
 use CRM_Civicase_BAO_CaseSalesOrder as CaseSalesOrderBAO;
 
 /**
- * Computes the total of a sales order
+ * Computes the total of a sales order.
  */
 class ComputeTotalAction extends AbstractAction {
   use DAOActionTrait;
 
   /**
-   * Sales order line items
+   * Sales order line items.
    *
    * @var array
    * @required
@@ -25,9 +25,9 @@ class ComputeTotalAction extends AbstractAction {
    * {@inheritDoc}
    */
   public function _run(Result $result) { // phpcs:ignore
-   if (is_array($this->lineItems)) {
-    $result[] = CaseSalesOrderBAO::computeTotal($this->lineItems);
-   }
+    if (is_array($this->lineItems)) {
+      $result[] = CaseSalesOrderBAO::computeTotal($this->lineItems);
+    }
   }
 
 }

--- a/Civi/Api4/Action/CaseSalesOrder/ComputeTotalAction.php
+++ b/Civi/Api4/Action/CaseSalesOrder/ComputeTotalAction.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Civi\Api4\Action\CaseSalesOrder;
+
+use Civi\Api4\Generic\Result;
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Traits\DAOActionTrait;
+use CRM_Civicase_BAO_CaseSalesOrder as CaseSalesOrderBAO;
+
+/**
+ * Computes the total of a sales order
+ */
+class ComputeTotalAction extends AbstractAction {
+  use DAOActionTrait;
+
+  /**
+   * Sales order line items
+   *
+   * @var array
+   * @required
+   */
+  protected $lineItems;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function _run(Result $result) { // phpcs:ignore
+   if (is_array($this->lineItems)) {
+    $result[] = CaseSalesOrderBAO::computeTotal($this->lineItems);
+   }
+  }
+
+}

--- a/Civi/Api4/Action/CaseSalesOrder/ComputeTotalAction.php
+++ b/Civi/Api4/Action/CaseSalesOrder/ComputeTotalAction.php
@@ -17,7 +17,6 @@ class ComputeTotalAction extends AbstractAction {
    * Sales order line items.
    *
    * @var array
-   * @required
    */
   protected $lineItems;
 

--- a/Civi/Api4/Action/CaseSalesOrder/SalesOrderSaveAction.php
+++ b/Civi/Api4/Action/CaseSalesOrder/SalesOrderSaveAction.php
@@ -54,7 +54,7 @@ class SalesOrderSaveAction extends AbstractSaveAction {
           array_walk($lineItems, function (&$lineItem) use ($result, $caseSalesOrderLineAPI) {
             $lineItem['sales_order_id'] = $result['id'];
             $caseSalesOrderLineAPI->addRecord($lineItem);
-        });
+          });
 
           $result['items'] = $caseSalesOrderLineAPI->execute()->jsonSerialize();
         }

--- a/Civi/Api4/Action/CaseSalesOrder/SalesOrderSaveAction.php
+++ b/Civi/Api4/Action/CaseSalesOrder/SalesOrderSaveAction.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Civi\Api4\Action\CaseSalesOrder;
+
+use CRM_Core_Transaction;
+use Civi\Api4\Generic\Result;
+use Civi\Api4\CaseSalesOrderLine;
+use Civi\Api4\Generic\AbstractSaveAction;
+use Civi\Api4\Generic\Traits\DAOActionTrait;
+use CRM_Civicase_BAO_CaseSalesOrder as CaseSalesOrderBAO;
+
+/**
+ * {@inheritDoc}
+ */
+class SalesOrderSaveAction extends AbstractSaveAction {
+  use DAOActionTrait;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function _run(Result $result) { // phpcs:ignore
+    foreach ($this->records as &$record) {
+      $record += $this->defaults;
+      $this->formatWriteValues($record);
+      $this->matchExisting($record);
+      if (empty($record['id'])) {
+        $this->fillDefaults($record);
+      }
+    }
+    $this->validateValues();
+
+    $resultArray = $this->writeRecord($this->records);
+
+    $result->exchangeArray($resultArray);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function writeRecord($items) {
+    $transaction = CRM_Core_Transaction::create();
+
+    try {
+      $output = [];
+      foreach ($items as $salesOrder) {
+        $lineItems = $salesOrder['items'];
+        $total = CaseSalesOrderBAO::computeTotal($lineItems);
+        $salesOrder['total_before_tax'] = $total['totalBeforeTax'];
+        $salesOrder['total_after_tax'] = $total['totalAfterTax'];
+        $result = array_pop($this->writeObjects([$salesOrder]));
+
+        $caseSalesOrderLineAPI = CaseSalesOrderLine::save();
+        if (!empty($result) && !empty($lineItems)) {
+          array_walk($lineItems, function (&$lineItem) use ($result, $caseSalesOrderLineAPI) {
+            $lineItem['sales_order_id'] = $result['id'];
+            $caseSalesOrderLineAPI->addRecord($lineItem);
+        });
+
+          $result['items'] = $caseSalesOrderLineAPI->execute()->jsonSerialize();
+        }
+
+        $output[] = $result;
+      }
+
+      return $output;
+    }
+    catch (\Exception $e) {
+      $transaction->rollback();
+
+      throw $e;
+    }
+  }
+
+}

--- a/Civi/Api4/Action/CaseSalesOrder/SalesOrderSaveAction.php
+++ b/Civi/Api4/Action/CaseSalesOrder/SalesOrderSaveAction.php
@@ -47,7 +47,8 @@ class SalesOrderSaveAction extends AbstractSaveAction {
         $total = CaseSalesOrderBAO::computeTotal($lineItems);
         $salesOrder['total_before_tax'] = $total['totalBeforeTax'];
         $salesOrder['total_after_tax'] = $total['totalAfterTax'];
-        $result = array_pop($this->writeObjects([$salesOrder]));
+        $salesOrders = $this->writeObjects([$salesOrder]);
+        $result = array_pop($salesOrders);
 
         $caseSalesOrderLineAPI = CaseSalesOrderLine::save();
         if (!empty($result) && !empty($lineItems)) {

--- a/Civi/Api4/CaseSalesOrder.php
+++ b/Civi/Api4/CaseSalesOrder.php
@@ -3,6 +3,7 @@
 namespace Civi\Api4;
 
 use Civi\Api4\Generic\DAOEntity;
+use Civi\Api4\Action\CaseSalesOrder\ComputeTotalAction;
 use Civi\Api4\Action\CaseSalesOrder\SalesOrderSaveAction;
 
 /**
@@ -25,6 +26,20 @@ class CaseSalesOrder extends DAOEntity {
    */
   public static function save($checkPermissions = TRUE) {
     return (new SalesOrderSaveAction(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * Compute the sum of the line items value.
+   *
+   * @param bool $checkPermissions
+   *   Should permission be checked for the user.
+   *
+   * @return Civi\Api4\Action\CaseSalesOrder\SalesOrderSaveAction
+   *   returns save order action
+   */
+  public static function computeTotal($checkPermissions = FALSE) {
+    return (new ComputeTotalAction(__CLASS__, __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 

--- a/Civi/Api4/CaseSalesOrder.php
+++ b/Civi/Api4/CaseSalesOrder.php
@@ -3,6 +3,7 @@
 namespace Civi\Api4;
 
 use Civi\Api4\Generic\DAOEntity;
+use Civi\Api4\Action\CaseSalesOrder\SalesOrderSaveAction;
 
 /**
  * CaseSalesOrder entity.
@@ -12,5 +13,19 @@ use Civi\Api4\Generic\DAOEntity;
  * @package Civi\Api4
  */
 class CaseSalesOrder extends DAOEntity {
+
+  /**
+   * Creates or Updates a SalesOrder with the line items.
+   *
+   * @param bool $checkPermissions
+   *   Should permission be checked for the user.
+   *
+   * @return Civi\Api4\Action\CaseSalesOrder\SalesOrderSaveAction
+   *   returns save order action
+   */
+  public static function save($checkPermissions = TRUE) {
+    return (new SalesOrderSaveAction(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
 
 }

--- a/Civi/Utils/CurrencyUtils.php
+++ b/Civi/Utils/CurrencyUtils.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Civi\Utils;
+
+use CRM_Core_DAO;
+
+/**
+ * Utility class to manage CiviCRM currency table.
+ */
+class CurrencyUtils {
+
+  /**
+   * CiviCRM Currencies.
+   *
+   * @var array
+   */
+  private static $currencies;
+
+  /**
+   * Returns a list of currencies supported by CiviCRM.
+   *
+   * @return array
+   *   array reference of all currency names and symbols
+   */
+  public static function getCurrencies() {
+    if (!self::$currencies) {
+      $query = "SELECT name, symbol FROM civicrm_currency";
+      $dao = CRM_Core_DAO::executeQuery($query);
+      self::$currencies = [];
+      while ($dao->fetch()) {
+        self::$currencies[] = ['name' => $dao->name, 'symbol' => $dao->symbol];
+      }
+    }
+
+    return self::$currencies;
+  }
+
+}

--- a/ang/civicase-features.ang.php
+++ b/ang/civicase-features.ang.php
@@ -8,7 +8,16 @@
  * http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules.
  */
 
+use Civi\Api4\OptionValue;
+use Civi\Utils\CurrencyUtils;
 use CRM_Civicase_Helper_GlobRecursive as GlobRecursive;
+use CRM_Civicase_Service_CaseTypeCategoryFeatures as CaseTypeCategoryFeatures;
+
+$options = [];
+
+set_currency_codes($options);
+set_case_sales_order_status($options);
+set_case_types_with_quotations_enabled($options);
 
 /**
  * Get a list of JS files.
@@ -28,22 +37,48 @@ function getFeaturesJsFiles() {
   );
 }
 
+/**
+ * Exposes currency codes to Angular.
+ */
+function set_currency_codes(&$options) {
+  $options['currencyCodes'] = CurrencyUtils::getCurrencies();
+}
+
+/**
+ * Exposes Case types that have quotations enabled to Angular.
+ */
+function set_case_types_with_quotations_enabled(&$options) {
+  $caseTypeCategoryFeatures = new CaseTypeCategoryFeatures();
+  $caseTypeCategories = $caseTypeCategoryFeatures->retrieveCaseInstanceWithEnabledFeatures(['quotations']);
+  $options['featureCaseTypes']['quotations'] = array_keys($caseTypeCategories);
+}
+
+/**
+ * Exposes case sales order statuses to Angular.
+ */
+function set_case_sales_order_status(&$options) {
+  $optionValues = OptionValue::get()
+    ->addSelect('id', 'value', 'name', 'label')
+    ->addWhere('option_group_id:name', '=', 'case_sales_order_status')
+    ->execute();
+
+  $options['salesOrderStatus'] = $optionValues->getArrayCopy();
+}
+
 $requires = [
-  'crmUi',
-  'crmCaseType',
-  'ngRoute',
-  'dialogService',
+  'api4',
+  'crmUtil',
+  'civicase',
   'civicase-base',
   'afsearchQuotations',
 ];
-
-$requires = CRM_Workflow_Hook_addDependentAngularModules::invoke($requires);
 
 return [
   'css' => [
     'css/*.css',
   ],
   'js' => getFeaturesJsFiles(),
+  'settings' => $options,
   'requires' => $requires,
   'partials' => [
     'ang/civicase-features',

--- a/ang/civicase-features/app.routes.js
+++ b/ang/civicase-features/app.routes.js
@@ -10,5 +10,13 @@
         `;
       }
     });
+    $routeProvider.when('/new', {
+      template: function () {
+        var urlParams = UrlParametersProvider.parse(window.location.search);
+        return `
+          <quotations-create case-type-category=${urlParams.case_type_category}"> </quotations-create>
+        `;
+      }
+    });
   });
 })(angular, CRM.$, CRM._);

--- a/ang/civicase-features/quotations/directives/quotations-create.directive.html
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.html
@@ -1,0 +1,247 @@
+<div id="bootstrap-theme" class="civicase__container">
+  <h1 crm-page-title>{{ ts('Create Quotations') }}</h1>
+
+  <div class="panel panel-default">
+    <div class="panel-body">
+      <form name="quotationsForm" class="form-horizontal">
+        <div class="form-group">
+          <label class="col-sm-2 control-label required-mark">
+            Client
+          </label>
+          <div class="col-sm-5">
+            <input class="form-control"
+              ng-model="salesOrder.client_id"
+              placeholder="Client"
+              name="client"
+              crm-entityref="{
+                entity: 'Contact',
+                select: { multiple: true, allowClear: true }
+              }"
+              required
+              ng-minlength="1"
+            />
+            <span class="crm-inline-error" ng-show="quotationsForm.client.$dirty && quotationsForm.client.$invalid && quotationsForm.client.$error.required">Client is required</span>
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-2 control-label required-mark">
+            Date
+          </label>
+          <div class="col-sm-5 civicase__ui-range">
+              <input
+                class="form-control" crm-ui-datepicker="{time: false}" id="sales_order_date"
+                ng-model="salesOrder.quotation_date" placeholder="Date" name="date" required/>
+                <span class="crm-inline-error" ng-show="quotationsForm.date.$dirty && quotationsForm.date.$invalid">Date is required</span>
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-2 control-label required-mark">
+            Description
+          </label>
+          <div class="col-sm-5">
+            <textarea name="description" ng-model="salesOrder.description" class="crm-form-wysiwyg" id="sales-order-description" required></textarea>
+            <span class="crm-inline-error" ng-show="quotationsForm.description.$dirty && quotationsForm.description.$invalid && quotationsForm.description.$error.required">Description is required</span>
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-2 control-label">
+            Case/Opportunity
+          </label>
+          <div class="col-sm-5">
+            <input class="form-control"
+              ng-model="salesOrder.case_id"
+              placeholder="Case"
+              name="case"
+              crm-entityref="{
+                entity: 'Case',
+                select: { multiple: false, allowClear: true },
+                api: caseApiParam(),
+              }"
+            />
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-2 control-label required-mark">
+            {{ts('Owner')}}
+          </label>
+          <div class="col-sm-5">
+            <input class="form-control"
+              ng-model="salesOrder.owner"
+              name="owner"
+              placeholder="Owner"
+              crm-entityref="{
+                create: true,
+                entity: 'Contact',
+                select: { multiple: true, allowClear: true }
+              }"
+              required
+              ng-minlength="1"
+            />
+            <span class="crm-inline-error" ng-show="quotationsForm.owner.$dirty && quotationsForm.owner.$invalid && quotationsForm.owner.$error.required">Owner is required</span>
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-2 control-label required-mark">
+            {{ts('Status')}}
+          </label>
+          <div class="col-sm-5">
+            <select class="form-control"
+              ng-model="salesOrder.status_id"
+              name="status"
+              required
+            >
+              <option value="">{{ ts('Status') }}</option>
+              <option ng-repeat="stauts in salesOrderStatus track by $index" value="{{ salesOrderStatus[$index].value }}">{{ salesOrderStatus[$index].label }}</option>
+            </select>
+            <span class="crm-inline-error" ng-show="quotationsForm.status.$dirty && quotationsForm.status.$invalid && quotationsForm.status.$error.required">Status is required</span>
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-2 control-label required-mark">
+            {{ts('Currency')}}
+          </label>
+          <div class="col-sm-5">
+            <select class="form-control"
+              ng-model="salesOrder.currency"
+              ng-change="handleCurrencyChange()"
+              placeholder="Currency"
+              name="currency"
+              required
+            >
+            <option value="">{{ ts('Currency') }}</option>
+            <option ng-repeat="currency in currencyCodes track by $index" value="{{ currencyCodes[$index].name }}">{{ currencyCodes[$index].name }}</option>
+            </select>
+            <span class="crm-inline-error" ng-show="quotationsForm.currency.$dirty && quotationsForm.currency.$invalid && quotationsForm.currency.$error.required">Currency is required</span>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label class="col-sm-2 control-label required-mark">
+            {{ts('Item')}}
+          </label>
+          <div class="col-sm-9">
+           <table class="table table-bordered">
+            <tr>
+              <th>Product</th>
+              <th class="required-mark">Item Description </th>
+              <th class="required-mark">Financial Type</th>
+              <th class="required-mark">Unit Price</th>
+              <th class="required-mark">Quantity</th>
+              <th>Discount %</th>
+              <th>Tax %</th>
+              <th>Subtotal</th>
+              <th></th>
+            </tr>
+            <tr ng-repeat="item in salesOrder.items track by $index">
+              <td>
+                <input class="form-control"
+                  ng-model="salesOrder.items[$index].product_id"
+                  ng-change="handleProductChange($index)"
+                  placeholder="Product"
+                  crm-entityref="{
+                    entity: 'Product',
+                    create: true,
+                    select: { allowClear: true, 'minimumInputLength': 0, create: true }
+                  }"
+                  ng-minlength="1"
+                />
+              </td>
+              <td>
+                <input type="text" name="item_description_{{$index}}" ng-model="salesOrder.items[$index].item_description" class="form-control" required />
+                <br />
+                <span class="crm-inline-error" ng-show="quotationsForm.item_description_{{$index}}.$dirty && quotationsForm.item_description_{{$index}}.$invalid && quotationsForm.item_description_{{$index}}.$error.required">Description is required</span>
+              </td>
+              <td>
+                <input class="form-control"
+                  ng-model="salesOrder.items[$index].financial_type_id"
+                  ng-change="handleFinancialTypeChange($index)"
+                  name="financial_type_{{$index}}"
+                  placeholder="Financial Type"
+                  crm-entityref="{
+                    entity: 'Financial Type',
+                    select: { allowClear: true, 'minimumInputLength': 0 }
+                  }"
+                  required
+                  ng-minlength="1"
+                />
+                <br />
+                <span class="crm-inline-error" ng-show="quotationsForm.financial_type_{{$index}}.$dirty && quotationsForm.financial_type_{{$index}}.$invalid && quotationsForm.financial_type_{{$index}}.$error.required">Financial Type is required</span>
+              </td>
+              <td>
+                <div class="input-group" style="width: 8em;">
+                  <span class="input-group-addon">{{ currencySymbol }}</span>
+                  <input type="number" name="unit_price_{{$index}}" required placeholder="Unit Price" ng-model="salesOrder.items[$index].unit_price" ng-change="calculateSubtotal($index)" class="form-control" />
+                </div>
+                <br />
+                <span class="crm-inline-error" ng-show="quotationsForm.unit_price_{{$index}}.$dirty && quotationsForm.unit_price_{{$index}}.$invalid && quotationsForm.unit_price_{{$index}}.$error.required">Unit price is required</span>
+              </td>
+              <td>
+                <div class="input-group" style="width: 8em;">
+                  <input type="number" name="quantity_{{$index}}" required placeholder="Quantity" ng-model="salesOrder.items[$index].quantity" class="form-control" ng-change="calculateSubtotal($index)" />
+                </div>
+                <br />
+                <span class="crm-inline-error" ng-show="quotationsForm.quantity_{{$index}}.$dirty && quotationsForm.quantity_{{$index}}.$invalid && quotationsForm.quantity_{{$index}}.$error.required">Quantity is required</span>
+              </td>
+              <td>
+                <div class="input-group" style="width: 8em;">
+                  <input type="number" min="0" max="100" name="discounted_percentage" placeholder="Discount" ng-model="salesOrder.items[$index].discounted_percentage" class="form-control" ng-change="calculateSubtotal($index)" />
+                </div>
+              </td>
+              <td>
+                {{ roundTo(salesOrder.items[$index].tax_rate, 2) }}
+              </td>
+              <td>{{ roundTo(salesOrder.items[$index].subtotal_amount, 2) }}</td>
+              <td><a ng-if="salesOrder.items.length > 1" href ng-click="removeSalesOrderItem($index)" ><i class="fa fa-trash"></i></a></td>
+            </tr>
+           </table>
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-2"></label>
+          <div class="col-sm-3">
+            <button class="btn btn-secondary" ng-click="newSalesOrderItem()" type="button"><span><i class="fa fa-plus"></i></span>{{ ts(' Add New') }}</button>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label class="col-sm-2"></label>
+          <div class="col-sm-3">
+            <table class="table">
+              <tr><th>Total</th><td>{{ currencySymbol }} {{ salesOrder.total }}</td></tr>
+                <tr ng-repeat="i in taxRates">
+                  <th>Tax @ {{ i.rate }}%</th>
+                  <td>{{ currencySymbol }} {{ i.value }}</td>
+                </tr>
+              <tr><th>Grand Total</th><td>{{ currencySymbol }} {{salesOrder.grandTotal}}</td></tr>
+            </table>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label class="col-sm-2 control-label">
+            {{ts('Notes')}}
+          </label>
+          <div class="col-sm-5">
+            <textarea name="notes" rows="5" cols="20" style="width: 100%;" ng-model="salesOrder.notes"></textarea>
+          </div>
+        </div>
+
+
+        <div class="form-group">
+          <div class="col-sm-12">
+            <div class="clearfix">
+              <div class="pull-left">
+                <button type="button" class="btn btn-primary-outline cancel" history-back>
+                  <span class="btn-icon"></span> {{ts('Cancel')}}</button>
+                  </div>
+                <div class="pull-right">
+                <button type="submit" class="btn btn-primary" ng-disabled="submitInProgress" ng-click="saveQuotation()">
+                  <span class="btn-icon"></span> {{ts('Save')}}</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/ang/civicase-features/quotations/directives/quotations-create.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.js
@@ -1,0 +1,287 @@
+(function (angular, $, _) {
+  var module = angular.module('civicase-features');
+
+  module.directive('quotationsCreate', function () {
+    return {
+      restrict: 'E',
+      controller: 'quotationsCreateController',
+      templateUrl: '~/civicase-features/quotations/directives/quotations-create.directive.html',
+      scope: {}
+    };
+  });
+
+  module.controller('quotationsCreateController', quotationsCreateController);
+
+  /**
+   * @param {object} $scope the controller scope
+   * @param {object} $window window object of the browser
+   * @param {object} CurrencyCodes CurrencyCodes service
+   * @param {Function} civicaseCrmApi crm api service
+   * @param {object} Contact contact service
+   * @param {object} crmApi4 api V4 service
+   * @param {object} FeatureCaseTypes FeatureCaseTypes service
+   * @param {object} SalesOrderStatus SalesOrderStatus service
+   */
+  function quotationsCreateController ($scope, $window, CurrencyCodes, civicaseCrmApi, Contact, crmApi4, FeatureCaseTypes, SalesOrderStatus) {
+    const defaultCurrency = 'GBP';
+    const productsCache = new Map();
+    const financialTypesCache = new Map();
+
+    $scope.formValid = true;
+    $scope.roundTo = roundTo;
+    $scope.submitInProgress = false;
+    $scope.caseApiParam = caseApiParam;
+    $scope.saveQuotation = saveQuotation;
+    $scope.calculateSubtotal = calculateSubtotal;
+    $scope.currencyCodes = CurrencyCodes.getAll();
+    $scope.handleProductChange = handleProductChange;
+    $scope.handleCurrencyChange = handleCurrencyChange;
+    $scope.salesOrderStatus = SalesOrderStatus.getAll();
+    $scope.handleFinancialTypeChange = handleFinancialTypeChange;
+    $scope.currencySymbol = CurrencyCodes.getSymbol(defaultCurrency);
+
+    (function init () {
+      initializeSalesOrder();
+      $scope.newSalesOrderItem = newSalesOrderItem;
+      CRM.wysiwyg.create('#sales-order-description');
+      $scope.removeSalesOrderItem = removeSalesOrderItem;
+
+      $scope.$on('totalChange', _.debounce(handleTotalChange, 250));
+    }());
+
+    /**
+     * Initializess the sales order object
+     */
+    function initializeSalesOrder () {
+      $scope.salesOrder = {
+        currency: defaultCurrency,
+        status_id: SalesOrderStatus.getValueByName('new'),
+        owner_id: Contact.getCurrentContactID(),
+        quotation_date: $.datepicker.formatDate('yy-mm-dd', new Date()),
+        items: [{
+          product_id: null,
+          item_description: null,
+          financial_type_id: null,
+          unit_price: null,
+          quantity: null,
+          discounted_percentage: null,
+          tax_rate: 0,
+          subtotal_amount: 0
+        }],
+        total: 0,
+        grandTotal: 0
+      };
+      $scope.total = 0;
+      $scope.taxRates = [];
+    }
+
+    /**
+     * Removes a sales order line item
+     *
+     * @param {number} index element index to be removed
+     */
+    function removeSalesOrderItem (index) {
+      $scope.salesOrder.items.splice(index, 1);
+    }
+
+    /**
+     * Initializes empty sales order line item
+     */
+    function newSalesOrderItem () {
+      $scope.salesOrder.items.push({
+        product: null,
+        description: null,
+        financial_type_id: null,
+        unit_price: null,
+        quantity: null,
+        discounted_percentage: null,
+        tax_rate: 0,
+        subtotal_amount: 0
+      });
+    }
+
+    /**
+     * Persists quotaiton and redirects on success
+     */
+    function saveQuotation () {
+      if (!validateForm()) {
+        return;
+      }
+
+      $scope.submitInProgress = true;
+      crmApi4('CaseSalesOrder', 'save', { records: [$scope.salesOrder] })
+        .then(function (results) {
+          $scope.submitInProgress = false;
+          showSucessNotification();
+          redirectToAppropraitePage();
+        }, function (failure) {
+          $scope.submitInProgress = false;
+          CRM.alert('Unable to generate quotations', ts('Error'), 'error');
+        });
+    }
+
+    /**
+     * Validates form before saving
+     *
+     * @returns {boolean} true if form is valid, otherwise false
+     */
+    function validateForm () {
+      angular.forEach($scope.quotationsForm.$$controls, function (control) {
+        control.$setDirty();
+        control.$validate();
+      });
+
+      return $scope.quotationsForm.$valid;
+    }
+
+    /**
+     * Updates description and unit price if user selects a product
+     *
+     * @param {*} index index of the sales order line item
+     */
+    function handleProductChange (index) {
+      if (!$scope.salesOrder.items[index].product_id) {
+        return;
+      }
+      const updateProductDependentFields = (productId) => {
+        $scope.salesOrder.items[index].item_description = productsCache.get(productId).description;
+        $scope.salesOrder.items[index].unit_price = parseFloat(productsCache.get(productId).price);
+        calculateSubtotal(index);
+      };
+
+      const productId = $scope.salesOrder.items[index].product_id;
+      if (productsCache.has(productId)) {
+        updateProductDependentFields(productId);
+        return;
+      }
+
+      civicaseCrmApi('Product', 'get', { id: productId })
+        .then(function (result) {
+          if (result.count > 0) {
+            productsCache.set(productId, result.values[productId]);
+            updateProductDependentFields(productId);
+          }
+        });
+    }
+
+    /**
+     * Update currency symbol if currecny field is upddated
+     */
+    function handleCurrencyChange () {
+      $scope.currencySymbol = CurrencyCodes.getSymbol($scope.salesOrder.currency);
+    }
+
+    /**
+     * Update tax filed and regenrate line item tax rates for line itme financial types
+     *
+     * @param {number} index index of the sales order line item
+     */
+    function handleFinancialTypeChange (index) {
+      $scope.salesOrder.items[index].tax_rate = 0;
+      $scope.$emit('totalChange');
+
+      const updateFinancialTypeDependentFields = (financialTypeId) => {
+        $scope.salesOrder.items[index].tax_rate = financialTypesCache.get(financialTypeId).tax_rate;
+        $scope.$emit('totalChange');
+      };
+
+      const financialTypeId = $scope.salesOrder.items[index].financial_type_id;
+      if (financialTypeId && financialTypesCache.has(financialTypeId)) {
+        updateFinancialTypeDependentFields(financialTypeId);
+        return;
+      }
+
+      if (financialTypeId) {
+        civicaseCrmApi('EntityFinancialAccount', 'get', {
+          account_relationship: 'Sales Tax Account is',
+          entity_table: 'civicrm_financial_type',
+          entity_id: financialTypeId,
+          'api.FinancialAccount.get': { id: '$value.financial_account_id' }
+        })
+          .then(function (result) {
+            if (result.count > 0) {
+              financialTypesCache.set(financialTypeId, Object.values(result.values)[0]['api.FinancialAccount.get'].values[0]);
+              updateFinancialTypeDependentFields(financialTypeId);
+            }
+          });
+      }
+    }
+
+    /**
+     * Sums sales order line item without tax, and computes tax rates separately
+     *
+     * @param {number} index index of the sales order line item
+     */
+    function calculateSubtotal (index) {
+      const item = $scope.salesOrder.items[index];
+      if (!item) {
+        return;
+      }
+
+      item.subtotal_amount = item.unit_price * item.quantity * ((100 - item.discounted_percentage) / 100) || 0;
+      $scope.$emit('totalChange');
+    }
+
+    /**
+     * Rounds floating ponumber n to specified number of places
+     *
+     * @param {*} n number to round
+     * @param {*} place decimal places to round to
+     * @returns {number} the rounded off number
+     */
+    function roundTo (n, place) {
+      return +(Math.round(n + 'e+' + place) + 'e-' + place);
+    }
+
+    /**
+     * Show Quotation success create notification
+     */
+    function showSucessNotification () {
+      CRM.alert('Your Quotation has been generated successfully.', ts('Saved'), 'success');
+    }
+
+    /**
+     * Handles page rediection after successfully creating quotation.
+     *
+     * redirects to main quotation list page if no case is selected
+     * else redirects to the case view of the selected case.
+     */
+    function redirectToAppropraitePage () {
+      if (!$scope.salesOrder.case_id) {
+        $window.location.href = 'a#/quotations';
+      }
+
+      const params = { id: $scope.salesOrder.case_id, return: ['case_type_category', 'case_type_id'] };
+      civicaseCrmApi('Case', 'getdetails', params)
+        .then(function (result) {
+          const categoryId = result.values[$scope.salesOrder.case_id].case_type_category;
+          $window.location.href = `../case/a/case_type_category=${categoryId}` +
+          `#/case/list?caseId=${$scope.salesOrder.case_id}&` +
+          `cf=%7B"case_type_category":"${categoryId}"%7D`;
+        });
+    }
+
+    /**
+     * @returns {object} api parameters for Case.getlist
+     */
+    function caseApiParam () {
+      const caseTypeCategoryId = FeatureCaseTypes.getCaseTypes('quotations');
+      return { params: { 'case_id.case_type_id.case_type_category': { IN: caseTypeCategoryId } } };
+    }
+
+    /**
+     * Computes total and tax rates from API
+     */
+    function handleTotalChange () {
+      crmApi4('CaseSalesOrder', 'computeTotal', {
+        lineItems: $scope.salesOrder.items
+      }).then(function (results) {
+        $scope.taxRates = results[0].taxRates;
+        $scope.salesOrder.total = results[0].totalBeforeTax;
+        $scope.salesOrder.grandTotal = results[0].totalAfterTax;
+      }, function (failure) {
+        // handle failure
+      });
+    }
+  }
+})(angular, CRM.$, CRM._);

--- a/ang/civicase-features/quotations/directives/quotations-list.directive.html
+++ b/ang/civicase-features/quotations/directives/quotations-list.directive.html
@@ -2,7 +2,7 @@
   <h1 crm-page-title>{{ ts('Manage Quotations') }}</h1>
 
     <a
-      ng-click="redirectToWorkflowCreationScreen()"
+      ng-click="redirectToQuotationCreationScreen()"
       class="btn btn-primary civicase-workflow-list__new-button">
       <i class="material-icons">add_circle</i>
     {{:: ts('Create Quotation') }}

--- a/ang/civicase-features/quotations/directives/quotations-list.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-list.directive.js
@@ -14,8 +14,16 @@
 
   /**
    * @param {object} $scope the controller scope
+   * @param {object} $window window object of the browser
    */
-  function quotationsListController ($scope) {
+  function quotationsListController ($scope, $window) {
+    $scope.redirectToQuotationCreationScreen = redirectToQuotationCreationScreen;
 
+    /**
+     * Redirect user to new quotation screen
+     */
+    function redirectToQuotationCreationScreen () {
+      $window.location.href = '/civicrm/case-features/a#/new';
+    }
   }
 })(angular, CRM._);

--- a/ang/civicase-features/services/currency-codes.service.js
+++ b/ang/civicase-features/services/currency-codes.service.js
@@ -1,0 +1,21 @@
+(function (angular, $, _, CRM) {
+  var module = angular.module('civicase-features');
+
+  module.service('CurrencyCodes', CurrencyCodes);
+
+  /**
+   * CurrencyCodes Service
+   */
+  function CurrencyCodes () {
+    this.getAll = function () {
+      return CRM['civicase-features'].currencyCodes;
+    };
+
+    this.getSymbol = function (name) {
+      return CRM['civicase-features']
+        .currencyCodes
+        .filter(currency => currency.name === name)
+        .pop().symbol || '£';
+    };
+  }
+})(angular, CRM.$, CRM._, CRM);

--- a/ang/civicase-features/services/feature-case-types.service.js
+++ b/ang/civicase-features/services/feature-case-types.service.js
@@ -1,0 +1,14 @@
+(function (angular, $, _, CRM) {
+  var module = angular.module('civicase-features');
+
+  module.service('FeatureCaseTypes', FeatureCaseTypes);
+
+  /**
+   * FeatureCaseTypes Service
+   */
+  function FeatureCaseTypes () {
+    this.getCaseTypes = function ($feature) {
+      return CRM['civicase-features'].featureCaseTypes[$feature] || [];
+    };
+  }
+})(angular, CRM.$, CRM._, CRM);

--- a/ang/civicase-features/services/sales-order-status.service.js
+++ b/ang/civicase-features/services/sales-order-status.service.js
@@ -1,0 +1,21 @@
+(function (angular, $, _, CRM) {
+  var module = angular.module('civicase-features');
+
+  module.service('SalesOrderStatus', SalesOrderStatus);
+
+  /**
+   * SalesOrderStatus Service
+   */
+  function SalesOrderStatus () {
+    this.getAll = function () {
+      return CRM['civicase-features'].salesOrderStatus;
+    };
+
+    this.getValueByName = function (name) {
+      return CRM['civicase-features']
+        .salesOrderStatus
+        .filter(status => status.name === name)
+        .pop().value || '';
+    };
+  }
+})(angular, CRM.$, CRM._, CRM);

--- a/ang/civicase/shared/directives/history-back.directive.js
+++ b/ang/civicase/shared/directives/history-back.directive.js
@@ -1,0 +1,14 @@
+(function (angular, $window) {
+  var module = angular.module('civicase');
+
+  module.directive('historyBack', function () {
+    return {
+      restrict: 'A',
+      link: function (scope, elem, attrs) {
+        elem.bind('click', function () {
+          $window.history.back();
+        });
+      }
+    };
+  });
+})(angular, window);

--- a/api/v3/Case/Getdetails.php
+++ b/api/v3/Case/Getdetails.php
@@ -6,6 +6,7 @@
  */
 
 require_once 'api/v3/Case.php';
+require_once 'api/v3/CaseType.php';
 use CRM_Civicase_APIHelpers_CaseDetails as CaseDetailsQuery;
 
 /**
@@ -215,6 +216,16 @@ function civicrm_api3_case_getdetails(array $params) {
     if (in_array('related_case_ids', $toReturn)) {
       foreach ($result['values'] as &$case) {
         $case['related_case_ids'] = CRM_Case_BAO_Case::getRelatedCaseIds($case['id']);
+      }
+    }
+
+    // Get case type category.
+    if (in_array('case_type_category', $toReturn)) {
+      foreach ($result['values'] as $id => &$case) {
+        $caseType = civicrm_api3_case_type_get(['id' => $case['case_type_id']]);
+        if (!empty($caseType['values']) && is_array($caseType['values'])) {
+          $case['case_type_category'] = $caseType['values'][$case['case_type_id']]['case_type_category'];
+        }
       }
     }
     if (!empty($params['sequential'])) {

--- a/tests/phpunit/Civi/Api4/CaseSalesOrder/ComputeTotalActionTest.php
+++ b/tests/phpunit/Civi/Api4/CaseSalesOrder/ComputeTotalActionTest.php
@@ -1,0 +1,114 @@
+<?php
+
+use Civi\Api4\CaseSalesOrder;
+use CRM_Civicase_Test_Fabricator_Contact as ContactFabricator;
+
+/**
+ * CaseSalesOrder.ComputeTotalAction API Test Case.
+ *
+ * @group headless
+ */
+class Civi_Api4_CaseSalesOrder_ComputeTotalActionTest extends BaseHeadlessTest {
+
+  use Helpers_CaseSalesOrderTrait;
+  use CRM_Civicase_Helpers_SessionTrait;
+
+  /**
+   * Setup data before tests run.
+   */
+  public function setUp() {
+    $contact = ContactFabricator::fabricate();
+    $this->registerCurrentLoggedInContactInSession($contact['id']);
+  }
+
+  /**
+   * Test case sales order compute action returns expected fields.
+   */
+  public function testComputeTotalActionReturnsExpectedFields() {
+    $items = [];
+    $items[] = $this->getCaseSalesOrderLineData(
+      ['quantity' => 10, 'unit_price' => 10, 'tax_rate' => 10]
+    );
+    $items[] = $this->getCaseSalesOrderLineData(
+      ['quantity' => 5, 'unit_price' => 10]
+    );
+
+    $computedTotal = CaseSalesOrder::computeTotal()
+      ->setLineItems($items)
+      ->execute()
+      ->jsonSerialize()[0];
+
+    $this->assertArrayHasKey('taxRates', $computedTotal);
+    $this->assertArrayHasKey('totalBeforeTax', $computedTotal);
+    $this->assertArrayHasKey('totalAfterTax', $computedTotal);
+  }
+
+  /**
+   * Test case sales order total is calculated appropraitely.
+   */
+  public function testComputeTotalActionReturnsExpectedTotal() {
+    $items = [];
+    $items[] = $this->getCaseSalesOrderLineData(
+      ['quantity' => 10, 'unit_price' => 10, 'tax_rate' => 10]
+    );
+    $items[] = $this->getCaseSalesOrderLineData(
+      ['quantity' => 5, 'unit_price' => 10]
+    );
+
+    $computedTotal = CaseSalesOrder::computeTotal()
+      ->setLineItems($items)
+      ->execute()
+      ->jsonSerialize()[0];
+
+    $this->assertEquals($computedTotal['totalBeforeTax'], 150);
+    $this->assertEquals($computedTotal['totalAfterTax'], 160);
+  }
+
+  /**
+   * Test case sales order tax rates is computed as epxected.
+   */
+  public function testComputeTotalActionReturnsExpectedTaxRates() {
+    $items = [];
+    $items[] = $this->getCaseSalesOrderLineData(
+      ['quantity' => 10, 'unit_price' => 10, 'tax_rate' => 10]
+    );
+    $items[] = $this->getCaseSalesOrderLineData(
+      ['quantity' => 5, 'unit_price' => 10, 'tax_rate' => 2]
+    );
+
+    $computedTotal = CaseSalesOrder::computeTotal()
+      ->setLineItems($items)
+      ->execute()
+      ->jsonSerialize()[0];
+
+    $this->assertNotEmpty($computedTotal['taxRates']);
+    $this->assertCount(2, $computedTotal['taxRates']);
+
+    // Ensure the tax rates are sorted in ascending order of rate.
+    $this->assertEquals($computedTotal['taxRates'][0]['rate'], 2);
+    $this->assertEquals($computedTotal['taxRates'][0]['value'], 1);
+    $this->assertEquals($computedTotal['taxRates'][1]['rate'], 10);
+    $this->assertEquals($computedTotal['taxRates'][1]['value'], 10);
+  }
+
+  /**
+   * Test compute action doesn't throw error for empty line items.
+   */
+  public function testComputeTotalActionReturnsEmptyResultForEmptyLineItems() {
+    $items = [];
+
+    $computedTotal = CaseSalesOrder::computeTotal()
+      ->setLineItems($items)
+      ->execute()
+      ->jsonSerialize()[0];
+
+    $this->assertArrayHasKey('taxRates', $computedTotal);
+    $this->assertArrayHasKey('totalBeforeTax', $computedTotal);
+    $this->assertArrayHasKey('totalAfterTax', $computedTotal);
+
+    $this->assertEmpty($computedTotal['taxRates']);
+    $this->assertEmpty($computedTotal['totalAfterTax']);
+    $this->assertEmpty($computedTotal['totalBeforeTax']);
+  }
+
+}

--- a/tests/phpunit/Civi/Api4/CaseSalesOrder/SalesOrderSaveActionTest.php
+++ b/tests/phpunit/Civi/Api4/CaseSalesOrder/SalesOrderSaveActionTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use Civi\Api4\CaseSalesOrderLine;
+use Civi\Api4\CaseSalesOrder;
+use CRM_Civicase_Test_Fabricator_Contact as ContactFabricator;
+
+/**
+ * CaseSalesOrder.SalesOrderSaveAction API Test Case.
+ *
+ * @group headless
+ */
+class Civi_Api4_CaseSalesOrder_SalesOrderSaveActionTest extends BaseHeadlessTest {
+
+  use Helpers_CaseSalesOrderTrait;
+  use CRM_Civicase_Helpers_SessionTrait;
+
+  /**
+   * Setup data before tests run.
+   */
+  public function setUp() {
+    $contact = ContactFabricator::fabricate();
+    $this->registerCurrentLoggedInContactInSession($contact['id']);
+  }
+
+  /**
+   * Test case sales order and line item can be saved with the save action.
+   */
+  public function testCanSaveCaseSalesOrder() {
+    $salesOrder = $this->getCaseSalesOrderData();
+
+    $salesOrderId = CaseSalesOrder::save()
+      ->addRecord($salesOrder)
+      ->execute()
+      ->jsonSerialize()[0]['id'];
+
+    $results = CaseSalesOrder::get()
+      ->addWhere('id', '=', $salesOrderId)
+      ->execute()
+      ->jsonSerialize();
+
+    $this->assertNotEmpty($results);
+    foreach (['client_id', 'owner_id', 'notes', 'total_before_tax'] as $key) {
+      $this->assertEquals($salesOrder[$key], $results[0][$key]);
+    }
+  }
+
+  /**
+   * Test case sales order and line item can be saved with the save action.
+   */
+  public function testCanSaveCaseSalesOrderAndLineItems() {
+    $salesOrder = $this->getCaseSalesOrderData();
+    $salesOrder['items'][] = $this->getCaseSalesOrderLineData();
+    $salesOrder['items'][] = $this->getCaseSalesOrderLineData();
+
+    $salesOrderId = CaseSalesOrder::save()
+      ->addRecord($salesOrder)
+      ->execute()
+      ->jsonSerialize()[0]['id'];
+
+    $results = CaseSalesOrderLine::get()
+      ->addWhere('sales_order_id', '=', $salesOrderId)
+      ->execute()
+      ->jsonSerialize();
+
+    $this->assertCount(2, $results);
+    foreach ($results as $result) {
+      $this->assertEquals($result['sales_order_id'], $salesOrderId);
+    }
+  }
+
+  /**
+   * Test case sales order total is calculated appropraitely.
+   */
+  public function testSaveCaseSalesOrderTotalIsCorrect() {
+    $salesOrderData = $this->getCaseSalesOrderData();
+    $salesOrderData['items'][] = $this->getCaseSalesOrderLineData(
+      ['quantity' => 10, 'unit_price' => 10, 'tax_rate' => 10]
+    );
+    $salesOrderData['items'][] = $this->getCaseSalesOrderLineData(
+      ['quantity' => 5, 'unit_price' => 10]
+    );
+
+    $salesOrderId = CaseSalesOrder::save()
+      ->addRecord($salesOrderData)
+      ->execute()
+      ->jsonSerialize()[0]['id'];
+
+    $salesOrder = CaseSalesOrder::get()
+      ->addWhere('id', '=', $salesOrderId)
+      ->execute()
+      ->jsonSerialize()[0];
+
+    $this->assertEquals($salesOrder['total_before_tax'], 150);
+    $this->assertEquals($salesOrder['total_after_tax'], 160);
+  }
+
+}

--- a/tests/phpunit/Helpers/CaseSalesOrderTrait.php
+++ b/tests/phpunit/Helpers/CaseSalesOrderTrait.php
@@ -1,0 +1,87 @@
+<?php
+
+use Civi\Api4\OptionValue;
+use CRM_Civicase_Test_Fabricator_Case as CaseFabricator;
+use CRM_Civicase_Test_Fabricator_Product as ProductFabricator;
+use CRM_Civicase_Test_Fabricator_Contact as ContactFabricator;
+use CRM_Civicase_Test_Fabricator_CaseType as CaseTypeFabricator;
+
+/**
+ * Case sales order helper trait.
+ */
+trait Helpers_CaseSalesOrderTrait {
+
+  /**
+   * Returns list of available statuses.
+   *
+   * @return array
+   *   Array of sales order statuses
+   */
+  public function getCaseSalesOrderStatus() {
+    $salesOrderStatus = OptionValue::get()
+      ->addSelect('id', 'value', 'name', 'label')
+      ->addWhere('option_group_id:name', '=', 'case_sales_order_status')
+      ->execute();
+
+    return $salesOrderStatus;
+  }
+
+  /**
+   * Returns fabricated case sales order data.
+   *
+   * @param array $default
+   *   Default value.
+   *
+   * @return array
+   *   Key-Value pair of a case sales order fields and values
+   */
+  public function getCaseSalesOrderData(array $default = []) {
+    $client = ContactFabricator::fabricate();
+    $caseType = CaseTypeFabricator::fabricate();
+    $case = CaseFabricator::fabricate(
+      [
+        'case_type_id' => $caseType['id'],
+        'contact_id' => $client['id'],
+        'creator_id' => $client['id'],
+      ]
+    );
+
+    return array_merge([
+      'client_id' => $client['id'],
+      'owner_id' => $client['id'],
+      'case_id' => $case['id'],
+      'currency' => 'GBP',
+      'status_id' => $this->getCaseSalesOrderStatus()[0]['value'],
+      'description' => 'test',
+      'notes' => 'test',
+      'total_before_tax' => 0,
+      'total_after_tax' => 0,
+      'quotation_date' => '2022-08-09',
+      'items' => [],
+    ], $default);
+  }
+
+  /**
+   * Returns fabricated case sales order line data.
+   *
+   * @param array $default
+   *   Default value.
+   *
+   * @return array
+   *   Key-Value pair of a case sales order line item fields and values
+   */
+  public function getCaseSalesOrderLineData(array $default = []) {
+    $product = ProductFabricator::fabricate();
+    return array_merge([
+      'financial_type_id' => 1,
+      'product_id' => $product['id'],
+      'item_description' => 'test',
+      'quantity' => 1,
+      'unit_price' => 50,
+      'tax_rate' => NULL,
+      'discounted_percentage' => NULL,
+      'subtotal_amount' => 50,
+    ], $default);
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR adds a new screen and API to create a new quotation.

## Before
The new sales order screen doesn't exist.

## After
The new quotation screen now exists.
![aqqq](https://user-images.githubusercontent.com/85277674/221755408-d3e4ec0c-0b66-4ffb-9702-7da08d9e1be7.gif)

## Technical Details
Two new API v4 endpoint actions were added to the Sales Order entity.

- **ComputeTotalAction**: This action takes an array of line items as input and returns an array of tax_rates in descending order based on the tax value, along with totalBeforeTax and totalAfterTax values.  
The purpose of this API is to recalculate the total amount when a change affecting the total is made by the user, such as modifying the quantity of a line item or selecting a new financial type. To prevent excessive calls, the API is debounced and triggered when a `totalChange` event is received `$scope.$on('totalChange', _.debounce(handleTotalChange, 250));`

- **SalesOrderSaveAction**: This action allows sales orders along with its array of line items to be created in a single API call.

Also, the `Case.Getdetails` API has been extended to include the `case_type_category` information for the case being retrieved. This additional data is necessary for redirecting the user to the correct case dashboard if a new quotation is associated with a case.

## Comments
The tests will be added in a separate PR
