### PR TITLE
BTHAB-21: Allow quotation to be filtered by description

### DIFF
--- a/ang/afsearchContactQuotations.aff.html
+++ b/ang/afsearchContactQuotations.aff.html
@@ -14,6 +14,7 @@
   </div>
   <div class="af-container row civicase__case-filter-form-elements" ng-show="expanded">
     <af-field name="owner_id" class="col-sm-3" />
+    <af-field name="description" class="col-sm-3" />
   </div>
   <div class="af-container row civicase__case-filter-form-elements" ng-show="expanded">
     <af-field name="status_id" defn="{input_attrs: {multiple: true}}" class="col-sm-3" />
@@ -21,3 +22,9 @@
   </div>
   <crm-search-display-table search-name="Civicase_Quotations" display-name="Civicase_Contact_Quotations_Table" filters="{client_id: routeParams.cid}"></crm-search-display-table>
 </div>
+<style>
+  #description-3 {
+    height: 30px;
+    padding: 4px 10px;
+  }
+</style>

--- a/ang/afsearchQuotations.aff.html
+++ b/ang/afsearchQuotations.aff.html
@@ -17,6 +17,7 @@
   <div class="af-container row civicase__case-filter-form-elements" ng-show="expanded">
     <af-field name="client_id" class="col-sm-3" />
     <af-field name="owner_id" class="col-sm-3" />
+    <af-field name="description" class="col-sm-3" />
   </div>
   <div class="af-container row civicase__case-filter-form-elements" ng-show="expanded">
     <af-field name="status_id" defn="{input_attrs: {multiple: true}}" class="col-sm-3" />
@@ -24,3 +25,9 @@
   </div>
   <crm-search-display-table search-name="Civicase_Quotations" display-name="Civicase_Quotations_Table" filters="{case_id: routeParams.caseId}"></crm-search-display-table>
 </div>
+<style>
+  #description-3 {
+    height: 30px;
+    padding: 4px 10px;
+  }
+</style>


### PR DESCRIPTION
## Overview
This PR adds a new field `description` to the list view, allowing the user to filter the listed quotations by description.

## Before
No description filter field.
<img width="1239" alt="Screenshot 2023-03-27 at 10 06 01" src="https://user-images.githubusercontent.com/85277674/227895523-df4ffb53-1dc0-46eb-a899-d36e354225d0.png">


## After
description filter field now exists.
<img width="1246" alt="Screenshot 2023-03-27 at 10 03 47" src="https://user-images.githubusercontent.com/85277674/227894958-e48bc984-f3a1-4c22-8ce7-17c6941afa94.png">
