### PR TITLE
BTHAB-257: Quotation and quotation invoice fix

### DIFF
--- a/Civi/Api4/CaseSalesOrder.php
+++ b/Civi/Api4/CaseSalesOrder.php
@@ -73,4 +73,14 @@ class CaseSalesOrder extends DAOEntity {
       ->setCheckPermissions($checkPermissions);
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  public static function permissions() {
+    return [
+      'meta' => ['access CiviCRM'],
+      'default' => ['access CiviCRM'],
+    ];
+  }
+
 }

--- a/Civi/Api4/CaseSalesOrderLine.php
+++ b/Civi/Api4/CaseSalesOrderLine.php
@@ -13,4 +13,14 @@ use Civi\Api4\Generic\DAOEntity;
  */
 class CaseSalesOrderLine extends DAOEntity {
 
+  /**
+   * {@inheritDoc}
+   */
+  public static function permissions() {
+    return [
+      'meta' => ['access CiviCRM'],
+      'default' => ['access CiviCRM'],
+    ];
+  }
+
 }

--- a/ang/civicase-features/quotations/directives/quotations-create.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-create.directive.js
@@ -235,6 +235,9 @@
         select: ['membership_type_id.Product_Discounts.Product_Discount_Amount'],
         where: [['contact_id', '=', clientID], ['status_id.is_current_member', '=', true]]
       }).then(function (results) {
+        if (!results || results.length < 1) {
+          return;
+        }
         let discountPercentage = 0;
         results.forEach((membership) => {
           discountPercentage += membership['membership_type_id.Product_Discounts.Product_Discount_Amount'];

--- a/civicase.php
+++ b/civicase.php
@@ -226,6 +226,10 @@ function civicase_civicrm_buildForm($formName, &$form) {
   }
 
   $isSearchKit = CRM_Utils_Request::retrieve('sk', 'Positive');
+  if ($formName == 'CRM_Contribute_Form_Task_PDF' && $isSearchKit) {
+    $form->add('hidden', 'mail_task_from_sk', $isSearchKit);
+  }
+
   if ($formName == 'CRM_Contribute_Form_Task_Invoice' && $isSearchKit) {
     $form->add('hidden', 'mail_task_from_sk', $isSearchKit);
     CRM_Core_Resources::singleton()->addScriptFile(
@@ -309,7 +313,12 @@ function civicase_civicrm_postProcess($formName, &$form) {
     $form->ajaxResponse['civicase_reload'] = $api['values'];
   }
 
-  if ($formName == 'CRM_Contribute_Form_Task_Invoice' && !empty($form->getVar('_submitValues')['mail_task_from_sk'])) {
+  if (
+      in_array($formName, [
+        'CRM_Contribute_Form_Task_Invoice', 'CRM_Contribute_Form_Task_PDF',
+      ])
+      && !empty($form->getVar('_submitValues')['mail_task_from_sk'])
+    ) {
     CRM_Utils_System::redirect($_SERVER['HTTP_REFERER']);
   }
 }
@@ -603,5 +612,11 @@ function civicase_civicrm_searchTasks(string $objectName, array &$tasks) {
       'url' => 'civicrm/contribute/task?reset=1&task_item=invoice&sk=1',
       'key' => 'invoice',
     ];
+
+    foreach ($tasks as &$task) {
+      if ($task['class'] === 'CRM_Contribute_Form_Task_PDF') {
+        $task['url'] .= '&sk=1';
+      }
+    }
   }
 }

--- a/templates/CRM/Civicase/Form/Contribute/AttachQuotation.tpl
+++ b/templates/CRM/Civicase/Form/Contribute/AttachQuotation.tpl
@@ -1,7 +1,7 @@
 <table>
   <tr class="crm-email-element attach-quote">
     <td class="label">{$form.attach_quote.label}</td>
-    <td class="html-adjust">{$form.attach_quote.html} <span>Yes</span></td>
+    <td class="html-adjust">{$form.attach_quote.html} {if isset($form.attach_quote.html)}<span>Yes</span>{/if}</td>
   </tr>
 </table>
 <div id="editMessageDetails"></div>


### PR DESCRIPTION
## Overview
This PR introduces two new changes 
-  Ensure discount alert is displayed only if a discount is applied
- Redirect the quotation invoice receipt task to the quotation list, instead of the contribution search page that shows an error.

## Before
![image](https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/09785d74-81bc-4fed-a4df-78d75bc5a0aa)


## After
![qwqwqwq](https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/4ddbce61-d5af-4448-b439-dc11b54b78b0)


## Before

https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/7774076e-9fe2-40ce-971a-26d0df1f732e

## After
![qeee](https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/75e47e35-f74c-46ef-9cf6-7b52423bb8d5)

