### PR TITLE
BTHAB-101: UI Improvements to Quotations list page

### DIFF
--- a/ang/afsearchContactQuotations.aff.html
+++ b/ang/afsearchContactQuotations.aff.html
@@ -1,20 +1,25 @@
 <div af-fieldset="">
-  <div class="af-container row civicase__case-filter-form-elements">
-    <af-field name="id" class="col-md-2" defn="{label: 'Quotation Id', input_attrs: {}}"/>
-    <af-field name="owner_id" class="col-md-2" ng-show="expanded"/>
-    <af-field name="description" class="col-md-2" ng-show="expanded"/>
-    <div class="civicase__features-filters">
-      <div />
-      <button class="btn btn-primary" ng-click="expanded = !expanded">
-        <span class="btn-text" ng-if="expanded">{{ ts(' Hide Filter ') }}</span>
-        <span class="btn-text" ng-if="!expanded">{{ ts(' Show Filter ') }}</span>
-        <span class="btn-icon"><i ng-if="expanded" class="fa fa-chevron-up"/> <i ng-if="!expanded" class="fa fa-chevron-down"/> </span>
-      </button>
+  <div class="civicase__features">
+    <div class="af-container row civicase__case-filter-form-elements">
+      <af-field name="id" class="col-md-2" defn="{label: 'Quotation Id', input_attrs: {}}"/>
+      <af-field name="owner_id" class="col-md-2" ng-show="expanded"/>
+      <af-field name="description" class="col-md-2" ng-show="expanded"/>
+      <div class="civicase__features-filters">
+        <div />
+        <button class="btn btn-primary" ng-click="expanded = !expanded">
+          <span class="btn-text" ng-if="expanded">{{ ts(' Hide Filter ') }}</span>
+          <span class="btn-text" ng-if="!expanded">{{ ts(' Show Filter ') }}</span>
+          <span class="btn-icon"><i ng-if="expanded" class="fa fa-chevron-up"/> <i ng-if="!expanded" class="fa fa-chevron-down"/> </span>
+        </button>
+      </div>
     </div>
-  </div>
-  <div class="af-container row civicase__case-filter-form-elements" ng-show="expanded">
-    <af-field name="status_id" defn="{input_attrs: {multiple: true}}" class="col-md-2" />
-    <af-field name="quotation_date" defn="{input_attrs: {time: false}, search_range: true, label: 'Date'}" class="col-md-3 civicase__ui-range" />
+    <div class="af-container row civicase__case-filter-form-elements" ng-show="expanded">
+      <af-field name="status_id" defn="{input_attrs: {multiple: true}}" class="col-md-2" />
+      <af-field name="quotation_date" defn="{input_attrs: {time: false}, search_range: true, label: 'Date'}" class="col-md-3 civicase__ui-range" />
+      <div class="col-md-1">
+        <button type="button" class="btn btn-link civicase__features-filters-clear" style="margin-top: 2em;">Clear All</button>
+      </div>
+    </div>
   </div>
   <crm-search-display-table search-name="Civicase_Quotations" display-name="Civicase_Contact_Quotations_Table" filters="{client_id: routeParams.cid}"></crm-search-display-table>
 </div>

--- a/ang/afsearchContactQuotations.aff.html
+++ b/ang/afsearchContactQuotations.aff.html
@@ -1,30 +1,20 @@
 <div af-fieldset="">
