### PR TITLE
COMCL-505: Remove unrequired APIv4 permission checks

### DIFF
--- a/CRM/Civicase/Form/CaseSalesOrderContributionCreate.php
+++ b/CRM/Civicase/Form/CaseSalesOrderContributionCreate.php
@@ -54,7 +54,7 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
       $this->addRule('to_be_invoiced', ts('Invoice value is required'), 'required');
     }
 
-    $statusOptions = OptionValue::get()
+    $statusOptions = OptionValue::get(FALSE)
       ->addSelect('value', 'label')
       ->addWhere('option_group_id:name', '=', 'case_sales_order_status')
       ->execute()
@@ -92,7 +92,7 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
    * {@inheritDoc}
    */
   public function setDefaultValues() {
-    $caseSalesOrder = CaseSalesOrder::get()
+    $caseSalesOrder = CaseSalesOrder::get(FALSE)
       ->addWhere('id', '=', $this->id)
       ->addSelect('status_id')
       ->execute()
@@ -173,7 +173,7 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
    * Checks if the sales order has left over balance to be invoiced.
    */
   public function hasRemainingBalance() {
-    $caseSalesOrder = CaseSalesOrder::get()
+    $caseSalesOrder = CaseSalesOrder::get(FALSE)
       ->addSelect('total_after_tax')
       ->addWhere('id', '=', $this->id)
       ->setLimit(1)
@@ -184,7 +184,7 @@ class CRM_Civicase_Form_CaseSalesOrderContributionCreate extends CRM_Core_Form {
     }
 
     // Get all the previous contributions.
-    $contributions = Contribution::get()
+    $contributions = Contribution::get(FALSE)
       ->addSelect('total_amount')
       ->addWhere('Opportunity_Details.Quotation', '=', $this->id)
       ->execute()

--- a/CRM/Civicase/Form/CaseSalesOrderInvoice.php
+++ b/CRM/Civicase/Form/CaseSalesOrderInvoice.php
@@ -137,7 +137,7 @@ class CRM_Civicase_Form_CaseSalesOrderInvoice extends CRM_Core_Form {
 
     $salesOrderId = CRM_Utils_Request::retrieveValue('id', 'Positive');
 
-    $caseSalesOrder = CaseSalesOrder::get()
+    $caseSalesOrder = CaseSalesOrder::get(FALSE)
       ->addWhere('id', '=', $salesOrderId)
       ->execute()
       ->first();

--- a/CRM/Civicase/Hook/BuildForm/AddCaseCategoryFeaturesField.php
+++ b/CRM/Civicase/Hook/BuildForm/AddCaseCategoryFeaturesField.php
@@ -85,7 +85,7 @@ class CRM_Civicase_Hook_BuildForm_AddCaseCategoryFeaturesField extends CRM_Civic
     $caseCategory = $form->getVar('_values')['value'];
     $enabledFeatures = [];
 
-    $caseCategoryFeatures = CaseCategoryFeatures::get()
+    $caseCategoryFeatures = CaseCategoryFeatures::get(FALSE)
       ->addWhere('category_id', '=', $caseCategory)
       ->execute();
 

--- a/CRM/Civicase/Hook/NavigationMenu/AlterForCaseMenu.php
+++ b/CRM/Civicase/Hook/NavigationMenu/AlterForCaseMenu.php
@@ -156,7 +156,7 @@ class CRM_Civicase_Hook_NavigationMenu_AlterForCaseMenu extends CRM_Civicase_Hoo
    * Returnd the ID of the case type category option group.
    */
   private function getCaseTypeCategoryGroupId() {
-    $optionGroups = OptionGroup::get()
+    $optionGroups = OptionGroup::get(FALSE)
       ->addSelect('id')
       ->addWhere('name', '=', 'case_type_categories')
       ->setLimit(25)

--- a/CRM/Civicase/Hook/Post/CaseSalesOrderPayment.php
+++ b/CRM/Civicase/Hook/Post/CaseSalesOrderPayment.php
@@ -35,7 +35,7 @@ class CRM_Civicase_Hook_Post_CaseSalesOrderPayment {
       return;
     }
 
-    $contribution = Contribution::get()
+    $contribution = Contribution::get(FALSE)
       ->addSelect('Opportunity_Details.Case_Opportunity', 'Opportunity_Details.Quotation')
       ->addWhere('id', '=', $contributionId)
       ->execute()
@@ -63,7 +63,7 @@ class CRM_Civicase_Hook_Post_CaseSalesOrderPayment {
       $paymentStatusID = $caseSaleOrderContributionService->calculatePaymentStatus();
       $invoicingStatusID = $caseSaleOrderContributionService->calculateInvoicingStatus();
 
-      CaseSalesOrder::update()
+      CaseSalesOrder::update(FALSE)
         ->addWhere('id', '=', $salesOrderID)
         ->addValue('invoicing_status_id', $invoicingStatusID)
         ->addValue('payment_status_id', $paymentStatusID)

--- a/CRM/Civicase/Hook/Post/CreateSalesOrderContribution.php
+++ b/CRM/Civicase/Hook/Post/CreateSalesOrderContribution.php
@@ -34,7 +34,7 @@ class CRM_Civicase_Hook_Post_CreateSalesOrderContribution {
       return;
     }
 
-    $salesOrder = CaseSalesOrder::get()
+    $salesOrder = CaseSalesOrder::get(FALSE)
       ->addSelect('status_id', 'case_id')
       ->addWhere('id', '=', $salesOrderId)
       ->execute()
@@ -51,7 +51,7 @@ class CRM_Civicase_Hook_Post_CreateSalesOrderContribution {
       $paymentStatusID = $caseSaleOrderContributionService->calculatePaymentStatus();
       $invoicingStatusID = $caseSaleOrderContributionService->calculateInvoicingStatus();
 
-      CaseSalesOrder::update()
+      CaseSalesOrder::update(FALSE)
         ->addWhere('id', '=', $salesOrderId)
         ->addValue('status_id', $salesOrderStatusId)
         ->addValue('invoicing_status_id', $invoicingStatusID)
@@ -90,7 +90,7 @@ class CRM_Civicase_Hook_Post_CreateSalesOrderContribution {
    * Gets quotation ID by contribution ID.
    */
   private function getQuotationId($id) {
-    return Contribution::get()
+    return Contribution::get(FALSE)
       ->addSelect('Opportunity_Details.Quotation')
       ->addWhere('id', '=', $id)
       ->execute()

--- a/CRM/Civicase/Hook/Pre/DeleteSalesOrderContribution.php
+++ b/CRM/Civicase/Hook/Pre/DeleteSalesOrderContribution.php
@@ -43,7 +43,7 @@ class CRM_Civicase_Hook_Pre_DeleteSalesOrderContribution {
       ->addValue('payment_status_id', $paymentStatusId)
       ->execute();
 
-    $caseSalesOrder = CaseSalesOrder::get()
+    $caseSalesOrder = CaseSalesOrder::get(FALSE)
       ->addSelect('case_id')
       ->addWhere('id', '=', $salesOrderId)
       ->execute()

--- a/CRM/Civicase/Hook/Tabset/CaseSalesOrderTabAdd.php
+++ b/CRM/Civicase/Hook/Tabset/CaseSalesOrderTabAdd.php
@@ -43,7 +43,7 @@ class CRM_Civicase_Hook_Tabset_CaseSalesOrderTabAdd {
    *   Contact ID to retrieve count for.
    */
   public function getContactSalesOrderCount(int $contactID) {
-    $result = CaseSalesOrder::get()
+    $result = CaseSalesOrder::get(FALSE)
       ->addSelect('COUNT(id) AS count')
       ->addWhere('client_id', '=', $contactID)
       ->execute()

--- a/CRM/Civicase/Hook/Tokens/SalesOrderTokens.php
+++ b/CRM/Civicase/Hook/Tokens/SalesOrderTokens.php
@@ -53,7 +53,7 @@ class CRM_Civicase_Hook_Tokens_SalesOrderTokens extends AbstractTokenSubscriber 
         if (!empty($row->context['salesOrderId'])) {
           $salesOrderId = $row->context['salesOrderId'];
 
-          $caseSalesOrder = CaseSalesOrder::get()
+          $caseSalesOrder = CaseSalesOrder::get(FALSE)
             ->addWhere('id', '=', $salesOrderId)
             ->execute()
             ->first();

--- a/CRM/Civicase/Hook/alterMailParams/AttachQuotation.php
+++ b/CRM/Civicase/Hook/alterMailParams/AttachQuotation.php
@@ -40,11 +40,11 @@ class CRM_Civicase_Hook_alterMailParams_AttachQuotation {
    *   The contribution ID.
    */
   private function getContributionQuotationInvoice($contributionId) {
-    $salesOrder = Contribution::get()
+    $salesOrder = Contribution::get(FALSE)
       ->addSelect('Opportunity_Details.Quotation')
       ->addWhere('Opportunity_Details.Quotation', 'IS NOT EMPTY')
       ->addWhere('id', '=', $contributionId)
-      ->addChain('salesOrder', CaseSalesOrder::get()
+      ->addChain('salesOrder', CaseSalesOrder::get(FALSE)
         ->addWhere('id', '=', '$Opportunity_Details.Quotation')
       )
       ->execute()

--- a/CRM/Civicase/Service/CaseSalesOrderOpportunityCalculator.php
+++ b/CRM/Civicase/Service/CaseSalesOrderOpportunityCalculator.php
@@ -129,7 +129,7 @@ class CRM_Civicase_Service_CaseSalesOrderOpportunityCalculator extends CRM_Civic
    * Updates opportunity financial details.
    */
   public function updateOpportunityFinancialDetails(): void {
-    CiviCase::update()
+    CiviCase::update(FALSE)
       ->addValue('Case_Opportunity_Details.Total_Amount_Quoted', $this->calculateTotalQuotedAmount())
       ->addValue('Case_Opportunity_Details.Total_Amount_Invoiced', $this->calculateTotalInvoicedAmount())
       ->addValue('Case_Opportunity_Details.Invoicing_Status', $this->calculateInvoicingStatus())

--- a/CRM/Civicase/Service/CaseTypeCategoryFeatures.php
+++ b/CRM/Civicase/Service/CaseTypeCategoryFeatures.php
@@ -15,7 +15,7 @@ class CRM_Civicase_Service_CaseTypeCategoryFeatures {
    * Gets the available additional features.
    */
   public function getFeatures() {
-    $optionValues = OptionValue::get()
+    $optionValues = OptionValue::get(FALSE)
       ->addSelect('id', 'label', 'value', 'name', 'option_group_id')
       ->addWhere('option_group_id:name', '=', self::NAME)
       ->execute();
@@ -33,13 +33,13 @@ class CRM_Civicase_Service_CaseTypeCategoryFeatures {
    *   Array of Key\Pair value grouped by case instance id.
    */
   public function retrieveCaseInstanceWithEnabledFeatures(array $features) {
-    $caseInstanceGroup = OptionGroup::get()->addWhere('name', '=', 'case_type_categories')->execute()[0] ?? NULL;
+    $caseInstanceGroup = OptionGroup::get(FALSE)->addWhere('name', '=', 'case_type_categories')->execute()[0] ?? NULL;
 
     if (empty($caseInstanceGroup)) {
       return [];
     }
 
-    $result = CaseCategoryFeatures::get()
+    $result = CaseCategoryFeatures::get(FALSE)
       ->addSelect('*', 'option_value.label', 'option_value.name', 'feature_id:name', 'feature_id:label', 'navigation.id')
       ->addJoin('OptionValue AS option_value', 'LEFT',
       ['option_value.value', '=', 'category_id']

--- a/Civi/Api4/Action/CaseSalesOrder/ContributionCreateAction.php
+++ b/Civi/Api4/Action/CaseSalesOrder/ContributionCreateAction.php
@@ -146,15 +146,15 @@ class ContributionCreateAction extends AbstractAction {
    *   Array of price fields
    */
   private function getDefaultPriceSetFields(): array {
-    $priceSet = PriceSet::get()
+    $priceSet = PriceSet::get(FALSE)
       ->addWhere('name', '=', 'default_contribution_amount')
       ->addWhere('is_quick_config', '=', 1)
       ->execute()
       ->first();
 
-    return PriceField::get()
+    return PriceField::get(FALSE)
       ->addWhere('price_set_id', '=', $priceSet['id'])
-      ->addChain('price_field_value', PriceFieldValue::get()
+      ->addChain('price_field_value', PriceFieldValue::get(FALSE)
         ->addWhere('price_field_id', '=', '$id')
       )->execute()
       ->getArrayCopy();
@@ -169,7 +169,7 @@ class ContributionCreateAction extends AbstractAction {
    *   Contribution ID.
    */
   private function linkCaseSalesOrderToContribution(int $salesOrderId, int $contributionId): void {
-    $salesOrder = CaseSalesOrder::get()
+    $salesOrder = CaseSalesOrder::get(FALSE)
       ->addWhere('id', '=', $salesOrderId)
       ->execute()
       ->first();
@@ -201,7 +201,7 @@ class ContributionCreateAction extends AbstractAction {
    *   pending status ID
    */
   private function getPendingContributionStatusId(): ?int {
-    $pendingStatus = OptionValue::get()
+    $pendingStatus = OptionValue::get(FALSE)
       ->addSelect('value')
       ->addWhere('option_group_id:name', '=', 'contribution_status')
       ->addWhere('name', '=', 'pending')

--- a/ang/civicase-features.ang.php
+++ b/ang/civicase-features.ang.php
@@ -60,7 +60,7 @@ function set_case_types_with_features_enabled(&$options) {
  * Exposes case sales order statuses to Angular.
  */
 function set_case_sales_order_status(&$options) {
-  $optionValues = OptionValue::get()
+  $optionValues = OptionValue::get(FALSE)
     ->addSelect('id', 'value', 'name', 'label')
     ->addWhere('option_group_id:name', '=', 'case_sales_order_status')
     ->execute();

--- a/api/v3/Case/Getrelations.php
+++ b/api/v3/Case/Getrelations.php
@@ -51,7 +51,7 @@ function civicrm_api3_case_getrelations(array $params) {
     ])['values']
   );
 
-  $relationships = Relationship::get()
+  $relationships = Relationship::get(FALSE)
     ->addSelect('relationship_type_id', 'contact_id_a', 'contact_id_b')
     ->addWhere('relationship_type.is_active', '=', TRUE)
     ->addWhere('is_active', '=', TRUE)

--- a/api/v3/CaseSalesOrder/Getlist.php
+++ b/api/v3/CaseSalesOrder/Getlist.php
@@ -66,7 +66,7 @@ function _civicrm_api3_case_sales_order_getlist_output($result, $request) {
   $output = [];
   if (!empty($result['values'])) {
     foreach ($result['values'] as $row) {
-      $caseSalesOrder = CaseSalesOrder::get()
+      $caseSalesOrder = CaseSalesOrder::get(FALSE)
         ->addSelect('contact.display_name', 'quotation_date')
         ->addJoin('Contact AS contact', 'LEFT', ['contact.id', '=', 'client_id'])
         ->addWhere('id', '=', $row['id'])


### PR DESCRIPTION
## Overview
This PR removes unrequired APIv4 permission checks, Because some of these methods have the tendency of being called by unauthorized users, i.e. via web form submission, the permission when checked will cause an unauthorized error to be thrown.

## Before
Non-civicrm user is not able to register for an event.
![COMCL-505](https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/7a43a2dd-e4d8-4b40-9572-28969c6f92e2)


## After
Non-civicrm user is able to register for an event.
<img width="1218" alt="Screenshot 2024-03-20 at 14 24 11" src="https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/eb8c73ee-4380-4e54-933c-9148b69f647b">

