### PR TITLE
BTHAB-44: Add quotations field to contribution settings

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/AddQuotationsNotesToContributionSettings.php
+++ b/CRM/Civicase/Hook/BuildForm/AddQuotationsNotesToContributionSettings.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Add Quotations Note field.
+ */
+class CRM_Civicase_Hook_BuildForm_AddQuotationsNotesToContributionSettings {
+
+  /**
+   * Adds the Quotations Note Form field.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   * @param string $formName
+   *   Form Name.
+   */
+  public function run(CRM_Core_Form &$form, $formName) {
+    if (!$this->shouldRun($formName)) {
+      return;
+    }
+
+    $this->addQuotationsNoteField($form);
+  }
+
+  /**
+   * Checks if this shook should run.
+   *
+   * @param string $formName
+   *   Form Name.
+   *
+   * @return bool
+   *   True if the hook should run.
+   */
+  public function shouldRun($formName) {
+    return $formName == CRM_Admin_Form_Preferences_Contribute::class;
+  }
+
+  /**
+   * Add Quotations note fields.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   */
+  public function addQuotationsNoteField(CRM_Core_Form &$form) {
+    $fieldName = 'quotations_notes';
+    $field = [
+      $fieldName => [
+        'html_type' => 'wysiwyg',
+        'title' => ts('Terms/Notes for Quotations'),
+        'weight' => 5,
+        'description' => ts('Enter note or message to be displyaed on quotations'),
+        'attributes' => ['rows' => 2, 'cols' => 40],
+      ],
+    ];
+
+    $form->add('wysiwyg', $fieldName, $field[$fieldName]['title'], $field[$fieldName]['attributes']);
+    $form->assign('htmlFields', array_merge($form->get_template_vars('htmlFields'), $field));
+    $value = Civi::settings()->get($fieldName) ?? NULL;
+    $form->setDefaults(array_merge($form->_defaultValues, [$fieldName => $value]));
+  }
+
+}

--- a/CRM/Civicase/Hook/PostProcess/SaveQuotationsNotesSettings.php
+++ b/CRM/Civicase/Hook/PostProcess/SaveQuotationsNotesSettings.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Save Quotations Note field.
+ */
+class CRM_Civicase_Hook_PostProcess_SaveQuotationsNotesSettings {
+
+  /**
+   * Saves the Quotations Note Form field.
+   *
+   * @param string $formName
+   *   Form Name.
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   */
+  public function run($formName, CRM_Core_Form $form) {
+    if (!$this->shouldRun($form, $formName)) {
+      return;
+    }
+
+    $this->saveQuotationsNoteField($form);
+  }
+
+  /**
+   * Checks if this shook should run.
+   *
+   * @param string $formName
+   *   Form Name.
+   *
+   * @return bool
+   *   True if the hook should run.
+   */
+  public function shouldRun($formName) {
+    return $formName == CRM_Admin_Form_Preferences_Contribute::class;
+  }
+
+  /**
+   * Saves the Quotations Note Form field.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   */
+  public function saveQuotationsNoteField(CRM_Core_Form &$form) {
+    $values = $form->getVar('_submitValues');
+    if (!empty($values['quotations_notes'])) {
+      Civi::settings()->set('quotations_notes', $values['quotations_notes']);
+    }
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -176,6 +176,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_PdfFormButtonsLabelChange(),
     new CRM_Civicase_Hook_BuildForm_AddScriptToCreatePdfForm(),
     new CRM_Civicase_Hook_BuildForm_AddCaseCategoryFeaturesField(),
+    new CRM_Civicase_Hook_BuildForm_AddQuotationsNotesToContributionSettings(),
   ];
 
   foreach ($hooks as $hook) {
@@ -292,6 +293,7 @@ function civicase_civicrm_postProcess($formName, &$form) {
     new CRM_Civicase_Hook_PostProcess_HandleDraftActivity(),
     new CRM_Civicase_Hook_PostProcess_SaveCaseCategoryCustomFields(),
     new CRM_Civicase_Hook_PostProcess_SaveCaseCategoryFeature(),
+    new CRM_Civicase_Hook_PostProcess_SaveQuotationsNotesSettings(),
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview
With this PR we add a new terms field to the Civi Contribution settings page  

## Before
This field doesn't exist

## After
The quotations terms field now exists.
<img width="1241" alt="Screenshot 2023-03-08 at 15 58 25" src="https://user-images.githubusercontent.com/85277674/223748221-dbdafaee-e5a4-42b3-8cc4-0152031559b6.png">


## Technical Details
The preferred way to add settings as described here https://docs.civicrm.org/dev/en/latest/framework/setting/extension/ is to create a `.setting.php` file, using this method doesn't produce the desired result as we couldn't move the new settings to the end of the form, also when the form is submitted the Quotations Notes field is encoded such that `<p>hello</p>` becomes `&lt;p&gt;hello&lt;/p&gt;` and doesn't get decoded back when being displayed.

So instead we decided to use hooks to add the field and save its value to settings.