### PR TITLE
BTHAB-46: Allow user to apply bulk discount to quotations

### DIFF
--- a/ang/civicase-features.ang.php
+++ b/ang/civicase-features.ang.php
@@ -67,6 +67,7 @@ function set_case_sales_order_status(&$options) {
 
 $requires = [
   'api4',
+  'crmUi',
   'crmUtil',
   'civicase',
   'civicase-base',

--- a/ang/civicase-features/quotations/directives/quotations-discount.directive.html
+++ b/ang/civicase-features/quotations/directives/quotations-discount.directive.html
@@ -1,0 +1,51 @@
+<div id="bootstrap-theme" class="civicase__container" crm-dialog="crmSearchTask">
+  <h1 class="text-center" style="margin-bottom: 2em">Apply Discount</h1>
+
+  <form name="bulkDiscount" class="form-horizontal" ng-controller="quotationsDiscountController as $ctrl">
+
+    <div class="row">
+      <div ng-show="$ctrl.stage === 'done'">{{$ctrl.completedMessage}}</div>
+    </div>
+
+    <div class="form-group row" style="margin-bottom: 2em; display: flex; justify-content: center;">
+      <label class="col-sm-2 control-label required-mark">
+        Select Product
+      </label>
+      <div class="col-sm-5">
+        <input class="form-control"
+          ng-model="$ctrl.products"
+          placeholder="Product"
+          crm-entityref="{
+            entity: 'Product',
+            create: true,
+            select: { allowClear: true, 'minimumInputLength': 0, create: true, multiple: true }
+          }"
+          ng-minlength="1"
+          required
+        />
+      </div>
+    </div>
+
+    <div class="form-group row" style="margin-bottom: 2em; display: flex; justify-content: center;">
+      <label class="col-sm-2 control-label required-mark">
+        Discount (%)
+      </label>
+      <div class="col-sm-5">
+        <div class="input-group" style="width: 100%;">
+          <input required type="number" min="0" max="100" name="discount" placeholder="Discount" ng-model="$ctrl.discount" class="form-control" />
+        </div>
+      </div>
+    </div>
+
+
+    <div class="form-group row">
+      <div class="col-sm-12">
+        <div class="clearfix">
+          <crm-dialog-button text="ts('Confirm')" icons="{primary: $ctrl.run ? 'fa-spin fa-spinner' : 'fa-file-text'}" on-click="$ctrl.applyDiscount()" disabled="$ctrl.run || $ctrl.stage === 'done' || !bulkDiscount.$valid" ></crm-dialog-button>
+          <crm-dialog-button text="ts(($ctrl.stage === 'done') ? 'Close' : 'Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" ></crm-dialog-button>
+        </div>
+      </div>
+    </div>
+
+  </form>
+</div>

--- a/ang/civicase-features/quotations/directives/quotations-discount.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-discount.directive.js
@@ -1,0 +1,51 @@
+(function (angular, _) {
+  var module = angular.module('civicase-features');
+
+  module.directive('quotationsDiscount', function () {
+    return {
+      restrict: 'E',
+      controller: 'quotationsDiscountController',
+      templateUrl: '~/civicase-features/quotations/directives/quotations-discount.directive.html',
+      scope: {}
+    };
+  });
+
+  module.controller('quotationsDiscountController', quotationsDiscountController);
+
+  /**
+   * @param {object} $q ng-promise object
+   * @param {object} $scope the controller scope
+   * @param {object} crmApi4 api V4 service
+   * @param {object} searchTaskBaseTrait searchkit trait
+   * @param {object} CaseUtils case utility service
+   */
+  function quotationsDiscountController ($q, $scope, crmApi4, searchTaskBaseTrait, CaseUtils) {
+    $scope.ts = CRM.ts('civicase');
+    const ctrl = angular.extend(this, $scope.model, searchTaskBaseTrait);
+    ctrl.stage = 'form';
+    $scope.submitInProgress = false;
+
+    this.applyDiscount = () => {
+      $q(async function (resolve, reject) {
+        const updatedSalesOrder = {};
+
+        for (const salesOrderId of ctrl.ids) {
+          const result = await CaseUtils.getSalesOrderAndLineItems(salesOrderId);
+          const selectedProducts = ctrl.products.split(',');
+          result.items.forEach((lineItem, index) => {
+            // The line item is part of the product user desires to apply discount to
+            if (lineItem.product_id && selectedProducts.includes((lineItem.product_id).toString())) {
+              const newDiscount = result.items[index].discounted_percentage + ctrl.discount;
+              result.items[index].discounted_percentage = Math.min(100, newDiscount);
+              updatedSalesOrder[salesOrderId] = result;
+            }
+          });
+        }
+
+        await crmApi4('CaseSalesOrder', 'save', { records: Object.values(updatedSalesOrder) });
+        ctrl.close();
+        CRM.alert(`Discount applied to ${Object.values(updatedSalesOrder).length} Quotation(s) successfully`, ts('Success'), 'success');
+      });
+    };
+  }
+})(angular, CRM._);

--- a/civicase.php
+++ b/civicase.php
@@ -547,3 +547,15 @@ function civicase_civicrm_alterMailParams(&$params, $context) {
     $hook->run($params, $context);
   }
 }
+
+/**
+ * Implements hook_civicrm_searchKitTasks().
+ */
+function civicase_civicrm_searchKitTasks(array &$tasks, bool $checkPermissions, ?int $userID) {
+  $tasks['CaseSalesOrder']['add_discount'] = [
+    'module' => 'civicase-features',
+    'icon'  => 'fa-percent',
+    'title' => ts('Add Discount'),
+    'uiDialog' => ['templateUrl' => '~/civicase-features/quotations/directives/quotations-discount.directive.html'],
+  ];
+}


### PR DESCRIPTION
## Overview
With this PR users can apply discounts to quotations in bulk

## Before
The bulk discount action doesn't exist.

## After
The bulk discount action now exists.
![lwapa](https://user-images.githubusercontent.com/85277674/224014570-673113e4-3512-44a9-9c47-55c6a63a7edc.gif)


## Technical Details
- User selects a list of quotations to apply discounts to
- A dialog appears where the user selects the specific products that the discount would be applied and enters the value of the discount.
- On submission, we look up each quotation for a line item that is linked to one of the selected products, if any, we add the discount to the line item discount.
- After updating the discounts we save every quotation that has been updated. saving the discount will recalculate the total amounts.
- Also since the discount is applied in bulk, and some line items might already be close to 100, we add this code `Math.min(100, newDiscount);` to ensure no discount goes beyond 100.