### PR TITLE
BTHAB-113: Hide terms when tax and invoicing is disabled

### DIFF
--- a/CRM/Civicase/Form/CaseSalesOrderInvoice.php
+++ b/CRM/Civicase/Form/CaseSalesOrderInvoice.php
@@ -1,5 +1,6 @@
 <?php
 
+use Civi\Api4\Setting;
 use Civi\Api4\Address;
 use Civi\Api4\CaseSalesOrder;
 use Civi\Api4\CaseSalesOrderLine;
@@ -191,7 +192,7 @@ class CRM_Civicase_Form_CaseSalesOrderInvoice extends CRM_Core_Form {
       ->first();
 
     $model = new CRM_Civicase_WorkflowMessage_SalesOrderInvoice();
-    $terms = Civi::settings()->get('quotations_notes');
+    $terms = self::getTerms();
     $model->setDomainLogo($organisation['image_URL']);
     $model->setSalesOrder($caseSalesOrder);
     $model->setTerms($terms);
@@ -199,6 +200,23 @@ class CRM_Civicase_Form_CaseSalesOrderInvoice extends CRM_Core_Form {
     $rendered = $model->renderTemplate();
 
     return $rendered;
+  }
+
+  /**
+   * Returns the Quotation invoice terms.
+   */
+  private static function getTerms() {
+    $terms = NULL;
+    $invoicing = Setting::get()
+      ->addSelect('invoicing')
+      ->execute()
+      ->first();
+
+    if (!empty($invoicing['value'])) {
+      $terms = Civi::settings()->get('quotations_notes');
+    }
+
+    return $terms;
   }
 
   /**

--- a/CRM/Civicase/Hook/Tokens/SalesOrderTokens.php
+++ b/CRM/Civicase/Hook/Tokens/SalesOrderTokens.php
@@ -58,7 +58,20 @@ class CRM_Civicase_Hook_Tokens_SalesOrderTokens extends AbstractTokenSubscriber 
             ->execute()
             ->first();
           foreach ($caseSalesOrder as $key => $value) {
-            $row->tokens(self::TOKEN, $key, $value);
+            try {
+              $row->tokens(self::TOKEN, $key, $value ?? '');
+            }
+            catch (\Throwable $th) {
+              \Civi::log()->error(
+                'Error resolving token: ' . self::TOKEN . '.' . $key,
+                [
+                  'context' => [
+                    'backtrace' => $th->getTraceAsString(),
+                    'message' => $th->getMessage(),
+                  ],
+                ]
+              );
+            }
           }
         }
       }

--- a/templates/CRM/Civicase/MessageTemplate/QuotationInvoice.tpl
+++ b/templates/CRM/Civicase/MessageTemplate/QuotationInvoice.tpl
@@ -120,14 +120,16 @@
       </div>
     </div>
 
+    {if !empty($terms) }
     <div style="margin-top: 16px;">
       <p><strong>Terms</strong></p>
 
-      <p>{if $terms }{$terms}{/if}</p>
+      <p>{$terms}</p>
 
       <table style="width:100%; margin-bottom: 14px;">
       </table>
     </div>
+    {/if}
   </div>
 </body>
 


### PR DESCRIPTION
## Overview
This PR 
- Display terms on quotation invoices only if `tax and invoicing`is enabled in CiviContribute settings.
- Ensure a null value in a sales_order doesn't break the token resolving process.

## Before
The invoice doesn't get downloaded
![2a](https://user-images.githubusercontent.com/85277674/233053870-d34b89b8-31a2-42fc-91e5-48da3b555b9b.gif)


## After
The invoice is now downloadable for the same quotation
![1a](https://user-images.githubusercontent.com/85277674/233053883-ccf364a9-ac10-4c66-9997-752e4a30e2f9.gif)

Also, terms would only show if `tax and invoicing` is enabled in CiviContribute settings.
![12121](https://user-images.githubusercontent.com/85277674/233055052-770f5fa4-6539-4e84-bc31-f8ee205feb2a.gif)

