### PR TITLE
COMCL-701: Fix Auto Filling Of Owner Id Field On Create Quotation Form

### DIFF
--- a/ang/civicase/contact/services/contact.service.js
+++ b/ang/civicase/contact/services/contact.service.js
@@ -9,8 +9,9 @@
      */
     this.getCurrentContactID = function () {
       var url = new URL(window.location.href);
+      var userIdFromConfig = CRM.config.user_contact_id ? CRM.config.user_contact_id : CRM.config.cid;
 
-      return url.searchParams.get('cid') !== null ? url.searchParams.get('cid') : CRM.config.user_contact_id;
+      return url.searchParams.get('cid') !== null ? url.searchParams.get('cid') : userIdFromConfig;
     };
   });
 })(angular, CRM.$, CRM._, CRM);


### PR DESCRIPTION
## Overview
This pr fixes a bug that restricted the auto filling of owner field on create quotation form.

## Before
![screen_recording_before](https://github.com/user-attachments/assets/f5f0e2bd-40e9-442d-a401-f0337cb4c1da)

## After
![screen_recording_after](https://github.com/user-attachments/assets/a24f935c-e315-4929-a68e-f2f69a251977)
