### PR TITLE
CIVIPLMMSR-474: Fix Case Webform Page

### DIFF
--- a/CRM/Civicase/Form/CaseWebforms.php
+++ b/CRM/Civicase/Form/CaseWebforms.php
@@ -1,11 +1,16 @@
 <?php
 
 /**
- * This class generates form components for Civicase webforms
+ * This class generates form components for Civicase webforms.
  */
 class CRM_Civicase_Form_CaseWebforms extends CRM_Admin_Form {
 
-  private $webforms = array();
+  /**
+   * The case related webforms.
+   *
+   * @var array
+   */
+  private $webforms = [];
 
   /**
    * Builds the form object.
@@ -14,13 +19,13 @@ class CRM_Civicase_Form_CaseWebforms extends CRM_Admin_Form {
     parent::buildQuickForm();
 
     $webforms = civicrm_api3('Case', 'getwebforms');
-    $errorMsg = null;
-    $webformids = array();
+    $errorMsg = NULL;
+    $webformids = [];
 
     if (isset($webforms['values']) && count($webforms['values'])) {
       foreach ($webforms['values'] as $item) {
-        $webformids[] = 'webforms_'.$item['nid'];
-        $this->add('checkbox', 'webforms_'.$item['nid'], $item['title']);
+        $webformids[] = 'webforms_' . $item['nid'];
+        $this->add('checkbox', 'webforms_' . $item['nid'], $item['title']);
         $this->webforms[$item['nid']] = $item;
       }
     }
@@ -36,17 +41,17 @@ class CRM_Civicase_Form_CaseWebforms extends CRM_Admin_Form {
     $this->assign('errorMsg', $errorMsg);
 
     $this->addButtons(
-      array(
-        array(
+      [
+        [
           'type' => 'cancel',
           'name' => ts('Cancel'),
-        ),
-        array(
+        ],
+        [
           'type' => 'submit',
           'name' => ts('Save'),
           'isDefault' => TRUE,
-        ),
-      )
+        ],
+      ]
     );
   }
 
@@ -69,11 +74,11 @@ class CRM_Civicase_Form_CaseWebforms extends CRM_Admin_Form {
   }
 
   /**
-   * postProcess function.
+   * PostProcess function.
    */
   public function postProcess() {
     $values = $this->getSubmitValues();
-    $items = array();
+    $items = [];
     foreach ($values as $k => $value) {
       if (strpos($k, 'webforms_') === 0) {
         $id = substr($k, 9);
@@ -82,6 +87,13 @@ class CRM_Civicase_Form_CaseWebforms extends CRM_Admin_Form {
     }
     Civi::settings()->set('civi_drupal_webforms', $items);
     CRM_Core_Session::setStatus(ts('Your changes have been saved successfully.'), 'Case Webforms', 'success');
+  }
+
+  /**
+   * Explicitly declare the entity api name.
+   */
+  public function getDefaultEntity() {
+    return 'Case';
   }
 
 }


### PR DESCRIPTION
## Overview
This PR fixes an error that restricted the user from accessing case webform page.

## Before
The page resulted in an error
<img width="1792" alt="Screenshot 2025-06-24 at 2 57 41 PM" src="https://github.com/user-attachments/assets/a36c2abc-b836-435d-a79d-c92d9a3bfb54" />


## After
The page is accessible
<img width="1792" alt="Screenshot 2025-06-24 at 2 57 23 PM" src="https://github.com/user-attachments/assets/74e585b9-351b-45ba-9dcc-03699912a988" />

## Technical Details
Any form that extends admin from and without its own preprocess method have to implement a method by the name of getDefaultEntity which was missing from this form and it has been added now. This issue existed from very long time but went unnoticed as this page is not used very frequently.
