### PR TITLE
COMCL-603: Correct visual bundle assets path

### DIFF
--- a/ang/civicase-base.ang.php
+++ b/ang/civicase-base.ang.php
@@ -9,11 +9,11 @@
  */
 
 use Civi\CCase\Utils as Utils;
-use CRM_Civicase_Helper_OptionValues as OptionValuesHelper;
+use CRM_Civicase_Helper_CaseUrl as CaseUrlHelper;
 use CRM_Civicase_Helper_GlobRecursive as GlobRecursive;
 use CRM_Civicase_Helper_NewCaseWebform as NewCaseWebform;
+use CRM_Civicase_Helper_OptionValues as OptionValuesHelper;
 use CRM_Civicase_Service_CaseCategoryCustomFieldsSetting as CaseCategoryCustomFieldsSetting;
-use CRM_Civicase_Helper_CaseUrl as CaseUrlHelper;
 
 [$caseCategoryId, $caseCategoryName] = CaseUrlHelper::getCategoryParamsFromUrl();
 
@@ -110,7 +110,7 @@ function expose_settings(array &$options, array $defaults) {
 function get_base_js_files() {
   return array_merge(
     [
-      'assetBuilder://visual-bundle.js',
+      Civi::service('asset_builder')->getUrl('visual-bundle.js'),
       'ang/civicase-base.js',
     ],
     GlobRecursive::getRelativeToExtension(

--- a/ang/civicase.ang.php
+++ b/ang/civicase.ang.php
@@ -8,12 +8,12 @@
  * http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules.
  */
 
-use CRM_Civicase_Helper_GlobRecursive as GlobRecursive;
-use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
-use CRM_Civicase_Helper_NewCaseWebform as NewCaseWebform;
 use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
-use CRM_Civicase_Hook_Permissions_ExportCasesAndReports as ExportCasesAndReports;
 use CRM_Civicase_Helper_CaseUrl as CaseUrlHelper;
+use CRM_Civicase_Helper_GlobRecursive as GlobRecursive;
+use CRM_Civicase_Helper_NewCaseWebform as NewCaseWebform;
+use CRM_Civicase_Hook_Permissions_ExportCasesAndReports as ExportCasesAndReports;
+use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
 
 load_resources();
 [$caseCategoryId, $caseCategoryName] = CaseUrlHelper::getCategoryParamsFromUrl();
@@ -96,7 +96,7 @@ function get_js_files() {
     [
       // At the moment, it's safe to include this multiple times.
       // deduped by resource manager.
-      'assetBuilder://visual-bundle.js',
+      Civi::service('asset_builder')->getUrl('visual-bundle.js'),
       'ang/civicase.js',
     ],
     GlobRecursive::getRelativeToExtension(
@@ -255,7 +255,7 @@ return [
   'css' => [
     // At the moment, it's safe to include this multiple times.
     // deduped by resource manager.
-    'assetBuilder://visual-bundle.css',
+    Civi::service('asset_builder')->getUrl('visual-bundle.css'),
     'css/*.css',
   ],
   'partials' => [


### PR DESCRIPTION
## Overview
This pr corrects the path for visual bundle assets to be compatible with civicrm version 5.75.0
