### PR TITLE
BTHAB-128: Support contribution quotation with unconstrained percentage

### DIFF
--- a/CRM/Civicase/Form/CaseSalesOrderContributionCreate.php
+++ b/CRM/Civicase/Form/CaseSalesOrderContributionCreate.php
@@ -163,6 +163,7 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
 
     $paidTotal = array_sum(array_column($caseSalesOrderContributions, 'contribution_id.total_amount'));
     $remainBalance = $caseSalesOrder['total_after_tax'] - $paidTotal;
+    $remainBalance = round($remainBalance, 2);
 
     if ($remainBalance <= 0) {
       $errors['to_be_invoiced'] = 'Unable to create a contribution due to insufficient balance.';

--- a/CRM/Civicase/Service/CaseSalesOrderLineItemsGenerator.php
+++ b/CRM/Civicase/Service/CaseSalesOrderLineItemsGenerator.php
@@ -1,9 +1,9 @@
 <?php
 
-use Civi\Api4\LineItem;
+use Civi\Api4\CaseSalesOrder;
 use Civi\Api4\CaseSalesOrderContribution;
 use Civi\Api4\CaseSalesOrderLine;
-use Civi\Api4\CaseSalesOrder;
+use Civi\Api4\LineItem;
 
 /**
  * Service class to generate sales order line items.

--- a/CRM/Civicase/Service/CaseSalesOrderLineItemsGenerator.php
+++ b/CRM/Civicase/Service/CaseSalesOrderLineItemsGenerator.php
@@ -23,7 +23,7 @@ class CRM_Civicase_Service_CaseSalesOrderLineItemsGenerator {
   /**
    * Constructs CaseSalesOrderContribution service.
    */
-  public function __construct(private int $salesOrderId, private string $type, private string $percentValue) {
+  public function __construct(private int $salesOrderId, private string $type, private ?string $percentValue) {
     $this->setSalesOrder();
   }
 

--- a/Civi/Api4/Action/CaseSalesOrder/ContributionCreateAction.php
+++ b/Civi/Api4/Action/CaseSalesOrder/ContributionCreateAction.php
@@ -2,18 +2,18 @@
 
 namespace Civi\Api4\Action\CaseSalesOrder;
 
-use Civi\Api4\OptionValue;
 use Civi\Api4\CaseSalesOrder;
-use Civi\Api4\PriceFieldValue;
-use Civi\Api4\PriceField;
-use Civi\Api4\PriceSet;
-use CRM_Core_Transaction;
-use Civi\Api4\Generic\Result;
-use Civi\Api4\Generic\AbstractAction;
-use Civi\Api4\Generic\Traits\DAOActionTrait;
-use CRM_Contribute_BAO_Contribution as Contribution;
-use CRM_Civicase_Service_CaseSalesOrderLineItemsGenerator as salesOrderlineItemGenerator;
 use Civi\Api4\CaseSalesOrderContribution as Api4CaseSalesOrderContribution;
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Result;
+use Civi\Api4\Generic\Traits\DAOActionTrait;
+use Civi\Api4\OptionValue;
+use Civi\Api4\PriceField;
+use Civi\Api4\PriceFieldValue;
+use Civi\Api4\PriceSet;
+use CRM_Civicase_Service_CaseSalesOrderLineItemsGenerator as salesOrderlineItemGenerator;
+use CRM_Contribute_BAO_Contribution as Contribution;
+use CRM_Core_Transaction;
 
 /**
  * Creates contribution for multiple sales orders.

--- a/Civi/Api4/Action/CaseSalesOrder/ContributionCreateAction.php
+++ b/Civi/Api4/Action/CaseSalesOrder/ContributionCreateAction.php
@@ -114,10 +114,14 @@ class ContributionCreateAction extends AbstractAction {
       $lineItem['price_field_value_id'] = $priceField[$index]['price_field_value'][0]['id'];
       $priceSetID = \CRM_Core_DAO::getFieldValue('CRM_Price_BAO_PriceField', $priceField[$index]['id'], 'price_set_id');
       $allLineItems[$priceSetID][$priceField[$index]['id']] = $lineItem;
-      $taxAmount += (float) ($lineItem['tax_amount'] ?? 0);
-      $lineTotal += (float) ($lineItem['line_total'] ?? 0);
+      $taxAmount += (float) $lineItem['tax_amount'] ?? 0;
+      $lineTotal += (float) $lineItem['line_total'] ?? 0;
     }
     $totalAmount = $lineTotal + $taxAmount;
+
+    if (round($totalAmount, 2) < 1) {
+      throw new \Exception("Contribution total amount must be greater than zero");
+    }
 
     $params = [
       'source' => "Quotation {$salesOrderId}",

--- a/Civi/Api4/Action/CaseSalesOrder/ContributionCreateAction.php
+++ b/Civi/Api4/Action/CaseSalesOrder/ContributionCreateAction.php
@@ -69,7 +69,7 @@ class ContributionCreateAction extends AbstractAction {
   public function _run(Result $result) { // phpcs:ignore
     $resultArray = $this->createContribution();
 
-    $result->exchangeArray($resultArray);
+    return $result->exchangeArray($resultArray);
   }
 
   /**
@@ -77,6 +77,7 @@ class ContributionCreateAction extends AbstractAction {
    */
   private function createContribution() {
     $priceField = $this->getDefaultPriceSetFields();
+    $createdContributionsCount = 0;
 
     foreach ($this->salesOrderIds as $id) {
       $transaction = CRM_Core_Transaction::create();
@@ -84,13 +85,14 @@ class ContributionCreateAction extends AbstractAction {
         $contribution = $this->createContributionWithLineItems($id, $priceField);
         $this->linkCaseSalesOrderToContribution($id, $contribution['id']);
         $this->updateCaseSalesOrderStatus($id);
+        $createdContributionsCount++;
       }
       catch (\Exception $e) {
         $transaction->rollback();
       }
     }
 
-    return [];
+    return ['created_contributions_count' => $createdContributionsCount];
   }
 
   /**

--- a/ang/civicase-features/quotations/directives/quotations-contribution-bulk.directive.html
+++ b/ang/civicase-features/quotations/directives/quotations-contribution-bulk.directive.html
@@ -18,7 +18,7 @@
         <label for="percent_toBeInvoiced">Enter % to be invoiced ?</label>
       </div>
       <div class="col-sm-5" ng-show="$ctrl.data.toBeInvoiced == 'percent'">
-        <input type="number" max="100" name="percentValue" class="form-control" ng-model="$ctrl.data.percentValue" ng-disabled="$ctrl.data.toBeInvoiced !== 'percent'" ng-required="$ctrl.data.toBeInvoiced == 'percent'" />
+        <input type="number" min="1" name="percentValue" class="form-control" ng-model="$ctrl.data.percentValue" ng-disabled="$ctrl.data.toBeInvoiced !== 'percent'" ng-required="$ctrl.data.toBeInvoiced == 'percent'" />
         <span class="crm-inline-error" ng-show="contributionForm.percentValue.$dirty && contributionForm.percentValue.$invalid && contributionForm.percentValue.$error.required">Amount is required</span>
       </div>
     </div>

--- a/ang/civicase-features/quotations/directives/quotations-contribution-bulk.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-contribution-bulk.directive.js
@@ -28,7 +28,7 @@
     $scope.submitInProgress = false;
     ctrl.data = {
       toBeInvoiced: 'percent',
-      percentValue: 0,
+      percentValue: null,
       statusId: null,
       financialTypeId: null,
       date: $.datepicker.formatDate('yy-mm-dd', new Date())
@@ -46,8 +46,8 @@
         const chunkedIds = _.chunk(ctrl.ids, BATCH_SIZE);
         for (const salesOrderIds of chunkedIds) {
           try {
-            await crmApi4('CaseSalesOrder', 'contributionCreateAction', { ...ctrl.data, salesOrderIds });
-            contributionCreated += salesOrderIds.length;
+            const result = await crmApi4('CaseSalesOrder', 'contributionCreateAction', { ...ctrl.data, salesOrderIds });
+            contributionCreated += result.created_contributions_count ?? 0;
           } catch (error) {
             console.log(error);
           } finally {


### PR DESCRIPTION
## Overview
This PR allows users to create contributions for a quotation with no limit on the percentage value. They can create a contribution with a value of 150% as many times as they want. However, if the `remaining` option is selected, we add checks to ensure that the contribution value created is not less than 1. If it will be less than 1, then no contribution will be created.

## Before
Users cannot create contributions with a percentage value greater than 100.
<img width="1155" alt="Screenshot 2023-05-02 at 09 11 05" src="https://user-images.githubusercontent.com/85277674/235613950-791b874c-cf2f-4d15-ae33-861151a6e1d6.png">

<img width="928" alt="Screenshot 2023-05-02 at 09 11 50" src="https://user-images.githubusercontent.com/85277674/235614098-c0c117c1-002d-42a7-a910-9d2fb8772426.png">


## After
Users can now create contributions with a percentage value greater than 100.

Single quotation contribution
![pop](https://user-images.githubusercontent.com/85277674/235613195-252ad2c2-cdd9-45b8-86f3-028e0039b960.gif)

Bulk quotation contribution
![lpop](https://user-images.githubusercontent.com/85277674/235613624-8ae05f41-cd63-4666-b113-7a3968f3f52d.gif)