### PR TITLE
COMCL-1395: Fix Api Permissions For Case Categories

### DIFF
--- a/CRM/Civicase/Hook/AlterAPIPermissions/CaseCategory.php
+++ b/CRM/Civicase/Hook/AlterAPIPermissions/CaseCategory.php
@@ -4,9 +4,9 @@ use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
 
 /**
- * Class CRM_Civicase_Hook_APIPermissions_alterPermissions.
+ * Adds api permissions for different case categories.
  */
-class CRM_Civicase_Hook_alterAPIPermissions_CaseCategory {
+class CRM_Civicase_Hook_AlterAPIPermissions_CaseCategory {
 
   /**
    * Case category name.
@@ -145,8 +145,41 @@ class CRM_Civicase_Hook_alterAPIPermissions_CaseCategory {
     }
 
     if ($entity == 'custom_value' && ($action == 'gettreevalues' || $action == 'getalltreevalues')) {
+      return $this->getCaseCategoryNameForCustomValueEntity($params);
+    }
+  }
+
+  /**
+   * Returns case category name for custom value entities.
+   *
+   * @param array $params
+   *   API parameters.
+   *
+   * @return string|null
+   *   Case category name.
+   */
+  private function getCaseCategoryNameForCustomValueEntity(array $params): ?string {
+    if (empty($params['entity_type']) || $params['entity_type'] === 'Case') {
       return $this->getCaseCategoryNameFromCaseId($params, 'entity_id');
     }
+
+    if ($params['entity_type'] !== 'Activity' || empty($params['entity_id']) || !is_numeric($params['entity_id'])) {
+      return NULL;
+    }
+
+    $caseActivity = civicrm_api4('CaseActivity', 'get', [
+      'select' => ['case_id'],
+      'where' => [['activity_id', '=', (int) $params['entity_id']]],
+      'orderBy' => ['case_id' => 'ASC'],
+      'limit' => 1,
+      'checkPermissions' => FALSE,
+    ])->first();
+
+    if (empty($caseActivity['case_id'])) {
+      return NULL;
+    }
+
+    return CaseCategoryHelper::getCategoryName($caseActivity['case_id']);
   }
 
   /**

--- a/CRM/Civicase/Hook/AlterAPIPermissions/CaseGetList.php
+++ b/CRM/Civicase/Hook/AlterAPIPermissions/CaseGetList.php
@@ -4,9 +4,9 @@ use CRM_Civicase_Helper_CaseCategory as CaseCategoryHelper;
 use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
 
 /**
- * Class CRM_Civicase_Hook_alterAPIPermissions_CaseGetList.
+ * Adds api permissions for case.getList api.
  */
-class CRM_Civicase_Hook_alterAPIPermissions_CaseGetList {
+class CRM_Civicase_Hook_AlterAPIPermissions_CaseGetList {
 
   /**
    * Alters the API permissions.

--- a/civicase.php
+++ b/civicase.php
@@ -394,8 +394,8 @@ function civicase_civicrm_apiWrappers(&$wrappers, $apiRequest) {
  */
 function civicase_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
   $hooks = [
-    new CRM_Civicase_Hook_alterAPIPermissions_CaseCategory(),
-    new CRM_Civicase_Hook_alterAPIPermissions_CaseGetList(),
+    new CRM_Civicase_Hook_AlterAPIPermissions_CaseCategory(),
+    new CRM_Civicase_Hook_AlterAPIPermissions_CaseGetList(),
   ];
 
   foreach ($hooks as $hook) {

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -7,6 +7,7 @@
     <!-- Hence the following rules are excluded -->
     <exclude name="Drupal.NamingConventions.ValidClassName.NoUnderscores"/>
     <exclude name="Drupal.Classes.ClassFileName.NoMatch"/>
+    <exclude name="Squiz.Classes.ClassFileName.NoMatch"/>
     <!--Drupal expects function names like civicase_civicrm_pre_process but civi can have-->
     <!--civicase_civicrm_preProcess which is valid for civi.-->
     <exclude name="Drupal.NamingConventions.ValidFunctionName.InvalidName"/>

--- a/tests/phpunit/CRM/Civicase/Hook/alterAPIPermissions/CaseCategoryTest.php
+++ b/tests/phpunit/CRM/Civicase/Hook/alterAPIPermissions/CaseCategoryTest.php
@@ -1,0 +1,246 @@
+<?php
+
+use CRM_Civicase_Hook_AlterAPIPermissions_CaseCategory as CaseCategoryAlterApiPermissions;
+use CRM_Civicase_Service_CaseCategoryPermission as CaseCategoryPermission;
+use CRM_Civicase_Test_Fabricator_Case as CaseFabricator;
+use CRM_Civicase_Test_Fabricator_CaseType as CaseTypeFabricator;
+
+/**
+ * Tests for case category API permission alterations.
+ *
+ * @group headless
+ */
+class CRM_Civicase_Hook_AlterAPIPermissions_CaseCategoryTest extends BaseHeadlessTest {
+
+  /**
+   * Tests activity entity resolves case category using CaseActivity mapping.
+   */
+  public function testActivityEntityTypeWithLinkedCaseUsesLinkedCaseCategoryPermissions() {
+    $fixtures = $this->createFixtures();
+
+    try {
+      $permissions = $this->getInitialPermissions();
+      $params = [
+        'entity_type' => 'Activity',
+        'entity_id' => $fixtures['linkedActivityId'],
+      ];
+
+      (new CaseCategoryAlterApiPermissions())->run('custom_value', 'gettreevalues', $params, $permissions);
+
+      $this->assertEquals(
+        (new CaseCategoryPermission())->getBasicCasePermissions($fixtures['caseCategoryName']),
+        $permissions['custom_value']['gettreevalues'][0]
+      );
+    }
+    finally {
+      $this->cleanupFixtures($fixtures);
+    }
+  }
+
+  /**
+   * Tests activity with no linked case returns default category permissions.
+   */
+  public function testActivityEntityTypeWithoutLinkedCaseReturnsDefaultPermissions() {
+    $fixtures = $this->createFixtures();
+
+    try {
+      $permissions = $this->getInitialPermissions();
+      $params = [
+        'entity_type' => 'Activity',
+        'entity_id' => $fixtures['unlinkedActivityId'],
+      ];
+
+      (new CaseCategoryAlterApiPermissions())->run('custom_value', 'gettreevalues', $params, $permissions);
+
+      $this->assertEquals(
+        (new CaseCategoryPermission())->getBasicCasePermissions(NULL),
+        $permissions['custom_value']['gettreevalues'][0]
+      );
+    }
+    finally {
+      $this->cleanupFixtures($fixtures);
+    }
+  }
+
+  /**
+   * Tests unsupported entity type returns default category permissions.
+   */
+  public function testUnsupportedEntityTypeReturnsDefaultPermissions() {
+    $fixtures = $this->createFixtures();
+
+    try {
+      $permissions = $this->getInitialPermissions();
+      $params = [
+        'entity_type' => 'Contact',
+        'entity_id' => 1,
+      ];
+
+      (new CaseCategoryAlterApiPermissions())->run('custom_value', 'gettreevalues', $params, $permissions);
+
+      $this->assertEquals(
+        (new CaseCategoryPermission())->getBasicCasePermissions(NULL),
+        $permissions['custom_value']['gettreevalues'][0]
+      );
+    }
+    finally {
+      $this->cleanupFixtures($fixtures);
+    }
+  }
+
+  /**
+   * Tests missing entity type falls back to legacy behavior.
+   */
+  public function testMissingEntityTypeFallsBackToLegacyCaseIdBehavior() {
+    $fixtures = $this->createFixtures();
+
+    try {
+      $permissions = $this->getInitialPermissions();
+      $params = [
+        'entity_id' => $fixtures['caseId'],
+      ];
+
+      (new CaseCategoryAlterApiPermissions())->run('custom_value', 'gettreevalues', $params, $permissions);
+
+      $this->assertEquals(
+        (new CaseCategoryPermission())->getBasicCasePermissions($fixtures['caseCategoryName']),
+        $permissions['custom_value']['gettreevalues'][0]
+      );
+    }
+    finally {
+      $this->cleanupFixtures($fixtures);
+    }
+  }
+
+  /**
+   * Create all fixture data required for a test.
+   *
+   * @return array
+   *   Fixture identifiers.
+   */
+  private function createFixtures() {
+    $testSuffix = strtolower(substr(md5(__METHOD__ . microtime(TRUE) . mt_rand()), 0, 12));
+
+    $caseCategoryResult = civicrm_api3('OptionValue', 'create', [
+      'option_group_id' => 'case_type_categories',
+      'name' => "test_award_{$testSuffix}",
+      'label' => "Test Award {$testSuffix}",
+      'is_active' => 1,
+    ]);
+    $caseCategory = $this->getApi3Entity($caseCategoryResult);
+
+    $caseType = CaseTypeFabricator::fabricate([
+      'name' => "test_award_case_type_{$testSuffix}",
+      'title' => "Test Award Case Type {$testSuffix}",
+      'case_type_category' => $caseCategory['value'],
+    ]);
+
+    $contactResult = civicrm_api3('Contact', 'create', [
+      'contact_type' => 'Individual',
+      'first_name' => 'CaseCategory',
+      'last_name' => "Test",
+      'email' => "casecategory@example.org",
+    ]);
+    $contact = $this->getApi3Entity($contactResult);
+
+    $case = CaseFabricator::fabricate([
+      'case_type_id' => $caseType['id'],
+      'contact_id' => $contact['id'],
+      'creator_id' => $contact['id'],
+    ]);
+
+    $linkedActivityResult = civicrm_api3('Activity', 'create', [
+      'case_id' => $case['id'],
+      'source_contact_id' => $contact['id'],
+      'activity_type_id' => 'Assign Case Role',
+      'subject' => "Linked activity {$testSuffix}",
+    ]);
+    $linkedActivity = $this->getApi3Entity($linkedActivityResult);
+
+    $unlinkedActivityResult = civicrm_api3('Activity', 'create', [
+      'source_contact_id' => $contact['id'],
+      'activity_type_id' => 'Meeting',
+      'subject' => "Unlinked activity {$testSuffix}",
+    ]);
+    $unlinkedActivity = $this->getApi3Entity($unlinkedActivityResult);
+
+    return [
+      'caseCategoryId' => $caseCategory['id'],
+      'caseCategoryName' => $caseCategory['name'],
+      'caseTypeId' => $caseType['id'],
+      'contactId' => $contact['id'],
+      'caseId' => $case['id'],
+      'linkedActivityId' => $linkedActivity['id'],
+      'unlinkedActivityId' => $unlinkedActivity['id'],
+    ];
+  }
+
+  /**
+   * Cleanup fixture data.
+   *
+   * @param array $fixtures
+   *   Fixture identifiers.
+   */
+  private function cleanupFixtures(array $fixtures) {
+    foreach (['linkedActivityId', 'unlinkedActivityId'] as $activityKey) {
+      if (!empty($fixtures[$activityKey])) {
+        civicrm_api3('Activity', 'delete', ['id' => $fixtures[$activityKey]]);
+      }
+    }
+
+    if (!empty($fixtures['caseId'])) {
+      civicrm_api3('Case', 'delete', ['id' => $fixtures['caseId']]);
+    }
+
+    if (!empty($fixtures['caseTypeId'])) {
+      civicrm_api3('CaseType', 'delete', ['id' => $fixtures['caseTypeId']]);
+    }
+
+    if (!empty($fixtures['contactId'])) {
+      civicrm_api3('Contact', 'delete', ['id' => $fixtures['contactId']]);
+    }
+
+    if (!empty($fixtures['caseCategoryId'])) {
+      civicrm_api3('OptionValue', 'delete', ['id' => $fixtures['caseCategoryId']]);
+    }
+  }
+
+  /**
+   * Returns the first entity payload from an API3 response.
+   *
+   * @param array $result
+   *   API3 response.
+   *
+   * @return array
+   *   Entity payload.
+   */
+  private function getApi3Entity(array $result) {
+    if (!empty($result['values']) && is_array($result['values'])) {
+      return (array) array_shift($result['values']);
+    }
+
+    return $result;
+  }
+
+  /**
+   * Returns initial permissions array expected by hook.
+   *
+   * @return array
+   *   The permissions array.
+   */
+  private function getInitialPermissions() {
+    return [
+      'default' => ['default' => ['access CiviCRM']],
+      'case' => [
+        'create' => ['add cases'],
+        'delete' => ['delete in CiviCase'],
+      ],
+      'relationship_type' => [
+        'get' => [['access CiviCRM']],
+      ],
+      'custom_value' => [
+        'gettreevalues' => [['access CiviCRM']],
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR fixes case-category permission resolution for CustomValue tree APIs when the custom values are attached to Activity records instead of Case records.

Previously, custom_value.gettreevalues / custom_value.getalltreevalues permission handling assumed entity_id was always a case ID. In review flows, entity_type is often Activity, so this could resolve the wrong category and trigger authorization failures for unrelated case-type categories. The fix introduces entity-aware category resolution for this path. 

## Technical Details
1) Route custom_value permission resolution through a dedicated helper
For custom_value + (gettreevalues or getalltreevalues), permissions now resolve case category via getCaseCategoryNameForCustomValueEntity($params) rather than directly using entity_id as a case ID. 

2) Entity-aware category resolution behavior
getCaseCategoryNameForCustomValueEntity() now handles:

- No entity_type provided: fallback to legacy behavior (entity_id treated as case ID). 
- entity_type = Case: resolve category directly from case ID. 
- entity_type = Activity: map activity → case via API4 CaseActivity.get, then resolve case category from the resulting case_id. 
- Invalid/missing input: return early to avoid incorrect category assumptions. 

## Example
Given a request like:
```
{
  "entity_type": "Activity",
  "entity_id": 1234
}
```
The resolver now:

- fetches case_id from CaseActivity where activity_id = 1234,
- resolves category from that case_id,
- applies the correct category-scoped permissions.
- (Previously, it could treat 1234 as a case ID directly.)