### PR TITLE
TCOSB-60: Form Builder (Afform) support for repeatable Case custom field sets

### DIFF
--- a/tests/e2e/specs/afform-repeatable-case-custom-data.spec.ts
+++ b/tests/e2e/specs/afform-repeatable-case-custom-data.spec.ts
@@ -28,15 +28,17 @@ const GROUP_TITLE = 'ZZ E2E Afform Repeat Case';
 const FIELD_LABEL = 'E2E Afform Name';
 const MAX_RECORDS = 2;
 const AFFORM_NAME = 'afformE2eRepeatCaseTest';
-const CASE_TYPE_ID = 2;
-const CLIENT_CONTACT_ID = 3;
 
 let groupName = '';
 let fieldName = '';
 let caseId = 0;
+let caseTypeId = 0;
+let contactId = 0;
 
 /** Call APIv4 inside the authenticated browser session (as the public form does). */
 async function api4(page: Page, entity: string, action: string, params: Record<string, unknown>): Promise<any> {
+  // Wait for CiviCRM's global CRM object to finish initialising to avoid a race.
+  await page.waitForFunction(() => typeof (window as unknown as { CRM?: { api4?: unknown } }).CRM?.api4 === 'function');
   return page.evaluate(
     ([e, a, p]) => (window as unknown as { CRM: { api4: (e: string, a: string, p: unknown) => Promise<any> } })
       .CRM.api4(e, a, p),
@@ -68,8 +70,17 @@ test.beforeAll(async () => {
   }))[0];
   fieldName = String(field.name);
 
+  // Resolve an active Case Type and a throwaway contact dynamically, so the spec
+  // does not depend on environment-specific seeded IDs.
+  caseTypeId = Number(civi.values(await civi.api3('CaseType', 'get', {
+    is_active: 1, options: { limit: 1, sort: 'id ASC' },
+  }))[0].id);
+  contactId = Number(civi.values(await civi.api3('Contact', 'create', {
+    contact_type: 'Individual', first_name: 'E2E', last_name: 'Afform Client',
+  }))[0].id);
+
   caseId = Number(civi.values(await civi.api3('Case', 'create', {
-    case_type_id: CASE_TYPE_ID, contact_id: CLIENT_CONTACT_ID, creator_id: CLIENT_CONTACT_ID,
+    case_type_id: caseTypeId, contact_id: contactId, creator_id: contactId,
     subject: 'E2E Afform Repeatable', status_id: 'Open',
   }))[0].id);
 });
