### PR TITLE
BTHAB-124: Redirect user to Previous page after editing contribution

### DIFF
--- a/ang/civicase-features/quotations/directives/quotations-create.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.js
@@ -286,6 +286,11 @@
      * else redirects to the case view of the selected case.
      */
     function redirectToAppropraitePage () {
+      if ($scope.isUpdate) {
+        $window.location.href = $window.document.referrer;
+        return;
+      }
+
       if (!$scope.salesOrder.case_id) {
         $window.location.href = 'a#/quotations';
       }

--- a/ang/civicase-features/quotations/directives/quotations-create.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.js
@@ -139,7 +139,6 @@
       $scope.submitInProgress = true;
       crmApi4('CaseSalesOrder', 'save', { records: [$scope.salesOrder] })
         .then(function (results) {
-          $scope.submitInProgress = false;
           showSucessNotification();
           redirectToAppropraitePage();
         }, function (failure) {

--- a/ang/civicase-features/quotations/directives/quotations-view.directive.html
+++ b/ang/civicase-features/quotations/directives/quotations-view.directive.html
@@ -10,7 +10,7 @@
               <table class="table" id="quotation__detail">
                 <tbody>
                   <tr>
-                    <td>Quotatioin Id</td>
+                    <td>Quotation Id</td>
                     <td>{{salesOrder.id}}</td>
                   </tr>
                   <tr>


### PR DESCRIPTION
## Overview
This PR redirect the user back to the previous page after editing the quotation and adds the following as extra
- Keep submit button disabled when save is successful
- Fix a typo on the quotation view page