### PR TITLE
Remove Deprecated function and deprecated code style with regards to …

### DIFF
--- a/CRM/Civicase/Form/Report/ExtendedReport.php
+++ b/CRM/Civicase/Form/Report/ExtendedReport.php
@@ -6549,12 +6549,12 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
 
       case CRM_Report_Form::OP_DATE:
         // build datetime fields
-        CRM_Core_Form_Date::buildDateRange($this, $prefix . $fieldName, $count, '_from', '_to', 'From:', FALSE, $operations);
+        $this->addDatePickerRange($prefix . $fieldName, $field['title'], FALSE, FALSE, 'From', 'To', $operations, '_to', '_from',);
         break;
 
       case CRM_Report_Form::OP_DATETIME:
         // build datetime fields
-        CRM_Core_Form_Date::buildDateRange($this, $prefix . $fieldName, $count, '_from', '_to', 'From:', FALSE, $operations, 'searchDate', TRUE);
+        $this->addDatePickerRange($prefix . $fieldName, $field['title'], TRUE, FALSE, 'From', 'To', $operations, '_to', '_from');
         break;
       case self::OP_SINGLEDATE:
         // build single datetime field
@@ -6599,11 +6599,9 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
         return $clause;
       }
       else {
-        $relative = CRM_Utils_Array::value("{$prefix}{$fieldName}_relative", $this->_params);
-        $from = CRM_Utils_Array::value("{$prefix}{$fieldName}_from", $this->_params);
-        $to = CRM_Utils_Array::value("{$prefix}{$fieldName}_to", $this->_params);
-        $fromTime = CRM_Utils_Array::value("{$prefix}{$fieldName}_from_time", $this->_params);
-        $toTime = CRM_Utils_Array::value("{$prefix}{$fieldName}_to_time", $this->_params);
+        $relative = $this->_params["{$prefix}{$fieldName}_relative"] ?? NULL;
+        $from = $this->_params["{$prefix}{$fieldName}_from"] ?? NULL;
+        $to = $this->_params["{$prefix}{$fieldName}_to"] ?? NULL;
         // next line is the changed one
         if (!empty($field['clause'])) {
           $clause = '';
@@ -6614,7 +6612,7 @@ ON ({$this->_aliases['civicrm_event']}.id = {$this->_aliases['civicrm_participan
           }
           return NULL;
         }
-        $clause = $this->dateClause($field['dbAlias'], $relative, $from, $to, $field, $fromTime, $toTime);
+        $clause = $this->dateClause($field['dbAlias'], $relative, $from, $to, $field['type']);
         return $clause;
       }
     }
@@ -7677,21 +7675,18 @@ WHERE cg.extends IN ('" . $extendsString . "') AND
       CRM_Utils_Array::value('operatorType', $field) !=
       CRM_Report_Form::OP_MONTH
     ) {
-      list($from, $to)
-        = CRM_Utils_Date::getFromTo(
-        CRM_Utils_Array::value("{$prefix}{$fieldName}_relative", $this->_params),
-        CRM_Utils_Array::value("{$prefix}{$fieldName}_from", $this->_params),
-        CRM_Utils_Array::value("{$prefix}{$fieldName}_to", $this->_params),
-        CRM_Utils_Array::value("{$prefix}{$fieldName}_from_time", $this->_params),
-        CRM_Utils_Array::value("{$prefix}{$fieldName}_to_time", $this->_params, '235959')
-      );
-      $from_time_format = !empty($this->_params["{$prefix}{$fieldName}_from_time"]) ? 'h' : 'd';
-      $from = CRM_Utils_Date::customFormat($from, NULL, [$from_time_format]);
-
-      $to_time_format = !empty($this->_params["{$prefix}{$fieldName}_to_time"]) ? 'h' : 'd';
-      $to = CRM_Utils_Date::customFormat($to, NULL, [$to_time_format]);
-
+      $from = $this->_params["{$fieldName}_from"] ?? NULL;
+      $to = $this->_params["{$fieldName}_to"] ?? NULL;
+      if (!empty($this->_params["{$fieldName}_relative"])) {
+        list($from, $to) = CRM_Utils_Date::getFromTo($this->_params["{$fieldName}_relative"], NULL, NULL);
+      }
       if ($from || $to) {
+        if ($from) {
+          $from = date('l j F Y, g:iA', strtotime($from));
+        }
+        if ($to) {
+          $to = date('l j F Y, g:iA', strtotime($to));
+        }
         return [
           'title' => $field['title'],
           'value' => E::ts("Between %1 and %2", [1 => $from, 2 => $to]),


### PR DESCRIPTION
…date ranges

This updates the code for building date ranges as per https://github.com/civicrm/civicrm-core/pull/15709 noting that in current released civicrm version CRM_Core_Form_Date::buildDateRange does not exist anymore at all