### PR TITLE
COMCL-792: Fix Pdf Creation For Cases

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/HandleDraftActivities.php
+++ b/CRM/Civicase/Hook/BuildForm/HandleDraftActivities.php
@@ -149,6 +149,10 @@ class CRM_Civicase_Hook_BuildForm_HandleDraftActivities {
         $form->setDefaults($draft);
       }
     }
+    $caseId = CRM_Utils_Request::retrieve('caseid', 'String');
+    if ($formName === self::PDF_LETTER_FORM_NAME && !empty($caseId)) {
+      $form->addElement('hidden', 'caseid', $caseId);
+    }
   }
 
   /**


### PR DESCRIPTION
## Overview
This pr fixes the saving of pdfs for cases as currently the pdfs are not getting attached to cases when user creates a pdf on a case.

## Before
![screen_recording_before](https://github.com/user-attachments/assets/56a13e07-1ec3-4977-a99f-bacdd95def7a)


## After
![screen_recording_after](https://github.com/user-attachments/assets/39977c57-d4ac-4f99-811a-3ac4ec904ddc)
