### PR TITLE
BTHAB-200: Display only relevant quotations for the viewed contact

### DIFF
--- a/CRM/Civicase/Form/CaseSalesOrderDelete.php
+++ b/CRM/Civicase/Form/CaseSalesOrderDelete.php
@@ -30,6 +30,8 @@ class CRM_Civicase_Form_CaseSalesOrderDelete extends CRM_Core_Form {
    * {@inheritDoc}
    */
   public function buildQuickForm() {
+    $this->assign('id', $this->id);
+
     $this->addButtons([
       [
         'type' => 'submit',

--- a/ang/afsearchContactQuotations.aff.html
+++ b/ang/afsearchContactQuotations.aff.html
@@ -21,5 +21,5 @@
       </div>
     </div>
   </div>
-  <crm-search-display-table search-name="Civicase_Quotations" display-name="Civicase_Contact_Quotations_Table" filters="{client_id: routeParams.cid}"></crm-search-display-table>
+  <crm-search-display-table search-name="Civicase_Quotations" display-name="Civicase_Contact_Quotations_Table" filters="{client_id: options.contact_id}"></crm-search-display-table>
 </div>

--- a/ang/civicase-features.ang.php
+++ b/ang/civicase-features.ang.php
@@ -73,6 +73,8 @@ $requires = [
   'crmUi',
   'crmUtil',
   'civicase',
+  'ui.sortable',
+  'dialogService',
   'civicase-base',
   'afsearchQuotations',
   'afsearchContactQuotations',

--- a/ang/civicase-features/quotations/directives/quotations-list.directive.html
+++ b/ang/civicase-features/quotations/directives/quotations-list.directive.html
@@ -11,7 +11,7 @@
   <div class="panel panel-default">
     <div class="panel-body">
       <div ng-switch="view">
-        <afsearch-contact-quotations ng-switch-when="contact"> </afsearch-contact-quotations>
+        <afsearch-contact-quotations options="{contact_id: contactId}" ng-switch-when="contact"> </afsearch-contact-quotations>
         <afsearch-quotations ng-switch-default> </afsearch-quotations>
       </div>
       

--- a/ang/civicase-features/quotations/directives/quotations-list.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-list.directive.js
@@ -24,10 +24,6 @@
     $scope.redirectToQuotationCreationScreen = redirectToQuotationCreationScreen;
 
     (function init () {
-      if ($scope.contactId) {
-        $location.search().cid = $scope.contactId;
-      }
-
       addEventToElementsWhenInDOMTree();
     }());
 

--- a/js/sales-order-contribution.js
+++ b/js/sales-order-contribution.js
@@ -40,10 +40,6 @@
       });
     }
 
-    $("a[target='crm-popup']").on('crmPopupFormSuccess', function (e) {
-      CRM.refreshParent(e);
-    });
-
     /**
      * @param {number} quantity Item quantity
      * @param {number} unitPrice Item unit price

--- a/templates/CRM/Civicase/Form/CaseSalesOrderDelete.tpl
+++ b/templates/CRM/Civicase/Form/CaseSalesOrderDelete.tpl
@@ -11,10 +11,13 @@
 </div>
 
 <script type="text/javascript">
+  const id = { $id }
   {literal}
     CRM.$(function($) {
       $("a[target='crm-popup']").on('crmPopupFormSuccess', function (e) {
-        CRM.refreshParent(e);
+        const val = CRM.$('.civicase__features input#id-0').val();
+        CRM.$('.civicase__features input#id-0').val(id).change();
+        CRM.$('.civicase__features input#id-0').val(val).change();
       });
     });
   {/literal}


### PR DESCRIPTION
## Overview
This pull request addresses issues where occasionally the contact quotation tab displays quotations belonging to other contacts. This PR ensures that only relevant quotations are displayed.

## Before
The previous implementation did not always filter the quotations based on the viewed contact, resulting in the display of irrelevant quotations.

<img width="1357" alt="Screenshot 2023-07-13 at 13 19 30" src="https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/0042e4af-cfb2-479a-8aa5-dd50fe601046">


## After
With this pull request, the quotations displayed for a viewed contact are filtered correctly. The code changes ensure that only quotations relevant to the contact are shown.

<img width="1364" alt="Screenshot 2023-07-13 at 13 14 27" src="https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/5b5ecbc1-954a-43f4-ac68-51ad27fdf895">


## Technical Details

The contact quotation tab uses the contact ID set in the route parameter `filters="{client_id: routeParams.cid}` to filter quotations that are relevant to the contact being viewed,  if in between tab navigations, the contact ID route parameter is unset or before it is set by the quotationListController ` $location. search().cid = $scope.contactId;` all quotations will be displayed.

To resolve this we instead filter the quotation display through the options attribute `filters="{client_id: options.contact_id}"`, which remains the same all through the tab navigation.