### PR TITLE
COMCL-603: Update Case Type Entity Name

### DIFF
--- a/civicase.php
+++ b/civicase.php
@@ -542,7 +542,9 @@ function civicase_civicrm_alterAngular(Manager $angular) {
  *   Entity types array.
  */
 function _civicase_add_case_category_case_type_entity(array &$entityTypes) {
-  $entityTypes['CRM_Case_DAO_CaseType']['fields_callback'][] = function ($class, &$fields) {
+  $caseTypeEntityName = isset($entityTypes['CRM_Case_DAO_CaseType']) ? 'CRM_Case_DAO_CaseType' : 'CaseType';
+
+  $entityTypes[$caseTypeEntityName]['fields_callback'][] = function ($class, &$fields) {
     $fields['case_type_category'] = [
       'name' => 'case_type_category',
       'type' => CRM_Utils_Type::T_INT,


### PR DESCRIPTION
## Overview
This pr updates the name of case type entity in entity types hook due to the changes in civicrm core.

## Technical Details
In [this](https://github.com/civicrm/civicrm-core/commit/64fc4923319ba4f5ce0a69fa1c1392d8178173a1) commit the entity definitions were moved from xml files to entity.php files and in this process the name of case type entity was changed from 'CRM_Case_DAO_CaseType' to 'CaseType'. BUt since we have not yet upgraded so this pr supports both the entity names for now that will allow this extension to work with our current civicrm version(5.51.3) and with version 5.75.0 as well.
