### PR TITLE
BTHAB-248: Remove unnecessary API 4 backend permission checks

### DIFF
--- a/CRM/Civicase/Service/CaseSalesOrderContributionCalculator.php
+++ b/CRM/Civicase/Service/CaseSalesOrderContributionCalculator.php
@@ -173,7 +173,7 @@ class CRM_Civicase_Service_CaseSalesOrderContributionCalculator extends CRM_Civi
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   private function getSalesOrder($saleOrderId) {
-    return CaseSalesOrder::get()
+    return CaseSalesOrder::get(FALSE)
       ->addWhere('id', '=', $saleOrderId)
       ->execute()
       ->first();

--- a/Civi/Api4/Action/CaseSalesOrder/SalesOrderSaveAction.php
+++ b/Civi/Api4/Action/CaseSalesOrder/SalesOrderSaveAction.php
@@ -64,7 +64,7 @@ class SalesOrderSaveAction extends AbstractSaveAction {
         $salesOrders = $this->writeObjects([$salesOrder]);
         $result = array_pop($salesOrders);
 
-        $caseSalesOrderLineAPI = CaseSalesOrderLine::save();
+        $caseSalesOrderLineAPI = CaseSalesOrderLine::save(FALSE);
         $this->removeStaleLineItems($salesOrder);
         if (!empty($result) && !empty($lineItems)) {
           array_walk($lineItems, function (&$lineItem) use ($result, $caseSalesOrderLineAPI) {
@@ -105,7 +105,7 @@ class SalesOrderSaveAction extends AbstractSaveAction {
       return;
     }
 
-    CaseSalesOrderLine::delete()
+    CaseSalesOrderLine::delete(FALSE)
       ->addWhere('sales_order_id', '=', $salesOrder['id'])
       ->addWhere('id', 'NOT IN', $lineItemsInUse)
       ->execute();
@@ -118,7 +118,7 @@ class SalesOrderSaveAction extends AbstractSaveAction {
    *   Sales Order Id.
    */
   private function updateOpportunityDetails($salesOrderId): void {
-    $caseSalesOrder = CaseSalesOrder::get()
+    $caseSalesOrder = CaseSalesOrder::get(FALSE)
       ->addSelect('case_id')
       ->addWhere('id', '=', $salesOrderId)
       ->execute()
@@ -154,7 +154,7 @@ class SalesOrderSaveAction extends AbstractSaveAction {
   protected function validateLinItemProductPrice(array &$lineItems) {
     array_walk($lineItems, function (&$lineItem) {
       if (!empty($lineItem['product_id'])) {
-        $product = Product::get()
+        $product = Product::get(FALSE)
           ->addSelect('cost')
           ->addWhere('id', '=', $lineItem['product_id'])
           ->execute()


### PR DESCRIPTION
## Overview
This PR removes unnecessary APIv4 backend permission checks, that prevent users from accessing the API methods via screens like webforms and others.