### PR TITLE
BASW-970: Prevents accessing of non array element as array

### DIFF
--- a/api/v3/Case/Getwebforms.php
+++ b/api/v3/Case/Getwebforms.php
@@ -90,6 +90,9 @@ function _get_case_type_ids_from_webform(array $webform) {
   $caseTypeIds = [];
 
   foreach ($webform['case'] as $cases) {
+    if (!is_array($cases)) {
+      continue;
+    }
     foreach ($cases['case'] as $case) {
       if (!empty($case['case_type_id'])) {
         array_push($caseTypeIds, $case['case_type_id']);


### PR DESCRIPTION
## Overview
This pull request addresses a bug in the `api/v3/Case/Getwebforms.php` file, where accessing a non-array element as an array causes a PHP error on PHP8. The fix prevents this error from occurring.

## Before
In the current implementation of `api/v3/Case/Getwebforms.php`, an error occurs when the code tries to access a non-array element as an array, which causes the PHP script to crash, throwing the error

```
Cannot access offset of type string on string in _get_case_type_ids_from_webform() (line 93 of /var/www/default/htdocs/httpdocs/sites/all/civicrm_extensions/uk.co.compucorp.civicase)
```

## After
With this pull request, the code now checks if the element is an array before accessing it as such. If the element is not an array, the code will skip it and continue to the next iteration of the loop.

## Technical Details
The code changes are limited to the `api/v3/Case/Getwebforms.php` file. The fix involves adding an `if` statement that checks if the element being accessed is an array before accessing it as an array. If the element is not an array, the code will skip it and move to the next iteration of the loop. This fix prevents the PHP error from occurring and allows the code to continue executing as expected.