-  <div class="af-container af-layout-inline civicase__case-filter-form-elements civicase__features-filters">
-    <af-field name="id" defn="{label: 'Quotation Id', input_attrs: {}}" />
-    <button class="btn btn-primary btn-sm civicase__case-filter-panel__button" ng-click="expanded = !expanded">
-    <span ng-if="expanded">
-      {{ ts('Hide Filter') }}
-      <i class="fa fa-chevron-up"/>
-    </span>
-    <span ng-if="!expanded">
-      {{ ts('Show Filter') }}
-      <i class="fa fa-chevron-down"/>
-    </span>
-    </button>
+  <div class="af-container row civicase__case-filter-form-elements">
+    <af-field name="id" class="col-md-2" defn="{label: 'Quotation Id', input_attrs: {}}"/>
+    <af-field name="owner_id" class="col-md-2" ng-show="expanded"/>
+    <af-field name="description" class="col-md-2" ng-show="expanded"/>
+    <div class="civicase__features-filters">
+      <div />
+      <button class="btn btn-primary" ng-click="expanded = !expanded">
+        <span class="btn-text" ng-if="expanded">{{ ts(' Hide Filter ') }}</span>
+        <span class="btn-text" ng-if="!expanded">{{ ts(' Show Filter ') }}</span>
+        <span class="btn-icon"><i ng-if="expanded" class="fa fa-chevron-up"/> <i ng-if="!expanded" class="fa fa-chevron-down"/> </span>
+      </button>
+    </div>
   </div>
   <div class="af-container row civicase__case-filter-form-elements" ng-show="expanded">
-    <af-field name="owner_id" class="col-sm-3" />
-    <af-field name="description" class="col-sm-3" />
-  </div>
-  <div class="af-container row civicase__case-filter-form-elements" ng-show="expanded">
-    <af-field name="status_id" defn="{input_attrs: {multiple: true}}" class="col-sm-3" />
-    <af-field name="quotation_date" defn="{input_attrs: {time: false}, search_range: true, label: 'Date'}" class="col-sm-3 civicase__ui-range" />
+    <af-field name="status_id" defn="{input_attrs: {multiple: true}}" class="col-md-2" />
+    <af-field name="quotation_date" defn="{input_attrs: {time: false}, search_range: true, label: 'Date'}" class="col-md-3 civicase__ui-range" />
   </div>
   <crm-search-display-table search-name="Civicase_Quotations" display-name="Civicase_Contact_Quotations_Table" filters="{client_id: routeParams.cid}"></crm-search-display-table>
 </div>
-<style>
-  #description-3 {
-    height: 30px;
-    padding: 4px 10px;
-  }
-</style>

--- a/ang/afsearchQuotations.aff.html
+++ b/ang/afsearchQuotations.aff.html
@@ -1,22 +1,27 @@
 <div af-fieldset="">
-  <div class="af-container row civicase__case-filter-form-elements">
-    <af-field class="col-md-2" name="id" defn="{label: 'Quotation Id', input_attrs: {}}" />
-    <af-field name="client_id" class="col-md-2" ng-show="expanded"/>
-    <af-field name="owner_id" class="col-md-2" ng-show="expanded"/>
-    <af-field name="description" class="col-md-2" ng-show="expanded"/>
-    <div class="civicase__features-filters">
-      <div />
-      <button class="btn btn-primary" ng-click="expanded = !expanded">
-        <span class="btn-text" ng-if="expanded">{{ ts(' Hide Filter ') }}</span>
-        <span class="btn-text" ng-if="!expanded">{{ ts(' Show Filter ') }}</span>
-        <span class="btn-icon"><i ng-if="expanded" class="fa fa-chevron-up"/> <i ng-if="!expanded" class="fa fa-chevron-down"/> </span>
-      </button>
+  <div class="civicase__features">
+    <div class="af-container row civicase__case-filter-form-elements">
+      <af-field class="col-md-2" name="id" defn="{label: 'Quotation Id', input_attrs: {}}" />
+      <af-field name="client_id" class="col-md-2" ng-show="expanded"/>
+      <af-field name="owner_id" class="col-md-2" ng-show="expanded"/>
+      <af-field name="description" class="col-md-2" ng-show="expanded"/>
+      <div class="civicase__features-filters">
+        <div />
+        <button class="btn btn-primary" ng-click="expanded = !expanded">
+          <span class="btn-text" ng-if="expanded">{{ ts(' Hide Filter ') }}</span>
+          <span class="btn-text" ng-if="!expanded">{{ ts(' Show Filter ') }}</span>
+          <span class="btn-icon"><i ng-if="expanded" class="fa fa-chevron-up"/> <i ng-if="!expanded" class="fa fa-chevron-down"/> </span>
+        </button>
+      </div>
     </div>
