### PR TITLE
Pass only the field ID to CRM_Core_BAO_CustomField::displayValue

### DIFF
--- a/CRM/Civicase/APIHelpers/CustomValues.php
+++ b/CRM/Civicase/APIHelpers/CustomValues.php
@@ -162,8 +162,8 @@ class CRM_Civicase_APIHelpers_CustomValues {
         unset($field['customValue']);
         if (!empty($fieldInfo['customValue'])) {
           $field['value'] = CRM_Utils_Array::first($fieldInfo['customValue']);
-          if (!$toReturn['custom_value'] || in_array('display', $toReturn['custom_value'])) {
-            $field['value']['display'] = CRM_Core_BAO_CustomField::displayValue($field['value']['data'], $fieldInfo);
+          if ((!$toReturn['custom_value'] || in_array('display', $toReturn['custom_value'])) && !empty($fieldInfo['id'])) {
+            $field['value']['display'] = CRM_Core_BAO_CustomField::displayValue($field['value']['data'], $fieldInfo['id']);
           }
           foreach (array_keys($field['value']) as $key) {
             if ($toReturn['custom_value'] && !in_array($key, $toReturn['custom_value'])) {


### PR DESCRIPTION
## Overview
When building the view of custom data for cases, CiviCase was crashing with no error message.  Traced this down to a problem loading custom values.
Appears to be a problem since 5.67

## Before
Array of fieldInfo is passed in

1. Have custom fields set up for case types.
2. Go to Cases / Manage Cases.
3. Click on a case tile to load the information, for one of the cases with custom fields.
4. Error 500 loading case details, user is left with the placeholder images only

## After
Only fieldIf is passed in

On step 4, case data is fully loaded.

## Comments
As noted, this is a new issue since CiviCRM 5.67; However in earlier versions including 5.51.1, the `displayValue` function converts passed arrays to an id as the first step anyway, so this should not introduce a compatibility problem