### PR TITLE
BTHA-188: Avoid calculating opportunity detail for deleted contribution

### DIFF
--- a/CRM/Civicase/Service/CaseSalesOrderOpportunityCalculator.php
+++ b/CRM/Civicase/Service/CaseSalesOrderOpportunityCalculator.php
@@ -172,7 +172,10 @@ class CRM_Civicase_Service_CaseSalesOrderOpportunityCalculator extends CRM_Civic
   private function getContributions($caseId) {
     $contributions = Contribution::get(FALSE)
       ->addSelect('*', 'Opportunity_Details.Quotation')
-      ->addWhere('Opportunity_Details.Case_Opportunity', '=', $caseId);
+      ->addWhere('Opportunity_Details.Case_Opportunity', '=', $caseId)
+      ->addJoin('CaseSalesOrder AS case_sales_order', 'INNER',
+        ['Opportunity_Details.Quotation', '=', 'case_sales_order.id']
+      );
 
     if ($this->deletingContributionId !== NULL) {
       $contributions->addWhere('id', '!=', $this->deletingContributionId);


### PR DESCRIPTION
## Overview
This PR excludes contributions from deleted quotations when computing the case financial amount

## Before
The user cannot save quotation
![aasw](https://github.com/user-attachments/assets/2b00bb47-bfa5-4f29-9081-e909d34b68ca)


## After
Quotation is saved successfully
![asw](https://github.com/user-attachments/assets/b236f22f-afd6-4180-9ec0-fb9736594451)