@@ -78,6 +89,7 @@ test.afterAll(async () => {
   const civi = CiviCrmApi.fromEnv();
   if (caseId) await civi.api3('Case', 'delete', { id: caseId }).catch(() => {});
   await civi.deleteCustomGroupByTitle(GROUP_TITLE).catch(() => {});
+  if (contactId) await civi.api3('Contact', 'delete', { id: contactId, skip_undelete: 1 }).catch(() => {});
 });
 
 test('Afform af-repeat creates multiple Case custom records and enforces the max', async ({ page }) => {

--- a/tests/e2e/specs/afform-repeatable-case-custom-data.spec.ts
+++ b/tests/e2e/specs/afform-repeatable-case-custom-data.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * TCOSB-60 — 1.6 Form Builder (Afform): Support Repeatable Case Custom Field Sets.
+ *
+ * A repeatable ("Tab with table") Case custom group is exposed by core as an
+ * Afform BLOCK (`afblockCustom_<name>`, entity_type=Case, join_entity=Custom_<name>)
+ * — byte-for-byte the same shape core produces for Contact multi-record groups.
+ * So Afform's native `af-repeat` handles it with no civicase runtime code: a form
+ * with the block set to repeat submits multiple records, each stored as a
+ * separate Custom_<name> record linked to the parent Case via entity_id.
+ *
+ * This spec is a regression guard driving `Afform.submit` (the exact call the
+ * public form makes) in the authenticated session:
+ *  - AC2/AC3/AC9: submitting two repeated instances creates two separate records
+ *    against the Case.
+ *  - AC4: the group's max_multiple is enforced — a submission beyond the limit
+ *    does not create additional records.
+ *
+ * Self-contained: creates its own repeatable Case group (max 2) + field + Case
+ * and the Afform, and tears them all down (Afform via revert — it has no delete).
+ */
+
+import { type Page } from '@playwright/test';
+import { test, expect } from '../helpers/fixtures';
+import { civiLogin } from '../helpers/civicrm-login';
+import { CiviCrmApi } from '../helpers/civicrm-api';
+
+const GROUP_TITLE = 'ZZ E2E Afform Repeat Case';
+const FIELD_LABEL = 'E2E Afform Name';
+const MAX_RECORDS = 2;
+const AFFORM_NAME = 'afformE2eRepeatCaseTest';
+const CASE_TYPE_ID = 2;
+const CLIENT_CONTACT_ID = 3;
+
+let groupName = '';
+let fieldName = '';
+let caseId = 0;
+
+/** Call APIv4 inside the authenticated browser session (as the public form does). */
+async function api4(page: Page, entity: string, action: string, params: Record<string, unknown>): Promise<any> {
+  return page.evaluate(
+    ([e, a, p]) => (window as unknown as { CRM: { api4: (e: string, a: string, p: unknown) => Promise<any> } })
+      .CRM.api4(e, a, p),
+    [entity, action, params] as const,
+  );
+}
+
+/** Count this group's records currently attached to the case. */
+async function recordCount(page: Page): Promise<number> {
+  const rows = await api4(page, `Custom_${groupName}`, 'get', {
+    where: [['entity_id', '=', caseId]], select: ['id'],
+  });
+  return Array.isArray(rows) ? rows.length : 0;
+}
+
+test.beforeAll(async () => {
+  const civi = CiviCrmApi.fromEnv();
+  await civi.deleteCustomGroupByTitle(GROUP_TITLE);
+
+  const group = civi.values(await civi.api3('CustomGroup', 'create', {
+    title: GROUP_TITLE, extends: 'Case', is_multiple: 1,
+    max_multiple: MAX_RECORDS, style: 'Tab with table',
+  }))[0];
+  groupName = String(group.name);
+
+  const field = civi.values(await civi.api3('CustomField', 'create', {
+    custom_group_id: group.id, label: FIELD_LABEL,
+    data_type: 'String', html_type: 'Text', is_active: 1, is_searchable: 1,
+  }))[0];
+  fieldName = String(field.name);
+
+  caseId = Number(civi.values(await civi.api3('Case', 'create', {
+    case_type_id: CASE_TYPE_ID, contact_id: CLIENT_CONTACT_ID, creator_id: CLIENT_CONTACT_ID,
+    subject: 'E2E Afform Repeatable', status_id: 'Open',
+  }))[0].id);
+});
+
+test.afterAll(async () => {
+  const civi = CiviCrmApi.fromEnv();
+  if (caseId) await civi.api3('Case', 'delete', { id: caseId }).catch(() => {});
+  await civi.deleteCustomGroupByTitle(GROUP_TITLE).catch(() => {});
+});
+
+test('Afform af-repeat creates multiple Case custom records and enforces the max', async ({ page }) => {
+  await civiLogin(page);
+  await page.goto('/civicrm/admin/search', { waitUntil: 'domcontentloaded' });
+
+  const layout =
+    `<af-form ctrl="afform">` +
+    `<af-entity type="Custom_${groupName}" name="Record" label="Rec" actions="{create: true}" security="RBAC" />` +
+    `<fieldset af-fieldset="Record" af-repeat="Add" min="1" max="${MAX_RECORDS}">` +
+    `<af-field name="entity_id" defn="{input_type: 'Hidden', label: false}" />` +
+    `<af-field name="${fieldName}" />` +
+    `</fieldset></af-form>`;
+
+  try {
+    // A form that repeats the Case custom group's fieldset (Form Builder output).
+    await api4(page, 'Afform', 'revert', { where: [['name', '=', AFFORM_NAME]] }).catch(() => {});
+    await api4(page, 'Afform', 'create', {
+      values: {
+        name: AFFORM_NAME, type: 'form', title: 'E2E Repeat Case',
+        server_route: 'civicrm/af/e2e-repeat-case-test',
+        is_public: false, permission: ['access CiviCRM'], layout,
+      },
+    });
+
+    // AC2/AC3/AC9: submit two repeated instances -> two separate records on the Case.
+    await api4(page, 'Afform', 'submit', {
+      name: AFFORM_NAME,
+      values: { Record: [
+        { fields: { entity_id: caseId, [fieldName]: 'Entry A' } },
+        { fields: { entity_id: caseId, [fieldName]: 'Entry B' } },
+      ] },
+    });
+    expect(await recordCount(page)).toBe(2);
+
+    // AC4: at the max now — an extra submission must not create a third record.
+    await api4(page, 'Afform', 'submit', {
+      name: AFFORM_NAME,
+      values: { Record: [{ fields: { entity_id: caseId, [fieldName]: 'Entry C (over limit)' } }] },
+    }).catch(() => { /* rejection is an acceptable enforcement path */ });
+    expect(await recordCount(page)).toBe(MAX_RECORDS);
+  } finally {
+    // Afform has no delete; revert removes the local-only form.
+    await api4(page, 'Afform', 'revert', { where: [['name', '=', AFFORM_NAME]] }).catch(() => {});
+  }
+});


### PR DESCRIPTION
## Overview

Requirement **1.6** of the Repeatable Custom Field Sets for Cases epic: the **Form Builder (Afform)** supports repeatable ("Tab with table", multi-record) Case custom field sets, so an admin can build a form where a user/applicant adds **multiple entries** of a Case custom group ("Add Another"), each saved as a separate record against the Case.

Investigation found this works **natively, with no runtime code** (see Technical Details). This PR adds an automated **regression guard**.

## Before

Core already generated an Afform block for repeatable Case custom groups, but nothing pinned the end-to-end behaviour (repeat → multiple records on the Case, max enforcement), so a future core/civicase change could have broken it unnoticed.

## After

A repeatable Case custom group can be dropped into a form as a repeating section; submitting multiple instances creates multiple records against the Case, and the group's max is enforced.

<img width="1280" height="720" alt="afform-add-another" src="https://github.com/user-attachments/assets/2969fc9a-e92e-45c8-9ff5-50184818cfe9" />


Verified via `Afform.submit` (the exact call the form makes), as an authenticated user:

- two repeated instances → **two separate `Custom_<group>` records** on the Case
- an over-limit submission → **no extra record created** (max enforced)

## Technical Details

Core auto-generates an Afform **block** for a repeatable Case group — `afblockCustom_<name>` with `entity_type=Case` and `join_entity=Custom_<name>` — byte-for-byte the same shape it produces for Contact multi-record groups. Afform's native `af-repeat` therefore handles the repeatable Case group with no extension code: each repeated instance is saved as a separate `Custom_<name>` record linked to the parent Case via `entity_id`, and `max_multiple` is enforced server-side (the same path 1.2 relies on).

This PR adds one Playwright E2E (`tests/e2e/specs/afform-repeatable-case-custom-data.spec.ts`) that provisions a repeatable Case group (max 2) + field + Case, builds an `af-repeat` form, and drives `Afform.submit` to assert AC2/AC3/AC9 (multiple records created) and AC4 (max enforced). Teardown reverts the local afform (`Afform` has no APIv4 delete).

### Core overrides

None. Purely additive (a test) — no core files overridden or patched.

## Manual QA Steps

Prerequisite: a Case custom group configured as repeatable (1.1) — Allow multiple records = Yes, Display style = "Tab with table", optionally a Maximum. (e.g. create one via **Administer → Custom Data & Screens → Custom Fields**.)

1. Go to **Administer → Form Builder** and create a **New Form** (submission form).
2. Add the **Case** entity to the form (or open a form that already includes a Case).
3. Add the repeatable Case custom group to the form — it appears as a block/fieldset for that group. Enable **repeat** on it (the "Add Another" behaviour); if the group has a Maximum, set the repeat max to match.
4. Add a couple of the group's fields into the block, **Save** the form, and open its public URL (or Preview).
5. On the form, use **Add Another** to add **two** entries, fill in the fields, and **Submit**.
6. Open the target **Case → the repeatable custom group tab** (the 1.2 tab): confirm **both** submitted entries appear as **separate records**.
7. **Max check:** on a group with Maximum = N, try to add more than N entries — the form should not allow submitting/creating beyond N (no extra record is created).
8. **No-max check:** on a group with no Maximum, confirm you can keep adding entries without a limit.
9. **Regression:** confirm a form using a **non-repeatable** Case custom group still renders and submits exactly as before.

## Comments

- No production code changes — 1.6 is delivered as verification + a regression test.
- Full local E2E suite green (4/4: 1.1, 1.2, 1.5, 1.6). CI does not run Playwright (local-only), consistent with the earlier PRs.
