### PR TITLE
COMCL-703: Resolve quotation link and search filter issues

### DIFF
--- a/CRM/Civicase/Hook/Post/CreateSalesOrderContribution.php
+++ b/CRM/Civicase/Hook/Post/CreateSalesOrderContribution.php
@@ -42,11 +42,17 @@ class CRM_Civicase_Hook_Post_CreateSalesOrderContribution {
 
     $salesOrderStatusId = CRM_Utils_Request::retrieve('sales_order_status_id', 'Integer');
     if (empty($salesOrderStatusId)) {
-      $salesOrder = $salesOrder['status_id'];
+      $salesOrderStatusId = $salesOrder['status_id'];
     }
 
     $transaction = CRM_Core_Transaction::create();
     try {
+      Contribution::update(FALSE)
+        ->addWhere('id', '=', $objectId)
+        ->addValue('Opportunity_Details.Case_Opportunity', $salesOrder['case_id'] ?? NULL)
+        ->addValue('Opportunity_Details.Quotation', $salesOrderId)
+        ->execute();
+
       $caseSaleOrderContributionService = new CRM_Civicase_Service_CaseSalesOrderContributionCalculator($salesOrderId);
       $paymentStatusID = $caseSaleOrderContributionService->calculatePaymentStatus();
       $invoicingStatusID = $caseSaleOrderContributionService->calculateInvoicingStatus();

--- a/ang/afsearchQuotations.aff.html
+++ b/ang/afsearchQuotations.aff.html
@@ -17,7 +17,7 @@
 
     <div class="af-container row civicase__case-filter-form-elements" ng-show="expanded">
       <af-field name="status_id" defn="{input_attrs: {multiple: true}}" class="col-md-2" />
-      <af-field name="quotation_date" defn="{input_attrs: {time: false}, search_range: true, label: 'Date'}" class="col-md-4 civicase__ui-range" />
+      <af-field name="DATE_quotation_date" defn="{search_range: true, time: false, input_attrs: {}, label: 'Date'}" class="col-md-4 civicase__ui-range" />
       <div class="col-md-1">
         <button type="button" class="btn btn-link civicase__features-filters-clear" style="margin-top: 2em;">Clear All</button>
       </div>
@@ -25,4 +25,10 @@
   </div>
   <crm-search-display-table search-name="Civicase_Quotations" display-name="Civicase_Quotations_Table" filters="{case_id: routeParams.caseId}"></crm-search-display-table>
 </div>
+
+<style>
+  af-field[name="DATE_quotation_date"] input.form-control.hasTimeEntry {
+    display: none !important;
+  }
+</style>
 

--- a/ang/civicase-features/quotations/directives/quotations-list.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-list.directive.js
@@ -52,7 +52,8 @@
 
         if ($('.civicase__features-filters-clear').length) {
           // Handle clear filter button.
-          $('.civicase__features-filters-clear').click(event => {
+          $('.civicase__features-filters-clear').off('click').click(event => {
+            CRM.$("input[id*='id']").select2('data', null)
             CRM.$('.civicase__features input, .civicase__features textarea').val('').change();
           });
         }

--- a/ang/civicase-features/quotations/directives/quotations-list.directive.js
+++ b/ang/civicase-features/quotations/directives/quotations-list.directive.js
@@ -53,7 +53,7 @@
         if ($('.civicase__features-filters-clear').length) {
           // Handle clear filter button.
           $('.civicase__features-filters-clear').off('click').click(event => {
-            CRM.$("input[id*='id']").select2('data', null)
+            CRM.$("input[id*='id']").select2('data', null);
             CRM.$('.civicase__features input, .civicase__features textarea').val('').change();
           });
         }

--- a/js/sales-order-contribution.js
+++ b/js/sales-order-contribution.js
@@ -43,11 +43,11 @@
         $(`<input type="hidden" value="${salesOrderStatusId}" name="sales_order_status_id" />`).insertBefore('#source');
         $(' #totalAmountORaddLineitem, #totalAmountORPriceSet, #price_set_id, #choose-manual').hide();
 
-        if ($('#customData')) {
+        if ($('#customData_Contribution')) {
           CRM.$(`[name^=${caseCustomField}_]`).val(caseSalesOrder.case_id).trigger('change');
           CRM.$(`[name^=${quotationCustomField}_]`).val(caseSalesOrder.id).trigger('change');
         }
-        waitForElement($, '#customData', function ($, elem) {
+        waitForElement($, '#customData_Contribution', function ($, elem) {
           CRM.$(`[name^=${caseCustomField}_]`).val(caseSalesOrder.case_id).trigger('change');
           CRM.$(`[name^=${quotationCustomField}_]`).val(caseSalesOrder.id).trigger('change');
         });


### PR DESCRIPTION
## Overview
This PR resolves the following issues
- Users not able to clear the applied filter on the quotation search widget
- Users not being able to link a contribution with the associated quotation


**Filter not cleared after clicking on the clear button**
## Before

https://github.com/user-attachments/assets/59b4539b-a9ca-494b-9aee-8d2cdaf81956




## After
![11111q1q1q1q1q1q1q1q1q1q1](https://github.com/user-attachments/assets/27ca6da6-ae0f-4dd4-9102-7e10cff84e1d)


**Contribution not linked with quotation**
## Before

https://github.com/user-attachments/assets/d148c42a-aa9b-4041-bc8b-8352e70721a0



## After

![11111q1q1q1q1q1q1q1q1q1q1](https://github.com/user-attachments/assets/df8cd6dc-9df0-44e6-91b6-db6f3e112dd7)

