### PR TITLE
CIVIMM-527: Support Invoice Helper Extension Form

### DIFF
--- a/civicase.php
+++ b/civicase.php
@@ -237,7 +237,7 @@ function civicase_civicrm_buildForm($formName, &$form) {
     $form->add('hidden', 'mail_task_from_sk', $isSearchKit);
   }
 
-  if ($formName == 'CRM_Contribute_Form_Task_Invoice' && $isSearchKit) {
+  if (in_array($formName, ['CRM_Contribute_Form_Task_Invoice', 'CRM_Invoicehelper_Contribute_Form_Task_Invoice'], TRUE) && $isSearchKit) {
     $form->add('hidden', 'mail_task_from_sk', $isSearchKit);
     CRM_Core_Resources::singleton()->addScriptFile(
       CRM_Civicase_ExtensionUtil::LONG_NAME,


### PR DESCRIPTION
## Overview
Supports the invoicehelper queue-based bulk "Send Invoice by email" flow by recognising the invoicehelper override form on the SearchKit invoice screen.

## Before
The SearchKit invoice screen's email-only behaviour (auto-select "Email Invoice", hide the PDF option, set the "Email Contribution Invoice" title) only applied when the form class was core `CRM_Contribute_Form_Task_Invoice`.

## After
The same behaviour applies whether the invoice task runs through the core class or invoicehelper's `CRM_Invoicehelper_Contribute_Form_Task_Invoice` override.

## Technical Details
- `civicase.php` — `civicase_civicrm_buildForm()`: the SearchKit invoice block now matches both class names via `in_array($formName, ['CRM_Contribute_Form_Task_Invoice', 'CRM_Invoicehelper_Contribute_Form_Task_Invoice'], TRUE)`, so the `mail_task_from_sk` hidden field, `invoice-bulk-mail.js`, and the "Email Contribution Invoice" title are added for the override form as well. This is purely additive and does not change behaviour for the core-class path.

### Core overrides
None.

## Comments
- Companion to the https://lab.civicrm.org/extensions/invoicehelper/-/merge_requests/13 PR, which repoints the contribution invoice search tasks to its queue-enabled override class. This change only widens an existing `formName` check, so it has no effect when the core class is in use.