### PR TITLE
BTHAB-38: Remove pledges from supported case instance features

### DIFF
--- a/CRM/Civicase/Setup/Manage/CaseTypeCategoryFeaturesManager.php
+++ b/CRM/Civicase/Setup/Manage/CaseTypeCategoryFeaturesManager.php
@@ -35,15 +35,6 @@ class CRM_Civicase_Setup_Manage_CaseTypeCategoryFeaturesManager extends CRM_Civi
       'is_active' => TRUE,
       'is_reserved' => TRUE,
     ]);
-
-    CRM_Core_BAO_OptionValue::ensureOptionValueExists([
-      'option_group_id' => CRM_Civicase_Service_CaseTypeCategoryFeatures::NAME,
-      'name' => 'pledges',
-      'label' => 'Pledges',
-      'is_default' => TRUE,
-      'is_active' => TRUE,
-      'is_reserved' => TRUE,
-    ]);
   }
 
   /**


### PR DESCRIPTION
## Overview
This PR removes the `Pledges` from the list of case instance features that can be enabled/disabled

## Before
<img width="820" alt="Screenshot 2023-04-25 at 14 37 44" src="https://user-images.githubusercontent.com/85277674/234295649-74a47e0b-aed3-48ae-b199-7098df19e8a3.png">


## After
<img width="848" alt="Screenshot 2023-04-25 at 14 35 39" src="https://user-images.githubusercontent.com/85277674/234295625-a9dc2237-cf11-4e69-bf84-2ab899b8a3ca.png">
