### PR TITLE
CIVIMM-338: Optimise OptionValue API calls

### DIFF
--- a/CRM/Civicase/Helper/CaseCategory.php
+++ b/CRM/Civicase/Helper/CaseCategory.php
@@ -38,6 +38,9 @@ class CRM_Civicase_Helper_CaseCategory {
     $result = civicrm_api3('OptionValue', 'get', [
       'sequential' => 1,
       'option_group_id' => self::CASE_TYPE_CATEGORY_GROUP_NAME,
+      'options' => [
+        'cache' => TRUE,
+      ],
     ]);
 
     return $result['values'];
@@ -134,6 +137,7 @@ class CRM_Civicase_Helper_CaseCategory {
       $result = civicrm_api3('OptionValue', 'getsingle', [
         'option_group_id' => 'case_type_category_word_replacement_class',
         'name' => $optionName,
+        'options' => ['cache' => TRUE],
       ]);
 
     }
@@ -422,6 +426,7 @@ class CRM_Civicase_Helper_CaseCategory {
     $apiParams = [
       'sequential' => 1,
       'option_group_id' => 'case_type_categories',
+      'options' => ['cache' => TRUE],
     ];
     $apiParams = array_merge($apiParams, $params);
     $result = civicrm_api3('OptionValue', 'get', $apiParams);
@@ -440,6 +445,7 @@ class CRM_Civicase_Helper_CaseCategory {
       'sequential' => 1,
       'option_group_id' => 'case_type_categories',
       'name' => self::CASE_TYPE_CATEGORY_NAME,
+      'options' => ['cache' => TRUE],
       'return' => ['value'],
     ]);
 

--- a/CRM/Civicase/Helper/OptionValues.php
+++ b/CRM/Civicase/Helper/OptionValues.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * CRM_Civicase_Helper_OptionValues class.
+ * OptionValue Helper class with useful functions that sets JS variables.
  */
 class CRM_Civicase_Helper_OptionValues {
 
@@ -16,7 +16,11 @@ class CRM_Civicase_Helper_OptionValues {
           'is_active', 'weight', 'filter',
         ],
         'option_group_id' => $option,
-        'options' => ['limit' => 0, 'sort' => 'weight'],
+        'options' => [
+          'limit' => 0,
+          'sort' => 'weight',
+          'cache' => TRUE,
+        ],
       ]);
       $option = [];
       foreach ($result['values'] as $item) {

--- a/CRM/Civicase/Hook/Tabset/CaseCategoryTabAdd.php
+++ b/CRM/Civicase/Hook/Tabset/CaseCategoryTabAdd.php
@@ -51,6 +51,9 @@ class CRM_Civicase_Hook_Tabset_CaseCategoryTabAdd {
     $result = civicrm_api3('OptionValue', 'get', [
       'option_group_id' => 'case_type_categories',
       'is_active' => 1,
+      'options' => [
+        'cache' => TRUE,
+      ],
     ]);
 
     if (empty($result['values'])) {

--- a/CRM/Civicase/Settings.php
+++ b/CRM/Civicase/Settings.php
@@ -1,7 +1,6 @@
 <?php
 
 use Civi\Api4\CaseType;
-use Civi\Api4\OptionValue;
 use Civi\CCase\Utils;
 use Civi\Utils\CurrencyUtils;
 use CRM_Civicase_Helper_CaseUrl as CaseUrlHelper;
@@ -367,7 +366,7 @@ class CRM_Civicase_Settings {
     $caseCategories = civicrm_api3('OptionValue', 'get', [
       'is_sequential' => '1',
       'option_group_id' => 'case_type_categories',
-      'options' => ['limit' => 0],
+      'options' => ['limit' => 0, 'cache' => TRUE],
     ]);
 
     foreach ($caseCategories['values'] as &$caseCategory) {
@@ -411,12 +410,15 @@ class CRM_Civicase_Settings {
    *   List of options to pass to the front-end.
    */
   public static function setCaseSalesOrderStatus(array &$options): void {
-    $optionValues = OptionValue::get(FALSE)
-      ->addSelect('id', 'value', 'name', 'label')
-      ->addWhere('option_group_id:name', '=', 'case_sales_order_status')
-      ->execute();
+    $result = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'case_sales_order_status',
+      'return' => ['id', 'value', 'name', 'label'],
+      'options' => ['cache' => TRUE],
+      'sequential' => 1,
+    ]);
 
-    $options['salesOrderStatus'] = $optionValues->getArrayCopy();
+    // The API puts the rows under $result['values'].
+    $options['salesOrderStatus'] = $result['values'];
   }
 
 }


### PR DESCRIPTION
## Overview

CiviCRM’s [Developer Guide](https://docs.civicrm.org/dev/en/latest/framework/pseudoconstant/#pseudoconstant-option-list-reference)  notes that option lists can be cached when the call includes the v3 flag

```php
'options' => ['cache' => TRUE]
```

This PR applies that flag to all OptionValue API calls, which also replaces v4 calls with v3 queries using the cache flag, removing redundant DB traffic.

## Before
Every OptionValue API call hit the database each time it was executed.

## After
OptionValue results are now served from cache, eliminating the repeat database query.

## Technical Details 

The `crmCiviCase` Angular module is loaded on Contact pages, and that module instructs CiviCRM to execute `CRM_Civicase_Settings::getAll()`.

`getAll()` chains a series of helper methods that populate page-wide settings and look-up tables—many of which call the OptionValue API.

By switching those OptionValue calls to v3 with `'options' => ['cache' => TRUE]`, the data now comes from CiviCRM’s cache. This means the database is hit only once per cache lifetime instead of on every page view.

### Why the module is loaded on Contact ▶ Summary

The **Contact Summary** template embeds several Angular widgets that belong to the same module (e.g., the open-case list, sales-order block, activity feed, etc.):

```html
<div ng-app="crmCiviCase">
  <civi-case-summary cid="{$contactId}"></civi-case-summary>
</div>
```

When the browser encounters `ng-app="crmCiviCase",` it loads the` crmCiviCase `resources. This in turn triggers the module’s settingsFactory—and therefore CRM_Civicase_Settings::getAll()—even though the user is not on the Case Dashboard screen.