### PR TITLE
NEUSPRT-295: Disable Non Selectable Tags In File Upload Activity

### DIFF
--- a/ang/civicase-base/directives/tags-selector.directive.js
+++ b/ang/civicase-base/directives/tags-selector.directive.js
@@ -80,6 +80,7 @@
 
       _.each(filteredTags, function (tag) {
         tag.text = tag.name;
+        tag.disabled = !isTruthy(tag.is_selectable);
         returnArray.push(tag);
         tag.indentationLevel = level;
         returnArray = returnArray.concat(prepareGenericTags(tags, tag.id, level + 1));


### PR DESCRIPTION
## Overview
This pr disables the the non selectable tags while creating the file upload activity.
