### PR TITLE
NEUSPRT-324: Allow user to customize activity date format

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
   run-unit-tests:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container: compucorp/civicrm-buildkit:1.3.1-php8.0-chrome
 
     env:

--- a/CRM/Civicase/Hook/BuildForm/AddCaseActivityDateFormatToDateSettings.php
+++ b/CRM/Civicase/Hook/BuildForm/AddCaseActivityDateFormatToDateSettings.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Add ActivityDateFormat To DateSettings BuildForm Hook Class.
+ */
+class CRM_Civicase_Hook_BuildForm_AddCaseActivityDateFormatToDateSettings {
+
+  /**
+   * Adds Activity DateFormat To Date Settings Form.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   * @param string $formName
+   *   Form Name.
+   */
+  public function run(CRM_Core_Form &$form, $formName) {
+    if (!$this->shouldRun($formName)) {
+      return;
+    }
+
+    $this->addActivityDateFormatField($form);
+  }
+
+  /**
+   * Checks if this shook should run.
+   *
+   * @param string $formName
+   *   Form Name.
+   *
+   * @return bool
+   *   True if the hook should run.
+   */
+  public function shouldRun($formName) {
+    return $formName == CRM_Admin_Form_Setting_Date::class;
+  }
+
+  /**
+   * Add activity date format field.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   */
+  private function addActivityDateFormatField($form) {
+    $name = 'civiCaseActivityDateformat';
+    $fieldName = '_qf_' . $name;
+    $field = [
+      $fieldName => [
+        'html_type' => 'text',
+        'title' => ts('Date Format: Activity Feed'),
+        'weight' => 5,
+      ],
+    ];
+
+    $form->add('text', $fieldName, $field[$fieldName]['title'], $field[$fieldName]['attributes']);
+    $value = Civi::settings()->get($name) ?? '%d %b %Y';
+    $form->setDefaults(array_merge($form->_defaultValues, [$fieldName => $value]));
+
+    CRM_Core_Region::instance('form-body')->add([
+      'template' => "CRM/Civicase/Form/CaseActivityDateFormat.tpl",
+    ]);
+  }
+
+}

--- a/CRM/Civicase/Hook/BuildForm/FormatCaseActivityDateFormat.php
+++ b/CRM/Civicase/Hook/BuildForm/FormatCaseActivityDateFormat.php
@@ -1,0 +1,48 @@
+<?php
+
+use CRM_Civicase_ExtensionUtil as E;
+
+/**
+ * FormatCaseActivityDateFormat BuildForm Hook Class.
+ */
+class CRM_Civicase_Hook_BuildForm_FormatCaseActivityDateFormat {
+
+  /**
+   * Adds Activity DateFormat To Date Settings Form.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   * @param string $formName
+   *   Form Name.
+   */
+  public function run(CRM_Core_Form &$form, $formName) {
+    if (!$this->shouldRun($form, $formName)) {
+      return;
+    }
+
+    $format = Civi::settings()->get('civiCaseActivityDateformat') ?? '%d %b %Y';
+    $dateValue = CRM_Utils_Date::customFormat($form->_defaultValues['activity_date_time'], $format);
+
+    \Civi::resources()->addVars('civicase', ['formatted_date' => $dateValue]);
+    \Civi::resources()->add([
+      'scriptFile' => [E::LONG_NAME, 'js/modify-activity-date.js'],
+      'region' => 'form-body',
+    ]);
+  }
+
+  /**
+   * Checks if this shook should run.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   * @param string $formName
+   *   Form Name.
+   *
+   * @return bool
+   *   True if the hook should run.
+   */
+  public function shouldRun($form, $formName) {
+    return $formName == CRM_Activity_Form_Activity::class && $form->getAction() & CRM_Core_Action::VIEW;
+  }
+
+}

--- a/CRM/Civicase/Hook/PostProcess/SaveCaseActivityDateFormat.php
+++ b/CRM/Civicase/Hook/PostProcess/SaveCaseActivityDateFormat.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Save Activity DateFormat.
+ */
+class CRM_Civicase_Hook_PostProcess_SaveCaseActivityDateFormat {
+
+  /**
+   * Saves The Activity DateFormat field.
+   *
+   * @param string $formName
+   *   Form Name.
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   */
+  public function run($formName, CRM_Core_Form $form) {
+    if (!$this->shouldRun($formName)) {
+      return;
+    }
+
+    $this->saveCaseActivityDateFormatField($form);
+  }
+
+  /**
+   * Checks if this shook should run.
+   *
+   * @param string $formName
+   *   Form Name.
+   *
+   * @return bool
+   *   True if the hook should run.
+   */
+  public function shouldRun($formName) {
+    return $formName == CRM_Admin_Form_Setting_Date::class;
+  }
+
+  /**
+   * Saves The Activity DateFormat field.
+   *
+   * @param CRM_Core_Form $form
+   *   Form Class object.
+   */
+  public function saveCaseActivityDateFormatField(CRM_Core_Form &$form) {
+    $values = $form->getVar('_submitValues');
+    if (!empty($values['_qf_civiCaseActivityDateformat'])) {
+      Civi::settings()->set('civiCaseActivityDateformat', $values['_qf_civiCaseActivityDateformat']);
+    }
+  }
+
+}