-  </div>
 
-  <div class="af-container row civicase__case-filter-form-elements" ng-show="expanded">
-    <af-field name="status_id" defn="{input_attrs: {multiple: true}}" class="col-md-2" />
-    <af-field name="quotation_date" defn="{input_attrs: {time: false}, search_range: true, label: 'Date'}" class="col-md-3 civicase__ui-range" />
+    <div class="af-container row civicase__case-filter-form-elements" ng-show="expanded">
+      <af-field name="status_id" defn="{input_attrs: {multiple: true}}" class="col-md-2" />
+      <af-field name="quotation_date" defn="{input_attrs: {time: false}, search_range: true, label: 'Date'}" class="col-md-3 civicase__ui-range" />
+      <div class="col-md-1">
+        <button type="button" class="btn btn-link civicase__features-filters-clear" style="margin-top: 2em;">Clear All</button>
+      </div>
+    </div>
   </div>
   <crm-search-display-table search-name="Civicase_Quotations" display-name="Civicase_Quotations_Table" filters="{case_id: routeParams.caseId}"></crm-search-display-table>
 </div>

--- a/ang/afsearchQuotations.aff.html
+++ b/ang/afsearchQuotations.aff.html
@@ -1,33 +1,23 @@
 <div af-fieldset="">
-  <div class="af-container af-layout-inline civicase__case-filter-form-elements civicase__features-filters">
-    <af-field name="id" defn="{label: 'Quotation Id', input_attrs: {}}" />
-    <button class="btn btn-primary btn-sm civicase__case-filter-panel__button" ng-click="expanded = !expanded">
-      
-    <span ng-if="expanded">
-      {{ ts('Hide Filter') }}
-      <i class="fa fa-chevron-up"/>
-    </span>
-    <span ng-if="!expanded">
-      {{ ts('Show Filter') }}
-      <i class="fa fa-chevron-down"/>
-    </span>
-  
-    </button>
+  <div class="af-container row civicase__case-filter-form-elements">
+    <af-field class="col-md-2" name="id" defn="{label: 'Quotation Id', input_attrs: {}}" />
+    <af-field name="client_id" class="col-md-2" ng-show="expanded"/>
+    <af-field name="owner_id" class="col-md-2" ng-show="expanded"/>
+    <af-field name="description" class="col-md-2" ng-show="expanded"/>
+    <div class="civicase__features-filters">
+      <div />
+      <button class="btn btn-primary" ng-click="expanded = !expanded">
+        <span class="btn-text" ng-if="expanded">{{ ts(' Hide Filter ') }}</span>
+        <span class="btn-text" ng-if="!expanded">{{ ts(' Show Filter ') }}</span>
+        <span class="btn-icon"><i ng-if="expanded" class="fa fa-chevron-up"/> <i ng-if="!expanded" class="fa fa-chevron-down"/> </span>
+      </button>
+    </div>
   </div>
+
   <div class="af-container row civicase__case-filter-form-elements" ng-show="expanded">
-    <af-field name="client_id" class="col-sm-3" />
-    <af-field name="owner_id" class="col-sm-3" />
-    <af-field name="description" class="col-sm-3" />
-  </div>
-  <div class="af-container row civicase__case-filter-form-elements" ng-show="expanded">
-    <af-field name="status_id" defn="{input_attrs: {multiple: true}}" class="col-sm-3" />
-    <af-field name="quotation_date" defn="{input_attrs: {time: false}, search_range: true, label: 'Date'}" class="col-sm-3 civicase__ui-range" />
+    <af-field name="status_id" defn="{input_attrs: {multiple: true}}" class="col-md-2" />
+    <af-field name="quotation_date" defn="{input_attrs: {time: false}, search_range: true, label: 'Date'}" class="col-md-3 civicase__ui-range" />
   </div>
   <crm-search-display-table search-name="Civicase_Quotations" display-name="Civicase_Quotations_Table" filters="{case_id: routeParams.caseId}"></crm-search-display-table>
 </div>
