### PR TITLE
BTHAB-126: Conditionally display contact Quotation tab

### DIFF
--- a/CRM/Civicase/Hook/Tabset/CaseSalesOrderTabAdd.php
+++ b/CRM/Civicase/Hook/Tabset/CaseSalesOrderTabAdd.php
@@ -1,6 +1,7 @@
 <?php
 
 use Civi\Api4\CaseSalesOrder;
+use CRM_Civicase_Service_CaseTypeCategoryFeatures as CaseTypeCategoryFeatures;
 
 /**
  * Hook Class to add case sales order tab to contact.
@@ -18,6 +19,13 @@ class CRM_Civicase_Hook_Tabset_CaseSalesOrderTabAdd {
    *   Weight to position the tab.
    */
   public function addCaseSalesOrderTab(array &$tabs, $contactID, $weight) {
+    $caseTypeCategoryFeatures = new CaseTypeCategoryFeatures();
+    $caseInstances = $caseTypeCategoryFeatures->retrieveCaseInstanceWithEnabledFeatures(['quotations']);
+
+    if (empty($caseInstances)) {
+      return;
+    }
+
     $tabs[] = [
       'id' => 'quotations',
       'url' => CRM_Utils_System::url("civicrm/case-features/quotations/contact-tab?cid=$contactID"),


### PR DESCRIPTION
## Overview
This pull request is aimed at displaying the contact Quotation tab only if the Quotation feature is enabled on at least one case instance.

## Before
Previously, the contact Quotation tab was displayed regardless of whether the Quotation feature was enabled on any case instance.

## After
With this pull request, the Quotation tab will only be displayed if the Quotation feature is enabled on at least one case instance. This will provide a more accurate representation of the features available to the user and prevent confusion.
![qqqaqa](https://user-images.githubusercontent.com/85277674/235593554-9bb69b1b-546b-4fc8-b0e2-8f94d2461136.gif)

