### PR TITLE
BTHAB-204: Apply contact membership type product discount to sale order items

### DIFF
--- a/ang/civicase-features/quotations/directives/quotations-create.directive.html
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.html
@@ -11,6 +11,7 @@
           <div class="col-sm-5">
             <input class="form-control"
               ng-model="salesOrder.client_id"
+              ng-change="handleClientChange()"
               placeholder="Client"
               name="client"
               crm-entityref="{


### PR DESCRIPTION
## Overview

This PR applies client's membership type's product discount percentage amount to each product line item. 

## Before

The feature did not exist. 

## After

[screencast-btha.localhost_9011-2023.09.01-13_54_34.webm](https://github.com/compucorp/uk.co.compucorp.civicase/assets/208713/3f34d6fd-c546-459f-b11a-dbb1080f0fd7)


## Technical Details

The product discount amount custom field for membership type was introduced in this [PR](https://github.com/compucorp/uk.co.compucorp.civicase/pull/965). In this PR, we applied the percentage to membership type percentage to each line item. 

There are few rules that apply to the implementation, which can be described as follows: 

1. The discount percentage amount will set to default zero if selected client does not have any membership. 
2. The discount percentage amount will set to the total of membership types's product discounted amount. For example.

_Scenario 1:_ 
Membership 1 - 50%
Membership 2 - 10%

The percentage amount would be 60%  

_Scenario 2:_

Membership 1 - 50%
Membership 2 - 50%

The percentage amount would be 100%

_Scenario 3:_

Membership 1 - 50%
Membership 2 - 50%
Membership 3 - 50%

The percentage amount would cap to 100% 

3. The user can still manually apply the percentage amount and If a user then overrides the discount, we do not reset it at any point. They would have to delete the line and add a new one for the discount to apply again.
4. Notification will be displayed if the discount percentage is greater than zero