### PR TITLE
BTHAMM-15: Add custom delay before updating line item total

### DIFF
--- a/CRM/Civicase/Service/CaseSalesOrderLineItemsGenerator.php
+++ b/CRM/Civicase/Service/CaseSalesOrderLineItemsGenerator.php
@@ -147,7 +147,7 @@ class CRM_Civicase_Service_CaseSalesOrderLineItemsGenerator {
       'entity_table' => 'civicrm_contribution',
       'financial_type_id' => $item['financial_type_id'],
       'line_total' => round($item['total'], 2),
-      'unit_price' => round($item['unit_price'], 2),
+      'unit_price' => $item['unit_price'],
     ];
   }
 

--- a/js/sales-order-contribution.js
+++ b/js/sales-order-contribution.js
@@ -33,24 +33,26 @@
     if (Array.isArray(lineItems)) {
       CRM.$.blockUI();
       CRM.$('form#Contribution').css('visibility', 'hidden');
-      await new Promise(resolve => setTimeout(resolve, 2000));
+      await new Promise(resolve => setTimeout(resolve, 1000));
       CRM.api4(apiRequest).then(function (batch) {
         const caseSalesOrder = batch.caseSalesOrders[0];
 
         lineItems.forEach(lineItem => {
-          addLineItem(lineItem.qty, lineItem.unit_price, lineItem.label, lineItem.financial_type_id, lineItem.tax_amount);
+          setTimeout(
+            () => addLineItem(lineItem.qty, lineItem.unit_price, lineItem.label, lineItem.financial_type_id, lineItem.tax_amount),
+            2000
+          );
         });
 
-        $('#total_amount').val(0);
+        $('input[id="total_amount"]').trigger('change');
         $('#contribution_status_id').val(batch.optionValues[0].value);
         $('#source').val(`Quotation ${caseSalesOrder.id}`).trigger('change');
         $('#contact_id').select2('val', caseSalesOrder.client_id).trigger('change');
-        $('input[id="total_amount"]', 'form.CRM_Contribute_Form_Contribution').trigger('change');
         $(`<input type="hidden" value="${salesOrderId}" name="sales_order" />`).insertBefore('#source');
         $(`<input type="hidden" value="${toBeInvoiced}" name="to_be_invoiced" />`).insertBefore('#source');
         $(`<input type="hidden" value="${percentValue}" name="percent_value" />`).insertBefore('#source');
         $(`<input type="hidden" value="${salesOrderStatusId}" name="sales_order_status_id" />`).insertBefore('#source');
-        $('#totalAmount, #totalAmountORaddLineitem, #totalAmountORPriceSet, #price_set_id, #choose-manual').hide();
+        $(' #totalAmountORaddLineitem, #totalAmountORPriceSet, #price_set_id, #choose-manual').hide();
 
         waitForElement($, '#customData', function ($, elem) {
           $(`[name^=${caseCustomField}_]`).val(caseSalesOrder.case_id).trigger('change');


### PR DESCRIPTION
## Overview
In this PR we have added a small delay between when the contribution page loads and when the quotation line items are populated, this is necessary because the quotation line items can be cleared by other extensions like [Financeextras](https://github.com/compucorp/io.compuco.financeextras) or [lineitemedit](https://lab.civicrm.org/extensions/lineitemedit) that initializes the line item with default values.

The Quotation items
<img width="1262" alt="Screenshot 2024-05-14 at 15 20 05" src="https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/3b7409f1-44d8-422e-9c8f-2035bd3e6f51">


Creating 100% contribution:

## Before
Occasionally the contribution line item total shows as ZERO or incorrect values.

<img width="841" alt="Screenshot 2024-05-14 at 15 11 18" src="https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/cc9ecc73-e439-4e77-b1bb-66b14e881ea3">


## After
The contribution line item total shows the correct values.
<img width="841" alt="Screenshot 2024-05-14 at 15 03 05" src="https://github.com/compucorp/uk.co.compucorp.civicase/assets/85277674/1bd455ad-f9aa-43ec-96f1-2edf4702c3ae">
