### PR TITLE
COMCL-640: Ensure submit buttons will validate the form properly

### DIFF
--- a/civicase.php
+++ b/civicase.php
@@ -634,3 +634,16 @@ function civicase_civicrm_searchTasks(string $objectName, array &$tasks) {
     }
   }
 }
+
+/**
+ * Implements hook_civicrm_alterContent().
+ */
+function civicase_civicrm_alterContent(&$content, $context, $tplName, &$object) {
+  if ($context == "form") {
+    if ($tplName == "CRM/Activity/Form/Activity.tpl") {
+      // See: templates/CRM/Core/Form/RecurringEntity.tpl#209
+      // Ensure submit buttons will validate the form properly.
+      $content = str_replace("#_qf_Activity_upload-top, #_qf_Activity_upload-bottom", "#_qf_Activity_upload-top, #_qf_Activity_upload-bottom, #_qf_Activity_submit-bottom, #_qf_Activity_submit-top, #_qf_Activity_refresh-top, #_qf_Activity_refresh-bottom", $content);
+    }
+  }
+}


### PR DESCRIPTION
## Overview
This PR addresses an issue where users are unable to create a new communication type activity under the contacts form New Activity. The problem occurs due to the Draft button being added to the New Activity form, which introduces a new button ID that is not accounted for in CiviCRM's form validation process. https://github.com/compucorp/uk.co.compucorp.civicase/blob/eaefbbdf9984c377db93553999496e849c2cad09/CRM/Civicase/Hook/BuildForm/HandleDraftActivities.php#L77-L91


After adding the button in the hook above, the new button ID is not catered for in CiviCRM https://github.com/civicrm/civicrm-core/blob/920907161e991952f07eb4b73910886022e8c414/templates/CRM/Core/Form/RecurringEntity.tpl#L209 where submit buttons are not expected to validate unchanged elements.

## Before
Users were unable to create activities under the contacts forms New Activity.

![22111ere111](https://github.com/user-attachments/assets/491433d2-2e6c-4c1a-a3b3-959959cc0603)


## After
Users can now successfully create activities under the contacts forms New Activity.

![111ere111](https://github.com/user-attachments/assets/54097d3e-8ba1-470f-afc0-c09bbd9c9989)

## Technical Implementation

The fix involves adding a new [hook_civicrm_alterContent()](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterContent/) implementation in civicase.php. This hook modifies the content of the Activity form template to include all relevant button IDs for proper form validation.
