### PR TITLE
COMCL-644: Fix contribution settings page

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/AddQuotationsNotesToContributionSettings.php
+++ b/CRM/Civicase/Hook/BuildForm/AddQuotationsNotesToContributionSettings.php
@@ -49,11 +49,13 @@ class CRM_Civicase_Hook_BuildForm_AddQuotationsNotesToContributionSettings {
         'weight' => 5,
         'description' => ts('Enter note or message to be displyaed on quotations'),
         'attributes' => ['rows' => 2, 'cols' => 40],
+        'name' => $fieldName,
+        'quick_form_type' => 'Element',
       ],
     ];
 
     $form->add('wysiwyg', $fieldName, $field[$fieldName]['title'], $field[$fieldName]['attributes']);
-    $form->assign('htmlFields', array_merge($form->get_template_vars('htmlFields'), $field));
+    $form->assign('fields', array_values(array_merge($form->getTemplateVars('fields'), $field)));
     $value = Civi::settings()->get($fieldName) ?? NULL;
     $form->setDefaults(array_merge($form->_defaultValues, [$fieldName => $value]));
 


### PR DESCRIPTION
## Overview
This pr fixes an issue that occurs due to upgrade to civicrm version 5.75.0 because of some structural changes to civicrm core form class and it restricted the user from accessing civi contribute settings page.

## Before
![COMCL-644](https://github.com/user-attachments/assets/cbb71f7d-ec00-42c6-85ad-f31d074c50f6)

## After
<img width="1792" alt="Screenshot 2024-07-25 at 5 18 57 PM" src="https://github.com/user-attachments/assets/90593f70-36ea-4398-8aab-4f6c2f369cd7">

