### PR TITLE
BTHAB-43: Add functionality to download / email Sales Order Invoice

### DIFF
--- a/CRM/Civicase/Form/CaseSalesOrderInvoice.php
+++ b/CRM/Civicase/Form/CaseSalesOrderInvoice.php
@@ -173,7 +173,7 @@ class CRM_Civicase_Form_CaseSalesOrderInvoice extends CRM_Core_Form {
       ->execute()
       ->first();
 
-    if (!empty($caseSalesOrder['client']['addressee_id'])) {
+    if (!empty($caseSalesOrder['client_id'])) {
       $caseSalesOrder['clientAddress'] = Address::get()
         ->addWhere('contact_id', '=', $caseSalesOrder['client_id'])
         ->execute()

--- a/CRM/Civicase/Form/CaseSalesOrderInvoice.php
+++ b/CRM/Civicase/Form/CaseSalesOrderInvoice.php
@@ -1,0 +1,231 @@
+<?php
+
+use Civi\Api4\Address;
+use Civi\Api4\CaseSalesOrder;
+use Civi\Api4\CaseSalesOrderLine;
+use Civi\Api4\Contact;
+use Civi\Token\TokenProcessor;
+
+/**
+ * Handles Sales Order Email Invoice Task.
+ */
+class CRM_Civicase_Form_CaseSalesOrderInvoice extends CRM_Core_Form {
+  use CRM_Contact_Form_Task_EmailTrait;
+
+  /**
+   * The array that holds all the contact ids.
+   *
+   * @var array
+   */
+  public $_contactIds; // phpcs:ignore
+
+  /**
+   * Current form context.
+   *
+   * @var string
+   */
+  public $_context; // phpcs:ignore
+
+  /**
+   * Sales Order ID.
+   *
+   * @var int
+   */
+  public $salesOrderId;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function preProcess() {
+    $this->setTitle('Email Quotation');
+    $this->salesOrderId = CRM_Utils_Request::retrieveValue('id', 'Positive');
+
+    $this->setContactIDs();
+    $this->setIsSearchContext(FALSE);
+    $this->traitPreProcess();
+  }
+
+  /**
+   * List available tokens for this form.
+   *
+   * Presently all tokens are returned.
+   *
+   * @return array
+   *   List of Available tokens
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function listTokens() {
+    $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['contactId']]);
+    $tokens = $tokenProcessor->listTokens();
+
+    return $tokens;
+  }
+
+  /**
+   * Submit the form values.
+   *
+   * This is also accessible for testing.
+   *
+   * @param array $formValues
+   *   Submitted values.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   * @throws \API_Exception
+   */
+  public function submit(array $formValues): void {
+    $this->saveMessageTemplate($formValues);
+    $sents = 0;
+    $from = $formValues['from_email_address'];
+    $text = $this->getSubmittedValue('text_message');
+    $html = $this->getSubmittedValue('html_message');
+    $from = CRM_Utils_Mail::formatFromAddress($from);
+
+    $cc = $this->getCc();
+    $additionalDetails = empty($cc) ? '' : "\ncc : " . $this->getEmailUrlString($this->getCcArray());
+
+    $bcc = $this->getBcc();
+    $additionalDetails .= empty($bcc) ? '' : "\nbcc : " . $this->getEmailUrlString($this->getBccArray());
+
+    $quotationInvoice = self::getQuotationInvoice();
+
+    foreach ($this->getRowsForEmails() as $values) {
+      $mailParams = [];
+      $mailParams['messageTemplate'] = [
+        'msg_text' => $text,
+        'msg_html' => $html,
+        'msg_subject' => $this->getSubject(),
+      ];
+      $mailParams['tokenContext'] = [
+        'contactId' => $values['contact_id'],
+        'salesOrderId' => $this->salesOrderId,
+      ];
+      $mailParams['tplParams'] = [];
+      $mailParams['from'] = $from;
+      $mailParams['toEmail'] = $values['email'];
+      $mailParams['cc'] = $cc ?? NULL;
+      $mailParams['bcc'] = $bcc ?? NULL;
+      $mailParams['attachments'][] = CRM_Utils_Mail::appendPDF('quotation_invoice.pdf', $quotationInvoice['html'], $quotationInvoice['format']);
+      // Send the mail.
+      [$sent, $subject, $message, $html] = CRM_Core_BAO_MessageTemplate::sendTemplate($mailParams);
+      $sents += ($sent ? 1 : 0);
+    }
+
+    CRM_Core_Session::setStatus(ts('One email has been sent successfully. ', [
+      'plural' => '%count emails were sent successfully. ',
+      'count' => $sents,
+    ]), ts('Message Sent', ['plural' => 'Messages Sent', 'count' => $sents]), 'success');
+
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function setContactIDs() { // phpcs:ignore
+    $this->_contactIds = $this->getContactIds();
+  }
+
+  /**
+   * Returns Sales Order Client Contact ID.
+   *
+   * @return array
+   *   Client Contact ID as an array
+   */
+  protected function getContactIds(): array {
+    if (isset($this->_contactIds)) {
+      return $this->_contactIds;
+    }
+
+    $salesOrderId = CRM_Utils_Request::retrieveValue('id', 'Positive');
+
+    $caseSalesOrder = CaseSalesOrder::get()
+      ->addWhere('id', '=', $salesOrderId)
+      ->execute()
+      ->first();
+
+    $this->_contactIds = [$caseSalesOrder['client_id']];
+
+    return $this->_contactIds;
+  }
+
+  /**
+   * Renders the quotatioin invoice message template.
+   *
+   * @return array
+   *   Rendered message, consistent of 'subject', 'text', 'html'
+   */
+  public static function getQuotationInvoice(): array {
+    $salesOrderId = CRM_Utils_Request::retrieveValue('id', 'Positive');
+    $caseSalesOrder = CaseSalesOrder::get()
+      ->addWhere('id', '=', $salesOrderId)
+      ->addChain('items', CaseSalesOrderLine::get()
+        ->addWhere('sales_order_id', '=', '$id')
+        ->addSelect('*', 'product_id.name', 'financial_type_id.name')
+      )
+      ->addChain('computedRates', CaseSalesOrder::computeTotal()
+        ->setLineItems('$items')
+      )
+      ->addChain('client', Contact::get()
+        ->addWhere('id', '=', '$client_id'), 0
+      )
+      ->execute()
+      ->first();
+
+    if (!empty($caseSalesOrder['client']['addressee_id'])) {
+      $caseSalesOrder['clientAddress'] = Address::get()
+        ->addWhere('contact_id', '=', $caseSalesOrder['client_id'])
+        ->execute()
+        ->first();
+    }
+
+    $caseSalesOrder['taxRates'] = $caseSalesOrder['computedRates'][0]['taxRates'] ?? [];
+    $caseSalesOrder['quotation_date'] = date('Y-m-d', strtotime($caseSalesOrder['quotation_date']));
+
+    $domain = CRM_Core_BAO_Domain::getDomain();
+    $organisation = Contact::get()
+      ->addSelect('image_URL')
+      ->addWhere('id', '=', $domain->contact_id)
+      ->execute()
+      ->first();
+
+    $model = new CRM_Civicase_WorkflowMessage_SalesOrderInvoice();
+    $terms = Civi::settings()->get('quotations_notes');
+    $model->setDomainLogo($organisation['image_URL']);
+    $model->setSalesOrder($caseSalesOrder);
+    $model->setTerms($terms);
+    $model->setSalesOrderId($salesOrderId);
+    $rendered = $model->renderTemplate();
+
+    return $rendered;
+  }
+
+  /**
+   * Get the rows for each contactID.
+   *
+   * @return array
+   *   Array if contact IDs.
+   */
+  protected function getRows(): array {
+    $rows = [];
+    foreach ($this->_contactIds as $index => $contactID) {
+      $rows[] = [
+        'contact_id' => $contactID,
+        'schema' => ['contactId' => $contactID],
+      ];
+    }
+    return $rows;
+  }
+
+  /**
+   * Renders and return the generated PDF to the browser.
+   */
+  public static function download(): void {
+    $rendered = self::getQuotationInvoice();
+    ob_end_clean();
+    CRM_Utils_PDF_Utils::html2pdf($rendered['html'], 'quotation_invoice.pdf', FALSE, $rendered['format'] ?? []);
+    CRM_Utils_System::civiExit();
+  }
+
+}

--- a/CRM/Civicase/Hook/PostProcess/SaveQuotationsNotesSettings.php
+++ b/CRM/Civicase/Hook/PostProcess/SaveQuotationsNotesSettings.php
@@ -14,7 +14,7 @@ class CRM_Civicase_Hook_PostProcess_SaveQuotationsNotesSettings {
    *   Form Class object.
    */
   public function run($formName, CRM_Core_Form $form) {
-    if (!$this->shouldRun($form, $formName)) {
+    if (!$this->shouldRun($formName)) {
       return;
     }
 

--- a/CRM/Civicase/Hook/Tokens/AddCaseTokenCategory.php
+++ b/CRM/Civicase/Hook/Tokens/AddCaseTokenCategory.php
@@ -34,6 +34,12 @@ class CRM_Civicase_Hook_Tokens_AddCaseTokenCategory {
    *   Available tokens.
    */
   private function setCaseTokenCategory(array &$tokens) {
+    if (CIVICRM_UF === 'UnitTests') {
+      // For unit tests where AddCaseCustomFieldsTokenValues might not be called
+      // using an empty key breaks the code.
+      return $tokens['case_cf'] = [];
+    }
+
     $tokens['case_cf'][''] = '';
   }
 

--- a/CRM/Civicase/Hook/Tokens/SalesOrderTokens.php
+++ b/CRM/Civicase/Hook/Tokens/SalesOrderTokens.php
@@ -1,0 +1,69 @@
+<?php
+
+use Civi\Token\Event\TokenValueEvent;
+use Civi\Token\Event\TokenRegisterEvent;
+use CRM_Civicase_ExtensionUtil as E;
+use Civi\Api4\CaseSalesOrder;
+use Civi\Token\AbstractTokenSubscriber;
+use Civi\Token\TokenRow;
+
+/**
+ * Sales Order Specific Tokens.
+ */
+class CRM_Civicase_Hook_Tokens_SalesOrderTokens extends AbstractTokenSubscriber {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function evaluateToken(TokenRow $row, $entity, $field, $prefetch = NULL) {
+  }
+
+  /**
+   * Key for token.
+   *
+   * @var string
+   */
+  const TOKEN = 'sales_order';
+
+  /**
+   * Sets sales order available tokens.
+   *
+   * @param \Civi\Token\Event\TokenRegisterEvent $e
+   *   Register Token Event.
+   */
+  public static function listSalesOrderTokens(TokenRegisterEvent $e) {
+    $fields = CaseSalesOrder::getFields()->execute()->jsonSerialize();
+    foreach ($fields as $field) {
+      $label = E::ts('Quotation ' . ucwords(str_replace("_", " ", $field['name'])));
+      $e->entity(self::TOKEN)->register($field['name'], $label);
+    }
+  }
+
+  /**
+   * Evaluates Token values.
+   *
+   * @param \Civi\Token\Event\TokenValueEvent $e
+   *   TokenValue Event.
+   */
+  public static function evaluateSalesOrderTokens(TokenValueEvent $e) {
+    $context = $e->getTokenProcessor()->context;
+
+    if (array_key_exists('schema', $context) && in_array('salesOrderId', $context['schema'])) {
+      foreach ($e->getRows() as $row) {
+        if (!empty($row->context['salesOrderId'])) {
+          $salesOrderId = $row->context['salesOrderId'];
+
+          $caseSalesOrder = CaseSalesOrder::get()
+            ->addWhere('id', '=', $salesOrderId)
+            ->execute()
+            ->first();
+          foreach ($caseSalesOrder as $key => $value) {
+            $row->tokens(self::TOKEN, $key, $value);
+          }
+        }
+      }
+    }
+
+  }
+
+}

--- a/CRM/Civicase/Setup/Manage/QuotationTemplateManager.php
+++ b/CRM/Civicase/Setup/Manage/QuotationTemplateManager.php
@@ -1,0 +1,84 @@
+<?php
+
+use Civi\Api4\MessageTemplate;
+use Civi\Api4\OptionValue;
+use CRM_Civicase_ExtensionUtil as E;
+use CRM_Civicase_WorkflowMessage_SalesOrderInvoice as SalesOrderInvoice;
+
+/**
+ * Manages Quotation Invoice Template.
+ */
+class CRM_Civicase_Setup_Manage_QuotationTemplateManager extends CRM_Civicase_Setup_Manage_AbstractManager {
+
+  /**
+   * Adds custom quotation invoice template.
+   */
+  public function create(): void {
+    $messageTemplate = MessageTemplate::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('workflow_name', '=', SalesOrderInvoice::WORKFLOW)
+      ->execute()
+      ->first();
+
+    $templatePath = E::path('/templates/CRM/Civicase/MessageTemplate/QuotationInvoice.tpl');
+    $templateBodyHtml = file_get_contents($templatePath);
+
+    $params = [
+      'workflow_name' => SalesOrderInvoice::WORKFLOW,
+      'msg_title' => 'Quotation Invoice',
+      'msg_subject' => 'Quotation Invoice',
+      'msg_html' => $templateBodyHtml,
+      'is_reserved' => 0,
+      'is_default' => 1,
+    ];
+
+    if (!empty($messageTemplate)) {
+      $params = array_merge(['id' => $messageTemplate['id']], $params);
+    }
+
+    $optionValue = OptionValue::get(FALSE)
+      ->addWhere('option_group_id:name', '=', 'msg_tpl_workflow_case')
+      ->addWhere('name', '=', SalesOrderInvoice::WORKFLOW)
+      ->execute()
+      ->first();
+
+    if (empty($optionValue)) {
+      $optionValue = OptionValue::create(FALSE)
+        ->addValue('option_group_id.name', 'msg_tpl_workflow_case')
+        ->addValue('label', 'Quotation Invoice')
+        ->addValue('name', SalesOrderInvoice::WORKFLOW)
+        ->execute()
+        ->first();
+    }
+
+    $params['workflow_id'] = $optionValue['id'];
+
+    MessageTemplate::save(FALSE)->addRecord($params)->execute();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function remove(): void {
+    MessageTemplate::delete(FALSE)
+      ->addWhere('workflow_name', '=', SalesOrderInvoice::WORKFLOW)
+      ->execute();
+
+    OptionValue::delete(FALSE)
+      ->addWhere('option_group_id:name', '=', 'msg_tpl_workflow_case')
+      ->addWhere('name', '=', SalesOrderInvoice::WORKFLOW)
+      ->execute()
+      ->first();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function toggle($status): void {
+    MessageTemplate::update(FALSE)
+      ->addValue('is_active', $status)
+      ->addWhere('workflow_name', '=', SalesOrderInvoice::WORKFLOW)
+      ->execute();
+  }
+
+}

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -17,6 +17,7 @@ use CRM_Civicase_ExtensionUtil as E;
 use CRM_Civicase_Setup_AddMyActivitiesMenu as AddMyActivitiesMenu;
 use CRM_Civicase_Setup_Manage_CaseTypeCategoryFeaturesManager as CaseTypeCategoryFeaturesManager;
 use CRM_Civicase_Setup_Manage_CaseSalesOrderStatusManager as CaseSalesOrderStatusManager;
+use CRM_Civicase_Setup_Manage_QuotationTemplateManager as QuotationTemplateManager;
 
 /**
  * Collection of upgrade steps.
@@ -152,6 +153,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     $this->createManageCasesMenuItem();
     (new CaseTypeCategoryFeaturesManager())->create();
     (new CaseSalesOrderStatusManager())->create();
+    (new QuotationTemplateManager())->create();
   }
 
   /**
@@ -250,6 +252,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
 
     (new CaseTypeCategoryFeaturesManager())->remove();
     (new CaseSalesOrderStatusManager())->remove();
+    (new QuotationTemplateManager())->remove();
   }
 
   /**
@@ -417,6 +420,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
 
     (new CaseTypeCategoryFeaturesManager())->enable();
     (new CaseSalesOrderStatusManager())->enable();
+    (new QuotationTemplateManager())->enable();
   }
 
   /**
@@ -428,6 +432,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     $this->toggleNav('Manage Cases', FALSE);
     (new CaseTypeCategoryFeaturesManager())->disable();
     (new CaseSalesOrderStatusManager())->disable();
+    (new QuotationTemplateManager())->disable();
   }
 
   /**

--- a/CRM/Civicase/Upgrader/Steps/Step0019.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0019.php
@@ -1,5 +1,6 @@
 <?php
 
+use CRM_Civicase_Setup_Manage_QuotationTemplateManager as QuotationTemplateManager;
 use CRM_Civicase_Setup_Manage_CaseTypeCategoryFeaturesManager as CaseTypeCategoryManager;
 use CRM_Civicase_Setup_Manage_CaseSalesOrderStatusManager as CaseSalesOrderStatusManager;
 
@@ -15,11 +16,22 @@ class CRM_Civicase_Upgrader_Steps_Step0019 {
    *   Return value in boolean.
    */
   public function apply() {
-    $upgrader = CRM_Civicase_Upgrader_Base::instance();
-    $upgrader->executeSqlFile('sql/auto_install.sql');
+    try {
+      $upgrader = CRM_Civicase_Upgrader_Base::instance();
+      $upgrader->executeSqlFile('sql/auto_install.sql');
 
-    (new CaseTypeCategoryManager())->create();
-    (new CaseSalesOrderStatusManager())->create();
+      (new QuotationTemplateManager())->create();
+      (new CaseTypeCategoryManager())->create();
+      (new CaseSalesOrderStatusManager())->create();
+    }
+    catch (\Throwable $th) {
+      \Civi::log()->error('Error upgrading Civicase', [
+        'context' => [
+          'backtrace' => $th->getTraceAsString(),
+          'message' => $th->getMessage(),
+        ],
+      ]);
+    }
 
     return TRUE;
   }

--- a/CRM/Civicase/WorkflowMessage/SalesOrderInvoice.php
+++ b/CRM/Civicase/WorkflowMessage/SalesOrderInvoice.php
@@ -15,6 +15,8 @@ use Civi\WorkflowMessage\GenericWorkflowMessage;
  * @method $this setDomainLocation(?array $domainLocation)
  * @method ?string getDomainLogo()
  * @method $this setDomainLogo(?string $logo)
+ * @method ?int getSalesOrderId()
+ * @method $this setSalesOrderId(?int $salesOrderId)
  */
 class CRM_Civicase_WorkflowMessage_SalesOrderInvoice extends GenericWorkflowMessage {
 
@@ -51,5 +53,13 @@ class CRM_Civicase_WorkflowMessage_SalesOrderInvoice extends GenericWorkflowMess
    * @scope tplParams as domain_logo
    */
   protected $domainLogo;
+
+  /**
+   * Sales Order ID.
+   *
+   * @var array
+   * @scope tokenContext
+   */
+  protected $salesOrderId;
 
 }

--- a/CRM/Civicase/WorkflowMessage/SalesOrderInvoice.php
+++ b/CRM/Civicase/WorkflowMessage/SalesOrderInvoice.php
@@ -1,0 +1,55 @@
+<?php
+
+use Civi\WorkflowMessage\GenericWorkflowMessage;
+
+/**
+ * Invoice for case sales order(Quotations).
+ *
+ * @support template-only
+ *
+ * @method ?string getTerms()
+ * @method $this setTerms(?string $terms)
+ * @method ?array getSalesOrder()
+ * @method $this setSalesOrder(?array $salesOrder)
+ * @method ?array getDomainLocation()
+ * @method $this setDomainLocation(?array $domainLocation)
+ * @method ?string getDomainLogo()
+ * @method $this setDomainLogo(?string $logo)
+ */
+class CRM_Civicase_WorkflowMessage_SalesOrderInvoice extends GenericWorkflowMessage {
+
+  public const WORKFLOW = 'sales_order_invoice';
+
+  /**
+   * Quotation Terms.
+   *
+   * @var string
+   * @scope tplParams
+   */
+  public $terms;
+
+  /**
+   * Sales Order object.
+   *
+   * @var array
+   * @scope tplParams as sales_order
+   */
+  protected $salesOrder;
+
+  /**
+   * Domain location information.
+   *
+   * @var array
+   * @scope tplParams as domain_location
+   */
+  protected $domainLocation;
+
+  /**
+   * Domain Orgnanisation Image URL.
+   *
+   * @var array
+   * @scope tplParams as domain_logo
+   */
+  protected $domainLogo;
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -79,6 +79,16 @@ function civicase_civicrm_config(&$config) {
     'hook_civicrm_buildAsset',
     ['CRM_Civicase_Event_Listener_AssetBuilder', 'addWordReplacements']
   );
+
+  Civi::dispatcher()->addListener(
+    'civi.token.list',
+    ['CRM_Civicase_Hook_Tokens_SalesOrderTokens', 'listSalesOrderTokens']
+  );
+
+  Civi::dispatcher()->addListener(
+    'civi.token.eval',
+    ['CRM_Civicase_Hook_Tokens_SalesOrderTokens', 'evaluateSalesOrderTokens']
+  );
 }
 
 /**

--- a/templates/CRM/Civicase/Form/CaseSalesOrderInvoice.tpl
+++ b/templates/CRM/Civicase/Form/CaseSalesOrderInvoice.tpl
@@ -1,0 +1,15 @@
+<div class="messages status no-popup">
+    {icon icon="fa-info-circle"}{/icon}
+    {ts}Your quotation will be emailed to the contact below as a PDF attachment.{/ts}
+  </div>
+{include file="CRM/Contact/Form/Task/Email.tpl"}
+
+{literal}
+<script>
+CRM.$(function($) {
+  $('#follow-up').hide();
+  $('#attachments').parent().parent().hide();
+  $('.crm-contactEmail-form-block-campaign_id').hide();
+});
+</script>
+{/literal}

--- a/templates/CRM/Civicase/MessageTemplate/QuotationInvoice.tpl
+++ b/templates/CRM/Civicase/MessageTemplate/QuotationInvoice.tpl
@@ -7,7 +7,7 @@
 </head>
 
 <body>
-  <div style="color: black; margin:16px">
+  <div style="color: black; margin:16px; font-family: Arial, Verdana, sans-serif;">
     <table style="width:100%; margin-bottom: 14px;">
       <tbody>
         <tr>

--- a/templates/CRM/Civicase/MessageTemplate/QuotationInvoice.tpl
+++ b/templates/CRM/Civicase/MessageTemplate/QuotationInvoice.tpl
@@ -1,0 +1,134 @@
+<!DOCTYPE html
+  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+</head>
+
+<body>
+  <div style="color: black; margin:16px">
+    <table style="width:100%; margin-bottom: 14px;">
+      <tbody>
+        <tr>
+          <td style="text-align:right">
+            <img alt="logo"
+                src="{$domain_logo}" />
+            
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div>
+      <table style="width: 100%; margin-bottom: 20px;">
+        <thead>
+          <tr>
+            <th style="text-align: left;">Client Name: {$sales_order.client.display_name}</th>
+            <th style="text-align: left;">Date</th>
+            <th style="text-align: right;">Address</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <span>{if $sales_order.clientAddress.street_address }{$sales_order.clientAddress.street_address}{/if}</span>
+              <br />
+              <span>{if $sales_order.clientAddress.supplemental_address_1 }{$sales_order.clientAddress.supplemental_address_1}{/if}</span>
+              <br />
+              <span>{if $sales_order.clientAddress.supplemental_address_2 }{$sales_order.clientAddress.supplemental_address_2}{/if}</span>
+              <br />
+              <span>
+                {if $sales_order.clientAddress.city}
+                  {$sales_order.clientAddress.city} {$sales_order.clientAddress.postal_code}{if $sales_order.clientAddress.postal_code_suffix} - {$sales_order.clientAddress.postal_code_suffix}{/if}<br />
+                {/if}
+              </span>
+            </td>
+            <td>
+              <span>{$sales_order.quotation_date|crmDate}</span>
+              <p><strong>Quote Number</strong></p>
+              <p>{$sales_order.id}</p>
+            </td>
+            <td style="text-align: right;">
+              <span>{domain.address}</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div>
+      <p><strong>Description</strong></p>
+
+      <p>{$sales_order.description}</p>
+
+      <table style="width:100%; margin-bottom: 14px;">
+      </table>
+    </div>
+
+    <div class="table" style="margin-bottom: 14px; ">
+      <table rules="cols" style="width:100%; border: 1px solid; text-align: center;">
+        <thead>
+          <tr class="head" style="background-color: #cac9c9;">
+            <th style="padding: 8px 10px; text-align: center;">Description</th>
+            <th style="padding: 8px 10px; text-align: center;">Quantity</th>
+            <th style="padding: 8px 10px; text-align: center;">Unit Price</th>
+            <th style="padding: 8px 10px; text-align: center;">Discount</th>
+            <th style="padding: 8px 10px; text-align: center;">VAT</th>
+            <th style="padding: 8px 10px; text-align: center;">Amount {$sales_order.currency} (without tax)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {foreach from=$sales_order.items key=k item=item}
+          <tr {if ($k%2) == 0} style="background-color: #e0e0e0;" {/if}>
+            <td style="padding: 8px 10px; text-align: center;" >{$item.item_description}</td>
+            <td style="padding: 8px 10px; text-align: center;">{$item.quantity}</td>
+            <td style="padding: 8px 10px; text-align: center;">{$item.unit_price|crmMoney:$sales_order.currency}</td>
+            <td style="padding: 8px 10px; text-align: center;">{if empty($item.discounted_percentage) } 0 {else}{$item.discounted_percentage}{/if}%</td>
+            <td style="padding: 8px 10px; text-align: center;">{if empty($item.tax_rate) } 0 {else}{$item.tax_rate}{/if}%</td>
+            <td style="padding: 8px 10px; text-align: center;">{$item.subtotal_amount|crmMoney:$sales_order.currency}</td>
+          </tr>
+          {/foreach}
+        </tbody>
+      </table>
+    </div>
+
+    <div style="margin-bottom: 14px; overflow: auto;">
+      <div style="margin-left: 300px;">
+        <table style="width: 100%;">
+          <tbody>
+            <tr>
+              <td>SubTotal (inclusive of discount)</td>
+              <td style="text-align: left;">{$sales_order.total_before_tax|crmMoney:$sales_order.currency}</td>
+            </tr>
+          </tbody>
+          {foreach from=$sales_order.taxRates item=tax}
+          <tbody>
+            <tr>
+              <td>Total VAT ({$tax.rate}%)</td>
+              <td style="text-align: left;">{$tax.value|crmMoney:$sales_order.currency}</td>
+            </tr>
+          </tbody>
+          {/foreach}
+          <tbody>
+            <tr class="total-row">
+              <td style="border-top: 1px solid #000; border-bottom: 1px solid #000;">Total Amount</td>
+              <td style="border-top: 1px solid #000; border-bottom: 1px solid #000; text-align: left;">{$sales_order.total_after_tax|crmMoney:$sales_order.currency}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div style="margin-top: 16px;">
+      <p><strong>Terms</strong></p>
+
+      <p>{if $terms }{$terms}{/if}</p>
+
+      <table style="width:100%; margin-bottom: 14px;">
+      </table>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/tests/phpunit/CRM/Civicase/Form/CaseSalesOrderInvoiceTest.php
+++ b/tests/phpunit/CRM/Civicase/Form/CaseSalesOrderInvoiceTest.php
@@ -1,0 +1,172 @@
+<?php
+
+use Civi\Api4\Address;
+use Civi\Api4\CaseSalesOrder;
+use Civi\Api4\Contact;
+use Civi\Api4\Email;
+use CRM_Civicase_Test_Fabricator_Contact as ContactFabricator;
+
+/**
+ * CaseSalesOrder Invoice Email Test Case.
+ *
+ * @group headless
+ */
+class CRM_Civicase_Form_CaseSalesOrderInvoiceTest extends BaseHeadlessTest {
+  use Helpers_CaseSalesOrderTrait;
+  use CRM_Civicase_Helpers_SessionTrait;
+
+  /**
+   * Setup data before tests run.
+   */
+  public function setUp() {
+    CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
+    $contact = ContactFabricator::fabricate();
+    $this->registerCurrentLoggedInContactInSession($contact['id']);
+  }
+
+  /**
+   * Ensures user sees the email form when the Email URL is accessed.
+   */
+  public function testEmailFormWillDisplayAsExpected() {
+    $salesOrder = $this->getCaseSalesOrderData();
+    $salesOrder = (object) (CaseSalesOrder::save(FALSE)
+      ->addRecord($salesOrder)
+      ->execute()
+      ->first());
+
+    Email::save(FALSE)
+      ->addRecord([
+        "contact_id" => $salesOrder->client_id,
+        "location_type_id" => 2,
+        "email" => "junwe@mail.com",
+        "is_primary" => TRUE,
+        "on_hold" => 0,
+      ])
+      ->execute();
+
+    $link = "civicrm/case-features/quotations/email?id={$salesOrder->id}";
+    $page = $this->imitateLinkVisit($link);
+
+    $this->assertRegExp('/name="subject"/', $page);
+    $this->assertRegExp('/name="from_email_address"/', $page);
+  }
+
+  /**
+   * Ensures the To Email is set to client email on email form.
+   */
+  public function testToEmailIsSetByDefaulToSalesOrderClientEmail() {
+    $expectedToEmail = "junwe@mail.com";
+    $salesOrder = $this->getCaseSalesOrderData();
+    $salesOrder = (object) (CaseSalesOrder::save(FALSE)
+      ->addRecord($salesOrder)
+      ->execute()
+      ->first());
+
+    Email::save(FALSE)
+      ->addRecord([
+        "contact_id" => $salesOrder->client_id,
+        "location_type_id" => 2,
+        "email" => $expectedToEmail,
+        "is_primary" => TRUE,
+        "on_hold" => 0,
+      ])
+      ->execute();
+
+    $link = "civicrm/case-features/quotations/email?id={$salesOrder->id}";
+    $page = $this->imitateLinkVisit($link);
+
+    $this->assertRegExp('/<' . $expectedToEmail . '>/', $page);
+  }
+
+  /**
+   * Ensures invoice will render expected tokens & tplParams.
+   *
+   * We only cheeck for some fields, that is enough to show that
+   * the right case sales order entity value is passed to
+   * the invoice.
+   */
+  public function testInvoiceRendersAsExpected() {
+    $salesOrder = $this->getCaseSalesOrderData();
+    $salesOrder['items'][] = $lineItem1 = $this->getCaseSalesOrderLineData();
+    $salesOrder['items'][] = $lineItem2 = $this->getCaseSalesOrderLineData();
+
+    $salesOrder = (object) (CaseSalesOrder::save(FALSE)
+      ->addRecord($salesOrder)
+      ->execute()
+      ->first());
+
+    $address = Address::save(FALSE)
+      ->addRecord([
+        "contact_id" => $salesOrder->client_id,
+        "location_type_id" => 5,
+        "is_primary" => TRUE,
+        "is_billing" => TRUE,
+        "street_address" => "Coldharbour Ln",
+        "street_number" => "42",
+        "supplemental_address_1" => "Supplementary Address 1",
+        "supplemental_address_2" => "Supplementary Address 2",
+        "supplemental_address_3" => "Supplementary Address 3",
+        "city" => "Hayes",
+        "postal_code" => "UB3 3EA",
+        "country_id" => 1226,
+        "manual_geo_code" => FALSE,
+        "timezone" => NULL,
+        "name" => NULL,
+        "master_id" => NULL,
+      ])
+      ->execute()
+      ->first();
+
+    $contact = (object) (Contact::get(FALSE)
+      ->addWhere('id', '=', $salesOrder->client_id)
+      ->execute()
+      ->first());
+
+    $_REQUEST['id'] = $_GET['id'] = $salesOrder->id;
+
+    $invoice = CRM_Civicase_Form_CaseSalesOrderInvoice::getQuotationInvoice();
+
+    $totalBeforeTax = CRM_Utils_Money::format($salesOrder->total_before_tax, $salesOrder->currency);
+    $totalAfterTax = CRM_Utils_Money::format($salesOrder->total_after_tax, $salesOrder->currency);
+    $this->assertArrayHasKey("html", $invoice);
+    $this->assertRegExp('/' . $contact->display_name . '/', $invoice['html']);
+    $this->assertRegExp('/Supplementary Address 1/', $invoice['html']);
+    $this->assertRegExp('/Supplementary Address 2/', $invoice['html']);
+    $this->assertRegExp('/' . $salesOrder->description . '/', $invoice['html']);
+    $this->assertRegExp('/' . str_replace(' ', '', $totalBeforeTax) . '/', $invoice['html']);
+    $this->assertRegExp('/' . str_replace(' ', '', $totalAfterTax) . '/', $invoice['html']);
+    $this->assertRegExp('/' . $lineItem1['item_description'] . '/', $invoice['html']);
+    $this->assertRegExp('/' . $lineItem2['item_description'] . '/', $invoice['html']);
+    $this->assertRegExp('/' . $lineItem1['quantity'] . '/', $invoice['html']);
+    $this->assertRegExp('/' . $lineItem2['quantity'] . '/', $invoice['html']);
+  }
+
+  /**
+   * Visits a CiviCRM link and returns the page content.
+   *
+   * @param string $url
+   *   URL to the page.
+   *
+   * @return string
+   *   Content of the page.
+   */
+  public function imitateLinkVisit(string $url) {
+    $_SERVER['REQUEST_URI'] = $url;
+    $urlParts = explode('?', $url);
+    $_GET['q'] = $urlParts[0];
+
+    if (!empty($urlParts[1])) {
+      $parsed = [];
+      parse_str($urlParts[1], $parsed);
+      foreach ($parsed as $param => $value) {
+        $_REQUEST[$param] = $value;
+      }
+    }
+
+    $item = CRM_Core_Invoke::getItem([$_GET['q']]);
+    ob_start();
+    CRM_Core_Invoke::runItem($item);
+    return ob_get_clean();
+  }
+
+}

--- a/tests/phpunit/Helpers/CaseSalesOrderTrait.php
+++ b/tests/phpunit/Helpers/CaseSalesOrderTrait.php
@@ -72,15 +72,18 @@ trait Helpers_CaseSalesOrderTrait {
    */
   public function getCaseSalesOrderLineData(array $default = []) {
     $product = ProductFabricator::fabricate();
+    $quantity = rand(2, 9);
+    $unitPrice = rand(50, 1000);
+
     return array_merge([
       'financial_type_id' => 1,
       'product_id' => $product['id'],
       'item_description' => 'test',
-      'quantity' => 1,
-      'unit_price' => 50,
+      'quantity' => $quantity,
+      'unit_price' => $unitPrice,
       'tax_rate' => NULL,
       'discounted_percentage' => NULL,
-      'subtotal_amount' => 50,
+      'subtotal_amount' => $quantity * $unitPrice,
     ], $default);
   }
 

--- a/xml/Menu/civicase.xml
+++ b/xml/Menu/civicase.xml
@@ -49,6 +49,16 @@
     <access_arguments>administer CiviCase</access_arguments>
   </item>
   <item>
+    <path>civicrm/case-features/quotations/download-pdf</path>
+    <page_callback>CRM_Civicase_Form_CaseSalesOrderInvoice::download</page_callback>
+    <access_arguments>administer CiviCase</access_arguments>
+  </item>
+  <item>
+    <path>civicrm/case-features/quotations/email</path>
+    <page_callback>CRM_Civicase_Form_CaseSalesOrderInvoice</page_callback>
+    <access_arguments>administer CiviCase</access_arguments>
+  </item>
+  <item>
     <path>civicrm/case/webforms</path>
     <page_callback>CRM_Civicase_Form_CaseWebforms</page_callback>
     <title>CaseWebforms</title>


### PR DESCRIPTION
## Overview
This PR adds the functionality allowing users to download a sales order invoice or send it as an attachment in an email.

## Before
The functionality doesn't exist

## After
A User can download an Invoice as a PDF
![espedient](https://user-images.githubusercontent.com/85277674/226905173-e4e75b1c-3a01-4f24-ad62-d492bec07733.gif)

A User can send an invoice as an attachment
![localaa](https://user-images.githubusercontent.com/85277674/226906429-ec198a84-43aa-4db6-a4f6-a6a2b5859500.gif)

## Technical Details
In this PR we've added support for new sales order tokens, only the sales order fields can be used as tokens, we didn't add support for sales order line items as tokens, also good to note that the tokens are only resolved if they are used in a mail sent from the sales order view.

This PR extends the CiviCRM EmailTrait to handle the email display but we handled the sending of the email form, this is because we needed to ensure tokens are resolved, especially the sales order entity tokens and also we wanted to generate an invoice for the sales order and attach it to the Email.

For the Invoice PDF, we added a new workflow message template `quotation_invoice` using an upgrader, check the doc here https://docs.civicrm.org/dev/en/latest/framework/message/ for more information on how the workflow works, and how the template params are resolved using class annotations.