### PR TITLE
BTHAB-33: Add quotations action and form for creating sales order contribution

### DIFF
--- a/CRM/Civicase/Form/CaseSalesOrderContributionCreate.php
+++ b/CRM/Civicase/Form/CaseSalesOrderContributionCreate.php
@@ -1,0 +1,148 @@
+<?php
+
+use Civi\Api4\OptionValue;
+use CRM_Certificate_ExtensionUtil as E;
+
+/**
+ * Case sales order contribution create Form controller class.
+ *
+ * @see https://docs.civicrm.org/dev/en/latest/framework/quickform/
+ */
+class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
+
+  /**
+   * Case sales order to delete.
+   *
+   * @var int
+   */
+  public $id;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function preProcess() {
+    CRM_Utils_System::setTitle('Create Contribution');
+
+    $this->id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function buildQuickForm() {
+    $this->addElement('radio', 'to_be_invoiced', '', ts('Enter % to be invoiced ?'),
+      'percent', [
+        'id' => 'invoice_percent',
+      ]);
+    $this->add('text', 'percent_value', '', [
+      'id' => 'percent_value',
+      'placeholder' => 'Percentage to be invoiced',
+      'class' => 'form-control',
+      'min' => 1,
+      'max' => 10,
+    ], FALSE);
+    $this->addElement('radio', 'to_be_invoiced', '', ts('Remaining Balance'),
+      'remain',
+      ['id' => 'invoice_remain']
+    );
+    $this->addRule('to_be_invoiced', ts('Invoice value is required'), 'required');
+
+    $statusOptions = OptionValue::get()
+      ->addSelect('value', 'label')
+      ->addWhere('option_group_id:name', '=', 'case_sales_order_status')
+      ->execute()
+      ->getArrayCopy();
+    array_combine(array_column($statusOptions, 'label'), array_column($statusOptions, 'value'));
+
+    $this->add(
+      'select',
+      'status',
+      ts('Status'),
+      array_merge(
+        ['' => 'Select'],
+        array_combine(
+          array_column($statusOptions, 'value'),
+          array_column($statusOptions, 'label')
+        ),
+      ),
+      TRUE,
+      ['class' => 'form-control']
+    );
+
+    $this->addButtons([
+      [
+        'type' => 'submit',
+        'name' => E::ts('Create Contribution'),
+      ],
+      [
+        'type' => 'cancel',
+        'name' => E::ts('Cancel'),
+        // 'isDefault' => TRUE,
+      ],
+    ]);
+
+    parent::buildQuickForm();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function addRules() {
+    $this->addFormRule([$this, 'formRule']);
+  }
+
+  /**
+   * Form Validation rule.
+   *
+   * This enforces the rule whereby,
+   * user must supply an amount if the
+   * enter percentage smount radio is selected.
+   *
+   * @param array $values
+   *   Array of submitted values.
+   *
+   * @return array|bool
+   *   Returns the form errors if form is invalid
+   */
+  public function formRule(array $values) {
+    $errors = [];
+
+    if ($values['to_be_invoiced'] == 'percent' && empty(floatval($values['percent_value']))) {
+      $errors['percent_value'] = 'Percentage value is required';
+    }
+
+    return $errors ?: TRUE;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function postProcess() {
+    $values = $this->getSubmitValues();
+
+    if (!empty($this->id) && $values['to_be_invoiced'] == 'percent') {
+      $this->createPercentageContribution($values);
+    }
+  }
+
+  /**
+   * Redirects user to contribution add page.
+   *
+   * This contribution page will have the line items
+   * prefilled from the sales order line items.
+   */
+  public function createPercentageContribution(array $values) {
+    $query = [
+      'action' => 'add',
+      'reset' => 1,
+      'context' => 'standalone',
+      'sales_order' => $this->id,
+      'sales_order_status_id' => $values['status'],
+      'percent_amount' => floatval($values['percent_value']),
+    ];
+
+    $url = CRM_Utils_System::url('civicrm/contribute/add', $query);
+    CRM_Utils_System::redirect($url);
+  }
+
+}

--- a/templates/CRM/Civicase/Form/CaseSalesOrderContributionCreate.tpl
+++ b/templates/CRM/Civicase/Form/CaseSalesOrderContributionCreate.tpl
@@ -1,0 +1,63 @@
+<div id="bootstrap-theme" class="civicase__container" style="background-color: #fff;">
+
+  <div>
+    <div class=" panel-body">
+      <div class="form-group" ">
+        <div class="row">
+          <div class="col-sm-12">
+            {$form.to_be_invoiced.percent.html}
+          </div>
+          <div class="col-sm-5">
+            {$form.percent_value.html}
+          </div>
+        </div>
+      </div>
+
+      <div class="form-group" style="margin-bottom: 3em;">
+        <div class="row">
+          <div class="col-sm-12">
+            {$form.to_be_invoiced.remain.html}
+          </div>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <div class="row">
+          <label class="col-sm-12 control-label">
+            {$form.status.label}
+          </label>
+          <div class="col-sm-5">
+            {$form.status.html}
+          </div>
+        </div>
+      </div>
+  </div>
+  </div>
+
+
+  <div class="crm-submit-buttons">
+    {include file="CRM/common/formButtons.tpl" location="bottom"}
+  </div>
+</div>
+
+{literal}
+<script language="javascript" type="text/javascript">
+
+  CRM.$(function ($) {
+    CRM.$('input[name="percent_amount"]').hide();
+    if ( CRM.$('input[name="to_be_invoiced"]').val() == 'percent') {
+      $('input[name="to_be_invoiced"]#invoice_percent').prop("checked", true);
+      CRM.$('input[name="percent_amount"]').show();
+    }
+
+    CRM.$('input[name="to_be_invoiced"]').on('input', (e) => {
+      if (e.target.value == 'percent') {
+        CRM.$('input[name="percent_amount"]').show();
+        return
+      }
+
+      CRM.$('input[name="percent_amount"]').hide();
+    });
+  });
+</script>
+{/literal}

--- a/xml/Menu/civicase.xml
+++ b/xml/Menu/civicase.xml
@@ -48,6 +48,11 @@
     <page_callback>CRM_Civicase_Page_ContactCaseSalesOrderTab</page_callback>
     <access_arguments>administer CiviCase</access_arguments>
   </item>
+   <item>
+    <path>civicrm/case-features/quotations/create-contribution</path>
+    <page_callback>CRM_Civicase_Form_CaseSalesOrderContributionCreate</page_callback>
+    <access_arguments>administer CiviCase</access_arguments>
+  </item>
   <item>
     <path>civicrm/case/webforms</path>
     <page_callback>CRM_Civicase_Form_CaseWebforms</page_callback>


### PR DESCRIPTION
## Overview
This pull request adds a menu item and a new page for creating sales order contributions. The core logic for creating the contribution will be added in a subsequent PR.

## Before
Previously, there was no way to create sales order contributions directly from the quotations list page. 

## After
With this pull request, the user can now create a sales order contribution from the quotations list page by selecting the "Create Contribution" option from the dropdown menu. 

![wwwwww](https://user-images.githubusercontent.com/85277674/228326663-07f71048-db30-44d6-8548-ed901a5528eb.gif)


## Technical Details
- The `civicase.xml` file was updated to add a new menu item for creating sales order contribution.
- A new form controller class, `CRM_Civicase_Form_CaseSalesOrderContributionCreate`, was added to handle the form for creating sales order contributions.
- A new template file, `CaseSalesOrderContributionCreate.tpl`, was added for the form layout.
- The form contains two options for selecting the amount to be invoiced, either as a percentage or the remaining balance.
- The status dropdown in the form is populated with options from the `case_sales_order_status` option group, this will be the status of the sales_order after creating the contribution