### PR TITLE
BTHAB-48: Add page to list quotation Invoices

### DIFF
--- a/CRM/Civicase/Hook/NavigationMenu/CaseInstanceFeaturesMenu.php
+++ b/CRM/Civicase/Hook/NavigationMenu/CaseInstanceFeaturesMenu.php
@@ -15,6 +15,7 @@ class CRM_Civicase_Hook_NavigationMenu_CaseInstanceFeaturesMenu extends CRM_Civi
    */
   const FEATURES_WITH_MENU = [
     'quotations',
+    'invoices',
   ];
 
   /**

--- a/ang/afsearchQuotationInvoices.aff.html
+++ b/ang/afsearchQuotationInvoices.aff.html
@@ -1,0 +1,3 @@
+<div af-fieldset="">
+  <crm-search-display-table search-name="Quotation_Invoices" display-name="Quotation_Invoices" filters="{'CaseSalesOrderContribution_CaseSalesOrder_case_sales_order_id_01.case_id': routeParams.caseId}"></crm-search-display-table>
+</div>

--- a/ang/afsearchQuotationInvoices.aff.json
+++ b/ang/afsearchQuotationInvoices.aff.json
@@ -1,0 +1,16 @@
+{
+  "type": "search",
+  "requires": [],
+  "title": "Quotation Invoice",
+  "description": "",
+  "is_dashlet": false,
+  "is_public": false,
+  "is_token": false,
+  "server_route": "",
+  "permission": "access CiviCRM",
+  "entity_type": null,
+  "join_entity": null,
+  "contact_summary": null,
+  "redirect": null,
+  "create_submission": null
+}

--- a/ang/civicase-features.ang.php
+++ b/ang/civicase-features.ang.php
@@ -17,7 +17,7 @@ $options = [];
 
 set_currency_codes($options);
 set_case_sales_order_status($options);
-set_case_types_with_quotations_enabled($options);
+set_case_types_with_features_enabled($options);
 
 /**
  * Get a list of JS files.
@@ -45,12 +45,15 @@ function set_currency_codes(&$options) {
 }
 
 /**
- * Exposes Case types that have quotations enabled to Angular.
+ * Exposes Case types that have features enabled to Angular.
  */
-function set_case_types_with_quotations_enabled(&$options) {
+function set_case_types_with_features_enabled(&$options) {
   $caseTypeCategoryFeatures = new CaseTypeCategoryFeatures();
-  $caseTypeCategories = $caseTypeCategoryFeatures->retrieveCaseInstanceWithEnabledFeatures(['quotations']);
-  $options['featureCaseTypes']['quotations'] = array_keys($caseTypeCategories);
+
+  array_map(function ($feature) use ($caseTypeCategoryFeatures, &$options) {
+    $caseTypeCategories = $caseTypeCategoryFeatures->retrieveCaseInstanceWithEnabledFeatures([$feature]);
+    $options['featureCaseTypes'][$feature] = array_keys($caseTypeCategories);
+  }, ['quotations', 'invoices']);
 }
 
 /**
@@ -73,6 +76,7 @@ $requires = [
   'civicase-base',
   'afsearchQuotations',
   'afsearchContactQuotations',
+  'afsearchQuotationInvoices',
 ];
 
 return [

--- a/ang/civicase-features/app.routes.js
+++ b/ang/civicase-features/app.routes.js
@@ -18,5 +18,13 @@
         `;
       }
     });
+    $routeProvider.when('/invoices', {
+      template: function () {
+        var urlParams = UrlParametersProvider.parse(window.location.search);
+        return `
+          <invoices-list case-type-category= ${urlParams.case_type_category}"> </invoices-list>
+        `;
+      }
+    });
   });
 })(angular, CRM.$, CRM._);

--- a/ang/civicase-features/invoices/directives/invoices-case-tab-content.html
+++ b/ang/civicase-features/invoices/directives/invoices-case-tab-content.html
@@ -1,0 +1,3 @@
+<div class="civicase__case-tab__container">
+  <invoices-list></invoices-list>
+</div>

--- a/ang/civicase-features/invoices/directives/invoices-list.directive.html
+++ b/ang/civicase-features/invoices/directives/invoices-list.directive.html
@@ -1,0 +1,8 @@
+<div id="bootstrap-theme" class="civicase__container">
+  <h1 crm-page-title>{{ ts('Quotation Invoices') }}</h1>
+  <div class="panel panel-default">
+    <div class="panel-body">
+      <afsearch-quotation-invoices></afsearch-quotation-invoices>
+    </div>
+  </div>
+</div>

--- a/ang/civicase-features/invoices/directives/invoices-list.directive.js
+++ b/ang/civicase-features/invoices/directives/invoices-list.directive.js
@@ -1,0 +1,23 @@
+(function (angular, $, _) {
+  var module = angular.module('civicase-features');
+
+  module.directive('invoicesList', function () {
+    return {
+      restrict: 'E',
+      controller: 'invoicesListController',
+      templateUrl: '~/civicase-features/invoices/directives/invoices-list.directive.html',
+      scope: {}
+    };
+  });
+
+  module.controller('invoicesListController', invoicesListController);
+
+  /**
+   * @param {object} $scope the controller scope
+   * @param {object} $location the location service
+   * @param {object} $window window object of the browser
+   */
+  function invoicesListController ($scope, $location, $window) {
+
+  }
+})(angular, CRM._);

