### PR TITLE
BTHAB-153: Add Helper Text to notes field

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/AddQuotationsNotesToContributionSettings.php
+++ b/CRM/Civicase/Hook/BuildForm/AddQuotationsNotesToContributionSettings.php
@@ -56,6 +56,10 @@ class CRM_Civicase_Hook_BuildForm_AddQuotationsNotesToContributionSettings {
     $form->assign('htmlFields', array_merge($form->get_template_vars('htmlFields'), $field));
     $value = Civi::settings()->get($fieldName) ?? NULL;
     $form->setDefaults(array_merge($form->_defaultValues, [$fieldName => $value]));
+
+    CRM_Core_Region::instance('form-buttons')->add([
+      'template' => "CRM/Civicase/Form/CaseSalesOrderInvoiceNote.tpl",
+    ]);
   }
 
 }

--- a/templates/CRM/Civicase/Form/CaseSalesOrderInvoiceNote.hlp
+++ b/templates/CRM/Civicase/Form/CaseSalesOrderInvoiceNote.hlp
@@ -1,0 +1,3 @@
+{htxt id="sales_order_invoce_note"}
+{ts}Notes will be displayed on the Quotation PDF.{/ts}</p>
+{/htxt}

--- a/templates/CRM/Civicase/Form/CaseSalesOrderInvoiceNote.tpl
+++ b/templates/CRM/Civicase/Form/CaseSalesOrderInvoiceNote.tpl
@@ -1,0 +1,5 @@
+{literal}
+<script>
+  CRM.$('.crm-preferences-form-block-quotations_notes > td:first-child').append('<a class="helpicon" title=" Help" aria-label=" Help" href="#" onclick=\'CRM.help("", {"id":"sales_order_invoce_note","file":"CRM\/Civicase\/Form\/CaseSalesOrderInvoiceNote"}); return false;\'> </a>')
+</script>
+{/literal}


### PR DESCRIPTION
## Overview
This PR adds a helper text to the quotation notes field on the civicontribute component settings page.

## Before
<img width="1222" alt="Screenshot 2023-05-02 at 08 11 51" src="https://user-images.githubusercontent.com/85277674/235602633-66550d47-d236-4a1d-9d53-2ebe17cac3d2.png">


## After
<img width="1255" alt="Screenshot 2023-05-02 at 08 12 26" src="https://user-images.githubusercontent.com/85277674/235602698-306ae039-c388-4c8f-b281-9796fac3b068.png">
