### PR TITLE
RSESPRT-397: Exclude deleted case from case count

### DIFF
--- a/CRM/Civicase/Helper/CaseCategory.php
+++ b/CRM/Civicase/Helper/CaseCategory.php
@@ -218,6 +218,7 @@ class CRM_Civicase_Helper_CaseCategory {
                                          AND ov.value          = ct.case_type_category
                                          AND ov.is_active      = 1
       WHERE cc.contact_id = %1
+        AND c.is_deleted = 0
       GROUP BY ov.name
       ORDER BY ov.name
     ";


### PR DESCRIPTION
## Overview
When a case is deleted, we discovered that the case count on the contact tab doesn't correctly reflect the case count.

This issue is becasue the case_count querey does not exclude case deleted from the count.

## Before
<img width="1524" height="340" alt="image" src="https://github.com/user-attachments/assets/e99893e5-f538-4a81-baf3-7cae563ab76a" />



## After
<img width="1550" height="382" alt="image" src="https://github.com/user-attachments/assets/e745743a-b16d-42eb-93a3-79887eeee367" />
