### PR TITLE
BTHAB-106: Fix issues on quotation edit screen and template

### DIFF
--- a/Civi/Api4/Action/CaseSalesOrder/ContributionCreateAction.php
+++ b/Civi/Api4/Action/CaseSalesOrder/ContributionCreateAction.php
@@ -59,7 +59,7 @@ class ContributionCreateAction extends AbstractAction {
   /**
    * Contribution Financial Type ID.
    *
-   * @var string
+   * @var string|int
    */
   protected $financialTypeId;
 

--- a/ang/civicase-features/quotations/directives/quotations-create.directive.html
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.html
@@ -1,5 +1,5 @@
 <div id="bootstrap-theme" class="civicase__container">
-  <h1 crm-page-title>{{ ts('Create Quotation') }}</h1>
+  <h1 crm-page-title>{{ ts(isUpdate ? 'Edit Quotation':'Create Quotation') }}</h1>
 
   <div class="panel panel-default" id="quotation__create">
     <div class="panel-body">

--- a/ang/civicase-features/quotations/directives/quotations-create.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.js
@@ -100,6 +100,7 @@
       CaseUtils.getSalesOrderAndLineItems(salesOrderId).then((result) => {
         $scope.isUpdate = true;
         $scope.salesOrder = result;
+        $scope.salesOrder.owner_id = parseInt(result.owner_id);
         $scope.salesOrder.quotation_date = $.datepicker.formatDate('yy-mm-dd', new Date(result.quotation_date));
         $scope.salesOrder.status_id = (result.status_id).toString();
         CRM.wysiwyg.setVal('#sales-order-description', $scope.salesOrder.description);

--- a/templates/CRM/Civicase/MessageTemplate/QuotationInvoice.tpl
+++ b/templates/CRM/Civicase/MessageTemplate/QuotationInvoice.tpl
@@ -88,7 +88,7 @@
         <tbody>
           {foreach from=$sales_order.items key=k item=item}
           <tr {if ($k%2) == 0} style="background-color: #eeeeee;" {/if}>
-            <td style="padding: 8px 10px; text-align: left; white-space: nowrap; border: 1px solid #000;" > <font size="1">{$item.item_description|truncate:30:"..."}</font></td>
+            <td style="padding: 8px 10px;text-align: left;border: 1px solid #000;" > <font size="1">{$item.item_description}</font></td>
             <td style="padding: 8px 10px;text-align: right;border: 1px solid #000;"><font size="1">{$item.quantity}</font></td>
             <td style="padding: 8px 10px;text-align: right;border: 1px solid #000;"><font size="1">{$item.unit_price|crmMoney:$sales_order.currency}</font></td>
             <td style="padding: 8px 10px;text-align: right;border: 1px solid #000;"><font size="1">{if empty($item.discounted_percentage) } 0 {else}{$item.discounted_percentage}{/if}%</font></td>


### PR DESCRIPTION
## Overview
This PR introduces the following updates:
- Contribution Create action should accept the financial type ID  of type int or string
- When editing a quotation the title of the page should be 'Edit Quotation'
- Set the owner_id to that of the quotation that is currently being edited.
- Allow the description column in the quotation invoice to be as long as needed.

## Before
The page title is 'Create Quotation' when editing a quotation.
<img width="529" alt="Screenshot 2023-05-19 at 15 05 29" src="https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/b4c4dfed-f0af-4083-b6b4-a5dc6cc43cf9">

## After
The page title is 'Edit Quotation' when editing a quotation.
<img width="501" alt="Screenshot 2023-05-19 at 15 00 38" src="https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/94c656bb-e6a2-4f43-bbf0-3069caa8bcdb">


## Before
The description column is limited to 30 words and extra words are truncated.
<img width="809" alt="Screenshot 2023-05-19 at 13 13 31" src="https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/ebf696ba-09f9-4fe3-8b8a-5f7a179e7b42">

## After
The description column can be as long as needed.
<img width="795" alt="Screenshot 2023-05-19 at 13 18 08" src="https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/06e3fedc-0520-4c2d-bd85-198399e43def">
