### PR TITLE
CIVIMM-293: Fix permission label

### DIFF
--- a/CRM/Civicase/Hook/Permissions/CaseCategory.php
+++ b/CRM/Civicase/Hook/Permissions/CaseCategory.php
@@ -56,8 +56,8 @@ class CRM_Civicase_Hook_Permissions_CaseCategory {
   private function addCivicaseDefaultPermissions() {
     $caseCategoryPermissions = $this->permissionService->get();
     $this->permissions[$caseCategoryPermissions['BASIC_CASE_CATEGORY_INFO']['name']] = [
-      $caseCategoryPermissions['BASIC_CASE_CATEGORY_INFO']['label'],
-      $caseCategoryPermissions['BASIC_CASE_CATEGORY_INFO']['description'],
+      'label' => $caseCategoryPermissions['BASIC_CASE_CATEGORY_INFO']['label'],
+      'description' => $caseCategoryPermissions['BASIC_CASE_CATEGORY_INFO']['description'],
     ];
 
     $this->permissions['Update cases with user role via webform'] = [
@@ -82,8 +82,8 @@ class CRM_Civicase_Hook_Permissions_CaseCategory {
       $caseCategoryPermissions = $this->permissionService->get($caseTypeCategory);
       foreach ($caseCategoryPermissions as $caseCategoryPermission) {
         $this->permissions[$caseCategoryPermission['name']] = [
-          $caseCategoryPermission['label'],
-          $caseCategoryPermission['description'],
+          'label' => $caseCategoryPermission['label'],
+          'description' => $caseCategoryPermission['description'],
         ];
       }
     }

--- a/CRM/Civicase/Hook/Permissions/ExportCasesAndReports.php
+++ b/CRM/Civicase/Hook/Permissions/ExportCasesAndReports.php
@@ -41,8 +41,8 @@ class CRM_Civicase_Hook_Permissions_ExportCasesAndReports {
    */
   private function addExportPermission() {
     $this->permissions[self::PERMISSION_NAME] = [
-      'CiviCase: ' . self::PERMISSION_NAME,
-      ts('Access export action in manage cases and reports'),
+      'label' => 'CiviCase: ' . self::PERMISSION_NAME,
+      'description' => ts('Access export action in manage cases and reports'),
     ];
   }
 


### PR DESCRIPTION
## Overview

CiviCRM 5.0+ uses a newer format for declaring permissions. As of Civi 5.71, the old format is deprecated.