### PR TITLE
COMCL-716: Fix Other Relationship Tab On Case Details Page

### DIFF
--- a/api/v3/Case/Getrelations.php
+++ b/api/v3/Case/Getrelations.php
@@ -53,7 +53,7 @@ function civicrm_api3_case_getrelations(array $params) {
 
   $relationships = Relationship::get(FALSE)
     ->addSelect('relationship_type_id', 'contact_id_a', 'contact_id_b')
-    ->addWhere('relationship_type.is_active', '=', TRUE)
+    ->addWhere('relationship_type_id.is_active', '=', TRUE)
     ->addWhere('is_active', '=', TRUE)
     ->addWhere('case_id', 'IS NULL');
 


### PR DESCRIPTION
## Overview
This pr fixes the other relationship tab on case details page as the relationships were not getting loaded due to an error in an api.

## Before
<img width="1792" alt="Screenshot 2024-08-13 at 2 13 06 PM" src="https://github.com/user-attachments/assets/abef3436-9f8e-4052-8cd5-ed7b69af7942">


## After
<img width="1792" alt="Screenshot 2024-08-13 at 2 11 54 PM" src="https://github.com/user-attachments/assets/43d42bef-ce5a-4ea1-a1b1-fa0e1258fde6">
