### PR TITLE
NEUSPRT-548: Lift 25-row cap on Linked Cases tab

### DIFF
--- a/ang/civicase/case/factories/get-case-query-params.factory.js
+++ b/ang/civicase/case/factories/get-case-query-params.factory.js
@@ -8,6 +8,11 @@
   // generous bound still covers realistic cases without that cost.
   var RELATED_BY_CONTACT_LIMIT = 300;
 
+  // Upper bound for explicitly linked cases. Links are created by deliberate
+  // user action (the reported case had 74), but a safe cap avoids pathological
+  // payload sizes from bulk imports or scripted linking.
+  var LINKED_CASES_LIMIT = 500;
+
   module.factory('getCaseQueryParams', function (currentCaseCategory) {
     var DEFAULT_FILTERS = {
       caseTypeCategory: currentCaseCategory,
@@ -56,7 +61,7 @@
           'case_type_id.case_type_category': filters.caseTypeCategory,
           id: { IN: '$value.related_case_ids' },
           is_deleted: 0,
-          options: { limit: 0 },
+          options: { limit: LINKED_CASES_LIMIT },
           return: caseListReturnParams
         },
         // For the "recent communication" panel

--- a/ang/civicase/case/factories/get-case-query-params.factory.js
+++ b/ang/civicase/case/factories/get-case-query-params.factory.js
@@ -1,6 +1,13 @@
 (function (angular, $, _, CRM) {
   var module = angular.module('civicase');
 
+  // Upper bound for cases fetched by shared contact. A contact such as a
+  // local-authority employer can be related to thousands of cases; an
+  // unbounded fetch here would bloat the payload and the per-row contact
+  // lookup in prepareRelatedCases(). The panel paginates client-side, so a
+  // generous bound still covers realistic cases without that cost.
+  var RELATED_BY_CONTACT_LIMIT = 300;
+
   module.factory('getCaseQueryParams', function (currentCaseCategory) {
     var DEFAULT_FILTERS = {
       caseTypeCategory: currentCaseCategory,
@@ -41,6 +48,7 @@
           contact_id: { IN: '$value.contact_id' },
           id: { '!=': '$value.id' },
           is_deleted: 0,
+          options: { limit: RELATED_BY_CONTACT_LIMIT },
           return: caseListReturnParams
         },
         // Linked cases
@@ -48,6 +56,7 @@
           'case_type_id.case_type_category': filters.caseTypeCategory,
           id: { IN: '$value.related_case_ids' },
           is_deleted: 0,
+          options: { limit: 0 },
           return: caseListReturnParams
         },
         // For the "recent communication" panel

--- a/ang/test/civicase/case/factories/get-case-query-params.factory.spec.js
+++ b/ang/test/civicase/case/factories/get-case-query-params.factory.spec.js
@@ -43,7 +43,7 @@
             'case_type_id.case_type_category': 'cases',
             id: { IN: '$value.related_case_ids' },
             is_deleted: 0,
-            options: { limit: 0 },
+            options: { limit: 500 },
             return: ['case_type_id', 'case_type_id.is_active', 'start_date',
               'end_date', 'status_id', 'contacts', 'subject']
           },

--- a/ang/test/civicase/case/factories/get-case-query-params.factory.spec.js
+++ b/ang/test/civicase/case/factories/get-case-query-params.factory.spec.js
@@ -34,6 +34,7 @@
             contact_id: { IN: '$value.contact_id' },
             id: { '!=': '$value.id' },
             is_deleted: 0,
+            options: { limit: 300 },
             return: ['case_type_id', 'case_type_id.is_active', 'start_date',
               'end_date', 'status_id', 'contacts', 'subject']
           },
@@ -42,6 +43,7 @@
             'case_type_id.case_type_category': 'cases',
             id: { IN: '$value.related_case_ids' },
             is_deleted: 0,
+            options: { limit: 0 },
             return: ['case_type_id', 'case_type_id.is_active', 'start_date',
               'end_date', 'status_id', 'contacts', 'subject']
           },


### PR DESCRIPTION
## Overview

On a collective case, the Linked Cases tab only ever displayed 25 cases even when many more were linked (one reported case has 74 linked cases). This change removes that hidden cap so all linked cases are shown, while keeping the related-by-shared-contact lookup bounded so it stays fast for contacts such as local-authority employers that can be associated with very large numbers of cases.

## Before

The Linked/Related Cases panel showed at most 25 cases. Linking more than 25 had no visible effect on the count; unlinking a visible case caused a previously hidden one to appear (the 25-row window simply shifted). No UI setting controlled this limit.

## Manual verification required

Reproduction requires an authenticated CiviCRM session on a NEU staging/dev environment with a collective case that has more than 25 linked cases.

Steps to reproduce on `master` (before this change):
1. Open a collective case that has 25+ explicitly linked cases (e.g. the reported Case ID 188873).
2. Open the **Linked Cases** tab.
3. Observe the pager total caps at 25 regardless of how many cases are actually linked.

After this change, the tab shows all linked cases (the client-side pager of 5 per page drives navigation through the full set).

_Automated visual reproduction was not run: the staging host is a client-specific domain outside the standard verification allowlist, and reproduction depends on an authenticated session plus seeded case data. Screenshots to be added before merge if required._

## Technical Details

Root cause is in the case-detail query builder `ang/civicase/case/factories/get-case-query-params.factory.js`. The case detail load issues two chained APIv3 calls that feed the Linked/Related Cases panel:

- `api.Case.getcaselist.linkedCases` — cases explicitly linked via "Link Cases" (`id IN $value.related_case_ids`).
- `api.Case.getcaselist.relatedCasesByContact` — cases sharing the same contact (`contact_id IN $value.contact_id`).

Neither set `options.limit`, so CiviCRM applied its default API page size of **25**. (The sibling `api.Relationship.get` call in the same payload already sets `options: { limit: 0 }`, confirming both the pattern and the omission.)

The two changes:

- `linkedCases` now sets `options: { limit: 0 }`. The count here is bounded by deliberate user linking, so lifting the cap fully is the correct fix for the reported symptom.
- `relatedCasesByContact` now sets `options: { limit: RELATED_BY_CONTACT_LIMIT }`, a documented module-level constant (`300`). This is the genuine unbounded-growth path — a local-authority employer contact can share thousands of cases — so a generous **bounded** limit avoids a large payload and the per-row `CasesUtils.fetchMoreContactsInformation()` lookup over the full merged set, rather than removing the cap entirely.

Rendering is unaffected: the panel paginates client-side (`relatedCasesPager.size = 5` and `isInRange()` in `ang/civicase/case/details/directives/case-details.directive.js`), so lifting the API cap does not dump rows into the DOM.

The factory spec `ang/test/civicase/case/factories/get-case-query-params.factory.spec.js` is updated to assert both `options` keys.

## Comments

- **No JS build step.** `ang/civicase.ang.php` loads `ang/civicase/*.js` directly via `GlobRecursive::getRelativeToExtension`, so the edited source file is what is served — there is no compiled JS bundle to regenerate (only SCSS is built via gulp).
- **Tests not run locally.** The Karma suite requires a provisioned CiviCRM install (`civicrm-cv`) and headless Chrome; relying on CI for the unit run. ESLint passed on both changed files locally.
- Branched from the `master` tip. The `relatedCasesByContact` bound of `300` is a pragmatic default; if a stricter or server-side-paginated approach is preferred for the shared-contact path, that can be a follow-up — this PR resolves the reported "stuck at 25" symptom.
