### PR TITLE
CPO-2535: Fix Redirect Link From Activity View Page

### DIFF
--- a/ang/civicase/activity/feed/directives/activity-feed.directive.js
+++ b/ang/civicase/activity/feed/directives/activity-feed.directive.js
@@ -547,7 +547,8 @@
           activity_id: '$value.id',
           activity_type_id: '$value.activity_type_id',
           source_record_id: '$value.source_record_id',
-          case_id: '$value.case_id'
+          case_id: '$value.case_id',
+          contact_id: params.contact_id ?? null
         }
       };
 

--- a/ang/test/civicase/activity/feed/directives/activity-feed.directive.spec.js
+++ b/ang/test/civicase/activity/feed/directives/activity-feed.directive.spec.js
@@ -94,6 +94,34 @@
           });
         });
 
+        describe('when viewing a specific contact\'s activities', () => {
+          const contactId = '42';
+
+          beforeEach(() => {
+            $scope.filters.$contact_id = contactId;
+
+            $scope.$digest();
+          });
+
+          it('passes the viewed contact id to the action links chained api call', () => {
+            const actsParams = civicaseCrmApi.calls.mostRecent().args[0].acts[2];
+
+            expect(actsParams['api.Activity.getactionlinks'].contact_id).toBe(contactId);
+          });
+        });
+
+        describe('when not viewing a specific contact', () => {
+          beforeEach(() => {
+            $scope.$digest();
+          });
+
+          it('still sends contact_id (as null) to the action links chained api call so the server can fall back to the logged-in contact', () => {
+            const actsParams = civicaseCrmApi.calls.mostRecent().args[0].acts[2];
+
+            expect(actsParams['api.Activity.getactionlinks'].contact_id).toBeNull();
+          });
+        });
+
         describe('when the filters are updated', () => {
           let expectedFilters;
 

--- a/api/v3/Activity/Getactionlinks.php
+++ b/api/v3/Activity/Getactionlinks.php
@@ -18,6 +18,10 @@ function _civicrm_api3_activity_getactionlinks_spec(array &$spec) {
   $spec['source_record_id']['api.required'] = 1;
   $spec['activity_id']['api.required'] = 1;
   $spec['case_id']['api.required'] = 0;
+  // Contact whose record is being viewed. Used to build the cid in action
+  // link URLs so that, e.g., closing the activity view returns the user to
+  // the contact they were reviewing rather than their own contact record.
+  $spec['contact_id']['api.required'] = 0;
 }
 
 /**
@@ -72,9 +76,14 @@ function _civicrm_api3_activity_getActivityActionLinks(array $params) {
   $caseId = (array) CRM_Utils_Array::value('case_id', $params);
   $caseId = ((array) $caseId)[0] ?? NULL;
 
+  $cid = CRM_Utils_Array::value('contact_id', $params);
+  if (empty($cid)) {
+    $cid = CRM_Core_Session::getLoggedInContactID();
+  }
+
   $values = [
     'id' => $params['activity_id'],
-    'cid' => CRM_Core_Session::getLoggedInContactID(),
+    'cid' => $cid,
     'cxt' => '',
     'caseid' => $caseId,
   ];


### PR DESCRIPTION
## Overview
Fixes a navigation bug on the contact summary **Activities** tab. After opening an activity via its action menu ("View Activity") and clicking **Done**, the user was returned to *their own* contact record instead of the contact they were reviewing.

## Before
From a contact's Activities tab, choosing **View Activity** → **Done** redirected the user to their own contact summary rather than the contact whose activity they were viewing.

<img width="1777" height="857" alt="screen_recording_before" src="https://github.com/user-attachments/assets/6edd8162-3ecd-47f0-ad80-847ce1cae257" />


## After
**Done** now returns the user to the summary of the contact they were actually reviewing.

<img width="1777" height="857" alt="screen_recording_after" src="https://github.com/user-attachments/assets/2b8ae35c-5d7c-4ad6-918a-1a776d900b5b" />

## Technical Details
The Activities tab renders action links via the `Activity.getactionlinks` API. The link URLs contain a `cid=%%cid%%` placeholder, and the value used to substitute it was hard-coded to `CRM_Core_Session::getLoggedInContactID()` — i.e. always the logged-in user. The activity feed never told the API which contact was being viewed, so every link (including "View Activity") was built with the logged-in user's `cid`. Since `CRM_Activity_Form_ActivityView` builds its "Done" return URL as `civicrm/contact/view?cid={cid}`, the user was sent back to their own record.

Two changes:

1. `ang/civicase/activity/feed/directives/activity-feed.directive.js` — `prepareActivityParams()` now passes the viewed contact through to the chained API call:

```js
   'api.Activity.getactionlinks': {
     activity_id: '$value.id',
     activity_type_id: '$value.activity_type_id',
     source_record_id: '$value.source_record_id',
     case_id: '$value.case_id',
     contact_id: params.contact_id ?? null
   }
```

   `params.contact_id` originates from the tab's `$contact_id` filter (`Contact.getCurrentContactID()`, read from the URL `cid`), so it is the contact being reviewed.

2. `api/v3/Activity/Getactionlinks.php` — `contact_id` is added as an optional spec param and used for the `cid` placeholder, falling back to the logged-in contact only when not supplied (preserving prior behaviour for case-view and my-activities contexts):

```php
   $cid = CRM_Utils_Array::value('contact_id', $params);
   if (empty($cid)) {
     $cid = CRM_Core_Session::getLoggedInContactID();
   }
```

### Core overrides
N/A — both changed files belong to this extension; no CiviCRM core files were overridden or patched.

## Comments
A CiviCRM cache clear (`cv flush` or Administer → System Settings → Cleanup Caches) and a hard browser refresh are required for the Angular change to take effect. When `contact_id` is absent (e.g. case view, my-activities) the API falls back to the logged-in contact, so those flows are unchanged.