### PR TITLE
BTHAB-178: Membeship Type product discounts custom field

### DIFF
--- a/CRM/Civicase/Setup/Manage/MembershipTypeCustomFieldManager.php
+++ b/CRM/Civicase/Setup/Manage/MembershipTypeCustomFieldManager.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Manages Membership Type Custom Field Entity.
+ */
+class CRM_Civicase_Setup_Manage_MembershipTypeCustomFieldManager extends CRM_Civicase_Setup_Manage_AbstractManager {
+
+  const OPTION_GROUP_NAME = 'cg_extend_objects';
+
+  /**
+   * Adds Membership Type entity to extend object.
+   */
+  public function create(): void {
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => self::OPTION_GROUP_NAME,
+      "label" => "Membership Type",
+      "value" => "MembershipType",
+      "name" => "civicrm_membership_type",
+      'is_active' => TRUE,
+      'is_reserved' => TRUE,
+    ]);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function remove(): void {}
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function toggle($status): void {}
+
+}

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -1,23 +1,24 @@
 <?php
 
-use CRM_Civicase_Setup_CaseTypeCategorySupport as CaseTypeCategorySupport;
-use CRM_Civicase_Setup_CreateCasesOptionValue as CreateCasesOptionValue;
+use CRM_Civicase_ExtensionUtil as E;
+use CRM_Civicase_Helper_CaseUrl as CaseUrlHelper;
+use CRM_Civicase_Service_CaseCategoryInstance as CaseCategoryInstance;
 use CRM_Civicase_Setup_AddCaseCategoryWordReplacementOptionGroup as AddCaseCategoryWordReplacementOptionGroup;
-use CRM_Civicase_Setup_MoveCaseTypesToCasesCategory as MoveCaseTypesToCasesCategory;
-use CRM_Civicase_Setup_CreateSafeFileExtensionOptionValue as CreateSafeFileExtensionOptionValue;
-use CRM_Civicase_Uninstall_RemoveCustomGroupSupportForCaseCategory as RemoveCustomGroupSupportForCaseCategory;
-use CRM_Civicase_Setup_ProcessCaseCategoryForCustomGroupSupport as ProcessCaseCategoryForCustomGroupSupport;
-use CRM_Civicase_Setup_CaseCategoryInstanceSupport as CaseCategoryInstanceSupport;
 use CRM_Civicase_Setup_AddChangeCaseRoleDateActivityTypes as AddChangeCaseRoleDateActivityTypes;
 use CRM_Civicase_Setup_AddManageWorkflowMenu as AddManageWorkflowMenu;
-use CRM_Civicase_Service_CaseCategoryInstance as CaseCategoryInstance;
-use CRM_Civicase_Helper_CaseUrl as CaseUrlHelper;
-use CRM_Civicase_Setup_AddSingularLabels as AddSingularLabels;
-use CRM_Civicase_ExtensionUtil as E;
 use CRM_Civicase_Setup_AddMyActivitiesMenu as AddMyActivitiesMenu;
-use CRM_Civicase_Setup_Manage_CaseTypeCategoryFeaturesManager as CaseTypeCategoryFeaturesManager;
+use CRM_Civicase_Setup_AddSingularLabels as AddSingularLabels;
+use CRM_Civicase_Setup_CaseCategoryInstanceSupport as CaseCategoryInstanceSupport;
+use CRM_Civicase_Setup_CaseTypeCategorySupport as CaseTypeCategorySupport;
+use CRM_Civicase_Setup_CreateCasesOptionValue as CreateCasesOptionValue;
+use CRM_Civicase_Setup_CreateSafeFileExtensionOptionValue as CreateSafeFileExtensionOptionValue;
 use CRM_Civicase_Setup_Manage_CaseSalesOrderStatusManager as CaseSalesOrderStatusManager;
+use CRM_Civicase_Setup_Manage_CaseTypeCategoryFeaturesManager as CaseTypeCategoryFeaturesManager;
+use CRM_Civicase_Setup_Manage_MembershipTypeCustomFieldManager as MembershipTypeCustomFieldManager;
 use CRM_Civicase_Setup_Manage_QuotationTemplateManager as QuotationTemplateManager;