--- a/ang/civicase/activity/card/directives/activity-card-big.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-big.directive.html
@@ -74,7 +74,7 @@
           </civicase-tooltip>
         </div>
         <!-- End - top section -->
-        <span class="civicase__activity-date" ng-class="{'civicase__overdue-activity-icon': activity.is_overdue}"><i class="material-icons">event</i>{{formatDate(activity.activity_date_time, 'DD MMM YYYY') }}</span>
+        <span class="civicase__activity-date" ng-class="{'civicase__overdue-activity-icon': activity.is_overdue}"><i class="material-icons">event</i>{{activity.formatted_activity_date_time}}</span>
         <!-- Subject -->
           <div class="civicase__activity-subject">{{ activity.subject }}</div>
         <!-- End - Subject -->

--- a/ang/civicase/activity/card/directives/activity-card-long.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-long.directive.html
@@ -84,7 +84,7 @@
             class="civicase__activity-date"
             ng-class="{'civicase__overdue-activity-icon': activity.is_overdue}">
             <span class="civicase__activity-date__with-year">
-              {{formatDate(activity.activity_date_time, 'DD MMM YYYY')}}
+              {{activity.formatted_activity_date_time}}
             </span>
             <span
               class="civicase__activity-date__without-year"

--- a/ang/civicase/activity/card/directives/activity-card-short.directive.html
+++ b/ang/civicase/activity/card/directives/activity-card-short.directive.html
@@ -11,7 +11,7 @@
         <span ng-if="activity.icon || activity.category.indexOf('milestone') > -1" activity-icon="activity"></span>
 
         <!-- Activity Date -->
-        <span class="civicase__activity-date" ng-class="{'civicase__overdue-activity-icon': activity.is_overdue}">{{ formatDate(activity.activity_date_time, 'DD MMM YYYY') }}</span>
+        <span class="civicase__activity-date" ng-class="{'civicase__overdue-activity-icon': activity.is_overdue}">{{activity.formatted_activity_date_time}}</span>
         <!-- End - Activity Date -->
 
         <span class="civicase__activity__right-container">

--- a/ang/civicase/activity/panel/directives/activity-panel.directive.html
+++ b/ang/civicase/activity/panel/directives/activity-panel.directive.html
@@ -96,7 +96,7 @@
           <span
             class="civicase__activity-date"
             ng-class="{'civicase__overdue-activity-icon': activity.is_overdue}">
-            {{formatDate(activity.activity_date_time, 'DD MMM YYYY')}}
+            {{activity.formatted_activity_date_time}}
           </span>
           <!-- End - Activity Date -->
 

--- a/ang/civicase/shared/directives/file-uploader.directive.html
+++ b/ang/civicase/shared/directives/file-uploader.directive.html
@@ -20,9 +20,9 @@
           <input type="text" class="form-control" id="uploadSubject" required placeholder="" ng-model="activity.subject"/>
         </div>
         <div class="row">
-          <div class="form-group col-md-4 civicase__ui-range">
+          <div class="form-group col-md-4 civicase__ui-range date_range">
             <div><label for="receivedDate">{{ts('Received Date')}}</label></div>
-            <input  id="receivedDate" class="form-control" crm-ui-datepicker="{time: false}" ng-model="activity.activity_date_time" placeholder=""/>
+            <input  id="receivedDate" class="form-control" crm-ui-datepicker="{time: true}" ng-model="activity.activity_date_time" placeholder=""/>
           </div>
         </div>
         <div class="row">
@@ -66,3 +66,12 @@
     </div>
   </fieldset>
 </form>
+
+<style>
+  .date_range > .crm-form-date-wrapper {
+    display: flex !important;
+  }
+  .date_range.civicase__ui-range .crm-form-date {
+    width: 100% !important;
+  }
+</style>

