### PR TITLE
CIVIIB-88: Avoid errors when some statuses are disabled 

### DIFF
--- a/ang/civicase/activity/factories/format-activity.factory.js
+++ b/ang/civicase/activity/factories/format-activity.factory.js
@@ -4,7 +4,7 @@
   module.factory('formatActivity', function (CasesUtils, ActivityStatusType,
     ActivityStatus, ActivityType, CaseStatus, CaseType, isTruthy) {
     var activityTypes = ActivityType.getAll(true);
-    var activityStatuses = ActivityStatus.getAll();
+    var activityStatuses = ActivityStatus.getAll(true);
     var caseStatuses = CaseStatus.getAll();
 
     return function (act, caseId) {


### PR DESCRIPTION
## Overview
This PR fixes the error that happens when a status used in a Case activity is disabled. here is the original PR https://github.com/compucorp/uk.co.compucorp.civicase/pull/846

## Before
<img width="1256" alt="Screenshot 2023-03-01 at 08 34 49" src="https://user-images.githubusercontent.com/85277674/222073738-65064ddb-ae9e-4e0b-a2ab-402decae4e0b.png">


## After
![image](https://user-images.githubusercontent.com/85277674/222072180-f713480f-ee74-4216-ae42-f12cf36f3bff.png)

