### PR TITLE
FEMSSPRT-399: Copy Target Contacts While Moving Or Copying Activities To A Case

### DIFF
--- a/CRM/Civicase/APIHelpers/ActivityQueryApi.php
+++ b/CRM/Civicase/APIHelpers/ActivityQueryApi.php
@@ -105,4 +105,21 @@ class CRM_Civicase_APIHelpers_ActivityQueryApi {
     return $dao->fetchAll();
   }
 
+  /**
+   * Add target contacts of an activity to params array.
+   *
+   * @param int $activityId
+   *   Activity id.
+   * @param array $params
+   *   All case params.
+   */
+  public function addTargetContactsToParams(int $activityId, array &$params): void {
+    $recordTypes = CRM_Activity_BAO_ActivityContact::buildOptions('record_type_id', 'validate');
+    $targetID = CRM_Utils_Array::key('Activity Targets', $recordTypes);
+    $targetContactIds = array_keys(CRM_Activity_BAO_ActivityContact::getNames($activityId, $targetID));
+    if (!empty($targetContactIds)) {
+      $params['targetContactIds'] = implode(',', $targetContactIds);
+    }
+  }
+
 }

--- a/api/v3/Activity/Copybyquery.php
+++ b/api/v3/Activity/Copybyquery.php
@@ -71,6 +71,8 @@ function civicrm_api3_activity_copybyquery(array $params) {
       $caseActivityParams['newSubject'] = $params['subject'];
     }
 
+    $activityQueryApiHelper->addTargetContactsToParams($activityId, $caseActivityParams);
+
     $result = CRM_Activity_Page_AJAX::_convertToCaseActivity($caseActivityParams);
     if (empty($result['error_msg']) && !empty($result['newId'])) {
       $activityQueryApiHelper->transferActivityTags($activityId, $result['newId']);

--- a/api/v3/Activity/Movebyquery.php
+++ b/api/v3/Activity/Movebyquery.php
@@ -73,6 +73,8 @@ function civicrm_api3_activity_movebyquery(array $params) {
       $caseActivityParams['newSubject'] = $params['subject'];
     }
 
+    $activityQueryApiHelper->addTargetContactsToParams($activityId, $caseActivityParams);
+
     $result = CRM_Activity_Page_AJAX::_convertToCaseActivity($caseActivityParams);
     if (empty($result['error_msg']) && !empty($result['newId'])) {
       $activityIds[] = $result['newId'];


### PR DESCRIPTION
## Overview
This PR fixes a bug in moving/copying of activities to cases due to which the target contacts of activities were not being carried over while  moving/copying of activities.

## Before
![screen_recording_before](https://github.com/user-attachments/assets/6c9424d7-995e-4b7b-8c7a-af0b41e7595e)


## After

![screen_recording_after](https://github.com/user-attachments/assets/8ed0a739-aaa0-4dcf-83bf-3d2a1505f0cf)
