### PR TITLE
BTHAB-109: UI improvement to Quotation create and filter screen

### DIFF
--- a/ang/afsearchContactQuotations.aff.html
+++ b/ang/afsearchContactQuotations.aff.html
@@ -15,7 +15,7 @@
     </div>
     <div class="af-container row civicase__case-filter-form-elements" ng-show="expanded">
       <af-field name="status_id" defn="{input_attrs: {multiple: true}}" class="col-md-2" />
-      <af-field name="quotation_date" defn="{input_attrs: {time: false}, search_range: true, label: 'Date'}" class="col-md-3 civicase__ui-range" />
+      <af-field name="quotation_date" defn="{input_attrs: {time: false}, search_range: true, label: 'Date'}" class="col-md-4 civicase__ui-range" />
       <div class="col-md-1">
         <button type="button" class="btn btn-link civicase__features-filters-clear" style="margin-top: 2em;">Clear All</button>
       </div>

--- a/ang/afsearchQuotations.aff.html
+++ b/ang/afsearchQuotations.aff.html
@@ -17,7 +17,7 @@
 
     <div class="af-container row civicase__case-filter-form-elements" ng-show="expanded">
       <af-field name="status_id" defn="{input_attrs: {multiple: true}}" class="col-md-2" />
-      <af-field name="quotation_date" defn="{input_attrs: {time: false}, search_range: true, label: 'Date'}" class="col-md-3 civicase__ui-range" />
+      <af-field name="quotation_date" defn="{input_attrs: {time: false}, search_range: true, label: 'Date'}" class="col-md-4 civicase__ui-range" />
       <div class="col-md-1">
         <button type="button" class="btn btn-link civicase__features-filters-clear" style="margin-top: 2em;">Clear All</button>
       </div>

--- a/ang/civicase-features/quotations/directives/quotations-create.directive.html
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.html
@@ -121,7 +121,7 @@
           <label class="col-sm-2 control-label required-mark">
             {{ts('Item')}}
           </label>
-          <div class="col-sm-9">
+          <div class="col-sm-10">
            <table class="table table-bordered">
             <tr>
               <th>Product</th>
@@ -135,7 +135,7 @@
               <th></th>
             </tr>
             <tr ng-repeat="item in salesOrder.items track by $index">
-              <td>
+              <td style="max-width: 15em;">
                 <input class="form-control"
                   style="width: 100%; min-width: 12em"
                   ng-model="salesOrder.items[$index].product_id"
@@ -154,7 +154,7 @@
                 <br />
                 <span class="crm-inline-error" ng-show="quotationsForm.item_description_{{$index}}.$dirty && quotationsForm.item_description_{{$index}}.$invalid && quotationsForm.item_description_{{$index}}.$error.required">Description is required</span>
               </td>
-              <td>
+              <td style="max-width: 15em;">
                 <input class="form-control"
                 style="width: 100%"
                   ng-model="salesOrder.items[$index].financial_type_id"
@@ -172,9 +172,9 @@
                 <span class="crm-inline-error" ng-show="quotationsForm.financial_type_{{$index}}.$dirty && quotationsForm.financial_type_{{$index}}.$invalid && quotationsForm.financial_type_{{$index}}.$error.required">Financial Type is required</span>
               </td>
               <td>
-                <div class="input-group">
+                <div class="input-group" style="width: 10em">
                   <span class="input-group-addon">{{ currencySymbol }}</span>
-                  <input type="number" min="0" name="unit_price_{{$index}}" required placeholder="Unit Price" ng-model="salesOrder.items[$index].unit_price" ng-change="calculateSubtotal($index)" class="form-control" />
+                  <input type="number" min="0" name="unit_price_{{$index}}" required placeholder="Unit Price" ng-model="salesOrder.items[$index].unit_price" ng-change="calculateSubtotal($index)" class="form-control" step="0.01" />
                 </div>
                 <br />
                 <span class="crm-inline-error" ng-show="quotationsForm.unit_price_{{$index}}.$dirty && (quotationsForm.unit_price_{{$index}}.$invalid || quotationsForm.unit_price_{{$index}}.$error.required)">Unit price is invalid</span>

--- a/ang/civicase-features/quotations/directives/quotations-list.directive.html
+++ b/ang/civicase-features/quotations/directives/quotations-list.directive.html
@@ -31,4 +31,7 @@
     background-color: transparent;
     border: none;
   }
+  .af-field-range-sep {
+    margin: 0em 1em;
+  }
 </style>

--- a/ang/civicase/shared/directives/history-back.directive.js
+++ b/ang/civicase/shared/directives/history-back.directive.js
@@ -7,6 +7,12 @@
       link: function (scope, elem, attrs) {
         elem.bind('click', function () {
           $window.history.back();
+          const currPage = window.location.href;
+          setTimeout(function () {
+            if ($window.location.href === currPage) {
+              $window.close();
+            }
+          }, 500);
         });
       }
     };


### PR DESCRIPTION
## Overview
Introduces UI improvement to the Quotation create and filter screen.

## Before
Date filter input fields had not enough spacing.
<img width="1204" alt="Screenshot 2023-04-25 at 14 20 33" src="https://user-images.githubusercontent.com/85277674/234295723-d3903d60-7f73-48c5-87a5-936940f96375.png">

## After
Enough spacing between the date filter input fields.
<img width="965" alt="Screenshot 2023-04-25 at 14 20 18" src="https://user-images.githubusercontent.com/85277674/234297285-ea73dbe2-4c90-405c-8f79-08905cc70ea3.png">


## Before
The width of the Financial Type field or Product field extends to the width of their content.
<img width="1218" alt="Screenshot 2023-04-25 at 14 21 41" src="https://user-images.githubusercontent.com/85277674/234295731-7c9184f4-0770-45c6-b1d5-e0fc5a6cac9c.png">

## After
The width of the Financial Type field or Product field is now limited.
<img width="1181" alt="Screenshot 2023-04-25 at 14 54 30" src="https://user-images.githubusercontent.com/85277674/234299180-f654d586-a45f-4621-926a-7007f8c2341e.png">



## Before
Clicking on cancel does nothing on the Quotation edit page, this is because the edit page has no previous page to go back to since it is opened in a new tab.

## After
Clicking on cancel on the Quotagion edit page, closes the tab.
![polipolll](https://user-images.githubusercontent.com/85277674/234300676-27eb258c-4a59-4edf-908a-819566ee8dad.gif)


