### PR TITLE
TCOSB-59: SearchKit support for repeatable Case custom field sets

### DIFF
--- a/tests/e2e/specs/manage-repeatable-case-custom-data.spec.ts
+++ b/tests/e2e/specs/manage-repeatable-case-custom-data.spec.ts
@@ -25,10 +25,13 @@ import { CiviCrmApi } from '../helpers/civicrm-api';
 const GROUP_TITLE = 'ZZ E2E Repeat Case Data';
 const FIELD_LABEL = 'E2E Entry Name';
 const MAX_RECORDS = 2;
-// Case category the civicase case app is opened under (Housing Support et al.).
-const CASE_TYPE_CATEGORY = 1;
-const CASE_TYPE_ID = 2;
-const CLIENT_CONTACT_ID = 3;
+
+// Resolved dynamically in beforeAll (no hardcoded, environment-specific IDs):
+// an active Case Type, the category it belongs to (the civicase app opens under
+// that category), and a throwaway client contact.
+let caseTypeId = 0;
+let caseCategory = 0;
+let contactId = 0;
 
 let groupName = '';
 let fieldName = '';
@@ -116,12 +119,23 @@ test.beforeAll(async () => {
   // hook_civicrm_post reconcile), so the tab works without an admin clearing
   // the cache. Flushing here would mask a regression of that behaviour.
 
+  // An active Case Type + its category (the civicase app opens under it) and a
+  // throwaway contact — resolved dynamically so this runs on any site.
+  const caseType = civi.values(await civi.api3('CaseType', 'get', {
+    is_active: 1, options: { limit: 1, sort: 'id ASC' },
+  }))[0];
+  caseTypeId = Number(caseType.id);
+  caseCategory = Number(caseType.case_type_category);
+  contactId = Number(civi.values(await civi.api3('Contact', 'create', {
+    contact_type: 'Individual', first_name: 'E2E', last_name: 'Manage Client',
+  }))[0].id);
+
   // A case to attach the records to.
   const kase = civi.values(
     await civi.api3('Case', 'create', {
-      case_type_id: CASE_TYPE_ID,
-      contact_id: CLIENT_CONTACT_ID,
-      creator_id: CLIENT_CONTACT_ID,
+      case_type_id: caseTypeId,
+      contact_id: contactId,
+      creator_id: contactId,
       subject: 'E2E Repeatable Custom Data',
       status_id: 'Open',
     }),
@@ -135,11 +149,12 @@ test.afterAll(async () => {
     await civi.api3('Case', 'delete', { id: caseId }).catch(() => {});
   }
   await civi.deleteCustomGroupByTitle(GROUP_TITLE).catch(() => {});
+  if (contactId) await civi.api3('Contact', 'delete', { id: contactId, skip_undelete: 1 }).catch(() => {});
 });
 
 test('add, edit, delete and max-limit on a repeatable Case custom-data tab', async ({ page }) => {
   await civiLogin(page);
-  await page.goto(`/civicrm/case/a/?case_type_category=${CASE_TYPE_CATEGORY}#/case/list?caseId=${caseId}`);
+  await page.goto(`/civicrm/case/a/?case_type_category=${caseCategory}#/case/list?caseId=${caseId}`);
 
   await openGroupTab(page);
 

--- a/tests/e2e/specs/search-repeatable-case-custom-data.spec.ts
+++ b/tests/e2e/specs/search-repeatable-case-custom-data.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * TCOSB-59 — 1.5 SearchKit: Support Repeatable Case Custom Field Sets.
+ *
+ * This capability is NATIVE: a repeatable ("Tab with table") Case custom group
+ * is exposed by APIv4 as a `Custom_<name>` entity whose `entity_id` field has
+ * `fk_entity = Case`, so SearchKit offers it as a join from Case exactly like a
+ * Contact multi-record group. No civicase runtime code is required — this spec
+ * is a regression guard so that if a future core/civicase change ever breaks the
+ * case join, dedup, or filtering, it is caught.
+ *
+ * Verified through `SearchDisplay.run` (the exact call the SearchKit UI makes),
+ * driven in the authenticated admin session via CRM.api4:
+ *  - AC1/AC2: Case→Custom_<group> join is usable and filterable.
+ *  - AC3:     a filter on a repeatable custom field returns the matching Case
+ *             (and a non-matching filter returns nothing).
+ *  - AC5:     all of a Case's repeatable records are considered by the filter.
+ *  - AC6:     GROUP BY Case yields ONE row even when several child records match
+ *             (no duplicate Cases).
+ *
+ * Self-contained: creates its own repeatable Case group + field + two Cases and
+ * their records, and tears them down.
+ */
+
+import { type Page } from '@playwright/test';
+import { test, expect } from '../helpers/fixtures';
+import { civiLogin } from '../helpers/civicrm-login';
+import { CiviCrmApi } from '../helpers/civicrm-api';
+
+const GROUP_TITLE = 'ZZ E2E Search Repeat Case';
+const FIELD_LABEL = 'E2E Search Name';
+const CASE_TYPE_ID = 2;
+const CLIENT_CONTACT_ID = 3;
+
+let groupName = '';
+let fieldName = '';
+let caseMatchId = 0;
+let caseOtherId = 0;
+
+/** Call APIv4 inside the authenticated browser session (as the SearchKit UI does). */
+async function api4(page: Page, entity: string, action: string, params: Record<string, unknown>): Promise<any[]> {
+  return page.evaluate(
+    ([e, a, p]) => (window as unknown as { CRM: { api4: (e: string, a: string, p: unknown) => Promise<any[]> } })
+      .CRM.api4(e, a, p),
+    [entity, action, params] as const,
+  );
+}
+
+/** Build the inline SavedSearch that joins Case to the repeatable group and filters it. */
+function caseSearch(where: unknown[]): Record<string, unknown> {
+  return {
+    savedSearch: {
+      api_entity: 'Case',
+      api_params: {
+        version: 4,
+        select: ['id', 'subject', 'COUNT(m.id) AS matches'],
+        join: [[`Custom_${groupName} AS m`, 'INNER', ['id', '=', 'm.entity_id']]],
+        where,
+        groupBy: ['id'],
+      },
+    },
+    display: null,
+    return: 'page:1',
+  };
+}
+
+test.beforeAll(async () => {
+  const civi = CiviCrmApi.fromEnv();
+  await civi.deleteCustomGroupByTitle(GROUP_TITLE);
+
+  const group = civi.values(
+    await civi.api3('CustomGroup', 'create', {
+      title: GROUP_TITLE,
+      extends: 'Case',
+      is_multiple: 1,
+      style: 'Tab with table',
+    }),
+  )[0];
+  groupName = String(group.name);
+
+  const field = civi.values(
+    await civi.api3('CustomField', 'create', {
+      custom_group_id: group.id,
+      label: FIELD_LABEL,
+      data_type: 'String',
+      html_type: 'Text',
+      is_active: 1,
+      is_searchable: 1,
+    }),
+  )[0];
+  fieldName = String(field.name);
+
+  caseMatchId = Number(civi.values(await civi.api3('Case', 'create', {
+    case_type_id: CASE_TYPE_ID, contact_id: CLIENT_CONTACT_ID, creator_id: CLIENT_CONTACT_ID,
+    subject: 'E2E Search MATCH', status_id: 'Open',
+  }))[0].id);
+
+  caseOtherId = Number(civi.values(await civi.api3('Case', 'create', {
+    case_type_id: CASE_TYPE_ID, contact_id: CLIENT_CONTACT_ID, creator_id: CLIENT_CONTACT_ID,
+    subject: 'E2E Search OTHER', status_id: 'Open',
+  }))[0].id);
+});
+
+test.afterAll(async () => {
+  const civi = CiviCrmApi.fromEnv();
+  for (const id of [caseMatchId, caseOtherId]) {
+    if (id) await civi.api3('Case', 'delete', { id }).catch(() => {});
+  }
+  await civi.deleteCustomGroupByTitle(GROUP_TITLE).catch(() => {});
+});
+
+test('SearchKit joins, filters and de-duplicates repeatable Case custom data', async ({ page }) => {
+  await civiLogin(page);
+  // Any CiviCRM page exposes CRM.api4; the SearchKit admin is a natural home.
+  await page.goto('/civicrm/admin/search', { waitUntil: 'domcontentloaded' });
+
+  // The matching Case has TWO repeatable records (so dedup is actually exercised);
+  // the other Case has one non-matching record.
+  await api4(page, `Custom_${groupName}`, 'save', {
+    records: [
+      { entity_id: caseMatchId, [fieldName]: 'MatchAlpha' },
+      { entity_id: caseMatchId, [fieldName]: 'MatchBeta' },
+      { entity_id: caseOtherId, [fieldName]: 'SomethingElse' },
+    ],
+  });
+
+  // AC3 / AC5 / AC6: filter matches the two records on caseMatch; GROUP BY Case
+  // returns exactly ONE row for it (matches = 2), and caseOther is excluded.
+  const matched = await api4(page, 'SearchDisplay', 'run', caseSearch([['m.' + fieldName, 'LIKE', 'Match%']]));
+  expect(matched).toHaveLength(1);
+  expect(matched[0].data.id).toBe(caseMatchId);
+  expect(matched[0].data.matches).toBe(2);
+
+  // AC3 (negative): a filter that matches no record returns no Cases.
+  const none = await api4(page, 'SearchDisplay', 'run', caseSearch([['m.' + fieldName, '=', 'NoSuchValueXYZ']]));
+  expect(none).toHaveLength(0);
+});

--- a/tests/e2e/specs/search-repeatable-case-custom-data.spec.ts
+++ b/tests/e2e/specs/search-repeatable-case-custom-data.spec.ts
@@ -28,16 +28,17 @@ import { CiviCrmApi } from '../helpers/civicrm-api';
 
 const GROUP_TITLE = 'ZZ E2E Search Repeat Case';
 const FIELD_LABEL = 'E2E Search Name';
-const CASE_TYPE_ID = 2;
-const CLIENT_CONTACT_ID = 3;
-
 let groupName = '';
 let fieldName = '';
 let caseMatchId = 0;
 let caseOtherId = 0;
+let caseTypeId = 0;
+let contactId = 0;
 
 /** Call APIv4 inside the authenticated browser session (as the SearchKit UI does). */
 async function api4(page: Page, entity: string, action: string, params: Record<string, unknown>): Promise<any[]> {
+  // Wait for CiviCRM's global CRM object to finish initialising to avoid a race.
+  await page.waitForFunction(() => typeof (window as unknown as { CRM?: { api4?: unknown } }).CRM?.api4 === 'function');
   return page.evaluate(
     ([e, a, p]) => (window as unknown as { CRM: { api4: (e: string, a: string, p: unknown) => Promise<any[]> } })
       .CRM.api4(e, a, p),
@@ -89,13 +90,22 @@ test.beforeAll(async () => {
   )[0];
   fieldName = String(field.name);
 
+  // Resolve an active Case Type and a throwaway contact dynamically, so the spec
+  // does not depend on environment-specific seeded IDs.
+  caseTypeId = Number(civi.values(await civi.api3('CaseType', 'get', {
+    is_active: 1, options: { limit: 1, sort: 'id ASC' },
+  }))[0].id);
+  contactId = Number(civi.values(await civi.api3('Contact', 'create', {
+    contact_type: 'Individual', first_name: 'E2E', last_name: 'Search Client',
+  }))[0].id);
+
   caseMatchId = Number(civi.values(await civi.api3('Case', 'create', {
-    case_type_id: CASE_TYPE_ID, contact_id: CLIENT_CONTACT_ID, creator_id: CLIENT_CONTACT_ID,
+    case_type_id: caseTypeId, contact_id: contactId, creator_id: contactId,
     subject: 'E2E Search MATCH', status_id: 'Open',
   }))[0].id);
 
   caseOtherId = Number(civi.values(await civi.api3('Case', 'create', {
-    case_type_id: CASE_TYPE_ID, contact_id: CLIENT_CONTACT_ID, creator_id: CLIENT_CONTACT_ID,
+    case_type_id: caseTypeId, contact_id: contactId, creator_id: contactId,
     subject: 'E2E Search OTHER', status_id: 'Open',
   }))[0].id);
 });
@@ -106,6 +116,7 @@ test.afterAll(async () => {
     if (id) await civi.api3('Case', 'delete', { id }).catch(() => {});
   }
   await civi.deleteCustomGroupByTitle(GROUP_TITLE).catch(() => {});
+  if (contactId) await civi.api3('Contact', 'delete', { id: contactId, skip_undelete: 1 }).catch(() => {});
 });
 
 test('SearchKit joins, filters and de-duplicates repeatable Case custom data', async ({ page }) => {


### PR DESCRIPTION
## Overview

Requirement **1.5** of the Repeatable Custom Field Sets for Cases epic: users can search Cases in **SearchKit** using data held in repeatable ("Tab with table", multi-record) Case custom field sets — the same way they already can for Contact multi-record groups.

Investigation found this works **natively with no runtime code** (see Technical Details). This PR therefore adds an automated **regression guard** so the behaviour can't silently break in a future core/civicase change.

## Before

Repeatable Case custom groups already worked as a data source in SearchKit, but nothing pinned the behaviour down — a future change to core/APIv4 metadata or civicase could have broken the Case↔custom-group join without anything catching it.

## After

A repeatable Case custom group is offered as a first-class SearchKit **join** from Cases (with a clean label), filterable, and de-duplicated (one Case row even when several child records match).

<img width="1280" height="883" alt="sk-join-dropdown" src="https://github.com/user-attachments/assets/cf104d22-5352-4b95-81ea-268434823e1d" />

<img width="1913" height="638" alt="Screenshot 2026-07-21 at 22 07 48" src="https://github.com/user-attachments/assets/3f093822-73ac-4c90-87de-814fec8968da" />

Verified through `SearchDisplay.run` (the exact call the SearchKit UI makes), as an authenticated admin:

- filter on a repeatable custom field → **1 matching Case row, `matches: 2`** (deduped, despite two matching child records)
- non-matching filter → **`[]`**
- as an anonymous user the run is correctly **blocked** on the custom entity (permissions enforced)

## Technical Details

A repeatable ("Tab with table") Case custom group is exposed by APIv4 as a `Custom_<name>` entity whose `entity_id` field has **`fk_entity = Case`** — identical to how Contact multi-record groups behave. SearchKit derives its join offers from exactly this metadata, so the Case → `Custom_<name>` join, field filtering, and `GROUP BY` de-duplication all work out of the box. No extension code is required for 1.5.

This PR adds one Playwright E2E (`tests/e2e/specs/search-repeatable-case-custom-data.spec.ts`) that provisions a repeatable Case group + field + two Cases and their records, then drives `SearchDisplay.run` in the authenticated browser session to assert the join, filter, dedup (AC3/AC5/AC6) and the negative-filter case.

### Core overrides

None. This PR is purely additive (a test) — no core files are overridden or patched.

## Manual QA Steps

**Prerequisite:** a repeatable Case custom group (from 1.1) — Allow multiple records = Yes, Display style = "Tab with table", with a few fields (e.g. a text field and a date). Add a Case and give it **2+ records** in that group (via the case's custom-data tab from 1.2). Give at least two records a value you can filter on (e.g. both containing "Alpha").

1. Go to **Administer → Search Kit** and create a **New Search**.
2. Set **Search for = Cases**.
3. Click the **"+ Entity"** (join) control and add the repeatable Case custom group — it appears labelled like **"<Group> — Custom group for Cases"** (e.g. "Test Case multiple"). Keep the default join.
4. Under **Select Fields**, add the group's custom field(s) as columns (plus Case ID / Subject).
5. Under **Filter Conditions**, add a filter on one of the custom fields (e.g. *contains* "Alpha").
6. Click **Search** — confirm Cases whose records match the filter are returned, and a non-matching value is excluded.
7. **De-duplication:** add **Group By = Case ID**. Confirm a Case that has several matching records now appears as **one row** (no duplicate Cases). Removing the Group By should show one row per matching record.
8. **Field types:** repeat step 5 with different field types (text *contains*, date range, number >/<, select =) — confirm each filters correctly.
9. **Permissions:** as a user **without** access to the Case (or without the custom group's permission), confirm the Case / custom data does not appear in results.
10. **Regression:** an existing SearchKit search over a **standard (non-repeatable)** Case custom field still builds and runs unchanged.

**Expected:** repeatable Case custom groups are selectable as a SearchKit join on Cases, filterable across field types, and Cases are not duplicated when multiple records match — consistent with Contact multi-record custom groups.

## Comments

- No production code changes — 1.5 is delivered as verification + a regression test.
- Full local E2E suite is green (3/3: 1.1, 1.2, 1.5). CI does not run the Playwright E2E (local-only), consistent with the 1.1/1.2 PRs.
- AC9 residual: permission *enforcement* is confirmed (anon blocked, admin allowed); a full negative test with a restricted Drupal user is the only thing not automated here.

