### PR TITLE
BTHAB-28: Prefill case/opportunity field for new quotations

### DIFF
--- a/ang/civicase-features/quotations/directives/quotations-create.directive.html
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.html
@@ -57,6 +57,7 @@
                 select: { multiple: false, allowClear: true },
                 api: caseApiParam(),
               }"
+              ng-disabled="defaultCaseId !== null"
             />
           </div>
         </div>

--- a/ang/civicase-features/quotations/directives/quotations-create.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.js
@@ -14,6 +14,7 @@
 
   /**
    * @param {object} $scope the controller scope
+   * @param {object} $location the location service
    * @param {object} $window window object of the browser
    * @param {object} CurrencyCodes CurrencyCodes service
    * @param {Function} civicaseCrmApi crm api service
@@ -23,7 +24,7 @@
    * @param {object} SalesOrderStatus SalesOrderStatus service
    * @param {object} CaseUtils case utility service
    */
-  function quotationsCreateController ($scope, $window, CurrencyCodes, civicaseCrmApi, Contact, crmApi4, FeatureCaseTypes, SalesOrderStatus, CaseUtils) {
+  function quotationsCreateController ($scope, $location, $window, CurrencyCodes, civicaseCrmApi, Contact, crmApi4, FeatureCaseTypes, SalesOrderStatus, CaseUtils) {
     const defaultCurrency = 'GBP';
     const productsCache = new Map();
     const financialTypesCache = new Map();
@@ -38,6 +39,7 @@
     $scope.handleProductChange = handleProductChange;
     $scope.handleCurrencyChange = handleCurrencyChange;
     $scope.salesOrderStatus = SalesOrderStatus.getAll();
+    $scope.defaultCaseId = $location.search().caseId || null;
     $scope.handleFinancialTypeChange = handleFinancialTypeChange;
     $scope.currencySymbol = CurrencyCodes.getSymbol(defaultCurrency);
 
@@ -70,7 +72,8 @@
           subtotal_amount: 0
         }],
         total: 0,
-        grandTotal: 0
+        grandTotal: 0,
+        case_id: $scope.defaultCaseId
       };
       $scope.total = 0;
       $scope.taxRates = [];
@@ -253,7 +256,7 @@
       }
 
       CaseUtils.getDashboardLink($scope.salesOrder.case_id).then(link => {
-        $window.location.href = link;
+        $window.location.href = `${link}&tab=Quotations`;
       });
     }
 

--- a/ang/civicase-features/quotations/directives/quotations-list.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-list.directive.js
@@ -14,16 +14,23 @@
 
   /**
    * @param {object} $scope the controller scope
+   * @param {object} $location the location service
    * @param {object} $window window object of the browser
    */
-  function quotationsListController ($scope, $window) {
+  function quotationsListController ($scope, $location, $window) {
     $scope.redirectToQuotationCreationScreen = redirectToQuotationCreationScreen;
 
     /**
      * Redirect user to new quotation screen
      */
     function redirectToQuotationCreationScreen () {
-      $window.location.href = '/civicrm/case-features/a#/new';
+      let url = '/civicrm/case-features/a#/new';
+      const caseId = $location.search().caseId;
+      if (caseId) {
+        url += `?caseId=${caseId}`;
+      }
+
+      $window.location.href = url;
     }
   }
 })(angular, CRM._);


### PR DESCRIPTION
## Overview
With this PR if a user clicks on the `Create Quotation` button from a case dashboard, the `case/opportunity` field will be pre-filled and disabled

## Before
Clicking on the `Create Quotation` button from a case dashboard doesn't make any difference.

## After
Clicking on the `Create Quotation` button from a case dashboard will have the case field prefilled
![waqqw](https://user-images.githubusercontent.com/85277674/223108067-a5add177-6a40-4324-807c-c3801c390f54.gif)
