### PR TITLE
NEUSPRT-239: Sort activities Tag list in alphabetical order

### DIFF
--- a/ang/civicase/shared/directives/file-uploader.directive.js
+++ b/ang/civicase/shared/directives/file-uploader.directive.js
@@ -180,7 +180,7 @@
       return civicaseCrmApi('Tag', 'get', {
         sequential: 1,
         used_for: { LIKE: '%civicrm_activity%' },
-        options: { limit: 0 }
+        options: { limit: 0, sort: 'name ASC' }
       }).then(function (data) {
         return data.values;
       });

--- a/ang/test/civicase/shared/directives/file-uploader.directive.spec.js
+++ b/ang/test/civicase/shared/directives/file-uploader.directive.spec.js
@@ -37,7 +37,7 @@
         expect(civicaseCrmApi).toHaveBeenCalledWith('Tag', 'get', {
           sequential: 1,
           used_for: { LIKE: '%civicrm_activity%' },
-          options: { limit: 0 }
+          options: { limit: 0, sort: 'name ASC' }
         });
       });
 


### PR DESCRIPTION
## Overview
This PR sorts the activities Tag list in alphabetical order.

## Before
The tag list was sorted by ID
![beforeneu](https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/3782f517-bde0-4d20-94c8-b9acc5e1df3d)


## After
The tag list is sorted by name in Ascending order.
![afterneu](https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/db046c13-bf1d-4861-8d55-c2eb5785116d)
