### PR TITLE
BTHAB-146: Update sales_order entity title

### DIFF
--- a/CRM/Civicase/DAO/CaseSalesOrder.php
+++ b/CRM/Civicase/DAO/CaseSalesOrder.php
@@ -174,7 +174,7 @@ class CRM_Civicase_DAO_CaseSalesOrder extends CRM_Core_DAO {
    *   Whether to return the plural version of the title.
    */
   public static function getEntityTitle($plural = FALSE) {
-    return $plural ? E::ts('Quotation') : E::ts('Quotations');
+    return $plural ? E::ts('Quotations') : E::ts('Quotation');
   }
 
   /**

--- a/ang/civicase-features/quotations/directives/quotations-create.directive.html
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.html
@@ -229,23 +229,14 @@
             <textarea name="notes" rows="5" cols="20" style="width: 100%;" ng-model="salesOrder.notes"></textarea>
           </div>
         </div>
-
-
-        <div class="form-group">
-          <div class="col-sm-12">
-            <div class="clearfix">
-              <div class="pull-left">
-                <button type="button" class="btn btn-primary-outline cancel" history-back>
-                  <span class="btn-icon"></span> {{ts('Cancel')}}</button>
-                  </div>
-                <div class="pull-right">
-                <button type="submit" class="btn btn-primary" ng-disabled="submitInProgress" ng-click="saveQuotation()">
-                  <span class="btn-icon"></span> {{ts('Save')}}</button>
-              </div>
-            </div>
-          </div>
-        </div>
       </form>
+    </div>
+
+    <div class="panel-footer flex-between crm-submit-buttons">
+      <button type="button" class="btn btn-primary-outline cancel" history-back>
+        <span class="btn-icon"></span> {{ts('Cancel')}}</button>
+      <button type="submit" class="btn btn-primary" ng-disabled="submitInProgress" ng-click="saveQuotation()">
+        <span class="btn-icon"></span> {{ts('Save')}}</button>
     </div>
   </div>
 </div>
@@ -253,5 +244,9 @@
 <style>
   #quotation__create .table>tbody>tr>td {
     padding: 10px 10px;
+  }
+  .flex-between {
+    display: flex;
+    justify-content: space-between;
   }
 </style>


### PR DESCRIPTION
## Overview
This PR updates the sales order entity title and also makes a visual update to the action buttons on the Quotation Create screen

## Before
The action buttons are in the panel body.
<img width="1397" alt="Screenshot 2023-05-15 at 16 17 36" src="https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/64b30cc0-bf23-4e42-b351-7ed9fbaf5b9e">

## After
The action buttons are in the panel footer.
<img width="1399" alt="Screenshot 2023-05-15 at 16 16 16" src="https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/a7eca7d4-4a82-4e78-a42a-c14f1531efd6">
