### PR TITLE
NEUSPRT-438: Prevent creating activities when previewing  PDF letter

### DIFF
--- a/js/create-pdf-form.js
+++ b/js/create-pdf-form.js
@@ -7,6 +7,12 @@
 
       $('body').off('submit', $form);
       $('body').on('submit', $form, openFileNamePopup);
+
+      // Update only the data-identifier on the button that already has it
+      $('button[data-identifier="buttons[_qf_PDF_submit_preview]"]').attr('data-identifier', '_qf_PDF_submit_preview');
+
+      // Update the name attribute on both buttons
+      $('button[name="buttons[_qf_PDF_submit_preview]"]').attr('name', '_qf_PDF_submit_preview');
     })();
 
     /**


### PR DESCRIPTION
## Overview

When a user creates a PDF letter and clicks the **Preview** button, CiviCRM currently treats it as a **Download** action. As a result:

* An activity record is created.
* The generated file is not marked with `_preview` in its filename.

This pull request resolves the issue by renaming the button’s action name to `_qf_PDF_submit_preview`. This allows core to properly recognise it as a preview action, not a download.

## Before

![kkkcivifguraalll](https://github.com/user-attachments/assets/6d5cd73c-b3ce-4965-ad16-9bc7aa2ad608)

## After

![civifguraa](https://github.com/user-attachments/assets/d0707cf3-8f3f-4373-a20d-b616f3f65fa3)
