### PR TITLE
NEUSPRT-456: Update casetype category menu label post update

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
   run-unit-tests:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: compucorp/civicrm-buildkit:1.3.1-php8.0-chrome
 
     env:

--- a/CRM/Civicase/Helper/Category.php
+++ b/CRM/Civicase/Helper/Category.php
@@ -13,7 +13,7 @@ class CRM_Civicase_Helper_Category {
    * @param string $categoryName
    *   Category name.
    *
-   * @return int|null
+   * @return array|null
    *   Case category data.
    */
   public static function get(string $categoryName) {

--- a/CRM/Civicase/Hook/PostProcess/SaveCaseCategoryCustomFields.php
+++ b/CRM/Civicase/Hook/PostProcess/SaveCaseCategoryCustomFields.php
@@ -1,5 +1,6 @@
 <?php
 
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 use CRM_Civicase_Service_CaseCategoryCustomFieldsSetting as CaseCategoryCustomFieldsSetting;
 
 /**
@@ -33,6 +34,12 @@ class CRM_Civicase_Hook_PostProcess_SaveCaseCategoryCustomFields extends CRM_Civ
         'singular_label' => $caseCategoryValues['singular_label'],
       ]);
     }
+
+    $caseTypeCategory = CaseCategoryHelper::getById($form->getVar('_id'));
+    $categoryMenu = new CRM_Civicase_Service_CaseCategoryMenu();
+
+    $caseTypeCategory['singular_label'] = $caseCategoryValues['singular_label'] ?? NULL;
+    $categoryMenu->resetCaseCategorySubmenusUrl($caseTypeCategory);
   }
 
   /**

--- a/CRM/Civicase/Service/CaseCategoryMenu.php
+++ b/CRM/Civicase/Service/CaseCategoryMenu.php
@@ -1,7 +1,8 @@
 <?php
 
-use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
 use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
+use CRM_Civicase_Service_CaseCategoryCustomFieldsSetting as CaseCategoryCustomFieldsSetting;
+use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
 
 /**
  * Create/Delete Case Type Category Menu items.
@@ -82,6 +83,7 @@ class CRM_Civicase_Service_CaseCategoryMenu {
         'api.Navigation.create' => [
           'id' => '$value.id',
           'url' => $item['url'],
+          'label' => $item['label'],
         ],
       ]);
     }
@@ -98,7 +100,7 @@ class CRM_Civicase_Service_CaseCategoryMenu {
    * @return array[]
    *   Array with the submenus info.
    */
-  public function getSubmenus(array $caseTypeCategory, array $permissions = NULL) {
+  public function getSubmenus(array $caseTypeCategory, array|null $permissions = NULL) {
     $labelForMenu = ucfirst(strtolower($caseTypeCategory['label']));
     $singularLabelForMenu = ucfirst(strtolower($caseTypeCategory['singular_label']));
     $caseTypeCategoryName = $caseTypeCategory['name'];
@@ -208,16 +210,22 @@ class CRM_Civicase_Service_CaseCategoryMenu {
    *   Case category name.
    */
   public function updateItems($caseCategoryId, array $menuParams) {
-    $caseCategoryOptionDetails = CaseCategoryHelper::getById($caseCategoryId);
+    $caseTypeCategory = CaseCategoryHelper::getById($caseCategoryId);
 
-    $parentMenu = civicrm_api3('Navigation', 'get', ['name' => $caseCategoryOptionDetails['name']]);
+    $parentMenu = civicrm_api3('Navigation', 'get', ['name' => $caseTypeCategory['name']]);
 
     if ($parentMenu['count'] == 0) {
       return;
     }
 
     $menuParams['id'] = $parentMenu['id'];
+    $menuParams['label'] = ucfirst(strtolower($caseTypeCategory['label']));
     civicrm_api3('Navigation', 'create', $menuParams);
+
+    $categoryCustomFields = (new CaseCategoryCustomFieldsSetting())->get($caseTypeCategory['value']);
+    $caseTypeCategory['singular_label'] = $categoryCustomFields['singular_label'] ?? NULL;
+
+    $this->resetCaseCategorySubmenusUrl($caseTypeCategory);
   }
 
   /**

--- a/CRM/Civicase/Service/CaseCategoryMenu.php
+++ b/CRM/Civicase/Service/CaseCategoryMenu.php
@@ -224,8 +224,6 @@ class CRM_Civicase_Service_CaseCategoryMenu {
 
     $categoryCustomFields = (new CaseCategoryCustomFieldsSetting())->get($caseTypeCategory['value']);
     $caseTypeCategory['singular_label'] = $categoryCustomFields['singular_label'] ?? NULL;
-
-    $this->resetCaseCategorySubmenusUrl($caseTypeCategory);
   }
 
   /**


### PR DESCRIPTION
## Overview
Before this PR, when a user updates the label of a case type category, the menu labels are not updated; instead, they keep the label they were set to on creation.

## Before
![NEUSPRT-454-issue2](https://github.com/user-attachments/assets/9a777689-f913-4d76-b7de-b51651e986c4)


## After

<img width="593" alt="Screenshot 2025-04-24 at 17 06 57" src="https://github.com/user-attachments/assets/407628c6-bae5-4953-9e21-21740e1efe98" />