--- a/ang/civicase-features/invoices/services/quotations-case-tab.service.js
+++ b/ang/civicase-features/invoices/services/quotations-case-tab.service.js
@@ -1,0 +1,17 @@
+(function (angular, $, _) {
+  var module = angular.module('civicase');
+
+  module.service('InvoicesCaseTab', InvoicesCaseTab);
+
+  /**
+   * Invoices Case Tab service.
+   */
+  function InvoicesCaseTab () {
+    /**
+     * @returns {string} Returns tab content HTMl template url.
+     */
+    this.activeTabContentUrl = function () {
+      return '~/civicase-features/invoices/directives/invoices-case-tab-content.html';
+    };
+  }
+})(angular, CRM.$, CRM._);

--- a/ang/civicase-features/shared/configs/add-features-tab.config.js
+++ b/ang/civicase-features/shared/configs/add-features-tab.config.js
@@ -1,21 +1,26 @@
 (function (angular) {
   const module = angular.module('civicase-features');
-  const FEATURE_NAME = 'quotations';
 
   module.config(function ($windowProvider, tsProvider, CaseDetailsTabsProvider) {
-    var $window = $windowProvider.$get();
-    var ts = tsProvider.$get();
-    var quotationsTab = {
-      name: 'Quotations',
-      label: ts('Quotations'),
-      weight: 100
-    };
+    const $window = $windowProvider.$get();
+    const ts = tsProvider.$get();
+    const featuresTab = [
+      {
+        name: 'Quotations',
+        label: ts('Quotations'),
+        weight: 100
+      }, {
+        name: 'Invoices',
+        label: ts('Invoices'),
+        weight: 110
+      }
+    ];
 
-    if (caseTypeCategoryHasQuotationEnabled()) {
-      CaseDetailsTabsProvider.addTabs([
-        quotationsTab
-      ]);
-    }
+    featuresTab.forEach(feature => {
+      if (caseTypeCategoryHasFeatureEnabled(feature.name)) {
+        CaseDetailsTabsProvider.addTabs([feature]);
+      }
+    });
 
     /**
      * Returns the current case type category parameter. This is used instead of
@@ -25,9 +30,9 @@
      * @returns {string|null} the name of the case type category, or null.
      */
     function getCaseTypeCategory () {
-      var urlParamRegExp = /case_type_category=([^&]+)/i;
-      var currentSearch = decodeURIComponent($window.location.search);
-      var results = urlParamRegExp.exec(currentSearch);
+      const urlParamRegExp = /case_type_category=([^&]+)/i;
+      const currentSearch = decodeURIComponent($window.location.search);
+      const results = urlParamRegExp.exec(currentSearch);
 
       return results && results[1];
     }
@@ -36,11 +41,13 @@
      * Returns true if the current case type category has quotations
      * features enabled
      *
+     * @param {string} feature THe name of the feature
+     *
      * @returns {boolean} true if quotations is enabled, otherwise false
      */
-    function caseTypeCategoryHasQuotationEnabled () {
+    function caseTypeCategoryHasFeatureEnabled (feature) {
       const caseTypeCategory = parseInt(getCaseTypeCategory());
-      const quotationCaseTypeCategories = CRM['civicase-features'].featureCaseTypes[FEATURE_NAME] || [];
+      const quotationCaseTypeCategories = CRM['civicase-features'].featureCaseTypes[feature.toLocaleLowerCase()] || [];
       if (Array.isArray(quotationCaseTypeCategories) && caseTypeCategory) {
         return quotationCaseTypeCategories.includes(caseTypeCategory);
       }


### PR DESCRIPTION
## Overview
This pull request adds a new page to list quotation invoices. The Invoices can be accessed under the Civicase instance that has the invoice feature enabled.

## Before
Before this pull request, there was no page for listing quotation invoices.

## After
After this pull request, a user can see a new tab called `invoices`  on the case dashboard, this view will list invoices created for the case quotations.

<img width="1440" alt="Screenshot 2023-04-03 at 15 29 25" src="https://user-images.githubusercontent.com/85277674/229540334-0702df3b-a0d5-4b9c-a5ae-6bdd751ef8e5.png">

Also, a new menu item called `invoices` can be seen under the `civicase` instance menu, this view will list all invoices created for any quotations either linked to a case or not.
![retre7](https://user-images.githubusercontent.com/85277674/229540907-059fd56b-9d31-4283-aa07-117ff64d1aa4.gif)


## Technical Details
The `afsearchQuotationInvoices` directive is used to create the search display table for the quotation invoices, it is created using `searchkit` and `afform`, see this [doc](https://docs.civicrm.org/dev/en/latest/afform/overview/) on how a `searchkit` display can be embedded into an Angular page;

This PR includes the Afform files for the view. [ang/afsearchQuotationInvoices.aff.html](https://github.com/compucorp/uk.co.compucorp.civicase/pull/926/files#diff-b163256138abb64a98fff57b3de98c173c58f29a7c0ffb226e0c35a72c6a95c6) and [ang/afsearchQuotationInvoices.aff.json](https://github.com/compucorp/uk.co.compucorp.civicase/pull/926/files#diff-66f10b8f53c8a13bcc1f34e8633c46f0b50ad818f5eb3a1d698eaa7b40a961cd). The `searchkit` configuration itself will be exported along with other search displays.

The ng `invoicesList` directive is used to create the invoices list page, also the `app.routes.js` file has been modified to add a new route to the invoices list page.