### PR TITLE
NEUSPRT-496: Fix empty case type dropdowns in CiviCase filtering and actions

### DIFF
--- a/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
+++ b/CRM/Civicase/Hook/Helper/CaseTypeCategory.php
@@ -52,9 +52,18 @@ class CRM_Civicase_Hook_Helper_CaseTypeCategory {
         return $ids;
       }
 
+      // Convert category name to category ID/value for comparison.
+      $caseCategoryOptions = CRM_Case_BAO_CaseType::buildOptions('case_type_category', 'validate');
+      $caseCategoryId = array_search($caseCategoryName, $caseCategoryOptions);
+
+      if ($caseCategoryId === FALSE) {
+        // Category name not found, return empty array.
+        return [];
+      }
+
       $rows = CaseType::get(FALSE)
         ->addSelect('id')
-        ->addWhere('case_type_category', '=', $caseCategoryName)
+        ->addWhere('case_type_category', '=', $caseCategoryId)
         ->addWhere('is_active', '=', 1)
         ->execute()
         ->getArrayCopy();


### PR DESCRIPTION
## Overview
This PR fixes the issue with empty case type dropdowns that prevented users from changing case types. The Case Type filters were not showing any options despite case types being available in the system.

## Before
The Case Type filter dropdown was empty on the manage case page
<img width="1323" height="519" alt="Screenshot 2025-10-01 at 09 03 14" src="https://github.com/user-attachments/assets/43b4f9f7-0677-45ac-b321-1a3ca287a341" />


## After
All case type filter dropdowns now populate correctly with available case types
<img width="884" height="514" alt="Screenshot 2025-10-01 at 09 22 43" src="https://github.com/user-attachments/assets/94f24bd3-42f3-4721-9759-b31b7b3f0bcd" />


## Technical Details
The core issue was in the `getCaseTypesForCategory()` method of the Case Type Helper (`CRM/Civicase/Hook/Helper/CaseTypeCategory.php`), which handles fetching Case Types in **"Change Application Type"** and similar actions. The method was comparing numeric category IDs with category names:

```php
// This was failing - comparing number (1,2,3,4) with string ("Applications")
->addWhere('case_type_category', '=', $caseCategoryName)
```

#### Fix

Added proper name-to-ID conversion:

```php
// Convert category name to category ID/value for comparison
$caseCategoryOptions = CRM_Case_BAO_CaseType::buildOptions('case_type_category', 'validate');
$caseCategoryId = array_search($caseCategoryName, $caseCategoryOptions);

if ($caseCategoryId === FALSE) {
    // Category name not found, return empty array
    return [];
}

// Now compare with the correct numeric ID
->addWhere('case_type_category', '=', $caseCategoryId)
```

This ensures the database query correctly matches case types to their categories, fixing the **empty dropdown issue** in "Change Case Type" actions.
