### PR TITLE
CIVIPLMMI-225: Fix activity filter dropdown text persisting from previous case instances

### DIFF
--- a/ang/civicase/activity/filters/directives/activity-filters.directive.js
+++ b/ang/civicase/activity/filters/directives/activity-filters.directive.js
@@ -3,7 +3,7 @@
 
   module.directive('civicaseActivityFilters', function ($rootScope, $timeout, ts,
     ActivityCategory, ActivityStatus, ActivityType, CustomActivityField,
-    CaseTypeCategory) {
+    CaseTypeCategory, CaseTypeCategoryTranslationService, UrlParameters) {
     return {
       restrict: 'A',
       scope: {
@@ -47,6 +47,20 @@
       $scope.showIncludeCasesOption = showIncludeCasesOption;
 
       (function init () {
+        // Get the current case type category from URL and restore its translations
+        // This ensures the activity filters show the correct context-specific text
+        var urlParams = UrlParameters.parse(window.location.href);
+        var currentCaseTypeCategory = urlParams.case_type_category || 'Cases';
+
+        // Find the category and restore its translations
+        var currentCategory = _.find($scope.caseTypeCategories, function (category) {
+          return category.name === currentCaseTypeCategory;
+        });
+
+        if (currentCategory) {
+          CaseTypeCategoryTranslationService.restoreTranslation(currentCategory.value);
+        }
+
         if ($scope.canSelectCaseTypeCategory) {
           $scope.filters.case_type_category = $scope.caseTypeCategories[0].name;
         }


### PR DESCRIPTION
## Overview
  Fix inconsistent text in the activity filters dropdown that was persisting from previously visited case category instances.

  ## Before
  When users visited different case category instances (like "impacts") and then navigated to the Activities tab, the dropdown would incorrectly show instance-specific text like "Show impacts activities" instead of the expected "Show case activities". This happened because word replacements from previous instances were persisting across different contexts.
  
![before](https://github.com/user-attachments/assets/86946c11-e5fb-49dd-a3f2-d6db7b90be6c)


  ## After
  The dropdown now consistently shows the correct text based on the current URL context:
  - On the default Activities tab: "Show case activities"
  - Text no longer persists incorrectly from previously visited instances
  
  
![after](https://github.com/user-attachments/assets/1d1bc3ad-09d4-4148-949d-a4de1d91c625)


  ## Technical Details
  The issue was caused by CiviCase's word replacement system storing and persisting translations across different contexts. The fix ensures translations are
  properly restored based on the current URL context.

  **Changes made:**
  1. Added `UrlParameters` service dependency to `activity-filters.directive.js`
  2. Enhanced the directive's `init()` function to:
     - Parse the current `case_type_category` from the URL fragment using `UrlParameters.parse()`
     - Find the corresponding category object from available case type categories
     - Restore appropriate translations using `CaseTypeCategoryTranslationService.restoreTranslation()`

  This follows the same pattern used in `handleContactTabChange` for consistent translation management across case category contexts.



