### PR TITLE
CIWEMB-514: Fix not able to create non-salesorder contribution

### DIFF
--- a/CRM/Civicase/Hook/Post/CaseSalesOrderPayment.php
+++ b/CRM/Civicase/Hook/Post/CaseSalesOrderPayment.php
@@ -41,8 +41,8 @@ class CRM_Civicase_Hook_Post_CaseSalesOrderPayment {
       ->execute()
       ->first();
 
-    $this->updateQuotationFinancialStatuses($contribution['Opportunity_Details.Quotation']);
-    $this->updateCaseOpportunityFinancialDetails($contribution['Opportunity_Details.Case_Opportunity']);
+    $this->updateQuotationFinancialStatuses($contribution['Opportunity_Details.Quotation'] ?: NULL);
+    $this->updateCaseOpportunityFinancialDetails($contribution['Opportunity_Details.Case_Opportunity'] ?: NULL);
   }
 
   /**
@@ -51,7 +51,7 @@ class CRM_Civicase_Hook_Post_CaseSalesOrderPayment {
    * @param int $salesOrderID
    *   CaseSalesOrder ID.
    */
-  private function updateQuotationFinancialStatuses(int $salesOrderID): void {
+  private function updateQuotationFinancialStatuses(?int $salesOrderID): void {
     if (empty($salesOrderID)) {
       return;
     }


### PR DESCRIPTION
## Overview
This PR fixes the issue with the `CaseSalesOrderPayment` hook preventing users from recording a contribution with an empty sales order field.

## Before
Contribution cannot be recorded with an empty sales order field.

## After
Contribution can be recorded with an empty sales order field.
