### PR TITLE
BTHAB-170: Fix issue with creating bulk contribution

### DIFF
--- a/CRM/Civicase/Service/CaseSalesOrderLineItemsGenerator.php
+++ b/CRM/Civicase/Service/CaseSalesOrderLineItemsGenerator.php
@@ -105,6 +105,7 @@ class CRM_Civicase_Service_CaseSalesOrderLineItemsGenerator {
       ->addSelect('contribution_id')
       ->addWhere('case_sales_order_id.id', '=', $this->salesOrderId)
       ->addChain('items', LineItem::get()
+        ->addSelect('qty', 'unit_price', 'tax_amount', 'line_total', 'entity_table', 'label', 'financial_type_id')
         ->addWhere('contribution_id', '=', '$contribution_id')
     )
       ->execute();
@@ -113,10 +114,11 @@ class CRM_Civicase_Service_CaseSalesOrderLineItemsGenerator {
       $items = $contribution['items'];
 
       if (empty($items)) {
-        return [];
+        continue;
       }
 
       foreach ($items as $item) {
+        unset($item['id']);
         $item['qty'] = $item['qty'];
         $item['unit_price'] = -1 * $item['unit_price'];
         $item['tax_amount'] = -1 * $item['tax_amount'];

--- a/Civi/Api4/Action/CaseSalesOrder/ContributionCreateAction.php
+++ b/Civi/Api4/Action/CaseSalesOrder/ContributionCreateAction.php
@@ -90,6 +90,8 @@ class ContributionCreateAction extends AbstractAction {
       catch (\Exception $e) {
         $transaction->rollback();
       }
+
+      $transaction->commit();
     }
 
     return ['created_contributions_count' => $createdContributionsCount];
@@ -104,7 +106,7 @@ class ContributionCreateAction extends AbstractAction {
    *   Array of price fields.
    */
   private function createContributionWithLineItems(int $salesOrderId, array $priceField): array {
-    $salesOrderContribution = new salesOrderlineItemGenerator($salesOrderId, $this->toBeInvoiced, $this->percentValue);
+    $salesOrderContribution = new salesOrderlineItemGenerator($salesOrderId, $this->toBeInvoiced, $this->percentValue ?? 0);
     $lineItems = $salesOrderContribution->generateLineItems();
 
     $taxAmount = $lineTotal = 0;


### PR DESCRIPTION
## Overview
It is expected that if a quotation has been invoiced in full, a user shouldn't be able to create a new bulk or single invoice using the 'remaining' option; this expectation works as expected for single contributions, but not for bulk contributions.

This PR addresses this issue.

## Before
Bulk contribution action is generating a contribution even when the invoice has no remaining balance.
https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/f7439c15-4b79-42d3-9bc2-09c59790c144


## After
Bulk contribution action doesn't generate a contribution when the invoice has no remaining balance.
![1qwewrwewewewe](https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/96a4d46b-829c-41d3-bb61-dd2302a0e76d)

## Technical Details
When the remaining option is selected, the application gets the previously created contribution line items, negating their values, and also gets the line items for the quotations, then adds them together to compute the remaining value;  The issue here is when the previously created line items are retrieved from the database:
https://github.com/compucorp/uk.co.compucorp.civicase/blob/045d4546003058009538d199710493c331482090/CRM/Civicase/Service/CaseSalesOrderLineItemsGenerator.php#L101-L111

The line item IDs are also returned from the DB, the problem is that when this line items array is passed to the Contribution Create API, CiviCRM in its wisdom moves these line items from the old contribution into the new contribution. Consequently, when the user selects the "remaining" option again, the previous contribution is not taken into account, resulting in a consistently remaining value.

To resolve this issue, it is necessary to unset the line item IDs before passing them to the Contribution Create API. You can find the solution in this code snippet:
https://github.com/compucorp/uk.co.compucorp.civicase/blob/045d4546003058009538d199710493c331482090/CRM/Civicase/Service/CaseSalesOrderLineItemsGenerator.php#L120-L121

- Also, we ensure that the `percentValue` argument has a default value of 0 when it is null.
- Also, [we ensure each contribution create is persisted in the loop](https://github.com/compucorp/uk.co.compucorp.civicase/pull/954/commits/78aaf71cc2974b54f333268ba9f5dbfe3383fc69)


