### PR TITLE
BTHAB-180: Only perform delete if id line item is not empty

### DIFF
--- a/Civi/Api4/Action/CaseSalesOrder/SalesOrderSaveAction.php
+++ b/Civi/Api4/Action/CaseSalesOrder/SalesOrderSaveAction.php
@@ -2,12 +2,12 @@
 
 namespace Civi\Api4\Action\CaseSalesOrder;
 
-use CRM_Core_Transaction;
-use Civi\Api4\Generic\Result;
 use Civi\Api4\CaseSalesOrderLine;
 use Civi\Api4\Generic\AbstractSaveAction;
+use Civi\Api4\Generic\Result;
 use Civi\Api4\Generic\Traits\DAOActionTrait;
 use CRM_Civicase_BAO_CaseSalesOrder as CaseSalesOrderBAO;
+use CRM_Core_Transaction;
 
 /**
  * {@inheritDoc}
@@ -86,6 +86,10 @@ class SalesOrderSaveAction extends AbstractSaveAction {
     }
 
     $lineItemsInUse = array_column($salesOrder['items'], 'id');
+
+    if (empty($lineItemsInUse)) {
+      return;
+    }
 
     CaseSalesOrderLine::delete()
       ->addWhere('sales_order_id', '=', $salesOrder['id'])


### PR DESCRIPTION
## Overview

This PR adds the logic to prevent deleting SaleOrderLine objects when there isn't any ID attaches to the SaleOrder['items'] which will cause the error as we are passing an empty array to the query. 

 This scenario is likely to happen when the API caller want to update a sale order/quotation with a new list of product items, where the product items have not been created yet. 