### PR TITLE
CIVIPLMMSR-596: Fix Case Detail Field Type

### DIFF
--- a/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
+++ b/ang/civicase/case/contact-case-tab/directives/contact-case-tab-case-details.directive.html
@@ -108,13 +108,14 @@
           class="civicase__summary-tab__description crm-entity"
           data-entity="Case"
           data-id="{{ item.id }}">
-          <p
+          <div
             ng-if="item['case_type_id.is_active'] !== '0'"
             crm-editable="item"
             data-field="details"
             data-type="textarea"
+            data-rich-text="true"
             data-placeholder="{{ ts('This case doesn\'t currently have a description. Click here to add now.') }}">
-          </p>
+          </div>
           <div
             ng-if="item['case_type_id.is_active'] === '0'"
             ng-bind-html="trustAsHtml(item.details)"

--- a/ang/civicase/case/details/summary-tab/directives/case-summary.directive.html
+++ b/ang/civicase/case/details/summary-tab/directives/case-summary.directive.html
@@ -13,13 +13,14 @@
         <p ng-if="item['case_type_id.is_active'] === '0'" ng-bind-html="item.subject"></p>
       </div>
       <div class="civicase__summary-tab__description">
-        <p
+        <div
           ng-if="item['case_type_id.is_active'] !== '0'"
           crm-editable="item"
           data-field="details"
           data-type="textarea"
+          data-rich-text="true"
           data-placeholder="{{ ts('This case doesn\'t currently have a description. Click here to add now.') }}">
-        </p>
+        </div>
         <div
           ng-if="item['case_type_id.is_active'] === '0'"
           ng-bind-html="trustAsHtml(item.details)"

--- a/ang/civicase/shared/directives/crm-editable.directive.js
+++ b/ang/civicase/shared/directives/crm-editable.directive.js
@@ -25,13 +25,12 @@
       CRM.loadScript(CRM.config.resourceBase + 'js/jquery/jquery.crmEditable.js')
         .done(function () {
           var textarea = elem.data('type') === 'textarea';
+          var richText = elem.data('rich-text') === true ||
+            elem.data('rich-text') === 'true' ||
+            elem.data('type') === 'wysiwyg';
           var field = elem.data('field');
           elem
-            .html(
-              textarea
-                ? nl2br(getHTMLToShow(scope, elem, attrs))
-                : getHTMLToShow(scope, elem, attrs)
-            )
+            .html(getDisplayHTML(scope, elem, attrs, textarea, richText))
             .on('crmFormSuccess', function (e, value) {
               $timeout(function () {
                 scope.$apply(function () {
@@ -39,20 +38,294 @@
                 });
                 applyLineLimitIfApplicableWithTimeout(scope, elem);
               });
-            })
-            .crmEditable();
+            });
 
-          scope.$watchCollection('model', function (model) {
-            elem.html(
-              textarea
-                ? nl2br(getHTMLToShow(scope, elem, attrs))
-                : getHTMLToShow(scope, elem, attrs));
+          if (richText) {
+            setUpRichTextEditing(scope, elem, attrs, field);
+          } else {
+            elem.crmEditable();
+          }
+
+          scope.$watchCollection('model', function () {
+            // Don't blow away the editor if the user is currently editing.
+            if (elem.hasClass('civicase__rich-text-editing')) {
+              return;
+            }
+            elem.html(getDisplayHTML(scope, elem, attrs, textarea, richText));
 
             applyLineLimitIfApplicableWithTimeout(scope, elem);
           });
 
           applyLineLimitIfApplicableWithTimeout(scope, elem);
         });
