### PR TITLE
[DRAFT] BTHAB-33: Implement feature to create multiple/single contribution for case sales order

### DIFF
--- a/CRM/Civicase/Form/CaseSalesOrderContributionCreate.php
+++ b/CRM/Civicase/Form/CaseSalesOrderContributionCreate.php
@@ -17,6 +17,9 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
    */
   public $id;
 
+  const INVOICE_PERCENT = 'percent';
+  const INVOICE_REMAIN = 'remain';
+
   /**
    * {@inheritDoc}
    */
@@ -31,7 +34,7 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
    */
   public function buildQuickForm() {
     $this->addElement('radio', 'to_be_invoiced', '', ts('Enter % to be invoiced ?'),
-      'percent', [
+      self::INVOICE_PERCENT, [
         'id' => 'invoice_percent',
       ]);
     $this->add('text', 'percent_value', '', [
@@ -39,10 +42,10 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
       'placeholder' => 'Percentage to be invoiced',
       'class' => 'form-control',
       'min' => 1,
-      'max' => 10,
+      'max' => 100,
     ], FALSE);
     $this->addElement('radio', 'to_be_invoiced', '', ts('Remaining Balance'),
-      'remain',
+      self::INVOICE_REMAIN,
       ['id' => 'invoice_remain']
     );
     $this->addRule('to_be_invoiced', ts('Invoice value is required'), 'required');
@@ -96,7 +99,7 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
    *
    * This enforces the rule whereby,
    * user must supply an amount if the
-   * enter percentage smount radio is selected.
+   * enter percentage amount radio is selected.
    *
    * @param array $values
    *   Array of submitted values.
@@ -107,8 +110,12 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
   public function formRule(array $values) {
     $errors = [];
 
-    if ($values['to_be_invoiced'] == 'percent' && empty(floatval($values['percent_value']))) {
+    if ($values['to_be_invoiced'] == self::INVOICE_PERCENT && empty(floatval($values['percent_value']))) {
       $errors['percent_value'] = 'Percentage value is required';
+    }
+
+    if ($values['to_be_invoiced'] == self::INVOICE_PERCENT && $values['percent_value'] > 100) {
+      $errors['percent_value'] = 'Percentage value cannot exceed 100 ';
     }
 
     return $errors ?: TRUE;
@@ -120,8 +127,8 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
   public function postProcess() {
     $values = $this->getSubmitValues();
 
-    if (!empty($this->id) && $values['to_be_invoiced'] == 'percent') {
-      $this->createPercentageContribution($values);
+    if (!empty($this->id) && !empty($values['to_be_invoiced'])) {
+      $this->createContribution($values);
     }
   }
 
@@ -131,14 +138,16 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
    * This contribution page will have the line items
    * prefilled from the sales order line items.
    */
-  public function createPercentageContribution(array $values) {
+  public function createContribution(array $values) {
     $query = [
       'action' => 'add',
       'reset' => 1,
       'context' => 'standalone',
       'sales_order' => $this->id,
       'sales_order_status_id' => $values['status'],
-      'percent_amount' => floatval($values['percent_value']),
+      'to_be_invoiced' => $values['to_be_invoiced'],
+      'percent_value' => $values['to_be_invoiced'] ==
+      self::INVOICE_PERCENT ? floatval($values['percent_value']) : 0,
     ];
 
     $url = CRM_Utils_System::url('civicrm/contribute/add', $query);

--- a/CRM/Civicase/Hook/BuildForm/CreateSalesOrderContribution.php
+++ b/CRM/Civicase/Hook/BuildForm/CreateSalesOrderContribution.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_Civicase_ExtensionUtil as E;
+
 /**
  * Adds the neccessary script to get sales order line items.
  */
@@ -15,13 +17,22 @@ class CRM_Civicase_Hook_BuildForm_CreateSalesOrderContribution {
    */
   public function run(CRM_Core_Form &$form, $formName) {
     $salesOrderId = CRM_Utils_Request::retrieve('sales_order', 'Integer');
+    $status = CRM_Utils_Request::retrieve('sales_order_status_id', 'Integer');
+    $toBeInvoiced = CRM_Utils_Request::retrieve('to_be_invoiced', 'String');
+    $percentValue = CRM_Utils_Request::retrieve('percent_value', 'Float');
 
     if (!$this->shouldRun($form, $formName, $salesOrderId)) {
       return;
     }
 
     CRM_Core_Resources::singleton()
-      ->addScriptFile('uk.co.compucorp.civicase', 'js/sales-order-contribution.js');
+      ->addScriptFile(E::LONG_NAME, 'js/sales-order-contribution.js')
+      ->addVars(E::LONG_NAME, [
+        'sales_order' => $salesOrderId,
+        'sales_order_status_id' => $status,
+        'to_be_invoiced' => $toBeInvoiced,
+        'percent_value' => $percentValue,
+      ]);
   }
 
   /**

--- a/CRM/Civicase/Hook/BuildForm/CreateSalesOrderContribution.php
+++ b/CRM/Civicase/Hook/BuildForm/CreateSalesOrderContribution.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Adds the neccessary script to get sales order line items.
+ */
+class CRM_Civicase_Hook_BuildForm_CreateSalesOrderContribution {
+
+  /**
+   * Populates the contribution form if triggered from sales order.
+   *
+   * @param CRM_Core_Form $form
+   *   Form object class.
+   * @param string $formName
+   *   Form name.
+   */
+  public function run(CRM_Core_Form &$form, $formName) {
+    $salesOrderId = CRM_Utils_Request::retrieve('sales_order', 'Integer');
+
+    if (!$this->shouldRun($form, $formName, $salesOrderId)) {
+      return;
+    }
+
+    CRM_Core_Resources::singleton()
+      ->addScriptFile('uk.co.compucorp.civicase', 'js/sales-order-contribution.js');
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * This hook is only valid for the Case form.
+   *
+   * The civicase client id parameter must be defined.
+   *
+   * @param CRM_Core_Form $form
+   *   Form class.
+   * @param string $formName
+   *   Form Name.
+   * @param int|null $salesOrderId
+   *   Sales Order ID.
+   */
+  public function shouldRun(CRM_Core_Form $form, string $formName, ?int $salesOrderId) {
+    return $formName === 'CRM_Contribute_Form_Contribution'
+      && $form->_action == CRM_Core_Action::ADD
+      && !empty($salesOrderId);
+  }
+
+}

--- a/CRM/Civicase/Hook/Post/CreateSalesOrderContribution.php
+++ b/CRM/Civicase/Hook/Post/CreateSalesOrderContribution.php
@@ -21,6 +21,8 @@ class CRM_Civicase_Hook_Post_CreateSalesOrderContribution {
    *   Object reference.
    */
   public function run($op, $objectName, $objectId, &$objectRef) {
+    $toBeInvoiced = CRM_Utils_Request::retrieve('to_be_invoiced', 'String');
+    $percentValue = CRM_Utils_Request::retrieve('percent_value', 'Float');
     $salesOrderId = CRM_Utils_Request::retrieve('sales_order', 'Integer');
     $salesOrderStatusId = CRM_Utils_Request::retrieve('sales_order_status_id', 'Integer');
 
@@ -30,6 +32,8 @@ class CRM_Civicase_Hook_Post_CreateSalesOrderContribution {
 
     CaseSalesOrderContribution::create()
       ->addValue('case_sales_order_id', $salesOrderId)
+      ->addValue('to_be_invoiced', $toBeInvoiced)
+      ->addValue('percent_value', $percentValue)
       ->addValue('contribution_id', $objectId)
       ->execute();
 

--- a/CRM/Civicase/Hook/Post/CreateSalesOrderContribution.php
+++ b/CRM/Civicase/Hook/Post/CreateSalesOrderContribution.php
@@ -1,0 +1,59 @@
+<?php
+
+use Civi\Api4\CaseSalesOrder;
+use Civi\Api4\CaseSalesOrderContribution;
+
+/**
+ * Handles sales order contribution post processing.
+ */
+class CRM_Civicase_Hook_Post_CreateSalesOrderContribution {
+
+  /**
+   * Creates Sales Order Contribtution.
+   *
+   * @param string $op
+   *   The operation being performed.
+   * @param string $objectName
+   *   Object name.
+   * @param mixed $objectId
+   *   Object ID.
+   * @param object $objectRef
+   *   Object reference.
+   */
+  public function run($op, $objectName, $objectId, &$objectRef) {
+    $salesOrderId = CRM_Utils_Request::retrieve('sales_order', 'Integer');
+    $salesOrderStatusId = CRM_Utils_Request::retrieve('sales_order_status_id', 'Integer');
+
+    if (!$this->shouldRun($op, $objectName, $salesOrderId)) {
+      return;
+    }
+
+    CaseSalesOrderContribution::create()
+      ->addValue('case_sales_order_id', $salesOrderId)
+      ->addValue('contribution_id', $objectId)
+      ->execute();
+
+    CaseSalesOrder::update()
+      ->addWhere('id', '=', $salesOrderId)
+      ->addValue('status_id', $salesOrderStatusId)
+      ->execute();
+  }
+
+  /**
+   * Determines if the hook should run or not.
+   *
+   * @param string $op
+   *   The operation being performed.
+   * @param string $objectName
+   *   Object name.
+   * @param string $salesOrderId
+   *   The sales order that triggered the contribution (if any).
+   *
+   * @return bool
+   *   returns a boolean to determine if hook will run or not.
+   */
+  private function shouldRun($op, $objectName, $salesOrderId) {
+    return strtolower($objectName) == 'contribution' && !empty($salesOrderId) && $op == 'create';
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -187,6 +187,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_AddScriptToCreatePdfForm(),
     new CRM_Civicase_Hook_BuildForm_AddCaseCategoryFeaturesField(),
     new CRM_Civicase_Hook_BuildForm_AddQuotationsNotesToContributionSettings(),
+    new CRM_Civicase_Hook_BuildForm_CreateSalesOrderContribution(),
   ];
 
   foreach ($hooks as $hook) {
@@ -279,6 +280,7 @@ function civicase_civicrm_validateForm($formName, &$fields, &$files, &$form, &$e
  */
 function civicase_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   $hooks = [
+    new CRM_Civicase_Hook_Post_CreateSalesOrderContribution(),
     new CRM_Civicase_Hook_Post_PopulateCaseCategoryForCaseType(),
     new CRM_Civicase_Hook_Post_CaseCategoryCustomGroupSaver(),
     new CRM_Civicase_Hook_Post_UpdateCaseTypeListForCaseCategoryCustomGroup(),

--- a/js/sales-order-contribution.js
+++ b/js/sales-order-contribution.js
@@ -1,0 +1,97 @@
+(function ($, _) {
+  $(document).one('crmLoad', function () {
+    const params = new URLSearchParams(window.location.search);
+    const salesOrderId = params.get('sales_order');
+    const salesOrderStatusId = params.get('sales_order_status_id');
+    const percentAmount = params.get('percent_amount');
+
+    $('#totalAmount, #totalAmountORaddLineitem, #totalAmountORPriceSet, #price_set_id').hide();
+    $('#total_amount').val(0);
+
+    const apiRequest = {};
+    apiRequest.caseSalesOrders = ['CaseSalesOrder', 'get', {
+      select: ['*', 'case_sales_order_line.*'],
+      where: [['id', '=', salesOrderId]],
+      chain: { items: ['CaseSalesOrderLine', 'get', { where: [['sales_order_id', '=', '$id']], select: ['*', 'product_id.name', 'financial_type_id.name'] }] }
+    }];
+
+    apiRequest.optionValues = ['OptionValue', 'get', {
+      select: ['value'],
+      where: [['option_group_id:name', '=', 'contribution_status'], ['name', '=', 'pending']]
+    }];
+
+    CRM.api4(apiRequest).then(function (batch) {
+      const caseSalesOrder = batch.caseSalesOrders[0];
+      CRM.$('#contact_id').select2('val', caseSalesOrder.client_id).trigger('change');
+      CRM.$('#source').val(`Quotation ${caseSalesOrder.id}`).trigger('change');
+      CRM.$('#contribution_status_id').val(batch.optionValues[0].value);
+
+      if (Array.isArray(caseSalesOrder.items) && caseSalesOrder.items.length > 0) {
+        $('#lineitem-add-block').show().removeClass('hiddenElement');
+
+        let count = 0;
+        caseSalesOrder.items.forEach((lineItem, index) => {
+          const newQuantity = (percentAmount / 100) * lineItem.quantity;
+
+          addLineItem(count, newQuantity, lineItem.unit_price, lineItem.item_description, lineItem.financial_type_id, lineItem.tax_rate);
+          count++;
+
+          if (lineItem.discounted_percentage > 0) {
+            const description = `${lineItem.item_description} Discount ${lineItem.discounted_percentage}%`;
+            const unitPrice = percent(lineItem.discounted_percentage, lineItem.unit_price);
+            addLineItem(count, newQuantity, -unitPrice, description, lineItem.financial_type_id, lineItem.tax_rate);
+
+            count++;
+          }
+          $('#add-another-item').hide();
+
+          $('input[id="total_amount"]', 'form.CRM_Contribute_Form_Contribution').trigger('change');
+        });
+
+        CRM.$(`<input type="hidden" value="${salesOrderId}" name="sales_order" />`).insertBefore('#source');
+        CRM.$(`<input type="hidden" value="${salesOrderStatusId}" name="sales_order_status_id" />`).insertBefore('#source');
+      }
+    }, function (failure) {
+    });
+
+    /**
+     * @param {number} index Item row index
+     * @param {number} quantity Item quantity
+     * @param {number} unitPrice Item unit price
+     * @param {string} description Item description
+     * @param {number} financialTypeId Item financial type
+     * @param {number} taxRate Item tax rate
+     */
+    function addLineItem (index, quantity, unitPrice, description, financialTypeId, taxRate) {
+      const row = $($('tr.hiddenElement')[index]);
+      row.show().removeClass('hiddenElement');
+
+      $('input[id^="item_label"]', row).val(ts(description));
+      $('select[id^="item_financial_type_id"]', row).select2('val', financialTypeId);
+      $('input[id^="item_qty"]', row).val(quantity);
+
+      const total = quantity * parseFloat(unitPrice);
+
+      $('input[id^="item_unit_price"]', row).val(CRM.formatMoney(unitPrice, true));
+      $('input[id^="item_line_total"]', row).val(CRM.formatMoney(total, true));
+      if (taxRate) {
+        const taxAmount = percent(taxRate, total);
+
+        $('input[id^="item_tax_amount"]', row).val(CRM.formatMoney(taxAmount, true));
+      }
+    }
+
+    /**
+     * Returns percentage% of value
+     * e.g. 5% of 10.
+     *
+     * @param {number} percentage Percentage to calculate
+     * @param {number} value The value to get percentage of
+     *
+     * @returns {number} Calculated Percentage in float
+     */
+    function percent (percentage, value) {
+      return (parseFloat(percentage) / 100) * parseFloat(value);
+    }
+  });
+})(CRM.$, CRM._);

--- a/js/sales-order-contribution.js
+++ b/js/sales-order-contribution.js
@@ -1,11 +1,14 @@
 (function ($, _) {
   $(document).one('crmLoad', function () {
-    const params = new URLSearchParams(window.location.search);
-    const salesOrderId = params.get('sales_order');
-    const salesOrderStatusId = params.get('sales_order_status_id');
-    const percentAmount = params.get('percent_amount');
+    const params = CRM.vars['uk.co.compucorp.civicase'];
+    const salesOrderId = params.sales_order;
+    const salesOrderStatusId = params.sales_order_status_id;
+    const percentValue = params.percent_value;
+    const toBeInvoiced = params.to_be_invoiced;
+    const PERCENT = 'percent';
+    let count = 0;
 
-    $('#totalAmount, #totalAmountORaddLineitem, #totalAmountORPriceSet, #price_set_id').hide();
+    if ($('input[name="sales_order"]').length) { $('#totalAmount, #totalAmountORaddLineitem, #totalAmountORPriceSet, #price_set_id').hide(); }
     $('#total_amount').val(0);
 
     const apiRequest = {};
@@ -22,48 +25,56 @@
 
     CRM.api4(apiRequest).then(function (batch) {
       const caseSalesOrder = batch.caseSalesOrders[0];
-      CRM.$('#contact_id').select2('val', caseSalesOrder.client_id).trigger('change');
-      CRM.$('#source').val(`Quotation ${caseSalesOrder.id}`).trigger('change');
-      CRM.$('#contribution_status_id').val(batch.optionValues[0].value);
 
-      if (Array.isArray(caseSalesOrder.items) && caseSalesOrder.items.length > 0) {
-        $('#lineitem-add-block').show().removeClass('hiddenElement');
+      $('#add-another-item').hide();
+      $('#lineitem-add-block').show().removeClass('hiddenElement');
+      $('#contribution_status_id').val(batch.optionValues[0].value);
+      $('#source').val(`Quotation ${caseSalesOrder.id}`).trigger('change');
+      $('#contact_id').select2('val', caseSalesOrder.client_id).trigger('change');
 
-        let count = 0;
-        caseSalesOrder.items.forEach((lineItem, index) => {
-          const newQuantity = (percentAmount / 100) * lineItem.quantity;
-
-          addLineItem(count, newQuantity, lineItem.unit_price, lineItem.item_description, lineItem.financial_type_id, lineItem.tax_rate);
-          count++;
-
-          if (lineItem.discounted_percentage > 0) {
-            const description = `${lineItem.item_description} Discount ${lineItem.discounted_percentage}%`;
-            const unitPrice = percent(lineItem.discounted_percentage, lineItem.unit_price);
-            addLineItem(count, newQuantity, -unitPrice, description, lineItem.financial_type_id, lineItem.tax_rate);
-
-            count++;
-          }
-          $('#add-another-item').hide();
-
-          $('input[id="total_amount"]', 'form.CRM_Contribute_Form_Contribution').trigger('change');
-        });
-
-        CRM.$(`<input type="hidden" value="${salesOrderId}" name="sales_order" />`).insertBefore('#source');
-        CRM.$(`<input type="hidden" value="${salesOrderStatusId}" name="sales_order_status_id" />`).insertBefore('#source');
+      if (!Array.isArray(caseSalesOrder.items) || caseSalesOrder.items.length < 1) {
+        return;
       }
+
+      prefillLineItemsFromCaseSalesOrder(caseSalesOrder);
+
+      $(`<input type="hidden" value="${salesOrderId}" name="sales_order" />`).insertBefore('#source');
+      $(`<input type="hidden" value="${toBeInvoiced}" name="to_be_invoiced" />`).insertBefore('#source');
+      $(`<input type="hidden" value="${percentValue}" name="percent_value" />`).insertBefore('#source');
+      $(`<input type="hidden" value="${salesOrderStatusId}" name="sales_order_status_id" />`).insertBefore('#source');
     }, function (failure) {
     });
 
     /**
-     * @param {number} index Item row index
+     * Prefills the contribution form with the sales order line items.
+     *
+     * @param {object} caseSalesOrder The case sales order object
+     */
+    function prefillLineItemsFromCaseSalesOrder (caseSalesOrder) {
+      caseSalesOrder.items.forEach((lineItem, index) => {
+        const newQuantity = (toBeInvoiced === PERCENT) ? (percentValue / 100) * lineItem.quantity : lineItem.quantity;
+
+        addLineItem(newQuantity, lineItem.unit_price, lineItem.item_description, lineItem.financial_type_id, lineItem.tax_rate);
+
+        if (lineItem.discounted_percentage > 0) {
+          const description = `${lineItem.item_description} Discount ${lineItem.discounted_percentage}%`;
+          const unitPrice = percent(lineItem.discounted_percentage, lineItem.unit_price);
+          addLineItem(newQuantity, -unitPrice, description, lineItem.financial_type_id, lineItem.tax_rate);
+        }
+
+        $('input[id="total_amount"]', 'form.CRM_Contribute_Form_Contribution').trigger('change');
+      });
+    }
+
+    /**
      * @param {number} quantity Item quantity
      * @param {number} unitPrice Item unit price
      * @param {string} description Item description
      * @param {number} financialTypeId Item financial type
-     * @param {number} taxRate Item tax rate
+     * @param {number|object} taxRate Item tax rate
      */
-    function addLineItem (index, quantity, unitPrice, description, financialTypeId, taxRate) {
-      const row = $($('tr.hiddenElement')[index]);
+    function addLineItem (quantity, unitPrice, description, financialTypeId, taxRate) {
+      const row = $($(`tr#add-item-row-${count}`));
       row.show().removeClass('hiddenElement');
 
       $('input[id^="item_label"]', row).val(ts(description));
@@ -74,11 +85,14 @@
 
       $('input[id^="item_unit_price"]', row).val(CRM.formatMoney(unitPrice, true));
       $('input[id^="item_line_total"]', row).val(CRM.formatMoney(total, true));
-      if (taxRate) {
-        const taxAmount = percent(taxRate, total);
 
-        $('input[id^="item_tax_amount"]', row).val(CRM.formatMoney(taxAmount, true));
+      let taxAmount = taxRate.amount;
+      if (!isNaN(taxRate)) {
+        taxAmount = percent(taxRate, total);
       }
+      $('input[id^="item_tax_amount"]', row).val(CRM.formatMoney(taxAmount, true));
+
+      count++;
     }
 
     /**

--- a/js/sales-order-contribution.js
+++ b/js/sales-order-contribution.js
@@ -9,7 +9,7 @@
     const REMAIN = 'remain';
     let count = 0;
 
-    if ($('input[name="sales_order"]').length) { $('#totalAmount, #totalAmountORaddLineitem, #totalAmountORPriceSet, #price_set_id').hide(); }
+    $('#totalAmount, #totalAmountORaddLineitem, #totalAmountORPriceSet, #price_set_id, #choose-manual, .remove_item').hide();
     $('#total_amount').val(0);
 
     const apiRequest = {};
@@ -99,7 +99,7 @@
             }
 
             previousContribution.items.forEach(item => {
-              addLineItem(item.qty, -item.unit_price, item.label, item.financial_type_id, { amount: item.tax_amount });
+              addLineItem(-item.qty, item.unit_price, item.label, item.financial_type_id, { amount: item.tax_amount });
             });
 
             $('input[id="total_amount"]', 'form.CRM_Contribute_Form_Contribution').trigger('change');

--- a/templates/CRM/Civicase/Form/CaseSalesOrderContributionCreate.tpl
+++ b/templates/CRM/Civicase/Form/CaseSalesOrderContributionCreate.tpl
@@ -44,19 +44,19 @@
 <script language="javascript" type="text/javascript">
 
   CRM.$(function ($) {
-    CRM.$('input[name="percent_amount"]').hide();
+    CRM.$('input[name="percent_value"]').hide();
     if ( CRM.$('input[name="to_be_invoiced"]').val() == 'percent') {
       $('input[name="to_be_invoiced"]#invoice_percent').prop("checked", true);
-      CRM.$('input[name="percent_amount"]').show();
+      CRM.$('input[name="percent_value"]').show();
     }
 
     CRM.$('input[name="to_be_invoiced"]').on('input', (e) => {
       if (e.target.value == 'percent') {
-        CRM.$('input[name="percent_amount"]').show();
+        CRM.$('input[name="percent_value"]').show();
         return
       }
 
-      CRM.$('input[name="percent_amount"]').hide();
+      CRM.$('input[name="percent_value"]').hide();
     });
   });
 </script>


### PR DESCRIPTION
## Overview
This PR adds the logic required to create a contribution for a sales order.

## Before
The create contribution popup is displayed but doesn't create a contribution when it's submitted
![apapo](https://user-images.githubusercontent.com/85277674/228326663-07f71048-db30-44d6-8548-ed901a5528eb.gif)

## After
When the create contribution form is submitted a contribution is created
![apapo](https://user-images.githubusercontent.com/85277674/228590201-57ff10ca-cc86-4e60-821b-18a6da4e6307.gif)

For each contribution created for a sales order a new row is inserted into the sales_order_contribution table
![afang](https://user-images.githubusercontent.com/85277674/228739803-f165e400-a4b8-4199-8856-0ccd194272bb.gif)


## Technical Details
A user can choose to create a contribution for a sales order based on % of quantity (referred to as `percent`) or the remaining amount for which contributions have not been created (referred to as `remain`).

Let's say a sales order has the line item below;

| **Product** | **Item Description**     | **Financial Type**    | **Unit Price** | **Quantity** | **Discount %** | **Tax %** | **Subtotal** |
|-------------|---------------------------|-----------------------|----------------|--------------|----------------|-----------|--------------|
| Oppulence   | ptest product description | Campaign Contribution | 34             | 5            | 5              | 0         | 161.5        |

**If a user decides to create a contribution of 25% of the sales order value**
we will calculate 25% of the quantity of each line item multiplied by the price of the sales order line item; for the sales order line item above this will be `0.25 * 5 * 34`
https://github.com/compucorp/uk.co.compucorp.civicase/blob/7606746be7202435c33fdf2b00b84c6ff16e64ea/js/sales-order-contribution.js#L65
Also, the discount applied to a sales order line item is added as a separate contribution line item for each item with a negative value; for the sales order line item above this be `- ((0.05) * (0.25 * 5 * 34))`
https://github.com/compucorp/uk.co.compucorp.civicase/blob/7606746be7202435c33fdf2b00b84c6ff16e64ea/js/sales-order-contribution.js#L69-L73

∴ the resultant line item for the created contribution will be:

| **Item**                               | **Financial Type**    | **Qty** | **Unit Price** | **Total Price** |
|----------------------------------------|-----------------------|---------|----------------|-----------------|
| ptest product description              | Campaign Contribution | 1.25    | £34.00         | £42.50          |
| ptest product description Discount 5%  | Campaign Contribution | 1.25    | -£1.70         | -£2.13          |
||||Total|£40.37|

**If a user decides to create a contribution for the sales order remaining balance**
The contribution created for the `remain` amount will have two categories of line items, the first category of the line item will be similar to the percentage calculation above, except that the percentage, in this case, will be 100%. The other category of line items to be added will be line items for each previously created contribution that is linked to the quotation, with their quantity set to be “-”. 

https://github.com/compucorp/uk.co.compucorp.civicase/blob/7606746be7202435c33fdf2b00b84c6ff16e64ea/js/sales-order-contribution.js#L87-L110

∴ the resultant line item for the created contribution will be:

| **Item**                               | **Financial Type**    | **Qty** | **Unit Price** | **Total Price** |
|----------------------------------------|-----------------------|---------|----------------|-----------------|
| ptest product description              | Campaign Contribution | 5       | £34.00         | £170.00         |
| ptest product description Discount 5%  | Campaign Contribution | 5       | -£1.70         | -£8.50          |
| ptest product description              | Campaign Contribution | -1.25    | £34.00        | -£42.50         |
| ptest product description Discount 5%  | Campaign Contribution | -1.25    | -£1.70          | £2.13           |
||||Total|£121.13|

<hr />

We also added validation in `Form_CaseSalesOrderContributionCreate`to ensure the total amount of the contribution to be created will not exceed the total amount of the sales order;

https://github.com/compucorp/uk.co.compucorp.civicase/blob/1dbe160de71ed134e2c63f07c1ff452fc4e4201c/CRM/Civicase/Form/CaseSalesOrderContributionCreate.php#L127-L148
Notwithstanding, this validation doesn't prevent a user from manually editing a contribution value.

Two hooks were used:
1. Hook_BuildForm_CreateSalesOrderContribution - This injects the JavaScript file and necessary JS variables into the contribution page, we are using Javascript because the line items in the contribution page can only be prefilled from the frontend, this is because the line items fields are prefilled by a hook in the `lineitemedit` extension and its almost impossible to guarantee the hook execution order.
https://github.com/compucorp/lineitemedit/blob/8578f6f8343d6eea4e8df99a11ead16d010e8f6e/lineitemedit.php#L130-L135
2. Hook_Post_CreateSalesOrderContribution - Creates a new `CaseSalesOrderContribution` entity post contribution is created.



## Comments
This PR doesn't include a unittest, might add it later if I figure out the best way to do it since the core logic is in the JS file that prefills the line items.


