### PR TITLE
NEUSPRT-447: Fix Case Opportunity Managed Entity

### DIFF
--- a/managed/CustomGroup_Cases_OpportunityDetails.mgd.php
+++ b/managed/CustomGroup_Cases_OpportunityDetails.mgd.php
@@ -10,7 +10,7 @@ return [
     'name' => 'CustomGroup_Case_Opportunity_Details',
     'entity' => 'CustomGroup',
     'cleanup' => 'unused',
-    'update' => 'always',
+    'update' => 'unmodified',
     'params' => [
       'version' => 4,
       'values' => [
@@ -40,7 +40,7 @@ return [
     'name' => 'CustomGroup_Case_Opportunity_Details_CustomField_Total_Amount_Quoted',
     'entity' => 'CustomField',
     'cleanup' => 'unused',
-    'update' => 'always',
+    'update' => 'unmodified',
     'params' => [
       'version' => 4,
       'values' => [
@@ -79,7 +79,7 @@ return [
     'name' => 'CustomGroup_Case_Opportunity_Details_CustomField_Total_Amount_Invoiced',
     'entity' => 'CustomField',
     'cleanup' => 'unused',
-    'update' => 'always',
+    'update' => 'unmodified',
     'params' => [
       'version' => 4,
       'values' => [
@@ -118,7 +118,7 @@ return [
     'name' => 'CustomGroup_Case_Opportunity_Details_CustomField_Invoicing_Status',
     'entity' => 'CustomField',
     'cleanup' => 'unused',
-    'update' => 'always',
+    'update' => 'unmodified',
     'params' => [
       'version' => 4,
       'values' => [
@@ -157,7 +157,7 @@ return [
     'name' => 'CustomGroup_Case_Opportunity_Details_CustomField_Total_amounts_paid',
     'entity' => 'CustomField',
     'cleanup' => 'unused',
-    'update' => 'always',
+    'update' => 'unmodified',
     'params' => [
       'version' => 4,
       'values' => [
@@ -196,7 +196,7 @@ return [
     'name' => 'CustomGroup_Case_Opportunity_Details_CustomField_Payments_Status',
     'entity' => 'CustomField',
     'cleanup' => 'unused',
-    'update' => 'always',
+    'update' => 'unmodified',
     'params' => [
       'version' => 4,
       'values' => [


### PR DESCRIPTION
## Overview
Currently the case opportunity details custom group managed entity is setup with an update option of **always** which means that the if any client disables it then it will be automatically enabled upon civicrm cache clearance. To fix this issue this PR changes the update option to ** unmodified** which will only update the entity if it has not been edited by the client.
