### PR TITLE
BTHAB-271: Fix Invoice And Payment Status Bugs For Quotations

### DIFF
--- a/CRM/Civicase/Hook/Pre/DeleteSalesOrderContribution.php
+++ b/CRM/Civicase/Hook/Pre/DeleteSalesOrderContribution.php
@@ -30,7 +30,10 @@ class CRM_Civicase_Hook_Pre_DeleteSalesOrderContribution {
       return;
     }
 
-    $caseSaleOrderContributionService = new CRM_Civicase_Service_CaseSalesOrderContributionCalculator($salesOrderId);
+    $caseSaleOrderContributionService = new CRM_Civicase_Service_CaseSalesOrderContributionCalculator(
+      $salesOrderId,
+      (int) $objectId
+    );
     $invoicingStatusId = $caseSaleOrderContributionService->calculateInvoicingStatus();
     $paymentStatusId = $caseSaleOrderContributionService->calculatePaymentStatus();
 
@@ -46,7 +49,10 @@ class CRM_Civicase_Hook_Pre_DeleteSalesOrderContribution {
       ->execute()
       ->first();
 
-    $caseSaleOrderContributionService = new \CRM_Civicase_Service_CaseSalesOrderOpportunityCalculator($caseSalesOrder['case_id']);
+    $caseSaleOrderContributionService = new \CRM_Civicase_Service_CaseSalesOrderOpportunityCalculator(
+      $caseSalesOrder['case_id'],
+      (int) $objectId
+    );
     $caseSaleOrderContributionService->updateOpportunityFinancialDetails();
   }
 

--- a/CRM/Civicase/Service/AbstractBaseSalesOrderCalculator.php
+++ b/CRM/Civicase/Service/AbstractBaseSalesOrderCalculator.php
@@ -13,7 +13,7 @@ abstract class CRM_Civicase_Service_AbstractBaseSalesOrderCalculator {
     INVOICING_STATUS_FULLY_INVOICED = 'fully_invoiced',
     PAYMENT_STATUS_NO_PAYMENTS = 'no_payments',
     PAYMENT_STATUS_PARTIALLY_PAID = 'partially_paid',
-    PAYMENT_STATUS_OVERPAID = 'overpaid',
+    PAYMENT_STATUS_OVERPAID = 'over_paid',
     PAYMENT_STATUS_FULLY_PAID = 'fully_paid';
 
   /**


### PR DESCRIPTION
## Overview
The payment and invoice statuses were being calculated in accordance to just invoiced amount without considering the quoted amount and the calculations previously also took into account the deleted invoices which were resulting in incorrect statuses calculations

## Before
These were the issues previously

- Quotation's payment status changed to fully paid upon paying total quotation amount partially
- Quotation's payment status did not change to overpaid even after paying more than quoted amount
- Quotation's payment status did not change to fully paid even after paying in full
- Deleting a invoice did not change the payment and invoice statuses correctly
 
## After
All issues described above are fixed and now quotation's payment and invoice statuses are being calculated correctly after creation, deletion and payment of invoices.

