### PR TITLE
NEUSPRT-490: Fix Pdf Form Buttons

### DIFF
--- a/js/create-pdf-form.js
+++ b/js/create-pdf-form.js
@@ -5,6 +5,15 @@
     (function init () {
       var $form = $('.CRM_Contact_Form_Task_PDF');
 
+      if ($form.length) {
+        $form.on('click', 'button[name="_qf_PDF_submit_preview"]', function () {
+          // delaying it by 100ms so that it runs after the form submit handler in misc/form-single-submit.js
+          setTimeout(function () {
+            $form.attr('data-drupal-form-submit-last', '');
+          }, 100);
+        });
+      }
+
       $('body').off('submit', $form);
       $('body').on('submit', $form, openFileNamePopup);
 


### PR DESCRIPTION
## Overview
This PR fixes an issue on create pdf form due to which users were not able to save draft or download document after previewing the document.

## Before
![screen_recording_after](https://github.com/user-attachments/assets/e81aa036-f180-4eb8-bdc7-7119f5f18715)

## After
![screen_recording_before](https://github.com/user-attachments/assets/6ba7dddc-5438-4a07-b202-97f73886b4d8)

## Technical Details
This issue was caused by form submit handler in drupal defined in misc/form-single-submit.js which was designed to prevent submitting the form with exact same values multiple times. But preview should be allowed multiple times so this PR clears out the `data-drupal-form-submit-last` attribute on form so that user can submit the preview multiple times and also be able to submit the form with other buttons after preview.