### PR TITLE
BTHAB-206: Add send invoice by email in bulk action menu for bulk invoice sending

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/AttachQuotationToInvoiceMail.php
+++ b/CRM/Civicase/Hook/BuildForm/AttachQuotationToInvoiceMail.php
@@ -40,7 +40,10 @@ class CRM_Civicase_Hook_BuildForm_AttachQuotationToInvoiceMail {
    *   TRUE if the hook should run, FALSE otherwise.
    */
   private function shouldRun($form, $formName) {
-    if ($formName != 'CRM_Contribute_Form_Task_Invoice') {
+    if (!in_array($formName, [
+      'CRM_Contribute_Form_Task_Invoice',
+      'CRM_Invoicehelper_Contribute_Form_Task_Invoice',
+    ])) {
       return FALSE;
     }
 

--- a/CRM/Civicase/Hook/alterMailParams/AttachQuotation.php
+++ b/CRM/Civicase/Hook/alterMailParams/AttachQuotation.php
@@ -25,7 +25,11 @@ class CRM_Civicase_Hook_alterMailParams_AttachQuotation {
 
     $rendered = $this->getContributionQuotationInvoice($params['tokenContext']['contributionId']);
 
-    $params['attachments'][] = CRM_Utils_Mail::appendPDF('quotation_invoice.pdf', $rendered['html'], $rendered['format']);
+    $attachment = CRM_Utils_Mail::appendPDF('quotation_invoice.pdf', $rendered['html'], $rendered['format']);
+
+    if ($attachment) {
+      $params['attachments'][] = $attachment;
+    }
   }
 
   /**

--- a/CRM/Civicase/Service/CaseSalesOrderInvoice.php
+++ b/CRM/Civicase/Service/CaseSalesOrderInvoice.php
@@ -13,7 +13,7 @@ use CRM_Civicase_WorkflowMessage_SalesOrderInvoice as SalesOrderInvoice;
 class CRM_Civicase_Service_CaseSalesOrderInvoice {
 
   /**
-   * CreditNoteInvoiceService constructor.
+   * CaseSalesOrderInvoice constructor.
    *
    * @param \CRM_Civicase_WorkflowMessage_SalesOrderInvoice $template
    *   Workflow template.

--- a/CRM/Civicase/Upgrader/Steps/Step0019.php
+++ b/CRM/Civicase/Upgrader/Steps/Step0019.php
@@ -18,8 +18,7 @@ class CRM_Civicase_Upgrader_Steps_Step0019 {
    */
   public function apply() {
     try {
-      $upgrader = CRM_Civicase_Upgrader_Base::instance();
-      $upgrader->executeSqlFile('sql/auto_install.sql');
+      CRM_Utils_File::sourceSQLFile(CIVICRM_DSN, CRM_Civicase_ExtensionUtil::path('sql/auto_install.sql'));
 
       (new QuotationTemplateManager())->create();
       (new CaseTypeCategoryManager())->create();

--- a/Civi/Api4/Action/CaseSalesOrder/SalesOrderSaveAction.php
+++ b/Civi/Api4/Action/CaseSalesOrder/SalesOrderSaveAction.php
@@ -26,6 +26,7 @@ class SalesOrderSaveAction extends AbstractSaveAction {
       $this->matchExisting($record);
       if (empty($record['id'])) {
         $this->fillDefaults($record);
+        $this->fillMandatoryFields($record);
       }
     }
     $this->validateValues();
@@ -127,6 +128,19 @@ class SalesOrderSaveAction extends AbstractSaveAction {
 
     $caseSaleOrderContributionService = new \CRM_Civicase_Service_CaseSalesOrderOpportunityCalculator($caseSalesOrder['case_id']);
     $caseSaleOrderContributionService->updateOpportunityFinancialDetails();
+  }
+
+  /**
+   * Fill mandatory fields.
+   *
+   * @param array $params
+   *   Single Sales Order Record.
+   */
+  protected function fillMandatoryFields(&$params) {
+    $saleOrderId = $params['id'] ?? NULL;
+    $caseSaleOrderContributionService = new \CRM_Civicase_Service_CaseSalesOrderContributionCalculator($saleOrderId);
+    $params['payment_status_id'] = $caseSaleOrderContributionService->calculateInvoicingStatus();
+    $params['invoicing_status_id'] = $caseSaleOrderContributionService->calculatePaymentStatus();
   }
 
 }

--- a/civicase.php
+++ b/civicase.php
@@ -228,6 +228,13 @@ function civicase_civicrm_buildForm($formName, &$form) {
   $isSearchKit = CRM_Utils_Request::retrieve('sk', 'Positive');
   if ($formName == 'CRM_Contribute_Form_Task_Invoice' && $isSearchKit) {
     $form->add('hidden', 'mail_task_from_sk', $isSearchKit);
+    CRM_Core_Resources::singleton()->addScriptFile(
+      CRM_Civicase_ExtensionUtil::LONG_NAME,
+      'js/invoice-bulk-mail.js',
+    );
+    $form->setTitle(ts('Email Contribution Invoice'));
+    $ids = CRM_Utils_Request::retrieve('id', 'Positive', $form, FALSE);
+    $form->assign('totalSelectedContributions', count(explode(',', $ids)));
   }
 }
 

--- a/civicase.php
+++ b/civicase.php
@@ -224,6 +224,11 @@ function civicase_civicrm_buildForm($formName, &$form) {
   if (!empty($_REQUEST['civicase_reload'])) {
     $form->civicase_reload = json_decode($_REQUEST['civicase_reload'], TRUE);
   }
+
+  $isSearchKit = CRM_Utils_Request::retrieve('sk', 'Positive');
+  if ($formName == 'CRM_Contribute_Form_Task_Invoice' && $isSearchKit) {
+    $form->add('hidden', 'mail_task_from_sk', $isSearchKit);
+  }
 }
 
 /**
@@ -295,6 +300,10 @@ function civicase_civicrm_postProcess($formName, &$form) {
   if (!empty($form->civicase_reload)) {
     $api = civicrm_api3('Case', 'getdetails', ['check_permissions' => 1] + $form->civicase_reload);
     $form->ajaxResponse['civicase_reload'] = $api['values'];
+  }
+
+  if ($formName == 'CRM_Contribute_Form_Task_Invoice' && !empty($form->getVar('_submitValues')['mail_task_from_sk'])) {
+    CRM_Utils_System::redirect($_SERVER['HTTP_REFERER']);
   }
 }
 
@@ -572,4 +581,20 @@ function civicase_civicrm_searchKitTasks(array &$tasks, bool $checkPermissions, 
   ];
 
   $tasks['CaseSalesOrder'] = $actions;
+
+}
+
+/**
+ * Implements hook_civicrm_searchTasks().
+ */
+function civicase_civicrm_searchTasks(string $objectName, array &$tasks) {
+  if ($objectName === 'contribution') {
+    $tasks['bulk_invoice'] = [
+      'title' => ts('Send Invoice by email'),
+      'class' => 'CRM_Contribute_Form_Task_Invoice',
+      'icon' => 'fa-paper-plane-o',
+      'url' => 'civicrm/contribute/task?reset=1&task_item=invoice&sk=1',
+      'key' => 'invoice',
+    ];
+  }
 }

--- a/js/invoice-bulk-mail.js
+++ b/js/invoice-bulk-mail.js
@@ -1,0 +1,5 @@
+(function ($, _) {
+  $('input[value=email_invoice]').prop('checked', true).click();
+  $('div.help').hide();
+  $('input[name=output]').parent().parent().hide();
+})(CRM.$, CRM._);

--- a/managed/SavedSearch_Civicase_Quotations.mgd.php
+++ b/managed/SavedSearch_Civicase_Quotations.mgd.php
@@ -584,7 +584,7 @@ $mgd = [
                     'icon' => 'fa-paper-plane-o',
                     'text' => 'Send By Email',
                     'style' => 'default',
-                    'path' => 'civicrm/contribute/invoice/email/?reset=1&id=[id]&select=email',
+                    'path' => 'civicrm/contribute/invoice/email/?reset=1&id=[id]&select=email&cid=[contact_id]',
                     'condition' => [],
                   ],
                 ],

--- a/templates/CRM/Civicase/Form/Contribute/AttachQuotation.tpl
+++ b/templates/CRM/Civicase/Form/Contribute/AttachQuotation.tpl
@@ -4,10 +4,16 @@
     <td class="html-adjust">{$form.attach_quote.html} <span>Yes</span></td>
   </tr>
 </table>
+<div id="editMessageDetails"></div>
 
 {literal}
   <script type="text/javascript">
     CRM.$(function ($) {
+      if ($('#html_message').length) {
+        $('#html_message').parent().parent().after($('tr.attach-quote'))
+
+        return
+      }
       $('#email_comment').parent().parent().after($('tr.attach-quote'))
     })
   </script>

--- a/templates/CRM/Civicase/Form/Contribute/AttachQuotation.tpl
+++ b/templates/CRM/Civicase/Form/Contribute/AttachQuotation.tpl
@@ -8,7 +8,7 @@
 {literal}
   <script type="text/javascript">
     CRM.$(function ($) {
-      $('form.CRM_Contribute_Form_Task_Invoice > table.form-layout-compressed > tbody').append($('tr.attach-quote'))
+      $('#email_comment').parent().parent().after($('tr.attach-quote'))
     })
   </script>
 {/literal}


### PR DESCRIPTION
## Overview
This PR adds `Send invoice by email` in the bulk action menu for bulk invoice sending


## Before
The `Send Invoice by email` action doesn't exist in the bulk action in the contribution search kit view
![image](https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/6664edf7-97a2-4160-9be1-1a18143f36ce)


## After
The `Send Invoice by email` action exists in the bulk action in the contribution search kit view
<img width="212" alt="Screenshot 2023-09-26 at 04 51 43" src="https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/42c8495c-1621-4b36-8fc1-89172bb08d3c">


![lokiki](https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/96fbd586-a967-419d-ad59-fd6b1e33050d)


With the `invoice-helper` extension installed, the `Template field` is displayed
<img width="864" alt="Screenshot 2023-09-26 at 07 16 27" src="https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/dc7ea123-d1a2-4f86-bd4a-4570bc9fdd53">


## Technical Details
This functionality uses the CiviCRM `CRM_Contribute_Form_Task_Invoice` class to send the email, to avoid having to duplicate the code, this also allows us to keep other customizations provided by third-party extensions like `invoice-helper` to the bulk contribution email screen.

The caveat is that `CRM_Contribute_Form_Task_Invoice`  class is meant to redirect to a contribution view after sending the email as hardcoded from the code. We introduced custom logic to override this redirect here https://github.com/compucorp/uk.co.compucorp.civicase/blob/b780a5897fe97114f787de6d94d5d36d583e5f85/civicase.php#L305-L307