### PR TITLE
CIVIMM-277: Fix Stripe Refund

### DIFF
--- a/CRM/Civicase/Hook/Post/LinkCase.php
+++ b/CRM/Civicase/Hook/Post/LinkCase.php
@@ -15,23 +15,23 @@ class CRM_Civicase_Hook_Post_LinkCase {
    *   The operation being performed.
    * @param string $objectName
    *   Object name.
-   * @param int $objectId
+   * @param null|int|string $objectId
    *   Object ID.
    * @param object $objectRef
    *   Object reference.
    */
-  public function run(string $op, string $objectName, ?int $objectId, &$objectRef) {
+  public function run(string $op, string $objectName, $objectId, &$objectRef) {
     if (!$this->shouldRun($op, $objectName)) {
       return;
     }
 
     $linkToCaseId = (int) CRM_Utils_Request::retrieve('linkToCaseId', 'Positive');
     $linkedToCaseDetails = $this->getLinkedToCaseDetails($linkToCaseId);
-    $caseDetails = $this->getCaseDetails($objectId);
+    $caseDetails = $this->getCaseDetails((int) $objectId);
 
     $params = [
       'case_id' => $linkToCaseId,
-      'link_to_case_id' => $objectId,
+      'link_to_case_id' => (int) $objectId,
       'activity_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Link Cases'),
       'medium_id' => CRM_Core_OptionGroup::values('encounter_medium', FALSE, FALSE, FALSE, 'AND is_default = 1'),
       'activity_date_time' => date('YmdHis'),
@@ -44,7 +44,7 @@ class CRM_Civicase_Hook_Post_LinkCase {
     $activity = CRM_Activity_BAO_Activity::create($params);
 
     $caseParams = [
-      'case_id' => $objectId,
+      'case_id' => (int) $objectId,
       'activity_id' => $activity->id,
     ];
     CRM_Case_BAO_Case::processCaseActivity($caseParams);


### PR DESCRIPTION
## Overview
This pr fixes an issue due to which the users were not able to use submit credit card refund option for a stripe contribution.

## Before
<img width="1792" alt="Screenshot 2025-02-05 at 10 17 28 PM" src="https://github.com/user-attachments/assets/ac922f44-1ab1-47f2-9f5d-8b1a57049701" />


## After
![screen_recording_after](https://github.com/user-attachments/assets/c1caf3db-bf5c-4ab1-9463-2f134ac95a03)


## Technical Details
The issue was caused by the fact that when a stripe refund is created it fires a post hook but the third parameter is a string instead of int. In CRM_Civicase_Hook_Post_LinkCase class the third parameter for the hook was type hinted as int so it errored out and was not letting the user to complete a refund
