### PR TITLE
BTHAB-147: Create Quotation UI Update

### DIFF
--- a/Civi/Utils/CurrencyUtils.php
+++ b/Civi/Utils/CurrencyUtils.php
@@ -3,6 +3,7 @@
 namespace Civi\Utils;
 
 use CRM_Core_DAO;
+use CRM_Utils_Money;
 
 /**
  * Utility class to manage CiviCRM currency table.
@@ -28,7 +29,11 @@ class CurrencyUtils {
       $dao = CRM_Core_DAO::executeQuery($query);
       self::$currencies = [];
       while ($dao->fetch()) {
-        self::$currencies[] = ['name' => $dao->name, 'symbol' => $dao->symbol];
+        self::$currencies[] = [
+          'name' => $dao->name,
+          'symbol' => $dao->symbol,
+          'format' => CRM_Utils_Money::format(1234.56, $dao->name),
+        ];
       }
     }
 

--- a/ang/civicase-features/quotations/directives/quotations-create.directive.html
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.html
@@ -38,6 +38,7 @@
         <div class="form-group">
           <label class="col-sm-2 control-label required-mark">
             Description
+            <a crm-ui-help="hs({title:ts('Description'), id:'sales_order_description'})"></a>
           </label>
           <div class="col-sm-5">
             <textarea name="description" ng-model="salesOrder.description" class="crm-form-wysiwyg" id="sales-order-description" required></textarea>
@@ -222,6 +223,7 @@
         <div class="form-group">
           <label class="col-sm-2 control-label">
             {{ts('Notes')}}
+            <a crm-ui-help="hs({title:ts('Notes'), id:'sales_order_notes'})"></a>
           </label>
           <div class="col-sm-5">
             <textarea name="notes" rows="5" cols="20" style="width: 100%;" ng-model="salesOrder.notes"></textarea>

--- a/ang/civicase-features/quotations/directives/quotations-create.directive.html
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.html
@@ -121,7 +121,7 @@
           <label class="col-sm-2 control-label required-mark">
             {{ts('Item')}}
           </label>
-          <div class="col-sm-10">
+          <div class="col-sm-10" style="overflow: scroll;">
            <table class="table table-bordered">
             <tr>
               <th>Product</th>
@@ -150,7 +150,7 @@
                 />
               </td>
               <td>
-                <textarea type="text" name="item_description_{{$index}}" ng-model="salesOrder.items[$index].item_description" class="form-control" required> </textarea>
+                <textarea type="text" name="item_description_{{$index}}" ng-model="salesOrder.items[$index].item_description" class="form-control" style="resize: none" required> </textarea>
                 <br />
                 <span class="crm-inline-error" ng-show="quotationsForm.item_description_{{$index}}.$dirty && quotationsForm.item_description_{{$index}}.$invalid && quotationsForm.item_description_{{$index}}.$error.required">Description is required</span>
               </td>
@@ -192,7 +192,7 @@
               <td>
                 {{ roundTo(salesOrder.items[$index].tax_rate, 2) }}
               </td>
-              <td>{{ roundTo(salesOrder.items[$index].subtotal_amount, 2) }}</td>
+              <td>{{ formatMoney(salesOrder.items[$index].subtotal_amount, salesOrder.currency) }}</td>
               <td><a ng-if="salesOrder.items.length > 1" href ng-click="removeSalesOrderItem($index)" ><i class="fa fa-trash"></i></a></td>
             </tr>
            </table>
@@ -209,12 +209,12 @@
           <label class="col-sm-2"></label>
           <div class="col-sm-3">
             <table class="table">
-              <tr><th>Total</th><td>{{ currencySymbol }} {{ salesOrder.total }}</td></tr>
+              <tr><th>Total</th><td>{{ currencySymbol }} {{ formatMoney(salesOrder.total, salesOrder.currency) }}</td></tr>
                 <tr ng-repeat="i in taxRates">
                   <th>Tax @ {{ i.rate }}%</th>
-                  <td>{{ currencySymbol }} {{ i.value }}</td>
+                  <td>{{ currencySymbol }} {{ formatMoney(i.value, salesOrder.currency) }}</td>
                 </tr>
-              <tr><th>Grand Total</th><td>{{ currencySymbol }} {{salesOrder.grandTotal}}</td></tr>
+              <tr><th>Grand Total</th><td>{{ currencySymbol }} {{formatMoney(salesOrder.grandTotal, salesOrder.currency)}}</td></tr>
             </table>
           </div>
         </div>

--- a/ang/civicase-features/quotations/directives/quotations-create.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.js
@@ -32,6 +32,7 @@
     $scope.isUpdate = false;
     $scope.formValid = true;
     $scope.roundTo = roundTo;
+    $scope.formatMoney = formatMoney;
     $scope.submitInProgress = false;
     $scope.caseApiParam = caseApiParam;
     $scope.saveQuotation = saveQuotation;
@@ -60,6 +61,7 @@
       $scope.salesOrder = {
         currency: defaultCurrency,
         status_id: SalesOrderStatus.getValueByName('new'),
+        clientId: null,
         owner_id: Contact.getCurrentContactID(),
         quotation_date: $.datepicker.formatDate('yy-mm-dd', new Date()),
         items: [{
@@ -320,6 +322,17 @@
       }, function (failure) {
         // handle failure
       });
+    }
+
+    /**
+     * Formats a number into the number format of the currently selected currency
+     *
+     * @param {number} value the number to be formatted
+     * @param {string } currency the selected currency
+     * @returns {number} the formatted number
+     */
+    function formatMoney (value, currency) {
+      return CRM.formatMoney(value, true, CurrencyCodes.getFormat(currency));
     }
   }
 })(angular, CRM.$, CRM._);

