### PR TITLE
NEUSPRT-222: Add date field to file upload screen

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,7 +6,7 @@ jobs:
   run-unit-tests:
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.3.0-php8.0-chrome
+    container: compucorp/civicrm-buildkit:1.3.1-php8.0-chrome
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions

--- a/ang/civicase/shared/directives/file-uploader.directive.html
+++ b/ang/civicase/shared/directives/file-uploader.directive.html
@@ -20,6 +20,12 @@
           <input type="text" class="form-control" id="uploadSubject" required placeholder="" ng-model="activity.subject"/>
         </div>
         <div class="row">
+          <div class="form-group col-md-4 civicase__ui-range">
+            <div><label for="receivedDate">{{ts('Received Date')}}</label></div>
+            <input  id="receivedDate" class="form-control" crm-ui-datepicker="{time: false}" ng-model="activity.activity_date_time" placeholder=""/>
+          </div>
+        </div>
+        <div class="row">
           <div class="civicase__file-upload-name col-md-8"><label>{{ts('Name')}}</label></div>
           <div class="civicase__file-upload-size col-md-2"><label>{{ts('Size')}}</label></div>
           <div class="civicase__file-upload-action col-md-2"></div>

--- a/ang/civicase/shared/directives/file-uploader.directive.js
+++ b/ang/civicase/shared/directives/file-uploader.directive.js
@@ -106,6 +106,10 @@
      * @returns {Promise} promise
      */
     function saveActivity () {
+      if ($scope.activity.activity_date_time === '') {
+        delete $scope.activity.activity_date_time;
+      }
+
       var promise = civicaseCrmApi('Activity', 'create', $scope.activity)
         .then(function (activity) {
           saveTags(activity.id);

--- a/ang/test/civicase/case/actions/services/go-to-webforms-case-action.service.spec.js
+++ b/ang/test/civicase/case/actions/services/go-to-webforms-case-action.service.spec.js
@@ -1,13 +1,14 @@
 (function (_, $) {
   describe('GoToWebformCaseAction', function () {
-    var GoToWebformCaseAction, CaseActionsData, CasesData;
+    var GoToWebformCaseAction, CaseActionsData, CasesData, civicaseCrmUrl;
 
     beforeEach(module('civicase', 'civicase.data'));
 
-    beforeEach(inject(function (_GoToWebformCaseAction_, _CaseActionsData_, _CasesData_) {
+    beforeEach(inject(function (_GoToWebformCaseAction_, _CaseActionsData_, _CasesData_, _civicaseCrmUrl_) {
       GoToWebformCaseAction = _GoToWebformCaseAction_;
       CaseActionsData = _CaseActionsData_;
       CasesData = _CasesData_.get().values;
+      civicaseCrmUrl = _civicaseCrmUrl_;
     }));
 
     describe('checkIfWebformVisible()', function () {
@@ -60,6 +61,8 @@
         var goToWebformAction = _.find(CaseActionsData.get(), function (action) {
           return action.action === 'Webforms';
         }).items[0];
+
+        civicaseCrmUrl.and.returnValue(goToWebformAction.path);
 
         GoToWebformCaseAction.doAction(cases, goToWebformAction);
       });


### PR DESCRIPTION
## Before

At the moment when uploading a file to case using:

![image](https://github.com/compucorp/uk.co.compucorp.civicase/assets/6275540/4db89a44-0310-449b-8d4d-18ac674d5363)

an activity will be created with a data that = today's date by default. 


## After

A new field called  "Received Date"  is added to the case file upload screen, which allow users to change the activity date if they wish, if no value is selected on such field, then it will use today's date by default :


![2023-08-09 14_21_59-Manage Cases _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.civicase/assets/6275540/3b153a20-5422-4c77-b115-92bf2197ff5e)


- Demo 1: using past date:  

![11111](https://github.com/compucorp/uk.co.compucorp.civicase/assets/6275540/4b4eafa9-5362-430c-af7e-46beb11bf351)

- Demo 2: using future date:  

![2222](https://github.com/compucorp/uk.co.compucorp.civicase/assets/6275540/bdbdd635-b142-49e3-a1b9-b2ece72e589b)

- Demo 3: Not selecting any date:

![44444](https://github.com/compucorp/uk.co.compucorp.civicase/assets/6275540/b988efff-9db1-4477-89d7-2862603da330)



