### PR TITLE
BTHAB-105: Link owner name to owner contact dashboard

### DIFF
--- a/ang/civicase-features/quotations/directives/quotations-view.directive.html
+++ b/ang/civicase-features/quotations/directives/quotations-view.directive.html
@@ -47,7 +47,7 @@
                 <tbody>
                   <tr>
                     <td>Owner</td>
-                    <td><a href="{{getContactLink(salesOrder.client_id)}}" target="_blank">{{salesOrder['owner_id.display_name']}}</a></td>
+                    <td><a href="{{getContactLink(salesOrder.owner_id)}}" target="_blank">{{salesOrder['owner_id.display_name']}}</a></td>
                   </tr>
                   <tr>
                     <td>Status</td>


### PR DESCRIPTION
## Overview
Link owner name to owner contact dashboard

## Before
The owner name when clicked navigates to the client contact dashboard

## After
Now, the owner name when clicked navigates to the owner contact dashboard