### PR TITLE
BTHAB-25: Allow user to save quotation edit with default date

### DIFF
--- a/ang/civicase-features/quotations/directives/quotations-create.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.js
@@ -93,6 +93,7 @@
 
       CaseUtils.getSalesOrderAndLineItems(salesOrderId).then((result) => {
         $scope.salesOrder = result;
+        $scope.salesOrder.quotation_date = $.datepicker.formatDate('yy-mm-dd', new Date(result.quotation_date));
         $scope.salesOrder.status_id = (result.status_id).toString();
         CRM.wysiwyg.setVal('#sales-order-description', $scope.salesOrder.description);
         $scope.$emit('totalChange');

--- a/ang/civicase-features/quotations/directives/quotations-create.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.js
@@ -29,6 +29,7 @@
     const productsCache = new Map();
     const financialTypesCache = new Map();
 
+    $scope.isUpdate = false;
     $scope.formValid = true;
     $scope.roundTo = roundTo;
     $scope.submitInProgress = false;
@@ -92,6 +93,7 @@
       }
 
       CaseUtils.getSalesOrderAndLineItems(salesOrderId).then((result) => {
+        $scope.isUpdate = true;
         $scope.salesOrder = result;
         $scope.salesOrder.quotation_date = $.datepicker.formatDate('yy-mm-dd', new Date(result.quotation_date));
         $scope.salesOrder.status_id = (result.status_id).toString();
@@ -263,7 +265,8 @@
      * Show Quotation success create notification
      */
     function showSucessNotification () {
-      CRM.alert('Your Quotation has been generated successfully.', ts('Saved'), 'success');
+      const msg = !$scope.isUpdate ? 'Your Quotation has been generated successfully.' : 'Details updated successfully';
+      CRM.alert(msg, ts('Saved'), 'success');
     }
 
     /**


### PR DESCRIPTION
## Overview
This pull request (PR) allows the user to save a quotation edit with a default or a previously set date. Also, updated the alert message shown to the user after an update.

## Before
Previously, when a user edited a quotation, they could not save the changes with a default date. The user would have to manually enter the quotation date every time they made an edit. 

![aaaaasas](https://user-images.githubusercontent.com/85277674/228162084-1d8b425e-e260-4ee1-abfd-423ebb7d78d6.gif)


## After
With this PR, the user can now save a quotation edit with a default or previously set date.

![scoppcc](https://user-images.githubusercontent.com/85277674/228162180-83621001-98af-48b0-9070-96130235c399.gif)


## Technical Details
This PR modifies the `quotations-create.directive.js` file in the `ang/civicase-features/quotations/directives/` directory. Specifically, it adds a line of code that sets the quotation date to the date from the retrieved quotation object in the "yy-mm-dd" format. The code uses the jQuery UI `datepicker` function to format the date. 
