### PR TITLE
BTHAB-158 Invoice list Fixes

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/RefreshInvoiceListOnUpdate.php
+++ b/CRM/Civicase/Hook/BuildForm/RefreshInvoiceListOnUpdate.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Refresh the invoice list upon updating an invoice.
+ */
+class CRM_Civicase_Hook_BuildForm_RefreshInvoiceListOnUpdate {
+
+  /**
+   * Refresh the invoice list upon updating an invoice.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   * @param string $formName
+   *   Form Name.
+   */
+  public function run(CRM_Core_Form &$form, $formName) {
+    if (!$this->shouldRun($form, $formName)) {
+      return;
+    }
+
+    CRM_Core_Resources::singleton()->addScript(
+      "CRM.$(function($) {
+        $(\"a[target='crm-popup']\").on('crmPopupFormSuccess', function (e) {
+          CRM.refreshParent(e);
+        });
+      });
+    ");
+  }
+
+  /**
+   * Determines if the hook will run.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   * @param string $formName
+   *   Form Name.
+   *
+   * @return bool
+   *   TRUE if the hook should run, FALSE otherwise.
+   */
+  private function shouldRun($form, $formName) {
+    if ($formName !== 'CRM_Contribute_Form_Contribution' || $form->getAction() !== CRM_Core_Action::UPDATE || !isset($_GET['snippet'])) {
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+}

--- a/ang/civicase-features/invoices/directives/invoices-list.directive.html
+++ b/ang/civicase-features/invoices/directives/invoices-list.directive.html
@@ -14,3 +14,9 @@
     </div>
   </div>
 </div>
+<style>
+  #bootstrap-theme crm-search-display-table p.alert-info {
+    background-color: transparent;
+    border: none;
+  }
+</style>

--- a/civicase.php
+++ b/civicase.php
@@ -154,6 +154,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_AddSalesOrderLineItemsToContribution(),
     new CRM_Civicase_Hook_BuildForm_AddEntityReferenceToCustomField(),
     new CRM_Civicase_Hook_BuildForm_AttachQuotationToInvoiceMail(),
+    new CRM_Civicase_Hook_BuildForm_RefreshInvoiceListOnUpdate(),
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview
This pr fixes following two issues in invoice list page for a case

- Fixes the style of **no record found** message when there are no invoices, to match the styles with other pages.
- Automatically refresh the invoice list after an update has been made to any of the invoices to reflect the changes made

## Before
The **no record found** message appeared in blue background
![image-20230427-181943](https://github.com/compucorp/uk.co.compucorp.civicase/assets/147053234/b3284b12-12a0-454d-ac16-50dc4fae7c82)
Secondly the invoice list did not refreshed automatically after updating an invoice hence user has to do a page reload to see the changes that he has just made.

## After
The **no record found** message styling has been fixed
<img width="1792" alt="Screenshot 2024-01-28 at 4 57 23 PM" src="https://github.com/compucorp/uk.co.compucorp.civicase/assets/147053234/8e346987-b7cc-4e8c-93df-8a1791376bf2">

Secondly whenever an invoice is updated the invoice list gets refreshed automatically.
