### PR TITLE
Add CRM_Civicase_Upgrader_Base compatibility shim

### DIFF
--- a/CRM/Civicase/Upgrader/Base.php
+++ b/CRM/Civicase/Upgrader/Base.php
@@ -1,0 +1,47 @@
+<?php
+
+// This file provides a compatibility shim for upgrade Step classes that call
+// CRM_Civicase_Upgrader_Base::instance(). The main upgrader (CRM_Civicase_Upgrader)
+// extends CRM_Extension_Upgrader_Base directly; this class exists solely to satisfy
+// the static instance() + executeSqlFile() calls in the Steps.
+
+use CRM_Civicase_ExtensionUtil as E;
+
+/**
+ * Compatibility base for CiviCase upgrade step classes.
+ */
+class CRM_Civicase_Upgrader_Base {
+
+  /**
+   * @var static
+   */
+  protected static $instance;
+
+  /**
+   * Returns the singleton upgrader instance.
+   *
+   * @return static
+   */
+  public static function instance() {
+    if (!isset(self::$instance)) {
+      self::$instance = new static();
+    }
+    return self::$instance;
+  }
+
+  /**
+   * Execute a SQL file relative to the extension root.
+   *
+   * @param string $relativePath
+   *
+   * @return bool
+   */
+  public function executeSqlFile($relativePath) {
+    CRM_Utils_File::sourceSQLFile(
+      CIVICRM_DSN,
+      E::path() . DIRECTORY_SEPARATOR . $relativePath
+    );
+    return TRUE;
+  }
+
+}


### PR DESCRIPTION
## Problem
Upgrade steps `CRM/Civicase/Upgrader/Steps/Step0001.php` and `Step0012.php` call `CRM_Civicase_Upgrader_Base::instance()`, but the main upgrader (`CRM_Civicase_Upgrader`) extends `CRM_Extension_Upgrader_Base` directly and there is **no** `CRM_Civicase_Upgrader_Base` class in the repo. On a fresh install/upgrade this fatals with a 'class not found' error.

(Surfaced during a CiviPlus lift & shift where civicase installs from scratch — the shim currently only lives in the civiplus-distribution overlay, so a clean pull of this extension is broken.)

## Fix
Add `CRM/Civicase/Upgrader/Base.php` providing the static `instance()` + `executeSqlFile()` that those Steps rely on.

## Test
- `Step0001`/`Step0012` resolve `CRM_Civicase_Upgrader_Base::instance()` without fatal.
- Fresh install of the extension completes its upgrade steps.