### PR TITLE
CIVIMM-336: Cache CaseType look-ups and auto-purge on change

### DIFF
--- a/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
+++ b/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
@@ -1,5 +1,6 @@
 <?php
 
+use Civi\Api4\CaseType;
 use CRM_Civicase_ExtensionUtil as E;
 use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 use CRM_Civicase_Service_CaseCategorySetting as CaseCategorySetting;
@@ -38,21 +39,35 @@ class CRM_Civicase_Hook_Helper_CaseTypeCategory {
    *   The case type id's e.g [1, 2, 3]
    */
   public static function getCaseTypesForCategory($caseCategoryName) {
-    try {
-      $result = civicrm_api3('CaseType', 'get', [
-        'return' => ['id'],
-        'is_active' => 1,
-        'case_type_category' => $caseCategoryName,
-        'options' => ['limit' => 0],
-      ]);
+    if (!$caseCategoryName) {
+      return NULL;
+    }
 
-      if ($result['count'] == 0) {
-        return NULL;
+    try {
+      $cacheKey = 'civicase_case_type_for_' . $caseCategoryName;
+      $cache = \Civi::cache();
+      $ids = $cache->get($cacheKey);
+
+      if ($ids !== NULL) {
+        return $ids;
       }
 
-      return array_column($result['values'], 'id');
+      $rows = CaseType::get()
+        ->addSelect('id')
+        ->addFilter('case_type_category', $caseCategoryName)
+        ->addFilter('is_active', 1)
+        ->execute()
+        ->getArrayCopy();
+
+      $ids = !empty($rows) ? array_column($rows, 'id') : NULL;
+
+      // 0 = never expire; hook_post clears when a type changes.
+      $cache->set($cacheKey, $ids, 0);
+
+      return $ids;
     }
     catch (Exception $e) {
+      return NULL;
     }
 
   }

--- a/CRM/Civicase/Hook/Post/CaseTypeCache.php
+++ b/CRM/Civicase/Hook/Post/CaseTypeCache.php
@@ -1,0 +1,82 @@
+<?php
+
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * Flush cached case-type information whenever a CaseType changes.
+ */
+class CRM_Civicase_Hook_Post_CaseTypeCache {
+
+  private const JS_KEY     = 'civicase_js_var_case_types';
+  private const PREFIX_CAT = 'civicase_case_type_for_';
+
+  /**
+   * Run the hook.
+   *
+   * @param string $op
+   *   Operation: create|edit|delete|view.
+   * @param string $objectName
+   *   DAO/API entity name.
+   * @param int $objectId
+   *   Record ID (unused).
+   * @param object $objectRef
+   *   DAO reference (unused).
+   */
+  public function run(string $op, string $objectName, $objectId, &$objectRef): void {
+    if (!$this->shouldRun($op, $objectName)) {
+      return;
+    }
+
+    $cache = Civi::cache();
+
+    // Drop JS bootstrap blob.
+    $cache->delete(self::JS_KEY);
+
+    // Remove every “case_type_for_xxx” entry.
+    if (method_exists($cache, 'deleteByPattern')) {
+      $cache->deleteByPattern('/^' . self::PREFIX_CAT . '/');
+    }
+    else {
+      $this->purgeByPrefix($cache, self::PREFIX_CAT);
+    }
+  }
+
+  /**
+   * Delete all keys that start with a given prefix.
+   *
+   * @param Psr\SimpleCache\CacheInterface $cache
+   *   Cache pool.
+   * @param string $prefix
+   *   Key prefix.
+   */
+  private function purgeByPrefix(CacheInterface $cache, string $prefix): void {
+    if ($cache instanceof IteratorAggregate) {
+      foreach ($cache->getIterator() as $key => $unused) {
+        if (strpos($key, $prefix) === 0) {
+          $cache->delete($key);
+        }
+      }
+    }
+    else {
+      // Non-iterable backend – clear whole pool (tiny & safe).
+      $cache->clear();
+    }
+  }
+
+  /**
+   * Decide whether this hook should act.
+   *
+   * @param string $op
+   *   Operation name.
+   * @param string $objectName
+   *   Entity name.
+   *
+   * @return bool
+   *   TRUE when the entity is CaseType and $op mutates data.
+   */
+  private function shouldRun(string $op, string $objectName): bool {
+    return $objectName === 'CaseType'
+      && in_array($op, ['create', 'edit', 'delete'], TRUE);
+  }
+
+}

--- a/civicase.php
+++ b/civicase.php
@@ -275,6 +275,7 @@ function civicase_civicrm_post($op, $objectName, $objectId, &$objectRef) {
     new CRM_Civicase_Hook_Post_CaseCategoryCustomGroupSaver(),
     new CRM_Civicase_Hook_Post_UpdateCaseTypeListForCaseCategoryCustomGroup(),
     new CRM_Civicase_Hook_Post_LinkCase(),
+    new CRM_Civicase_Hook_Post_CaseTypeCache(),
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Overview

This PR implements caching for case-type lookups to improve performance and automatically purge stale data whenever a case type is modified.

It focuses on two methods:

- `getCaseTypesForCategory` in `CRM_Civicase_Hook_Helper_CaseTypeCategory`  
- `setCaseTypesToJsVars` in `CRM_Civicase_Settings`

These methods were chosen because they exhibited the slowest response times—especially under the v3 API format—according to our New Relic results.

## Before

Data was fetched on every single call.

## After

The case types in these two functions:

- `getCaseTypesForCategory` in `CRM_Civicase_Hook_Helper_CaseTypeCategory`  
- `setCaseTypesToJsVars` in `CRM_Civicase_Settings`  

are now cached unless a case type is modified or a new case type is created.

## Technical Details

- **API v3 → v4**  
  One of the functions that slowed response time was the v3 formatting call. This PR also migrates both methods from API v3 to API v4.

- **Caching layer**  
  - Switched both hot paths to the wrapped default pool via `\Civi::cache()`  
    ```php
    $cache = \Civi::cache();  // helper methods available
    ```  
  - Cache lifetime set to `0` (never expires)—the hook handles purging.

- **Cache keys**  
  - `civicase_js_var_case_types` — complete CaseType blob for Angular  
  - `civicase_case_type_for_<category>` — per-category ID lists

- **Automatic invalidation**  
  - New class `CRM_Civicase_Hook_Post_CaseTypeCache`  
    - Implements `hook_civicrm_post()` delegate  
    - Listens for `CaseType` **create**, **edit**, and **delete**  
    - Clears the two key families:  
      ```php
      $cache->delete('civicase_js_var_case_types');
      $cache->deleteByPattern('/^civicase_case_type_for_/');
      ```  
    - On Civi < 5.74 or non-wrapper back-ends, falls back to iterating keys or calling `clear()`.

- **Compatibility**  
  - Works on APCu, Redis, Memcache, and ArrayCache  
  - Gracefully skips `deleteByPattern()` on Civi < 5.74, using an iterator-based purge instead.  