+use CRM_Civicase_Setup_MoveCaseTypesToCasesCategory as MoveCaseTypesToCasesCategory;
+use CRM_Civicase_Setup_ProcessCaseCategoryForCustomGroupSupport as ProcessCaseCategoryForCustomGroupSupport;
+use CRM_Civicase_Uninstall_RemoveCustomGroupSupportForCaseCategory as RemoveCustomGroupSupportForCaseCategory;
 
 /**
  * Collection of upgrade steps.
@@ -154,6 +155,7 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     (new CaseTypeCategoryFeaturesManager())->create();
     (new CaseSalesOrderStatusManager())->create();
     (new QuotationTemplateManager())->create();
+    (new MembershipTypeCustomFieldManager())->create();
   }
 
   /**

--- a/CRM/Civicase/Upgrader/Steps/Step0020.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0020.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Add custom fields.
+ */
+class CRM_Civicase_Upgrader_Steps_Step0020 {
+
+  /**
+   * Runs the upgrader changes.
+   *
+   * @return bool
+   *   Return value in boolean.
+   */
+  public function apply() {
+    try {
+      (new CRM_Civicase_Setup_Manage_MembershipTypeCustomFieldManager())->create();
+    }
+    catch (\Throwable $th) {
+      \Civi::log()->error('Error upgrading Civicase', [
+        'context' => [
+          'backtrace' => $th->getTraceAsString(),
+          'message' => $th->getMessage(),
+        ],
+      ]);
+    }
+
+    return TRUE;
+  }
+
+}

--- a/managed/CustomGroup_Product_Discounts.mgd.php
+++ b/managed/CustomGroup_Product_Discounts.mgd.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * @file
+ * Exported Product Discounts CustomGroup.
+ */
+
+use Civi\Api4\OptionValue;
+
+$mgd = [
+  [
+    'name' => 'CustomGroup_Product_Discounts',
+    'entity' => 'CustomGroup',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Product_Discounts',
+        'title' => 'Product Discounts',
+        'extends' => 'MembershipType',
+        'extends_entity_column_value' => NULL,
+        'style' => 'Inline',
+        'collapse_display' => FALSE,
+        'help_pre' => '',
+        'help_post' => '',
+        'weight' => 107,
+        'is_active' => TRUE,
+        'is_multiple' => FALSE,
+        'min_multiple' => NULL,
+        'max_multiple' => NULL,
+        'collapse_adv_display' => TRUE,
+        'created_date' => '2023-08-25 07:22:08',
+        'is_reserved' => FALSE,
+        'is_public' => TRUE,
+        'icon' => '',
+        'extends_entity_column_id' => NULL,
+      ],
+    ],
+  ],
+  [
+    'name' => 'CustomGroup_Product_Discounts_CustomField_Product_Discount_Amount',
+    'entity' => 'CustomField',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'custom_group_id.name' => 'Product_Discounts',
+        'name' => 'Product_Discount_Amount',
+        'label' => 'Product Discount Amount',
+        'data_type' => 'Float',
+        'html_type' => 'Text',
+        'default_value' => NULL,
+        'is_required' => FALSE,
+        'is_searchable' => FALSE,
+        'is_search_range' => FALSE,
+        'help_pre' => NULL,
+        'help_post' => 'Specify a discount that will automatically be applied when adding a product line item to a quotation if the contact is a member of this type.',
+        'mask' => NULL,
+        'attributes' => NULL,
+        'javascript' => NULL,
+        'is_active' => TRUE,
+        'is_view' => FALSE,
+        'options_per_line' => NULL,
+        'text_length' => 255,
+        'start_date_years' => NULL,
+        'end_date_years' => NULL,
+        'date_format' => NULL,
+        'time_format' => NULL,
+        'note_columns' => 60,
+        'note_rows' => 4,
+        'column_name' => 'product_discount_amount',
+        'serialize' => 0,
+        'filter' => NULL,
+        'in_selector' => FALSE,
+      ],
+    ],
+  ],
+];
+
+$rowCount = OptionValue::get(FALSE)
+  ->selectRowCount()
+  ->addSelect('*')
+  ->addWhere('option_group_id:name', '=', 'cg_extend_objects')
+  ->addWhere('name', '=', 'civicrm_membership_type')
+  ->execute()
+  ->count();
+
+if ($rowCount == 1) {
+  return $mgd;
+}
+
+return [];


### PR DESCRIPTION
## Overview

This pull request adds

* Membership Type to the `cg_extend_objects` option group so, custom fields can be created against the membership type entity. The value will only be created if it does not exist. 
* Add product discounts custom field to the membership type. 

## Before

Feature didn't exist. 

## After

![screenshot-btha localhost_9011-2023 08 25-09_18_10](https://github.com/compucorp/uk.co.compucorp.civicase/assets/208713/cf793718-ff18-43b8-873a-9f4e3ca95f97)

## Technical Details

The custom field was created and exported using CiviCRM v4. I added the [check ](https://github.com/compucorp/uk.co.compucorp.civicase/compare/BTHAB-3-workstream...compucorp:uk.co.compucorp.civicase:BTHAB-178-membership-type-custom-field?expand=1#diff-159c7c58abaafe1914ba43096244e5a1cadd5d9df9a93813ca97ea6572f78170R75) to ensure that the entity can only be installed if membership type value existed in `cg_extend_objects `option value. 
