### PR TITLE
CSTMM-110: Handle Opportunity details custom field being disabled

### DIFF
--- a/CRM/Civicase/Hook/BuildForm/AttachQuotationToInvoiceMail.php
+++ b/CRM/Civicase/Hook/BuildForm/AttachQuotationToInvoiceMail.php
@@ -22,15 +22,20 @@ class CRM_Civicase_Hook_BuildForm_AttachQuotationToInvoiceMail {
     }
 
     $contributionId = CRM_Utils_Request::retrieve('id', 'Positive', $form, FALSE);
-    $salesOrder = Contribution::get()
-      ->addSelect('Opportunity_Details.Quotation')
-      ->addWhere('Opportunity_Details.Quotation', 'IS NOT EMPTY')
-      ->addWhere('id', 'IN', explode(',', $contributionId))
-      ->addChain('salesOrder', CaseSalesOrder::get()
-        ->addWhere('id', '=', '$Opportunity_Details.Quotation')
-      )
-      ->execute()
-      ->getArrayCopy();
+    try {
+      $salesOrder = Contribution::get(FALSE)
+        ->addSelect('Opportunity_Details.Quotation')
+        ->addWhere('Opportunity_Details.Quotation', 'IS NOT EMPTY')
+        ->addWhere('id', 'IN', explode(',', $contributionId))
+        ->addChain('salesOrder', CaseSalesOrder::get()
+          ->addWhere('id', '=', '$Opportunity_Details.Quotation')
+        )
+        ->execute()
+        ->getArrayCopy();
+    }
+    catch (Exception $e) {
+      return;
+    }
 
     if (!empty($salesOrder)) {
       $form->add('checkbox', 'attach_quote', ts('Attach Quotation'));

--- a/CRM/Civicase/Hook/Pre/DeleteSalesOrderContribution.php
+++ b/CRM/Civicase/Hook/Pre/DeleteSalesOrderContribution.php
@@ -75,7 +75,7 @@ class CRM_Civicase_Hook_Pre_DeleteSalesOrderContribution {
    * Gets quotation ID by contribution ID.
    */
   private function getQuotationId($id) {
-    return Contribution::get()
+    return Contribution::get(FALSE)
       ->addSelect('Opportunity_Details.Quotation')
       ->addWhere('id', '=', $id)
       ->execute()


### PR DESCRIPTION
## Overview
Handle Opportunity details custom field being disabled

In the system we allow users to add quotation invoices to contribution invoices, and we use API4 to check if the contribution has a quotation in the logic, but if the quotation custom field is disabled this API4 request fails. In this PR we have placed the API request in a try-catch block to prevent it from throwing errors.

