### PR TITLE
BTHAB-33: Implement feature to create contribution for a quotation

### DIFF
--- a/CRM/Civicase/Form/CaseSalesOrderContributionCreate.php
+++ b/CRM/Civicase/Form/CaseSalesOrderContributionCreate.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Api4\CaseSalesOrderContribution;
+use Civi\Api4\CaseSalesOrder;
 use Civi\Api4\OptionValue;
 use CRM_Certificate_ExtensionUtil as E;
 
@@ -17,6 +19,9 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
    */
   public $id;
 
+  const INVOICE_PERCENT = 'percent';
+  const INVOICE_REMAIN = 'remain';
+
   /**
    * {@inheritDoc}
    */
@@ -31,7 +36,7 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
    */
   public function buildQuickForm() {
     $this->addElement('radio', 'to_be_invoiced', '', ts('Enter % to be invoiced ?'),
-      'percent', [
+      self::INVOICE_PERCENT, [
         'id' => 'invoice_percent',
       ]);
     $this->add('text', 'percent_value', '', [
@@ -39,10 +44,10 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
       'placeholder' => 'Percentage to be invoiced',
       'class' => 'form-control',
       'min' => 1,
-      'max' => 10,
+      'max' => 100,
     ], FALSE);
     $this->addElement('radio', 'to_be_invoiced', '', ts('Remaining Balance'),
-      'remain',
+      self::INVOICE_REMAIN,
       ['id' => 'invoice_remain']
     );
     $this->addRule('to_be_invoiced', ts('Invoice value is required'), 'required');
@@ -52,19 +57,16 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
       ->addWhere('option_group_id:name', '=', 'case_sales_order_status')
       ->execute()
       ->getArrayCopy();
-    array_combine(array_column($statusOptions, 'label'), array_column($statusOptions, 'value'));
 
     $this->add(
       'select',
       'status',
       ts('Status'),
-      array_merge(
-        ['' => 'Select'],
+        ['' => 'Select'] +
         array_combine(
           array_column($statusOptions, 'value'),
           array_column($statusOptions, 'label')
         ),
-      ),
       TRUE,
       ['class' => 'form-control']
     );
@@ -89,6 +91,7 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
    */
   public function addRules() {
     $this->addFormRule([$this, 'formRule']);
+    $this->addFormRule([$this, 'validateAmount']);
   }
 
   /**
@@ -96,7 +99,7 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
    *
    * This enforces the rule whereby,
    * user must supply an amount if the
-   * enter percentage smount radio is selected.
+   * enter percentage amount radio is selected.
    *
    * @param array $values
    *   Array of submitted values.
@@ -107,8 +110,68 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
   public function formRule(array $values) {
     $errors = [];
 
-    if ($values['to_be_invoiced'] == 'percent' && empty(floatval($values['percent_value']))) {
+    if ($values['to_be_invoiced'] == self::INVOICE_PERCENT && empty(floatval($values['percent_value']))) {
       $errors['percent_value'] = 'Percentage value is required';
+    }
+
+    if ($values['to_be_invoiced'] == self::INVOICE_PERCENT && $values['percent_value'] > 100) {
+      $errors['percent_value'] = 'Percentage value cannot exceed 100 ';
+    }
+
+    return $errors ?: TRUE;
+  }
+
+  /**
+   * Validate Invoice value.
+   *
+   * Ensures that percent amount entered by user or
+   * calculated as part of other remaining balance
+   * selection is correct and  not exceeding the
+   * balance amount.
+   *
+   * e.g. If a sales_order total_amount is 1000,
+   * and has  the following contributions
+   * contribution 1 with value - 500
+   * contribution 2 with value - 250
+   * the amount owed is 250, so any new contribution
+   * that will exceed this amount should return an error.
+   *
+   * @param array $values
+   *   Array of submitted values.
+   *
+   * @return array|bool
+   *   Returns the form errors if form is invalid
+   */
+  public function validateAmount(array $values) {
+    $errors = [];
+
+    $caseSalesOrder = CaseSalesOrder::get()
+      ->addSelect('total_after_tax')
+      ->addWhere('id', '=', $this->id)
+      ->setLimit(1)
+      ->execute()
+      ->first();
+    if (empty($caseSalesOrder)) {
+      throw new CRM_Core_Exception("The specified case sales order doesn't exist");
+    }
+
+    // Get all the previous contributions.
+    $caseSalesOrderContributions = CaseSalesOrderContribution::get()
+      ->addSelect('contribution_id', 'contribution_id.total_amount')
+      ->addWhere('case_sales_order_id.id', '=', $this->id)
+      ->execute()
+      ->jsonSerialize();
+
+    $paidTotal = array_sum(array_column($caseSalesOrderContributions, 'contribution_id.total_amount'));
+    $paidPercent = ($paidTotal * 100) / $caseSalesOrder['total_after_tax'];
+    $remainPercent = 100 - $paidPercent;
+
+    if ($remainPercent <= 0) {
+      $errors['to_be_invoiced'] = 'Contribution amount cannot exceed the total sales order amount';
+    }
+
+    if ($values['to_be_invoiced'] == self::INVOICE_PERCENT && $values['percent_value'] > $remainPercent) {
+      $errors['percent_value'] = 'Percentage value cannot exceed ' . round($remainPercent, 2);
     }
 
     return $errors ?: TRUE;
@@ -120,8 +183,8 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
   public function postProcess() {
     $values = $this->getSubmitValues();
 
-    if (!empty($this->id) && $values['to_be_invoiced'] == 'percent') {
-      $this->createPercentageContribution($values);
+    if (!empty($this->id) && !empty($values['to_be_invoiced'])) {
+      $this->createContribution($values);
     }
   }
 
@@ -131,14 +194,16 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
    * This contribution page will have the line items
    * prefilled from the sales order line items.
    */
-  public function createPercentageContribution(array $values) {
+  public function createContribution(array $values) {
     $query = [
       'action' => 'add',
       'reset' => 1,
       'context' => 'standalone',
       'sales_order' => $this->id,
       'sales_order_status_id' => $values['status'],
-      'percent_amount' => floatval($values['percent_value']),
+      'to_be_invoiced' => $values['to_be_invoiced'],
+      'percent_value' => $values['to_be_invoiced'] ==
+      self::INVOICE_PERCENT ? floatval($values['percent_value']) : 0,
     ];
 
     $url = CRM_Utils_System::url('civicrm/contribute/add', $query);

--- a/CRM/Civicase/Hook/BuildForm/AddSalesOrderLineItemsToContribution.php
+++ b/CRM/Civicase/Hook/BuildForm/AddSalesOrderLineItemsToContribution.php
@@ -1,0 +1,62 @@
+<?php
+
+use CRM_Civicase_ExtensionUtil as E;
+use CRM_Civicase_Service_CaseSalesOrderLineItemsGenerator as salesOrderlineItemGenerator;
+
+/**
+ * Adds the neccessary script to get sales order line items.
+ */
+class CRM_Civicase_Hook_BuildForm_AddSalesOrderLineItemsToContribution {
+
+  /**
+   * Populates the contribution form if triggered from sales order.
+   *
+   * @param CRM_Core_Form $form
+   *   Form object class.
+   * @param string $formName
+   *   Form name.
+   */
+  public function run(CRM_Core_Form &$form, $formName) {
+    $salesOrderId = CRM_Utils_Request::retrieve('sales_order', 'Integer');
+    $status = CRM_Utils_Request::retrieve('sales_order_status_id', 'Integer');
+    $toBeInvoiced = CRM_Utils_Request::retrieve('to_be_invoiced', 'String');
+    $percentValue = CRM_Utils_Request::retrieve('percent_value', 'Float');
+
+    if (!$this->shouldRun($form, $formName, $salesOrderId)) {
+      return;
+    }
+    $lineItemGenerator = new salesOrderlineItemGenerator($salesOrderId, $toBeInvoiced, $percentValue);
+    $lineItems = $lineItemGenerator->generateLineItems();
+
+    CRM_Core_Resources::singleton()
+      ->addScriptFile(E::LONG_NAME, 'js/sales-order-contribution.js')
+      ->addVars(E::LONG_NAME, [
+        'sales_order' => $salesOrderId,
+        'sales_order_status_id' => $status,
+        'to_be_invoiced' => $toBeInvoiced,
+        'percent_value' => $percentValue,
+        'line_items' => json_encode($lineItems),
+      ]);
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * This hook is only valid for the Case form.
+   *
+   * The civicase client id parameter must be defined.
+   *
+   * @param CRM_Core_Form $form
+   *   Form class.
+   * @param string $formName
+   *   Form Name.
+   * @param int|null $salesOrderId
+   *   Sales Order ID.
+   */
+  public function shouldRun(CRM_Core_Form $form, string $formName, ?int $salesOrderId) {
+    return $formName === 'CRM_Contribute_Form_Contribution'
+      && $form->_action == CRM_Core_Action::ADD
+      && !empty($salesOrderId);
+  }
+
+}

--- a/CRM/Civicase/Hook/Post/CreateSalesOrderContribution.php
+++ b/CRM/Civicase/Hook/Post/CreateSalesOrderContribution.php
@@ -1,0 +1,70 @@
+<?php
+
+use Civi\Api4\CaseSalesOrder;
+use Civi\Api4\CaseSalesOrderContribution;
+
+/**
+ * Handles sales order contribution post processing.
+ */
+class CRM_Civicase_Hook_Post_CreateSalesOrderContribution {
+
+  /**
+   * Creates Sales Order Contribtution.
+   *
+   * @param string $op
+   *   The operation being performed.
+   * @param string $objectName
+   *   Object name.
+   * @param mixed $objectId
+   *   Object ID.
+   * @param object $objectRef
+   *   Object reference.
+   */
+  public function run($op, $objectName, $objectId, &$objectRef) {
+    $toBeInvoiced = CRM_Utils_Request::retrieve('to_be_invoiced', 'String');
+    $percentValue = CRM_Utils_Request::retrieve('percent_value', 'Float');
+    $salesOrderId = CRM_Utils_Request::retrieve('sales_order', 'Integer');
+    $salesOrderStatusId = CRM_Utils_Request::retrieve('sales_order_status_id', 'Integer');
+
+    if (!$this->shouldRun($op, $objectName, $salesOrderId)) {
+      return;
+    }
+
+    $transaction = CRM_Core_Transaction::create();
+    try {
+      CaseSalesOrderContribution::create()
+        ->addValue('case_sales_order_id', $salesOrderId)
+        ->addValue('to_be_invoiced', $toBeInvoiced)
+        ->addValue('percent_value', $percentValue)
+        ->addValue('contribution_id', $objectId)
+        ->execute();
+
+      CaseSalesOrder::update()
+        ->addWhere('id', '=', $salesOrderId)
+        ->addValue('status_id', $salesOrderStatusId)
+        ->execute();
+    }
+    catch (\Throwable $th) {
+      $transaction->rollback();
+      CRM_Core_Error::statusBounce(ts('Error creating sales order contribution'));
+    }
+  }
+
+  /**
+   * Determines if the hook should run or not.
+   *
+   * @param string $op
+   *   The operation being performed.
+   * @param string $objectName
+   *   Object name.
+   * @param string $salesOrderId
+   *   The sales order that triggered the contribution (if any).
+   *
+   * @return bool
+   *   returns a boolean to determine if hook will run or not.
+   */
+  private function shouldRun($op, $objectName, $salesOrderId) {
+    return strtolower($objectName) == 'contribution' && !empty($salesOrderId) && $op == 'create';
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -187,6 +187,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_AddScriptToCreatePdfForm(),
     new CRM_Civicase_Hook_BuildForm_AddCaseCategoryFeaturesField(),
     new CRM_Civicase_Hook_BuildForm_AddQuotationsNotesToContributionSettings(),
+    new CRM_Civicase_Hook_BuildForm_AddSalesOrderLineItemsToContribution(),
   ];
 
   foreach ($hooks as $hook) {

--- a/civicase.php
+++ b/civicase.php
@@ -280,6 +280,7 @@ function civicase_civicrm_validateForm($formName, &$fields, &$files, &$form, &$e
  */
 function civicase_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   $hooks = [
+    new CRM_Civicase_Hook_Post_CreateSalesOrderContribution(),
     new CRM_Civicase_Hook_Post_PopulateCaseCategoryForCaseType(),
     new CRM_Civicase_Hook_Post_CaseCategoryCustomGroupSaver(),
     new CRM_Civicase_Hook_Post_UpdateCaseTypeListForCaseCategoryCustomGroup(),

--- a/js/sales-order-contribution.js
+++ b/js/sales-order-contribution.js
@@ -1,0 +1,72 @@
+(function ($, _) {
+  $(document).one('crmLoad', function () {
+    const params = CRM.vars['uk.co.compucorp.civicase'];
+    const salesOrderId = params.sales_order;
+    const salesOrderStatusId = params.sales_order_status_id;
+    const percentValue = params.percent_value;
+    const toBeInvoiced = params.to_be_invoiced;
+    const lineItems = JSON.parse(params.line_items);
+    let count = 0;
+
+    const apiRequest = {};
+    apiRequest.caseSalesOrders = ['CaseSalesOrder', 'get', {
+      select: ['*'],
+      where: [['id', '=', salesOrderId]]
+    }];
+    apiRequest.optionValues = ['OptionValue', 'get', {
+      select: ['value'],
+      where: [['option_group_id:name', '=', 'contribution_status'], ['name', '=', 'pending']]
+    }];
+
+    if (Array.isArray(lineItems)) {
+      CRM.api4(apiRequest).then(function (batch) {
+        const caseSalesOrder = batch.caseSalesOrders[0];
+
+        lineItems.forEach(lineItem => {
+          addLineItem(lineItem.qty, lineItem.unit_price, lineItem.label, lineItem.financial_type_id, lineItem.tax_amount);
+        });
+
+        $('#total_amount').val(0);
+        $('#lineitem-add-block').show().removeClass('hiddenElement');
+        $('#contribution_status_id').val(batch.optionValues[0].value);
+        $('#source').val(`Quotation ${caseSalesOrder.id}`).trigger('change');
+        $('#contact_id').select2('val', caseSalesOrder.client_id).trigger('change');
+        $('input[id="total_amount"]', 'form.CRM_Contribute_Form_Contribution').trigger('change');
+        $(`<input type="hidden" value="${salesOrderId}" name="sales_order" />`).insertBefore('#source');
+        $(`<input type="hidden" value="${toBeInvoiced}" name="to_be_invoiced" />`).insertBefore('#source');
+        $(`<input type="hidden" value="${percentValue}" name="percent_value" />`).insertBefore('#source');
+        $(`<input type="hidden" value="${salesOrderStatusId}" name="sales_order_status_id" />`).insertBefore('#source');
+        $('#totalAmount, #totalAmountORaddLineitem, #totalAmountORPriceSet, #price_set_id, #choose-manual, .remove_item, #add-another-item').hide();
+      });
+    }
+
+    $("a[target='crm-popup']").on('crmPopupFormSuccess', function (e) {
+      CRM.refreshParent(e);
+    });
+
+    /**
+     * @param {number} quantity Item quantity
+     * @param {number} unitPrice Item unit price
+     * @param {string} description Item description
+     * @param {number} financialTypeId Item financial type
+     * @param {number|object} taxAmount Item tax amount
+     */
+    function addLineItem (quantity, unitPrice, description, financialTypeId, taxAmount) {
+      const row = $($(`tr#add-item-row-${count}`));
+      row.show().removeClass('hiddenElement');
+
+      $('input[id^="item_label"]', row).val(ts(description));
+      $('select[id^="item_financial_type_id"]', row).select2('val', financialTypeId);
+      $('input[id^="item_qty"]', row).val(quantity);
+
+      const total = quantity * parseFloat(unitPrice);
+
+      $('input[id^="item_unit_price"]', row).val(CRM.formatMoney(unitPrice, true));
+      $('input[id^="item_line_total"]', row).val(CRM.formatMoney(total, true));
+
+      $('input[id^="item_tax_amount"]', row).val(CRM.formatMoney(taxAmount, true));
+
+      count++;
+    }
+  });
+})(CRM.$, CRM._);


### PR DESCRIPTION
## Overview
This PR adds the logic required to create a contribution for a single quotation, it is a continuation of the work done in this [PR](https://github.com/compucorp/uk.co.compucorp.civicase/pull/923)

## Before
The create contribution popup is displayed but doesn't create a contribution when it's submitted
![apapo](https://user-images.githubusercontent.com/85277674/228326663-07f71048-db30-44d6-8548-ed901a5528eb.gif)

## After
When the create contribution form is submitted a contribution is created
![apapo](https://user-images.githubusercontent.com/85277674/228590201-57ff10ca-cc86-4e60-821b-18a6da4e6307.gif)

For each contribution created for a quotaion a new row is inserted into the sales_order_contribution table
![afang](https://user-images.githubusercontent.com/85277674/228739803-f165e400-a4b8-4199-8856-0ccd194272bb.gif)


## Technical Details
This PR simply uses the `CaseSalesOrderLineItemsGenerator` service to generate line items and then passes these line items as a JSON array to [sales-order-contribution.js] which will display the line items in the new contribution form 
 and also hide necessary fields. (https://github.com/compucorp/uk.co.compucorp.civicase/pull/928/files#diff-ab51cdbed75be517bc2815895c8668b271cd2e682edfd7627e060b90fed12f8b)

We also added validation in `Form_CaseSalesOrderContributionCreate`to ensure the total amount of the contribution to be created will not exceed the total amount of the sales order;

https://github.com/compucorp/uk.co.compucorp.civicase/blob/bbbb55905c8d235ab2298a42675e797a786faaa3/CRM/Civicase/Form/CaseSalesOrderContributionCreate.php#L124-L145
Notwithstanding, this validation doesn't prevent a user from manually editing a contribution value, and also this validation is currently not applicable when the user is creating bulk contributions.

Two hooks were used:
1. [CRM/Civicase/Hook/BuildForm/AddSalesOrderLineItemsToContribution.php](https://github.com/compucorp/uk.co.compucorp.civicase/pull/928/files#diff-5f498ceec11dc5675e85989f736856584ea89f65a34c21f365508a74cd58fb18) - This injects the JavaScript file and necessary JS variables into the contribution page, we are using Javascript because the line items in the contribution page can only be prefilled from the frontend, this is because the line items fields are prefilled by a hook in the `lineitemedit` extension and its almost impossible to guarantee the hook execution order.
https://github.com/compucorp/lineitemedit/blob/8578f6f8343d6eea4e8df99a11ead16d010e8f6e/lineitemedit.php#L130-L135
2. [CRM/Civicase/Hook/Post/CreateSalesOrderContribution.php](https://github.com/compucorp/uk.co.compucorp.civicase/pull/928/files#diff-78f79fd6437cbcc7f9ba3b705b3562383ff01ea5a776f63b73fe6279d9efc09f) - Creates a new `CaseSalesOrderContribution` entity and updates the sales order status after contribution is created.

