### PR TITLE
COMCL-707: Fix Case Type Category Terms

### DIFF
--- a/CRM/Civicase/Hook/PageRun/AddCaseTypeCategoryToCache.php
+++ b/CRM/Civicase/Hook/PageRun/AddCaseTypeCategoryToCache.php
@@ -1,0 +1,33 @@
+<?php
+
+use CRM_Civicase_Helper_CaseUrl as CaseUrlHelper;
+
+/**
+ * Add case type category to cache.
+ */
+class CRM_Civicase_Hook_PageRun_AddCaseTypeCategoryToCache {
+
+  /**
+   * Add case type category to cache.
+   *
+   * @param object $page
+   *   Page Object.
+   */
+  public function run(&$page): void {
+    $this->addCaseTypeCategoryToCache();
+  }
+
+  /**
+   * Add case type category to cache.
+   */
+  private function addCaseTypeCategoryToCache(): void {
+    if (CRM_Utils_System::currentPath() === 'civicrm/case/a') {
+      $caseCategoryInfo = CaseUrlHelper::getCategoryParamsFromUrl();
+      \Civi::cache('metadata')->set('current_case_category', $caseCategoryInfo[1]);
+    }
+    elseif (!in_array(CRM_Utils_System::currentPath(), ['civicrm/asset/builder', 'civicrm/user-menu'], TRUE)) {
+      \Civi::cache('metadata')->set('current_case_category', NULL);
+    }
+  }
+
+}

--- a/ang/civicase.ang.php
+++ b/ang/civicase.ang.php
@@ -26,8 +26,6 @@ if (CRM_Utils_System::currentPath() !== 'civicrm/case/contact-case-tab') {
     if (!in_array($caseCategoryName, CaseCategoryHelper::getAccessibleCaseTypeCategories())) {
       throw new Exception('Access denied! You are not authorized to access this page.');
     }
-
-    CRM_Civicase_Hook_Helper_CaseTypeCategory::addWordReplacements($caseCategoryName);
   }
 }
 

--- a/civicase.php
+++ b/civicase.php
@@ -415,6 +415,7 @@ function civicase_civicrm_pageRun(&$page) {
     new CRM_Civicase_Hook_PageRun_AddCaseAngularPageResources(),
     new CRM_Civicase_Hook_PageRun_AddContactPageSummaryResources(),
     new CRM_Civicase_Hook_PageRun_CaseCategoryCustomGroupListing(),
+    new CRM_Civicase_Hook_PageRun_AddCaseTypeCategoryToCache(),
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview
This pr fixes the case type category terms usages. Currently awrads and prospect also uses the term 'cases' instead of awards and prospect on dashboard pages.

## Before
![image-20240807-080655](https://github.com/user-attachments/assets/4ead7a8f-a2ea-4e1d-9885-5dc9fa5649c7)


## After
![image-20240807-080743](https://github.com/user-attachments/assets/d2768831-d3af-445d-85bf-0f5009a12f3b)