### PR TITLE
CST-334: Fix case entity not being imported

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,7 +6,7 @@ jobs:
   run-unit-tests:
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.3.0-php8.0-chrome
+    container: compucorp/civicrm-buildkit:1.3.1-php8.0-chrome
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions

--- a/CRM/Civicase/Helper/CaseCategory.php
+++ b/CRM/Civicase/Helper/CaseCategory.php
@@ -1,9 +1,9 @@
 <?php
 
 use CRM_Case_BAO_CaseType as CaseType;
+use CRM_Civicase_BAO_CaseCategoryInstance as CaseCategoryInstance;
 use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
 use CRM_Civicase_Service_CaseManagementUtils as CaseManagementUtils;
-use CRM_Civicase_BAO_CaseCategoryInstance as CaseCategoryInstance;
 
 /**
  * CaseCategory Helper class with useful functions for managing case categories.
@@ -87,7 +87,7 @@ class CRM_Civicase_Helper_CaseCategory {
     try {
       $result = civicrm_api3('CaseType', 'getvalue', [
         'id' => $caseTypeId,
-        'return' => ['case_type_category'],
+        'return' => 'case_type_category',
       ]);
 
       if (!empty($result['is_error'])) {


### PR DESCRIPTION
## Overview
This PR fixes an issue in the extension that prevents the case entity from being imported using the `CSV import` extension


## Before
Import hangs and the error below is thrown

```
TypeError: Illegal offset type in isset or empty in civicrm_api3_generic_getvalue() (line 338 of /Applications/MAMP/htdocs/cst/profiles/compuclient/modules/contrib/civicrm/api/v3/Generic.php).
```

## After
Import is successfully completed
<img width="1344" alt="Screenshot 2023-09-06 at 16 16 24" src="https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/87af6337-fc7d-4c78-8e9c-64c2b19c8788">


## Technical Details
This error happened because the `CaseType.getvalue` endpoint expects the return param to be a string type and not an array

