### PR TITLE
BTHAB-130: Fix pre-filled quotation contribution create screen

### DIFF
--- a/js/sales-order-contribution.js
+++ b/js/sales-order-contribution.js
@@ -54,6 +54,7 @@
     function addLineItem (quantity, unitPrice, description, financialTypeId, taxAmount) {
       const row = $($(`tr#add-item-row-${count}`));
       row.show().removeClass('hiddenElement');
+      quantity = +parseFloat(quantity).toFixed(10); // limit to 10 decimal places
 
       $('input[id^="item_label"]', row).val(ts(description));
       $('select[id^="item_financial_type_id"]', row).select2('val', financialTypeId);

--- a/js/sales-order-contribution.js
+++ b/js/sales-order-contribution.js
@@ -62,10 +62,10 @@
 
       const total = quantity * parseFloat(unitPrice);
 
-      $('input[id^="item_unit_price"]', row).val(CRM.formatMoney(unitPrice, true));
+      $('input[id^="item_unit_price"]', row).val(unitPrice);
       $('input[id^="item_line_total"]', row).val(CRM.formatMoney(total, true));
 
-      $('input[id^="item_tax_amount"]', row).val(CRM.formatMoney(taxAmount, true));
+      $('input[id^="item_tax_amount"]', row).val(taxAmount);
 
       count++;
     }


### PR DESCRIPTION
## Overview
This pull request contains two fixes to address issues related to the sales order contribution module in CiviCRM.
-  Fixes a problem where the quantity field throws an error due to excess decimal places. 
- Fix an issue where the contribution line items with tax_amount in thousands are not handled appropriately by CiviCRM when creating a contribution, resulting in an incorrect quotation contribution total. 

## Before
- Before the fix, the line item quantity field is not limited

![image](https://user-images.githubusercontent.com/85277674/234940401-01ddb9bc-5eee-4094-9a7b-5e718ff5675c.png)


-  Contribution line items with tax_amount expressed in money format are not handled appropriately by CiviCRM
![image](https://user-images.githubusercontent.com/85277674/234941426-6513dabc-9513-4c03-9bf9-f1e3e75d7037.png)


## After
- After applying the first fix, the quantity field is now limited to 10 decimal places, preventing any errors caused by excess decimal places. 


- After the money formatter has been removed from the tax_amount and unit_price a, the quotation contribution total is now correct.

![image](https://user-images.githubusercontent.com/85277674/234941533-02e6c1c4-ef8a-4c98-88e9-39de2ecacab0.png)


