### PR TITLE
BTHAB-257: Fetch discount information for case client

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/AttachQuotationToInvoiceMail.php
+++ b/CRM/Civicase/Hook/BuildForm/AttachQuotationToInvoiceMail.php
@@ -22,6 +22,7 @@ class CRM_Civicase_Hook_BuildForm_AttachQuotationToInvoiceMail {
     }
 
     $form->add('checkbox', 'attach_quote', ts('Attach Quotation'));
+    $form->setDefaults(array_merge($form->_defaultValues, ['attach_quote' => TRUE]));
 
     CRM_Core_Region::instance('page-body')->add([
       'template' => "CRM/Civicase/Form/Contribute/AttachQuotation.tpl",

--- a/CRM/Civicase/Hook/alterMailParams/AttachQuotation.php
+++ b/CRM/Civicase/Hook/alterMailParams/AttachQuotation.php
@@ -23,12 +23,13 @@ class CRM_Civicase_Hook_alterMailParams_AttachQuotation {
       return;
     }
 
-    $rendered = $this->getContributionQuotationInvoice($params['tokenContext']['contributionId']);
+    $contributionId = $params['tokenContext']['contributionId'] ?? $params['tplParams']['id'];
+    $rendered = $this->getContributionQuotationInvoice($contributionId);
 
     $attachment = CRM_Utils_Mail::appendPDF('quotation_invoice.pdf', $rendered['html'], $rendered['format']);
 
     if ($attachment) {
-      $params['attachments'][] = $attachment;
+      $params['attachments']['quotaition_invoice'] = $attachment;
     }
   }
 
@@ -73,7 +74,7 @@ class CRM_Civicase_Hook_alterMailParams_AttachQuotation {
    */
   private function shouldRun(array $params, $context, $shouldAttachQuote) {
     $component = $params['tplParams']['component'] ?? '';
-    if ($component !== 'contribute' || $context !== 'messageTemplate' || empty($shouldAttachQuote)) {
+    if ($component !== 'contribute' || empty($shouldAttachQuote)) {
       return FALSE;
     }
 

--- a/ang/civicase-features/quotations/directives/quotations-create.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.js
@@ -123,6 +123,9 @@
       }).then(function (caseContacts) {
         if (Array.isArray(caseContacts) && caseContacts.length > 0) {
           $scope.salesOrder.client_id = caseContacts[0].contact_id ?? null;
+          if ($scope.salesOrder.client_id) {
+            handleClientChange();
+          }
         }
       });
     }
@@ -230,7 +233,7 @@
       const clientID = $scope.salesOrder.client_id;
       crmApi4('Membership', 'get', {
         select: ['membership_type_id.Product_Discounts.Product_Discount_Amount'],
-        where: [['contact_id', '=', clientID]]
+        where: [['contact_id', '=', clientID], ['status_id.is_current_member', '=', true]]
       }).then(function (results) {
         let discountPercentage = 0;
         results.forEach((membership) => {

--- a/templates/CRM/Civicase/Form/Contribute/AttachQuotation.tpl
+++ b/templates/CRM/Civicase/Form/Contribute/AttachQuotation.tpl
@@ -9,6 +9,7 @@
 {literal}
   <script type="text/javascript">
     CRM.$(function ($) {
+      $('#attach_quote').prop('checked', 1)
       if ($('#html_message').length) {
         $('#html_message').parent().parent().after($('tr.attach-quote'))
 


### PR DESCRIPTION
## Overview
This PR ensures the membership discount information for case clients when creating quotations from the application screen, and also ensures Quotation invoices will be attached by default to invoice mail.

## Before
Membership discount is not working when a Quotation is created from  **Application**
https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/9ad9d889-b48d-4531-98a1-85350ff235be


## After
Membership discount is working when a Quotation is created from  **Application**
![derer](https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/8f532d2e-2ab0-4eb2-b6e6-f3f3eae2a0f0)

## Before
Quotation will not be attached by default
![211ddddd](https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/70f70547-8a12-4695-a749-9415472ca08b)


## After
Quotation will is attached by default
![ddddd](https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/2d5db69b-b41c-4fec-b47f-28af23405eb5)


