### PR TITLE
BTHAB-155: Update sales order contribution create screen

### DIFF
--- a/CRM/Civicase/Form/CaseSalesOrderContributionCreate.php
+++ b/CRM/Civicase/Form/CaseSalesOrderContributionCreate.php
@@ -1,7 +1,7 @@
 <?php
 
-use Civi\Api4\CaseSalesOrderContribution;
 use Civi\Api4\CaseSalesOrder;
+use Civi\Api4\CaseSalesOrderContribution;
 use Civi\Api4\OptionValue;
 use CRM_Certificate_ExtensionUtil as E;
 

--- a/CRM/Civicase/Form/CaseSalesOrderContributionCreate.php
+++ b/CRM/Civicase/Form/CaseSalesOrderContributionCreate.php
@@ -89,6 +89,21 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
   /**
    * {@inheritDoc}
    */
+  public function setDefaultValues() {
+    $caseSalesOrder = CaseSalesOrder::get()
+      ->addWhere('id', '=', $this->id)
+      ->addSelect('status_id')
+      ->execute()
+      ->first();
+
+    return [
+      'status' => $caseSalesOrder['status_id'] ?? NULL,
+    ];
+  }
+
+  /**
+   * {@inheritDoc}
+   */
   public function addRules() {
     $this->addFormRule([$this, 'formRule']);
     $this->addFormRule([$this, 'validateAmount']);

--- a/CRM/Civicase/Form/CaseSalesOrderContributionCreate.php
+++ b/CRM/Civicase/Form/CaseSalesOrderContributionCreate.php
@@ -61,7 +61,7 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
     $this->add(
       'select',
       'status',
-      ts('Status'),
+      ts('Update status of quotation to'),
         ['' => 'Select'] +
         array_combine(
           array_column($statusOptions, 'value'),

--- a/ang/civicase-features/quotations/directives/quotations-contribution-bulk.directive.html
+++ b/ang/civicase-features/quotations/directives/quotations-contribution-bulk.directive.html
@@ -64,7 +64,7 @@
 
     <div class="form-group">
       <label class="col-sm-2 control-label required-mark">
-        {{ts('Status')}}
+        {{ts('Update status of quotation to')}}
       </label>
       <div class="col-sm-5">
         <select class="form-control"

--- a/ang/civicase-features/quotations/directives/quotations-contribution-bulk.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-contribution-bulk.directive.js
@@ -37,6 +37,13 @@
     this.progress = null;
     const BATCH_SIZE = 50;
 
+    (function () {
+      CaseUtils.getSalesOrderAndLineItems(ctrl.ids[0]).then((result) => {
+        ctrl.data.financialTypeId = result.items[0].financial_type_id ?? null;
+        ctrl.data.statusId = Number(result.status_id).toString();
+      });
+    })();
+
     this.createBulkContribution = () => {
       $q(async function (resolve, reject) {
         ctrl.run = true;

--- a/ang/civicase-features/quotations/directives/quotations-view.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-view.directive.js
@@ -51,6 +51,7 @@
           $scope.salesOrder = caseSalesOrders.pop();
           $scope.salesOrder.taxRates = $scope.salesOrder.computedRates[0].taxRates;
           $scope.currencySymbol = CurrencyCodes.getSymbol($scope.salesOrder.currency);
+          $scope.salesOrder.quotation_date = CRM.utils.formatDate($scope.salesOrder.quotation_date);
 
           if (!$scope.salesOrder.case_id) {
             return;


### PR DESCRIPTION
## Overview
This PR introduces the following changes
- Updates the status field label on the single quotation contribution create screen and uses the quotation status as the default status.
- Sets the default value for status and financial type from the first sales order on the bulk contribution create screen.

## Before
![q](https://user-images.githubusercontent.com/85277674/235594803-6ad46beb-50ca-418a-9083-f379a83c5b84.gif)


## After
![a](https://user-images.githubusercontent.com/85277674/235595078-eac62848-b9d3-437c-bb28-d5730960675c.gif)


Also, the Date on the Quotation view screen is formatted.

## Before
<img width="1262" alt="Screenshot 2023-05-02 at 07 34 05" src="https://user-images.githubusercontent.com/85277674/235596247-530cd104-56d4-4a19-a98b-a5c1dc398187.png">


## After
<img width="1289" alt="Screenshot 2023-05-02 at 07 32 03" src="https://user-images.githubusercontent.com/85277674/235595949-a2f5bbcd-8811-4515-bf31-71285c32eec0.png">

