### PR TITLE
CIVIMM-364: Optimize Word Replacements For Case Type Categories

### DIFF
--- a/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
+++ b/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
@@ -85,9 +85,22 @@ class CRM_Civicase_Hook_Helper_CaseTypeCategory {
       return;
     }
 
-    CRM_Core_Resources::singleton()->flushStrings()->resetCacheCode();
-    CRM_Core_Session::singleton()->set('current_case_category', $caseCategoryName);
-    $wordReplacements = CaseCategoryHelper::getWordReplacements($caseCategoryName);
+    $currentCaseCategory = CRM_Core_Session::singleton()->get('current_case_category');
+    if ($currentCaseCategory !== $caseCategoryName) {
+      CRM_Core_Resources::singleton()->flushStrings()->resetCacheCode();
+      CRM_Core_Session::singleton()->set('current_case_category', $caseCategoryName);
+    }
+
+    $cacheKey = 'civicase_word_replacement_for_' . $caseCategoryName;
+    $cache = \Civi::cache();
+    $wordReplacements = $cache->get($cacheKey);
+
+    if ($wordReplacements === NULL) {
+      $wordReplacements = CaseCategoryHelper::getWordReplacements($caseCategoryName);
+      // A month.
+      $cache->set($cacheKey, $wordReplacements, 60 * 60 * 24 * 30);
+    }
+
     if (empty($wordReplacements)) {
       return;
     }


### PR DESCRIPTION
## Overview
This PR optimizes the word replacements for case categories by doing following two things

- Dont refresh cache on each page load i.e once user opens a page related to a case type category we cache resources and it will only be refreshed when user changes case type category but currently each page load even within same case type category results in cache regeneration.
- Add the word replacements to a cache for each category for one month.
