### PR TITLE
NEUSPRT-284: Restrict Activity Creation With File Upload Of Size 0

### DIFF
--- a/ang/civicase/shared/directives/file-uploader.directive.js
+++ b/ang/civicase/shared/directives/file-uploader.directive.js
@@ -110,6 +110,10 @@
         delete $scope.activity.activity_date_time;
       }
 
+      _.each($scope.uploader.getNotUploadedItems(), function (item) {
+        validateFileSize(item);
+      });
+
       var promise = civicaseCrmApi('Activity', 'create', $scope.activity)
         .then(function (activity) {
           saveTags(activity.id);
@@ -120,7 +124,6 @@
             item.formData = [
               _.extend({ crm_attachment_token: CRM.crmAttachment.token }, target, item.crmData)
             ];
-            validateFileSize(item);
           });
           return $scope.uploader.uploadAllWithPromise();
         }).then(function () {
@@ -136,14 +139,7 @@
 
       return $scope.block(crmStatus({
         start: $scope.ts('Uploading...'),
-        success: $scope.ts('Uploaded'),
-        error: function (error) {
-          let msg = 'Sorry an error occurred while uploading file';
-          if (error && error.cause && error.cause === 'Invalid size') {
-            msg = error.message;
-          }
-          CRM.alert(msg, $scope.ts('Attachment failed'), 'error');
-        }
+        success: $scope.ts('Uploaded')
       }, promise));
     }
 
@@ -157,6 +153,7 @@
     function validateFileSize (item) {
       if (item.file.size <= 0) {
         const msg = 'Your file(s) cannot be uploaded because one or more of your files is empty. Your file(s) will not be uploaded. Check the contents of your file(s) and then try again.';
+        CRM.alert(msg, $scope.ts('Attachment failed'), 'error');
         throw new Error(msg, { cause: 'Invalid size' });
       }
       return true;


### PR DESCRIPTION
## Overview
Stop activity creation while uploading files of size 0.

## Before
If any of the uploaded files has size equals to 0, we showed error to the user but still acivity was created.

## After
If any of the uploaded files is 0 in size then along with showing the error we dont create any activity as well.