### PR TITLE
CSTMM-149: Reset breadcrumbs when building settings

### DIFF
--- a/CRM/Civicase/Settings.php
+++ b/CRM/Civicase/Settings.php
@@ -10,6 +10,7 @@ use CRM_Civicase_Hook_Permissions_ExportCasesAndReports as ExportCasesAndReports
 use CRM_Civicase_Service_CaseCategoryCustomFieldsSetting as CaseCategoryCustomFieldsSetting;
 use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
 use CRM_Civicase_Service_CaseTypeCategoryFeatures as CaseTypeCategoryFeatures;
+use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 
 /**
  * Get a list of settings for angular pages.
@@ -38,6 +39,8 @@ class CRM_Civicase_Settings {
 
     OptionValuesHelper::setToJsVariables($options);
     NewCaseWebform::addWebformDataToOptions($options, $caseCategorySetting);
+
+    CaseCategoryHelper::updateBreadcrumbs($caseCategoryId);
     self::setCaseActions($options, $caseCategoryPermissions);
     self::setContactTasks($options);
     self::setCaseTypesToJsVars($options);


### PR DESCRIPTION
## Overview

This PR fixes the issue where case dashboard breadcrumb is navigating to CiviCase dashboard rather than Awards, Prospects, etc. dashboard, this is fixed by reseting the breadcrumbs when building the case type cateogry settings.

## Before
BreadCrumbs shows the default links

![aasasasasasasabefore](https://github.com/user-attachments/assets/2df1de70-d717-49e7-846b-2e62ac012acd)


## After
BreadCrumbs links corresponds to the current case type category 
![aaaaasas](https://github.com/user-attachments/assets/15f96c5d-3c81-42c9-91f8-34c607e11483)