+    }
+
+    /**
+     * Sets up rich-text inline editing for the given element
+     *
+     * @param {object} scope scope of the directive
+     * @param {object} elem element
+     * @param {object} attrs attributes
+     * @param {string} field the model field name being edited
+     */
+    function setUpRichTextEditing (scope, elem, attrs, field) {
+      elem.addClass('crm-editable crm-editable-enabled civicase__rich-text-editable');
+      if (!elem.attr('title')) {
+        elem.attr('title', ts('Click to edit'));
+      }
+
+      elem.on('click.civicaseRichTextEdit', function (event) {
+        if (elem.hasClass('civicase__rich-text-editing') ||
+          $(event.target).closest('a, button, input, textarea, select').length) {
+          return;
+        }
+
+        event.preventDefault();
+        startRichTextEdit(scope, elem, attrs, field);
+      });
+    }
+
+    /**
+     * Replaces the element's contents with a CKEditor instance pre-populated with the current value.
+     *
+     * @param {object} scope scope of the directive
+     * @param {object} elem element
+     * @param {object} attrs attributes
+     * @param {string} field the model field name being edited
+     */
+    function startRichTextEdit (scope, elem, attrs, field) {
+      var info = elem.crmEditableEntity();
+
+      if (!info || !info.entity || !info.id) {
+        return;
+      }
+
+      var originalValue = scope.model[field] || '';
+      var escapedInitial = $('<div>').text(originalValue).html();
+      var editorId = 'civicase-rich-text-' + info.entity + '-' + info.id +
+        '-' + field + '-' + Date.now();
+      var editorLabel = elem.data('label') ||
+        attrs.placeholder ||
+        field;
+      var $form = $(
+        '<div class="civicase__rich-text-form">' +
+          '<label class="sr-only" for="' + editorId + '">' +
+            _.escape(editorLabel) +
+          '</label>' +
+          '<textarea class="crm-form-wysiwyg" id="' + editorId + '" ' +
+            'name="' + _.escape(field) + '" ' +
+            'aria-label="' + _.escape(editorLabel) + '" ' +
+            'rows="6">' + escapedInitial + '</textarea>' +
+          '<div class="civicase__rich-text-form__actions" ' +
+            'style="margin-top: 6px; text-align: right;">' +
+            '<button type="button" ' +
+              'class="civicase__rich-text-form__btn ' +
+                'civicase__rich-text-form__btn--save crm-button crm-form-submit" ' +
+              'title="' + ts('Save') + '" ' +
+              'aria-label="' + ts('Save') + '" ' +
+              'style="margin-right: 4px;">' +
+              '<i class="crm-i fa-check" aria-hidden="true"></i>' +
+            '</button>' +
+            '<button type="button" ' +
+              'class="civicase__rich-text-form__btn ' +
+                'civicase__rich-text-form__btn--cancel crm-button cancel" ' +
+              'title="' + ts('Cancel') + '" ' +
+              'aria-label="' + ts('Cancel') + '">' +
+              '<i class="crm-i fa-times" aria-hidden="true"></i>' +
+            '</button>' +
+          '</div>' +
+        '</div>'
+      );
+      var previousHtml = elem.html();
+
+      elem.addClass('civicase__rich-text-editing crm-editable-editing');
+      elem.empty().append($form);
+
+      CRM.wysiwyg.create('#' + editorId).done(function () {
+        CRM.wysiwyg.setVal('#' + editorId, originalValue);
+      });
+
+      $form.find('.civicase__rich-text-form__btn--save')
+        .on('click', function () { saveRichTextEdit(); });
+      $form.find('.civicase__rich-text-form__btn--cancel')
+        .on('click', function () { cancelRichTextEdit(); });
+
+      /**
+       * Tears down the editor and restores the rendered display markup.
+       *
+       * @param {string} html markup to restore inside the element
+       */
+      function teardown (html) {
+        try {
+          CRM.wysiwyg.destroy('#' + editorId);
+        } catch (e) { /* destroy is best-effort; ignore failures */ }
+        $form.remove();
+        elem.removeClass(
+          'civicase__rich-text-editing crm-editable-editing crm-editable-saving'
+        );
+        elem.html(html);
+      }
+
+      /**
+       * Cancels the in-progress edit and restores the previous markup.
+       */
+      function cancelRichTextEdit () {
+        teardown(previousHtml);
+      }
+
+      /**
+       * Persists the new value via CRM.api4 then triggers `crmFormSuccess`
+       * so the directive's existing handler updates the model and refreshes
+       * the rendered display.
+       *
+       * APIv4 is preferred for new code (project convention). The legacy
+       * jeditable callback in jquery.crmEditable.js still uses APIv3 and
+       * supports a `setvalue` pseudo-action; APIv4 has no equivalent —
+       * `update` covers the same use case and is what we use here. If a
+       * caller has explicitly opted into APIv3 by setting `data-action`
+       * to "create"/"setvalue" on the element, we still honour that for
+       * backwards compatibility (with a console warning), otherwise we go
+       * straight to APIv4 `update`.
+       */
+      function saveRichTextEdit () {
+        var newValue = CRM.wysiwyg.getVal('#' + editorId);
+        var explicitAction = elem.data('action');
+        var values = {};
+        values[field] = newValue;
+
+        elem.addClass('crm-editable-saving');
+
+        var apiPromise;
+        if (explicitAction === 'setvalue' || explicitAction === 'create') {
+          // Preserve legacy behaviour for any consumer still relying on
+          // APIv3 actions via `data-action`. Should be removed once all
+          // call sites have been migrated.
+          if (window.console && console.warn) {
+            console.warn(
+              '[civicase] crm-editable: data-action="' + explicitAction +
+              '" uses APIv3. New code should drop data-action and let the' +
+              ' directive use APIv4 update.'
+            );
+          }
+          var legacyParams = _.extend({}, info.params || {});
+          if (info.id && info.id !== 'new') {
+            legacyParams.id = info.id;
+          }
+          if (explicitAction === 'setvalue') {
+            legacyParams.field = field;
+            legacyParams.value = newValue;
+          } else {
+            legacyParams[field] = newValue;
+          }
+          apiPromise = CRM.api3(info.entity, explicitAction, legacyParams, { error: null });
+        } else {
+          apiPromise = CRM.api4(info.entity, 'update', {
+            where: [['id', '=', info.id]],
+            values: values
+          });
+        }
+
+        // Both CRM.api3 (jQuery Deferred) and CRM.api4 (Promise/Deferred)
+        // support .then(onSuccess, onError), so we use that uniformly.
+        apiPromise.then(
+          function (data) {
+            // APIv3 surfaces errors via `data.is_error`; APIv4 rejects.
+            // Handle the APIv3 error shape here for the legacy branch.
+            if (data && data.is_error) {
+              elem.removeClass('crm-editable-saving');
+              CRM.alert(
+                (data && data.error_message) ||
+                  ts('Sorry an error occurred and your information was not saved'),
+                ts('Error'),
+                'error'
+              );
+              return;
+            }
+            var savedValue = newValue;
+            var record;
+            if (_.isArray(data) && data.length) {
+              record = data[0];
+            } else if (data && data.values) {
+              record = _.isArray(data.values)
+                ? data.values[0]
+                : (data.values[info.id] || data.values);
+            }
+            if (record && typeof record[field] !== 'undefined') {
+              savedValue = record[field];
+            }
+            teardown('');
+            elem.trigger('crmFormSuccess', [savedValue]);
+          },
+          function (error) {
+            elem.removeClass('crm-editable-saving');
+            CRM.alert(
+              (error && error.error_message) ||
+                ts('Sorry an error occurred and your information was not saved'),
+              ts('Error'),
+              'error'
+            );
+          }
+        );
+      }
+    }
+
+    /**
+     * Builds the markup placed inside the editable element when not in edit mode.
+     *
+     * @param {object} scope scope object
+     * @param {object} elem element
+     * @param {object} attrs attributes
+     * @param {boolean} textarea whether the element uses textarea editing
+     * @param {boolean} richText whether the field stores HTML (rich text)
+     * @returns {string} HTML to render in display mode
+     */
+    function getDisplayHTML (scope, elem, attrs, textarea, richText) {
+      var field = elem.data('field');
+      var placeholder = attrs.placeholder;
+      var value = scope.model[field];
+      var hasValue = value !== null && typeof value !== 'undefined' && value !== '';
+
+      if (!hasValue) {
+        return placeholder;
+      }
+
+      if (richText) {
+        return purifyHtml(value);
+      }
+
+      var escaped = escapeString(value);
+
+      return textarea ? nl2br(escaped) : escaped;
+    }
+
+    /**
+     * Defence-in-depth client-side HTML sanitiser for rich-text values.
+     *
+     * @param {string} value the HTML string to sanitise
+     * @returns {string} sanitised HTML string
+     */
+    function purifyHtml (value) {
+      if (CRM.utils && typeof CRM.utils.purifyHtml === 'function') {
+        return CRM.utils.purifyHtml(value);
+      }
+
+      var nodes = $.parseHTML(value, document, false);
+      var $tmp = $('<div>').append(nodes);
+      // Strip inline event handlers (onclick, onerror, ...) and javascript:
+      // URLs from any element that survived the parse.
+      $tmp.find('*').each(function () {
+        var attrs = this.attributes;
+        for (var i = attrs.length - 1; i >= 0; i--) {
+          var name = attrs[i].name;
+          var attrValue = attrs[i].value || '';
+          if (/^on/i.test(name) ||
+            (/^(href|src|xlink:href)$/i.test(name) &&
+              /^\s*javascript:/i.test(attrValue))) {
+            this.removeAttribute(name);
+          }
+        }
+      });
+      return $tmp.html();
     }
 
     /**
@@ -63,24 +336,6 @@
      */
     function nl2br (string) {
       return (string + '').replace(/([^>\r\n]?)(\r\n|\n\r|\r|\n)/g, '$1<br />$2');
-    }
-
-    /**
-     * Retuns the text to be shown as HTML,
-     * if the model value is null or empty string, retuns the placeholder.
-     *
-     * @param {object} scope scope object
-     * @param {object} elem element
-     * @param {object} attrs attributes
-     * @returns {string} html to show
-     */
-    function getHTMLToShow (scope, elem, attrs) {
-      var field = elem.data('field');
-      var placeholder = attrs.placeholder;
-
-      return (scope.model[field] && scope.model[field] !== '')
-        ? escapeString(scope.model[field])
-        : placeholder;
     }
 
     /**

--- a/ang/test/civicase/shared/directives/crm-editable.directive.spec.js
+++ b/ang/test/civicase/shared/directives/crm-editable.directive.spec.js
@@ -1,0 +1,381 @@
+/* eslint-env jasmine */
+(function ($, _) {
+  describe('crmEditable (rich-text)', function () {
+    // eslint-disable-next-line no-unused-vars
+    var $compile, $rootScope, $scope, $q, $timeout, element, wrapper;
+    var originalCRM, originalCrmEditable, originalCrmEditableEntity;
+    var crmApi3Spy, crmApi4Spy, alertSpy, loadScriptDeferred,
+      wysiwygCreateDeferred, currentTextareaValue;
+
+    beforeEach(module('civicase.templates', 'civicase', 'civicase.data'));
+
+    beforeEach(inject(function (_$compile_, _$rootScope_, _$q_, _$timeout_) {
+      $compile = _$compile_;
+      $rootScope = _$rootScope_;
+      $q = _$q_;
+      $timeout = _$timeout_;
+      $scope = $rootScope.$new();
+
+      // Snapshot CRM-level globals we are about to override so we can put
+      // them back in afterEach.
+      originalCRM = {
+        loadScript: CRM.loadScript,
+        wysiwyg: CRM.wysiwyg,
+        api3: CRM.api3,
+        api4: CRM.api4,
+        alert: CRM.alert,
+        utils: CRM.utils
+      };
+      originalCrmEditable = $.fn.crmEditable;
+      originalCrmEditableEntity = $.fn.crmEditableEntity;
+
+      loadScriptDeferred = $.Deferred().resolve();
+      CRM.loadScript = jasmine.createSpy('loadScript')
+        .and.returnValue(loadScriptDeferred);
+
+      // Stub the legacy jQuery plugin so we can detect (or not) calls to it.
+      $.fn.crmEditable = jasmine.createSpy('crmEditable');
+      // crmEditableEntity is what the directive uses to read entity / id.
+      $.fn.crmEditableEntity = function () {
+        return {
+          entity: 'Case',
+          id: 42,
+          action: 'create',
+          field: 'details',
+          params: {}
+        };
+      };
+
+      // Stub CRM.wysiwyg.
+      wysiwygCreateDeferred = $.Deferred().resolve();
+      currentTextareaValue = '<p>edited via wysiwyg</p>';
+      CRM.wysiwyg = {
+        create: jasmine.createSpy('wysiwygCreate')
+          .and.returnValue(wysiwygCreateDeferred),
+        setVal: jasmine.createSpy('wysiwygSetVal'),
+        getVal: jasmine.createSpy('wysiwygGetVal')
+          .and.callFake(function () { return currentTextareaValue; }),
+        destroy: jasmine.createSpy('wysiwygDestroy')
+      };
+
+      // API stubs default to never-resolving deferreds; individual tests
+      // override .and.returnValue() with the response shape they need.
+      crmApi3Spy = jasmine.createSpy('api3').and.returnValue($.Deferred());
+      crmApi4Spy = jasmine.createSpy('api4').and.returnValue($.Deferred());
+      CRM.api3 = crmApi3Spy;
+      CRM.api4 = crmApi4Spy;
+
+      alertSpy = jasmine.createSpy('alert');
+      CRM.alert = alertSpy;
+
+      // CRM.utils may not exist in the test harness; the directive
+      // detects it before calling purifyHtml so we leave it alone here.
+      CRM.utils = CRM.utils || {};
+    }));
+
+    afterEach(function () {
+      _.each(originalCRM, function (value, key) {
+        if (typeof value === 'undefined') {
+          delete CRM[key];
+        } else {
+          CRM[key] = value;
+        }
+      });
+      $.fn.crmEditable = originalCrmEditable;
+      $.fn.crmEditableEntity = originalCrmEditableEntity;
+      delete CRM.utils.purifyHtml;
+    });
+
+    describe('display mode — rich text', function () {
+      describe('renders HTML rather than escaping it', function () {
+        beforeEach(function () {
+          $scope.item = { id: 42, details: '<p>Hello <strong>world</strong></p>' };
+          compileRichText();
+        });
+
+        it('preserves the inline tags as real DOM elements', function () {
+          expect(element.find('strong').length).toBe(1);
+          expect(element.find('p').length).toBe(1);
+        });
+
+        it('does not escape the markup as text', function () {
+          expect(element.html()).not.toContain('&lt;p&gt;');
+        });
+
+        it('does not bind the legacy jQuery jeditable plugin', function () {
+          expect($.fn.crmEditable).not.toHaveBeenCalled();
+        });
+
+        it('marks the element as click-to-edit', function () {
+          expect(element.hasClass('civicase__rich-text-editable')).toBe(true);
+          expect(element.hasClass('crm-editable-enabled')).toBe(true);
+        });
+      });
+
+      describe('defence-in-depth purification (no CRM.utils.purifyHtml)', function () {
+        beforeEach(function () {
+          $scope.item = {
+            id: 42,
+            details: '<p onclick="alert(1)">x</p>' +
+              '<a href="javascript:alert(1)">y</a>'
+          };
+          compileRichText();
+        });
+
+        it('strips inline event-handler attributes', function () {
+          expect(element.find('p').attr('onclick')).toBeUndefined();
+        });
+
+        it('strips javascript: URLs from href', function () {
+          expect(element.find('a').attr('href')).toBeUndefined();
+        });
+      });
+
+      describe('uses CRM.utils.purifyHtml when core exposes it', function () {
+        beforeEach(function () {
+          CRM.utils.purifyHtml = jasmine.createSpy('purifyHtml')
+            .and.returnValue('<p>SAFE</p>');
+          $scope.item = { id: 42, details: '<p>raw</p>' };
+          compileRichText();
+        });
+
+        it('routes the value through CRM.utils.purifyHtml', function () {
+          expect(CRM.utils.purifyHtml).toHaveBeenCalledWith('<p>raw</p>');
+        });
+
+        it('renders the purified output', function () {
+          expect(element.html()).toContain('SAFE');
+        });
+      });
+
+      describe('placeholder fallback for empty values', function () {
+        beforeEach(function () {
+          $scope.item = { id: 42, details: '' };
+          compileRichText();
+        });
+
+        it('shows the placeholder text', function () {
+          expect(element.text()).toContain('Click to add notes');
+        });
+      });
+    });
+
+    describe('display mode — plain textarea (regression)', function () {
+      beforeEach(function () {
+        $scope.item = { description: '<b>raw</b>' };
+        wrapper = angular.element(
+          '<div class="crm-entity" data-entity="Case" data-id="42">' +
+            '<div crm-editable="item" data-field="description" ' +
+            'data-type="textarea"></div>' +
+          '</div>'
+        );
+        $compile(wrapper)($scope);
+        $scope.$digest();
+        $rootScope.$apply();
+        element = wrapper.find('[crm-editable]');
+      });
+
+      it('still escapes HTML so plain text is shown literally', function () {
+        expect(element.find('b').length).toBe(0);
+        expect(element.text()).toContain('<b>raw</b>');
+      });
+
+      it('still hands off to the legacy jeditable plugin', function () {
+        expect($.fn.crmEditable).toHaveBeenCalled();
+      });
+    });
+
+    describe('inline editing', function () {
+      beforeEach(function () {
+        $scope.item = { id: 42, details: '<p>Initial</p>' };
+        compileRichText();
+      });
+
+      it('opens a CKEditor textarea on click', function () {
+        element.click();
+        $scope.$digest();
+        expect(CRM.wysiwyg.create).toHaveBeenCalled();
+        var selector = CRM.wysiwyg.create.calls.mostRecent().args[0];
+        expect(selector).toMatch(/^#civicase-rich-text-Case-42-details/);
+      });
+
+      it('seeds the editor with the existing HTML via setVal', function () {
+        element.click();
+        $scope.$digest();
+        expect(CRM.wysiwyg.setVal).toHaveBeenCalledWith(
+          jasmine.any(String),
+          '<p>Initial</p>'
+        );
+      });
+
+      it('renders an accessible label for the textarea', function () {
+        element.click();
+        $scope.$digest();
+        var $textarea = element.find('textarea.crm-form-wysiwyg');
+        expect($textarea.length).toBe(1);
+        expect($textarea.attr('aria-label')).toBeTruthy();
+        expect(element.find('label.sr-only').length).toBe(1);
+        expect(element.find('label.sr-only').attr('for'))
+          .toBe($textarea.attr('id'));
+      });
+
+      it('marks the wrapper while editing so model watchers don\'t clobber it', function () {
+        element.click();
+        $scope.$digest();
+        expect(element.hasClass('civicase__rich-text-editing')).toBe(true);
+      });
+
+      it('ignores clicks on inner anchors / buttons', function () {
+        element.html('<p><a href="#x">link</a></p>');
+        element.find('a').trigger('click');
+        $scope.$digest();
+        expect(CRM.wysiwyg.create).not.toHaveBeenCalled();
+      });
+
+      describe('saving (defaults to APIv4)', function () {
+        beforeEach(function () {
+          element.click();
+          $scope.$digest();
+        });
+
+        it('calls CRM.api4 with Case.update', function () {
+          var deferred = $.Deferred().resolve([
+            { id: 42, details: '<p>edited via wysiwyg</p>' }
+          ]);
+          crmApi4Spy.and.returnValue(deferred);
+          element.find('.civicase__rich-text-form__btn--save').trigger('click');
+          $scope.$digest();
+          expect(crmApi4Spy).toHaveBeenCalledWith('Case', 'update', {
+            where: [['id', '=', 42]],
+            values: { details: '<p>edited via wysiwyg</p>' }
+          });
+        });
+
+        it('does not fall back to APIv3', function () {
+          crmApi4Spy.and.returnValue($.Deferred().resolve([
+            { id: 42, details: '<p>edited via wysiwyg</p>' }
+          ]));
+          element.find('.civicase__rich-text-form__btn--save').trigger('click');
+          $scope.$digest();
+          expect(crmApi3Spy).not.toHaveBeenCalled();
+        });
+
+        it('updates the model with the saved value from the response', function () {
+          crmApi4Spy.and.returnValue($.Deferred().resolve([
+            { id: 42, details: '<p>SERVER_NORMALISED</p>' }
+          ]));
+          element.find('.civicase__rich-text-form__btn--save').trigger('click');
+          $scope.$digest();
+          $timeout.flush();
+          expect($scope.item.details).toBe('<p>SERVER_NORMALISED</p>');
+        });
+
+        it('alerts the user on failure and keeps the editor open', function () {
+          crmApi4Spy.and.returnValue($.Deferred().reject({
+            error_message: 'Server exploded'
+          }));
+          element.find('.civicase__rich-text-form__btn--save').trigger('click');
+          $scope.$digest();
+          expect(alertSpy).toHaveBeenCalled();
+          expect(element.hasClass('civicase__rich-text-editing')).toBe(true);
+        });
+      });
+
+      describe('saving (legacy data-action falls back to APIv3)', function () {
+        beforeEach(function () {
+          // Re-compile with data-action="setvalue" to opt into legacy.
+          wrapper.remove();
+          $scope.item = { id: 42, details: '<p>Initial</p>' };
+          wrapper = angular.element(
+            '<div class="crm-entity" data-entity="Case" data-id="42">' +
+              '<div crm-editable="item" data-field="details" ' +
+              'data-type="textarea" data-rich-text="true" ' +
+              'data-action="setvalue" ' +
+              'data-placeholder="Click to add notes"></div>' +
+            '</div>'
+          );
+          $compile(wrapper)($scope);
+          $scope.$digest();
+          $rootScope.$apply();
+          element = wrapper.find('[crm-editable]');
+          element.click();
+          $scope.$digest();
+        });
+
+        it('uses APIv3 setvalue', function () {
+          crmApi3Spy.and.returnValue($.Deferred().resolve({
+            is_error: 0,
+            values: [{ id: 42, details: '<p>edited via wysiwyg</p>' }]
+          }));
+          element.find('.civicase__rich-text-form__btn--save').trigger('click');
+          $scope.$digest();
+          expect(crmApi3Spy).toHaveBeenCalled();
+          var args = crmApi3Spy.calls.mostRecent().args;
+          expect(args[0]).toBe('Case');
+          expect(args[1]).toBe('setvalue');
+          expect(args[2]).toEqual(jasmine.objectContaining({
+            id: 42,
+            field: 'details',
+            value: '<p>edited via wysiwyg</p>'
+          }));
+        });
+
+        it('does not call APIv4 in legacy mode', function () {
+          crmApi3Spy.and.returnValue($.Deferred().resolve({ is_error: 0 }));
+          element.find('.civicase__rich-text-form__btn--save').trigger('click');
+          $scope.$digest();
+          expect(crmApi4Spy).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('cancelling', function () {
+        beforeEach(function () {
+          element.click();
+          $scope.$digest();
+          element.find('.civicase__rich-text-form__btn--cancel').trigger('click');
+          $scope.$digest();
+        });
+
+        it('destroys the WYSIWYG instance', function () {
+          expect(CRM.wysiwyg.destroy).toHaveBeenCalled();
+        });
+
+        it('removes the editing-state class', function () {
+          expect(element.hasClass('civicase__rich-text-editing')).toBe(false);
+        });
+
+        it('does not save', function () {
+          expect(crmApi3Spy).not.toHaveBeenCalled();
+          expect(crmApi4Spy).not.toHaveBeenCalled();
+        });
+
+        it('restores the original rendered HTML', function () {
+          expect(element.find('p').length).toBe(1);
+          expect(element.text()).toContain('Initial');
+        });
+      });
+    });
+
+    /**
+     * Compiles the directive in rich-text mode wrapped in a `crm-entity` so
+     * crmEditableEntity() can resolve entity / id, and stashes the inner
+     * editable element on `element` for assertions.
+     */
+    function compileRichText () {
+      wrapper = angular.element(
+        '<div class="crm-entity" data-entity="Case" data-id="42">' +
+          '<div crm-editable="item" data-field="details" ' +
+          'data-type="textarea" data-rich-text="true" ' +
+          'data-placeholder="Click to add notes"></div>' +
+        '</div>'
+      );
+      $compile(wrapper)($scope);
+      $scope.$digest();
+      // CRM.loadScript() is mocked to a resolved deferred so the directive's
+      // setup runs synchronously; trigger one more digest just in case any
+      // watchers were registered inside the .done() callback.
+      $rootScope.$apply();
+      element = wrapper.find('[crm-editable]');
+    }
+  });
+}(CRM.$, CRM._));

--- a/scss/components/_rich-text-inline-edit.scss
+++ b/scss/components/_rich-text-inline-edit.scss
@@ -1,0 +1,28 @@
+/**
+ * Styles for the rich-text inline editor used by the `crm-editable` directive.
+ */
+
+.civicase__rich-text-editable {
+  cursor: pointer;
+}
+
+.civicase__rich-text-editing {
+  cursor: default;
+}
+
+.civicase__rich-text-form {
+  width: 100%;
+
+  .crm-form-wysiwyg {
+    width: 100%;
+  }
+}
+
+.civicase__rich-text-form__actions {
+  margin-top: 6px;
+  text-align: right;
+}
+
+.civicase__rich-text-form__btn {
+  margin-left: 4px;
+}


### PR DESCRIPTION
## Overview

The Case *Details* field is captured with a CKEditor on the *Open Case* form, but the CiviCase summary panels were both displaying and editing it as plain text. This PR fixes both, behind an opt-in flag so other inline-editable fields keep their existing safe-by-default escape behavior.

## Before
The detail field on case a case displayed the html tags within the text rather than rendering the html
<img width="1761" height="783" alt="Screenshot 2026-04-27 at 10 22 09 PM" src="https://github.com/user-attachments/assets/79dd1288-40e5-44ab-9e83-672967bfb3b0" />


## After
The field correctly renders the html of the detail field, also upon editing a wysiwyg editor is opened rather than normal inline text editor
<img width="1777" height="857" alt="screen_recording_after" src="https://github.com/user-attachments/assets/4cb5fadb-a042-4d1e-b334-36d2a1bd28c1" />
