### PR TITLE
CPO-147: Allow Anonymous User to submit case with roles via webform

### DIFF
--- a/CRM/Civicase/Service/CaseRoleCreationPostProcess.php
+++ b/CRM/Civicase/Service/CaseRoleCreationPostProcess.php
@@ -189,6 +189,10 @@ class CRM_Civicase_Service_CaseRoleCreationPostProcess extends CRM_Civicase_Serv
    *   Activity Subject.
    */
   private function createCaseActivity($caseId, $activityType, $subject) {
+    if (empty(CRM_Core_Session::getLoggedInContactID())) {
+      return;
+    }
+
     civicrm_api3('Activity', 'create', [
       'case_id' => $caseId,
       'target_contact_id' => $this->getCaseClients($caseId),


### PR DESCRIPTION
## Overview
When creating a case, with roles Civicase has an event listener that creates a new activity record `Assign case Role` for the contact creating the case.

But this activity shouldn't be created when an anonymous user submits the case via a web form or other means.

In this PR we've simply added a check to see if a user is logged in before attempting to create the activity.



