### PR TITLE
COMCL-333: Fix Bug With Empty Target Contact For File Upload Activities

### DIFF
--- a/CRM/Civicase/Hook/ValidateForm/RemoveEmptyTargetContactFromActivity.php
+++ b/CRM/Civicase/Hook/ValidateForm/RemoveEmptyTargetContactFromActivity.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Remove empty target contact from activity.
+ *
+ * CiviCRM errors out if an empty string is sent for target
+ * contact id and to solve this we remove the target_contact_id param
+ * for activity form if its value is empty string.
+ */
+class CRM_Civicase_Hook_ValidateForm_RemoveEmptyTargetContactFromActivity {
+
+  /**
+   * Implement the remove empty target contact functionality.
+   *
+   * @param string $formName
+   *   Form Name.
+   * @param array $fields
+   *   Fields List.
+   * @param array $files
+   *   Files list.
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   * @param array $errors
+   *   Errors.
+   *
+   * @return bool
+   *   TRUE if the hook ran, false otherwise.
+   */
+  public function run(
+    string $formName,
+    array &$fields,
+    array &$files,
+    CRM_Core_Form $form,
+    array &$errors
+  ): bool {
+    if (!$this->shouldRun($formName)) {
+      return FALSE;
+    }
+
+    $submittedData = &$form->controller->container();
+    if (is_array($submittedData)
+      && isset($submittedData['values']['Activity']['target_contact_id'])
+      && $submittedData['values']['Activity']['target_contact_id'] === ''
+    ) {
+      unset($submittedData['values']['Activity']['target_contact_id']);
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * @param string $formName
+   *   Form Name.
+   *
+   * @return bool
+   *   Returns TRUE the Hook should run.
+   */
+  private function shouldRun(string $formName): bool {
+    return $formName === 'CRM_Case_Form_Activity';
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -310,6 +310,7 @@ function civicase_civicrm_validateForm($formName, &$fields, &$files, &$form, &$e
     new CRM_Civicase_Hook_ValidateForm_SaveActivityDraft(),
     new CRM_Civicase_Hook_ValidateForm_SaveCaseTypeCategory(),
     new CRM_Civicase_Hook_ValidateForm_SendBulkEmail(),
+    new CRM_Civicase_Hook_ValidateForm_RemoveEmptyTargetContactFromActivity(),
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview
Civi core errors out if an empty string is posted target contact id while editing file upload activity. This pr resolves the bug by removing the target contact id param from activity form if its submitted value is empty string.
## Before
![before](https://github.com/compucorp/uk.co.compucorp.civicase/assets/147053234/099f499d-7100-433a-a063-38ce7c6ec6b8)


## After
![Screenshot from 2023-11-09 00-08-01](https://github.com/compucorp/uk.co.compucorp.civicase/assets/147053234/47b33670-8046-4335-a0c7-534c7d1879df)