-<style>
-  #description-3 {
-    height: 30px;
-    padding: 4px 10px;
-  }
-</style>
+

--- a/ang/civicase-features/quotations/directives/quotations-list.directive.html
+++ b/ang/civicase-features/quotations/directives/quotations-list.directive.html
@@ -18,3 +18,17 @@
     </div>
   </div>
 </div>
+<style>
+  #description-3 {
+    height: 30px;
+    padding: 4px 10px;
+    width: 100% !important;
+  }
+  .btn-text {
+    margin-right: 8px;
+  }
+  #bootstrap-theme crm-search-display-table p.alert-info {
+    background-color: transparent;
+    border: none;
+  }
+</style>

--- a/ang/civicase-features/quotations/directives/quotations-list.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-list.directive.js
@@ -28,7 +28,7 @@
         $location.search().cid = $scope.contactId;
       }
 
-      preventDatePickerNavigation();
+      addEventToElementsWhenInDOMTree();
     }());
 
     /**
@@ -45,12 +45,20 @@
     }
 
     /**
-     * Prevents date picker from triggering route navigation.
+     * Add events to elements that are occasionally removed from DOM tree
      */
-    function preventDatePickerNavigation () {
+    function addEventToElementsWhenInDOMTree () {
       const observer = new window.MutationObserver(function (mutations) {
         if ($('#ui-datepicker-div:visible a').length) {
+          // Prevents date picker from triggering route navigation.
           $('#ui-datepicker-div:visible a').click((event) => { event.preventDefault(); });
+        }
+
+        if ($('.civicase__features-filters-clear').length) {
+          // Handle clear filter button.
+          $('.civicase__features-filters-clear').click(event => {
+            CRM.$('.civicase__features input, .civicase__features textarea').val('').change();
+          });
         }
       });
 

--- a/ang/civicase-features/quotations/directives/quotations-list.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-list.directive.js
@@ -1,4 +1,4 @@
-(function (angular, _) {
+(function (angular, _, $) {
   var module = angular.module('civicase-features');
 
   module.directive('quotationsList', function () {
@@ -27,9 +27,12 @@
       if ($scope.contactId) {
         $location.search().cid = $scope.contactId;
       }
+
+      preventDatePickerNavigation();
     }());
+
     /**
-     * Redirect user to new quotation screen
+     * Redirects user to new quotation screen
      */
     function redirectToQuotationCreationScreen () {
       let url = '/civicrm/case-features/a#/quotations/new';
@@ -40,5 +43,21 @@
 
       $window.location.href = url;
     }
+
+    /**
+     * Prevents date picker from triggering route navigation.
+     */
+    function preventDatePickerNavigation () {
+      const observer = new window.MutationObserver(function (mutations) {
+        if ($('#ui-datepicker-div:visible a').length) {
+          $('#ui-datepicker-div:visible a').click((event) => { event.preventDefault(); });
+        }
+      });
+
+      observer.observe(document.body, {
+        childList: true,
+        subtree: true
+      });
+    }
   }
-})(angular, CRM._);
+})(angular, CRM._, CRM.$);


### PR DESCRIPTION
## Overview
This PR 
- Makes UI improvements to the quotation list page
- Adds a button to clear the filter fields
- Prevent the browser from navigating user to another page when the date input is clicked

## Before
![espre](https://user-images.githubusercontent.com/85277674/232123185-606e8498-e7f1-47ca-83b7-d7ceeda7b2ba.gif)

Empty state - blue background
<img width="1302" alt="Screenshot 2023-04-14 at 19 17 51" src="https://user-images.githubusercontent.com/85277674/232125301-e7750196-13f3-496d-a8f7-e6b8f6e70c8c.png">


## After
![maclean](https://user-images.githubusercontent.com/85277674/232430293-3159f3d8-802e-4df6-a6c2-c006d67efe4c.gif)



Empty State - no blue background
<img width="1297" alt="Screenshot 2023-04-17 at 09 33 56" src="https://user-images.githubusercontent.com/85277674/232430400-c4996074-76d9-484b-b997-f4a05bd73553.png">


