### PR TITLE
BTHAB-119: Round off quotation line-item money fields to 2 decimal places

### DIFF
--- a/CRM/Civicase/Service/CaseSalesOrderLineItemsGenerator.php
+++ b/CRM/Civicase/Service/CaseSalesOrderLineItemsGenerator.php
@@ -140,12 +140,12 @@ class CRM_Civicase_Service_CaseSalesOrderLineItemsGenerator {
   private function lineItemToContributionLineItem(array $item) {
     return [
       'qty' => $item['quantity'],
-      'tax_amount' => $item['tax'],
+      'tax_amount' => round($item['tax'], 2),
       'label' => $item['item_description'],
       'entity_table' => 'civicrm_contribution',
       'financial_type_id' => $item['financial_type_id'],
-      'line_total' => $item['total'],
-      'unit_price' => $item['unit_price'],
+      'line_total' => round($item['total'], 2),
+      'unit_price' => round($item['unit_price'], 2),
     ];
   }
 

--- a/civicase.php
+++ b/civicase.php
@@ -579,7 +579,8 @@ function civicase_civicrm_searchKitTasks(array &$tasks, bool $checkPermissions, 
 
   $actions['add_discount'] = [
     'module' => 'civicase-features',
-    'title' => ts('Add Discount %'),
+    'icon' => 'fa-percent',
+    'title' => ts('Add Discount'),
     'uiDialog' => ['templateUrl' => '~/civicase-features/quotations/directives/quotations-discount.directive.html'],
   ];
 


### PR DESCRIPTION
## Overview
This PR rounds off quotation line-item money fields to 2 decimal places.
In addition, this pull request includes moving the percentage icon to the front of the `Add Discount` bulk action link.

## Before
Before, the tax_amount input field or the total_price field could have multiple digits after the decimal point.
<img width="836" alt="Screenshot 2023-05-03 at 16 23 36" src="https://user-images.githubusercontent.com/85277674/235962670-db16f763-affa-4b56-912c-50a0691db5a4.png">


## After
After, the tax_amount input field and the total_price field would only have a maximum of two digits after the decimal point.
<img width="857" alt="Screenshot 2023-05-03 at 16 25 03" src="https://user-images.githubusercontent.com/85277674/235962972-3f4ed2a7-6446-4d7a-a960-ffc6eaf4bc86.png">

## Before
The percentage icon is after the `Add Discount` text
![image](https://user-images.githubusercontent.com/85277674/236127055-e3b5f773-88c5-435d-990b-c2a241059527.png)

## After
The percentage icon is before the `Add Discount` text
<img width="184" alt="Screenshot 2023-05-04 at 07 28 20" src="https://user-images.githubusercontent.com/85277674/236127010-2c1b5f27-2e7d-42e2-bd15-c4230c53526c.png">
