### PR TITLE
CIVIMM-302: Ensure filters display appropriately

### DIFF
--- a/ang/civicase/case/list/directives/case-list-table.directive.html
+++ b/ang/civicase/case/list/directives/case-list-table.directive.html
@@ -124,3 +124,8 @@
     case-type-category="filters.case_type_category">
   </div>
 </div>
+<style>
+  #select2-drop.select2-with-searchbox {
+    min-width: fit-content !important;
+  }
+</style>


### PR DESCRIPTION
## Overview
This PR ensures filters select display option texts appropriately

## Before
<img width="420" alt="Screenshot 2025-05-05 at 16 26 03" src="https://github.com/user-attachments/assets/935787fd-2056-4858-9636-e54ba5cd3752" />


## After
<img width="472" alt="Screenshot 2025-05-05 at 16 28 42" src="https://github.com/user-attachments/assets/4b0c6755-f4b5-4d54-bbac-d9129daeac11" />
