### PR TITLE
BTHAB-129: Ensure quotation financial type can be updated

### DIFF
--- a/ang/civicase-features/quotations/directives/quotations-create.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.js
@@ -214,6 +214,10 @@
       $scope.salesOrder.items[index].tax_rate = 0;
       $scope.$emit('totalChange');
 
+      if ($scope.salesOrder.items[index]['financial_type_id.name']) {
+        $scope.salesOrder.items[index]['financial_type_id.name'] = '';
+      }
+
       const updateFinancialTypeDependentFields = (financialTypeId) => {
         $scope.salesOrder.items[index].tax_rate = financialTypesCache.get(financialTypeId).tax_rate;
         $scope.$emit('totalChange');


### PR DESCRIPTION
## Overview
Ensure quotation financial type can be updated

## Before
![q2](https://user-images.githubusercontent.com/85277674/234311383-ed22394d-ec02-47ed-8ec6-0a295acce8c9.gif)


## After
![qawwq](https://user-images.githubusercontent.com/85277674/234310716-beed6ca8-6734-4e9e-8a43-d727230b65d5.gif)


## Technical Overview
This happens because when the edit page is to be populated we get the financial type id and the name, but clearing from the UI only clears the id and not the name of the existing financial type.

The solution is to manually clear the financial type name, when its value gets updated from theUI.