### PR TITLE
BTHAB-119: Ensure salesorder invoice line item totals are correct

### DIFF
--- a/CRM/Civicase/Form/CaseSalesOrderContributionCreate.php
+++ b/CRM/Civicase/Form/CaseSalesOrderContributionCreate.php
@@ -170,7 +170,7 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
       $errors['to_be_invoiced'] = 'Contribution amount cannot exceed the total sales order amount';
     }
 
-    if ($values['to_be_invoiced'] == self::INVOICE_PERCENT && $values['percent_value'] > $remainPercent) {
+    if ($values['to_be_invoiced'] == self::INVOICE_PERCENT && floatval($values['percent_value']) > $remainPercent) {
       $errors['percent_value'] = 'Percentage value cannot exceed ' . round($remainPercent, 2);
     }
 

--- a/CRM/Civicase/Service/CaseSalesOrderLineItemsGenerator.php
+++ b/CRM/Civicase/Service/CaseSalesOrderLineItemsGenerator.php
@@ -79,10 +79,10 @@ class CRM_Civicase_Service_CaseSalesOrderLineItemsGenerator {
       $items[] = $this->lineItemToContributionLineItem($item);
 
       if ($item['discounted_percentage'] > 0) {
-        $item['tax'] = 0;
         $item['item_description'] = "{$item['item_description']} Discount {$item['discounted_percentage']}%";
         $item['unit_price'] = $this->percent($item['discounted_percentage'], -$item['unit_price']);
         $item['total'] = $item['quantity'] * floatval($item['unit_price']);
+        $item['tax'] = empty($item['tax_rate']) ? 0 : $this->percent($item['tax_rate'], $item['total']);
         $items[] = $this->lineItemToContributionLineItem($item);
       }
     }

--- a/CRM/Civicase/Service/CaseSalesOrderLineItemsGenerator.php
+++ b/CRM/Civicase/Service/CaseSalesOrderLineItemsGenerator.php
@@ -117,7 +117,9 @@ class CRM_Civicase_Service_CaseSalesOrderLineItemsGenerator {
       }
 
       foreach ($items as $item) {
-        $item['qty'] = -1 * $item['qty'];
+        $item['qty'] = $item['qty'];
+        $item['unit_price'] = -1 * $item['unit_price'];
+        $item['tax_amount'] = -1 * $item['tax_amount'];
         $item['line_total'] = $item['qty'] * floatval($item['unit_price']);
         $previousItems[] = $item;
       }

--- a/Civi/Api4/Action/CaseSalesOrder/ContributionCreateAction.php
+++ b/Civi/Api4/Action/CaseSalesOrder/ContributionCreateAction.php
@@ -2,6 +2,7 @@
 
 namespace Civi\Api4\Action\CaseSalesOrder;
 
+use Civi\Api4\OptionValue;
 use Civi\Api4\CaseSalesOrder;
 use Civi\Api4\PriceFieldValue;
 use Civi\Api4\PriceField;
@@ -124,6 +125,7 @@ class ContributionCreateAction extends AbstractAction {
       'financial_type_id' => $this->financialTypeId,
       'receive_date' => $this->date,
       'contact_id' => $salesOrderContribution->salesOrder['client_id'],
+      'contribution_status_id' => $this->getPendingContributionStatusId(),
     ];
 
     return Contribution::create($params)->toArray();
@@ -181,6 +183,27 @@ class ContributionCreateAction extends AbstractAction {
       ->addWhere('id', '=', $salesOrderId)
       ->addValue('status_id', $this->statusId)
       ->execute();
+  }
+
+  /**
+   * Returns ID for pending contribution status.
+   *
+   * @return int
+   *   pending status ID
+   */
+  private function getPendingContributionStatusId(): ?int {
+    $pendingStatus = OptionValue::get()
+      ->addSelect('value')
+      ->addWhere('option_group_id:name', '=', 'contribution_status')
+      ->addWhere('name', '=', 'pending')
+      ->execute()
+      ->first();
+
+    if (!empty($pendingStatus)) {
+      return $pendingStatus['value'];
+    }
+
+    return NULL;
   }
 
 }


### PR DESCRIPTION
## Overview
This pull request introduces the following changes
- Set sales order bulk contribution status to pending
- Ensure that the correct line-item total is displayed for the previous contributions.

## Before
Before this pull request, the `CaseSalesOrderLineItemsGenerator.php` file did not include tax rate in the discount line items. 

## After
With this pull request, the tax rate is now included in the calculation of the discount line items total.
<img width="810" alt="Screenshot 2023-04-20 at 09 58 30" src="https://user-images.githubusercontent.com/85277674/233315848-1bd5b226-36e2-4592-964a-a1bf99d6e79c.png">
