### PR TITLE
BTHAB-152: Use Quotation as case_sales_order title and update invoice

### DIFF
--- a/CRM/Civicase/DAO/CaseSalesOrder.php
+++ b/CRM/Civicase/DAO/CaseSalesOrder.php
@@ -174,7 +174,7 @@ class CRM_Civicase_DAO_CaseSalesOrder extends CRM_Core_DAO {
    *   Whether to return the plural version of the title.
    */
   public static function getEntityTitle($plural = FALSE) {
-    return $plural ? E::ts('Case Sales Orders') : E::ts('Case Sales Order');
+    return $plural ? E::ts('Quotation') : E::ts('Quotations');
   }
 
   /**

--- a/CRM/Civicase/DAO/CaseSalesOrderContribution.php
+++ b/CRM/Civicase/DAO/CaseSalesOrderContribution.php
@@ -91,7 +91,7 @@ class CRM_Civicase_DAO_CaseSalesOrderContribution extends CRM_Core_DAO {
    *   Whether to return the plural version of the title.
    */
   public static function getEntityTitle($plural = FALSE) {
-    return $plural ? E::ts('Case Sales Order Contributions') : E::ts('Case Sales Order Contribution');
+    return $plural ? E::ts('Quotation Contributions') : E::ts('Quotation Contribution');
   }
 
   /**

--- a/CRM/Civicase/DAO/CaseSalesOrderLine.php
+++ b/CRM/Civicase/DAO/CaseSalesOrderLine.php
@@ -134,7 +134,7 @@ class CRM_Civicase_DAO_CaseSalesOrderLine extends CRM_Core_DAO {
    *   Whether to return the plural version of the title.
    */
   public static function getEntityTitle($plural = FALSE) {
-    return $plural ? E::ts('Case Sales Order Lines') : E::ts('Case Sales Order Line');
+    return $plural ? E::ts('Quotation Lines') : E::ts('Quotation Line');
   }
 
   /**

--- a/CRM/Civicase/Form/CaseSalesOrderInvoice.php
+++ b/CRM/Civicase/Form/CaseSalesOrderInvoice.php
@@ -201,6 +201,7 @@ class CRM_Civicase_Form_CaseSalesOrderInvoice extends CRM_Core_Form {
     $model->setTerms($terms);
     $model->setSalesOrderId($salesOrderId);
     $model->setDomainLocation(self::getDomainLocation());
+    $model->setDomainName($domain->name ?? '');
     $rendered = $model->renderTemplate();
 
     $rendered['format'] = $rendered['format'] ?? self::defaultInvoiceFormat();

--- a/CRM/Civicase/WorkflowMessage/SalesOrderInvoice.php
+++ b/CRM/Civicase/WorkflowMessage/SalesOrderInvoice.php
@@ -17,6 +17,8 @@ use Civi\WorkflowMessage\GenericWorkflowMessage;
  * @method $this setDomainLogo(?string $logo)
  * @method ?int getSalesOrderId()
  * @method $this setSalesOrderId(?int $salesOrderId)
+ * @method ?string getDomainName()
+ * @method $this setDomainName(?string $domainName)
  */
 class CRM_Civicase_WorkflowMessage_SalesOrderInvoice extends GenericWorkflowMessage {
 
@@ -57,9 +59,17 @@ class CRM_Civicase_WorkflowMessage_SalesOrderInvoice extends GenericWorkflowMess
   /**
    * Sales Order ID.
    *
-   * @var array
+   * @var int
    * @scope tokenContext
    */
   protected $salesOrderId;
+
+  /**
+   * Domain Name.
+   *
+   * @var string
+   * @scope tplParams as domain_name
+   */
+  protected $domainName;
 
 }

--- a/templates/CRM/Civicase/MessageTemplate/QuotationInvoice.tpl
+++ b/templates/CRM/Civicase/MessageTemplate/QuotationInvoice.tpl
@@ -8,10 +8,10 @@
 </head>
 
 <body>
-  <div style="padding-top:100px;margin-right:50px;border-style: none; font-family: Arial, Verdana, sans-serif;">
-    <table style="margin-top:5px;padding-bottom:50px;" cellpadding="5" cellspacing="0">
+  <div style="padding-top:25px;margin-right:50px;border-style: none; font-family: Arial, Verdana, sans-serif;">
+    <table style="margin-top:5px;padding-bottom:50px; width:100%;" cellpadding="5" cellspacing="0">
       <tr>
-        <td><img src="{$domain_logo}" height="34px" width="99px"></td>
+        <td style="text-align:right;"><img src="{$domain_logo}" style="width: width: auto; max-height: 120px;"></td>
       </tr>
     </table>
 

--- a/templates/CRM/Civicase/MessageTemplate/QuotationInvoice.tpl
+++ b/templates/CRM/Civicase/MessageTemplate/QuotationInvoice.tpl
@@ -20,7 +20,7 @@
         <tr>
           <td width="30%"><b><font size="1" align="center">{ts}Client Name: {$sales_order.client.display_name}<{/ts}</font></b></td>
           <td width="50%" valign="bottom"><b><font size="1" align="center">{ts}Date:{/ts}</font></b></td>
-          <td valign="bottom" style="white-space: nowrap"><b><font size="1" align="right">Address</font></b></td>
+          <td valign="bottom" style="white-space: nowrap"><b><font size="1" align="right">{$domain_name}</font></b></td>
         </tr>
         <tr>
           <td><font size="1" align="center">


### PR DESCRIPTION
## Overview
This PR introduces the following changes
- `Quotation` instead of `Case Sales Order` is used as the case_sales_order entity title
- The domain logo on the quotation invoice is made to be responsive
- Domain name is added to the Invoice heading

## Before
The image is not displayed properly.
![image](https://user-images.githubusercontent.com/85277674/235950344-94056621-7dff-4d48-b765-9650815188a5.png)

## After
The image is displayed properly and aligned to the right as specified in the spec.
<img width="861" alt="Screenshot 2023-05-03 at 15 42 52" src="https://user-images.githubusercontent.com/85277674/235950934-6deab753-f03a-4d86-9f71-96c7841c06f6.png">

<img width="848" alt="Screenshot 2023-05-03 at 15 45 54" src="https://user-images.githubusercontent.com/85277674/235951934-4175b41e-da1e-4c89-bb90-23f6f4fce58a.png">


[quotation_invoice (84).pdf](https://github.com/compucorp/uk.co.compucorp.civicase/files/11383657/quotation_invoice.84.pdf)