--- a/ang/civicase/shared/directives/file-uploader.directive.js
+++ b/ang/civicase/shared/directives/file-uploader.directive.js
@@ -179,7 +179,8 @@
       $scope.activity = {
         case_id: $scope.ctx.id,
         activity_type_id: 'File Upload',
-        subject: ''
+        subject: '',
+        activity_date_time: moment().format('YYYY-MM-DD HH:MM:SS')
       };
     }
 

--- a/api/v3/Activity/Getall.php
+++ b/api/v3/Activity/Getall.php
@@ -80,6 +80,10 @@ function civicrm_api3_activity_getall(array $params) {
     if (!empty($activityIdsToFetchContactsFor[$row['id']])) {
       $row = array_merge($activityIdsToFetchContactsFor[$row['id']], $row);
     }
+
+    if (!empty($row['activity_date_time'])) {
+      $row['formatted_activity_date_time'] = CRM_Utils_Date::customFormat($row['activity_date_time'], Civi::settings()->get('civiCaseActivityDateformat') ?? '%d %b %Y');
+    }
   }
 
   return $result;

--- a/civicase.php
+++ b/civicase.php
@@ -156,6 +156,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_AttachQuotationToInvoiceMail(),
     new CRM_Civicase_Hook_BuildForm_RefreshInvoiceListOnUpdate(),
     new CRM_Civicase_Hook_BuildForm_AddCaseActivityDateFormatToDateSettings(),
+    new CRM_Civicase_Hook_BuildForm_FormatCaseActivityDateFormat(),
   ];
 
   foreach ($hooks as $hook) {

--- a/civicase.php
+++ b/civicase.php
@@ -155,6 +155,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
     new CRM_Civicase_Hook_BuildForm_AddEntityReferenceToCustomField(),
     new CRM_Civicase_Hook_BuildForm_AttachQuotationToInvoiceMail(),
     new CRM_Civicase_Hook_BuildForm_RefreshInvoiceListOnUpdate(),
+    new CRM_Civicase_Hook_BuildForm_AddCaseActivityDateFormatToDateSettings(),
   ];
 
   foreach ($hooks as $hook) {
@@ -304,6 +305,7 @@ function civicase_civicrm_postProcess($formName, &$form) {
     new CRM_Civicase_Hook_PostProcess_SaveCaseCategoryCustomFields(),
     new CRM_Civicase_Hook_PostProcess_SaveCaseCategoryFeature(),
     new CRM_Civicase_Hook_PostProcess_SaveQuotationsNotesSettings(),
+    new CRM_Civicase_Hook_PostProcess_SaveCaseActivityDateFormat(),
   ];
 
   foreach ($hooks as $hook) {

--- a/js/modify-activity-date.js
+++ b/js/modify-activity-date.js
@@ -1,0 +1,7 @@
+CRM.$(function ($) {
+  (function () {
+    const date = CRM.vars.civicase.formatted_date;
+
+    CRM.$('.crm-activity-form-block-activity_date_time > td.view-value').text(date);
+  })();
+});

--- a/templates/CRM/Civicase/Form/CaseActivityDateFormat.tpl
+++ b/templates/CRM/Civicase/Form/CaseActivityDateFormat.tpl
@@ -1,0 +1,12 @@
+<table class="form-layout-compressed">
+<tr class="crm-date-form-block-_qf_civiCaseActivityDateformat">
+   <td class="label">{$form._qf_civiCaseActivityDateformat.label}</td>
+   <td>{$form._qf_civiCaseActivityDateformat.html}</td>
+</tr>
+</table>
+
+{literal}
+  <script>
+    CRM.$('.crm-date-form-block-dateformatTime').last().after(CRM.$('.crm-date-form-block-_qf_civiCaseActivityDateformat'))
+  </script>
+{/literal}


### PR DESCRIPTION
## Overview
In this PR we allow the users to customize the activity date format, which will be used when displaying activity date in the CiviCase panel.

Also, we have exposed the time field when uploading a file in CiviCase


## Before
- The CiviCase activity feeds use a hardcoded date format 


- The user cannot change the time field when uploading a file
![image](https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/6caa56ac-e7c8-4c65-93aa-6409dd18705b)


## After
- The CiviCase activity feeds use the user-specified date format from the Date settings.
![after1111](https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/59468952-5f98-4122-b17f-98eea0aa9b2d)

- The user can change the time field when uploading a file
<img width="1284" alt="Screenshot 2024-05-10 at 11 54 47" src="https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/16278fb8-b4f7-441e-8f71-e034b96f0d44">


## Technical Details
The settings name is `civiCaseActivityDateformat`