### PR TITLE
BTHAB-253: Fix Validation For Discount Amount Field

### DIFF
--- a/managed/CustomGroup_Product_Discounts.mgd.php
+++ b/managed/CustomGroup_Product_Discounts.mgd.php
@@ -58,7 +58,7 @@ $mgd = [
         'help_pre' => NULL,
         'help_post' => 'Specify a discount that will automatically be applied when adding a product line item to a quotation if the contact is a member of this type.',
         'mask' => NULL,
-        'attributes' => NULL,
+        'attributes' => ' pattern="([0-9]*[.])?[0-9]+" ',
         'javascript' => NULL,
         'is_active' => TRUE,
         'is_view' => FALSE,


### PR DESCRIPTION
## Overview
Restrict user from submitting new membership type form if product discount amount field includes string characters.

## Before
User was able to submit the form with alphabets typed in the field.

## After
An error is shown to the user and user is unable to submit the form if product discount amount field contains alphabets.