### PR TITLE
COMCL-706: Fix Menu Styles

### DIFF
--- a/ang/civicase-features/quotations/directives/quotations-list.directive.html
+++ b/ang/civicase-features/quotations/directives/quotations-list.directive.html
@@ -14,7 +14,7 @@
         <afsearch-contact-quotations options="{contact_id: contactId}" ng-switch-when="contact"> </afsearch-contact-quotations>
         <afsearch-quotations ng-switch-default> </afsearch-quotations>
       </div>
-      
+
     </div>
   </div>
 </div>
@@ -35,7 +35,6 @@
     margin: 0em 1em;
   }
   #bootstrap-theme.civicase__container .quotation__list ul.dropdown-menu {
-    right: 0;
     left: auto;
   }
 </style>


### PR DESCRIPTION
## Overview
This pr fixes the styling of bulk action dropdown menu for quotations tab.

## Before
<img width="1792" alt="Screenshot 2024-08-08 at 1 25 11 PM" src="https://github.com/user-attachments/assets/b293c20d-2e60-4ea4-90d4-3eaaaa80dae1">


## After
<img width="1792" alt="Screenshot 2024-08-08 at 1 26 45 PM" src="https://github.com/user-attachments/assets/a484394c-715d-4774-aa55-d5281e0238a9">

