### PR TITLE
NEUSPRT-405: Fix issues with mysql 8 compatibility

### DIFF
--- a/CRM/Civicase/APIHelpers/CustomFieldFilter.php
+++ b/CRM/Civicase/APIHelpers/CustomFieldFilter.php
@@ -51,9 +51,11 @@ class CRM_Civicase_APIHelpers_CustomFieldFilter {
     $value = $value['IN'] ?? $value;
     $table = $columnGroup[0];
     $column = $columnGroup[1];
+    $mysqlVersion = CRM_Core_DAO::executeQuery('SELECT VERSION() AS version;')->fetchValue();
+    $isMysql8 = version_compare($mysqlVersion, '8.0') !== -1;
 
-    $conditions = array_map(function ($param) use ($table, $column) {
-      return "custom_case_to_{$table}.{$column} REGEXP '[[:<:]]" . $param . "[[:>:]]'";
+    $conditions = array_map(function ($param) use ($table, $column, $isMysql8) {
+      return $isMysql8 ? "custom_case_to_{$table}.{$column} REGEXP '\\\b" . $param . "\\\b'" : "custom_case_to_{$table}.{$column} REGEXP '[[:<:]]" . $param . "[[:>:]]'";
     }, $value);
     $conditions = implode(" AND ", $conditions);
 


### PR DESCRIPTION
## Overview
This pr makes the custom fields filters to work with mysql8 as well. Currently the api for fetching cases results in an error on mysql 8 when used with sny custom field filter.

## Before
![screen_recording_before](https://github.com/user-attachments/assets/ec64fc21-01ff-49f1-9428-5e00ec3a81f6)


## After
![screen_recording_after](https://github.com/user-attachments/assets/170d6de6-8942-4555-9fb0-82e33d5ae625)


## Technical Details
As explained [here](https://stackoverflow.com/questions/59998409/error-code-3685-illegal-argument-to-a-regular-expression) the regular expression engine was changed in mysql8 so now regular expression syntax has changed.