--- a/ang/civicase-features/quotations/directives/quotations-create.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.js
@@ -83,6 +83,7 @@
       $scope.total = 0;
       $scope.taxRates = [];
 
+      setDefaultClientID();
       prefillSalesOrderForUpdate();
     }
 
@@ -103,6 +104,25 @@
         $scope.salesOrder.status_id = (result.status_id).toString();
         CRM.wysiwyg.setVal('#sales-order-description', $scope.salesOrder.description);
         $scope.$emit('totalChange');
+      });
+    }
+
+    /**
+     * Sets client ID to case client.
+     */
+    function setDefaultClientID () {
+      if (!$scope.defaultCaseId || $scope.isUpdate) {
+        return;
+      }
+
+      crmApi4('Relationship', 'get', {
+        select: ['contact_id_a'],
+        where: [['case_id', '=', $scope.defaultCaseId], ['relationship_type_id:name', '=', 'Case Coordinator is'], ['is_current', '=', true]],
+        limit: 1
+      }).then(function (relationships) {
+        if (Array.isArray(relationships) && relationships.length > 0) {
+          $scope.salesOrder.client_id = relationships[0].contact_id_a ?? null;
+        }
       });
     }
 

--- a/ang/civicase-features/quotations/directives/quotations-create.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.js
@@ -23,11 +23,13 @@
    * @param {object} FeatureCaseTypes FeatureCaseTypes service
    * @param {object} SalesOrderStatus SalesOrderStatus service
    * @param {object} CaseUtils case utility service
+   * @param {object} crmUiHelp crm ui help service
    */
-  function quotationsCreateController ($scope, $location, $window, CurrencyCodes, civicaseCrmApi, Contact, crmApi4, FeatureCaseTypes, SalesOrderStatus, CaseUtils) {
+  function quotationsCreateController ($scope, $location, $window, CurrencyCodes, civicaseCrmApi, Contact, crmApi4, FeatureCaseTypes, SalesOrderStatus, CaseUtils, crmUiHelp) {
     const defaultCurrency = 'GBP';
     const productsCache = new Map();
     const financialTypesCache = new Map();
+    $scope.hs = crmUiHelp({ file: 'CRM/Civicase/SalesOrderCtrl' });
 
     $scope.isUpdate = false;
     $scope.formValid = true;

--- a/ang/civicase-features/shared/services/currency-codes.service.js
+++ b/ang/civicase-features/shared/services/currency-codes.service.js
@@ -17,5 +17,12 @@
         .filter(currency => currency.name === name)
         .pop().symbol || '£';
     };
+
+    this.getFormat = function (name) {
+      return CRM['civicase-features']
+        .currencyCodes
+        .filter(currency => currency.name === name)
+        .pop().format || null;
+    };
   }
 })(angular, CRM.$, CRM._, CRM);

--- a/templates/CRM/Civicase/SalesOrderCtrl.hlp
+++ b/templates/CRM/Civicase/SalesOrderCtrl.hlp
@@ -1,0 +1,11 @@
+{htxt id="sales_order_notes"}
+<p>
+  {ts}Add any notes related to the quotation here. They will be visible on the quotation PDF.{/ts}
+</p>
+{/htxt}
+
+{htxt id="sales_order_description}
+<p>
+  {ts}This is an internal field for adding a description for the quotation. It will not be displayed anywhere.{/ts}
+</p>
+{/htxt}


### PR DESCRIPTION
## Overview
This PR introduces the following changes to the quotation create screen:
- [Format displayed total in selected currency format](https://github.com/compucorp/uk.co.compucorp.civicase/pull/942/commits/fe84c53b748cfaa669d2165ec67a87d5cde4597e)
- [Add help text to notes and descrition field](https://github.com/compucorp/uk.co.compucorp.civicase/pull/942/commits/322015525578245e5cffd960b012662ff8bf1267)
- [Use case client as default quotation client](https://github.com/compucorp/uk.co.compucorp.civicase/pull/942/commits/8fe0f127945be8bc634758fbef768bc78a0cd8dc)

## Before
It will be noticed that the total field is displayed in money format.
![aaqq](https://user-images.githubusercontent.com/85277674/235605147-abd4c44c-535e-418c-afa1-54c68f0ebd75.gif)

## After
The total field is displayed in money format, notes have a help button, and the client field is prefilled from the current case/prospect client.
![ooop](https://user-images.githubusercontent.com/85277674/235667914-67b69781-a938-40e7-83a4-66b6222d7f8d.gif)


## Technical Details
The formatting of this currency is done using `CRM.formatMoney`, which uses the currency format to format the value. although it was noticed that this doesn't work for all currencies. A related issue is reported here https://lab.civicrm.org/dev/translation/-/issues/47

See this PR https://github.com/civicrm/civicrm-core/pull/19151 and https://github.com/civicrm/civicrm-core/pull/19185 For limitations on JS money formatting in CiviCRM.