### PR TITLE
TCOSB-62: CiviCRM export support for repeatable Case custom field sets

### DIFF
--- a/tests/e2e/specs/export-repeatable-case-custom-data.spec.ts
+++ b/tests/e2e/specs/export-repeatable-case-custom-data.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * TCOSB-62 — 1.7 CiviCRM Exports: Support Repeatable Case Custom Field Sets.
+ *
+ * Core's legacy Export UI cannot export multi-record custom data (true even for
+ * Contacts — see the spec's open question), so the sanctioned path is SearchKit
+ * export. Because a repeatable Case group is a native SearchKit join (see 1.5),
+ * SearchKit's export emits each repeatable record as its own row with the parent
+ * Case columns repeated — no civicase runtime code.
+ *
+ * This spec is a regression guard driving `SearchDisplay.download` (the exact
+ * action the SearchKit "Export" button calls) in the authenticated session:
+ *  - AC2: every repeatable record on the Case is exported as a separate row.
+ *  - AC3: each row carries the parent Case's identifying columns.
+ *  - AC4: custom field values are exported.
+ *
+ * Self-contained: creates its own repeatable Case group + field + Case + records
+ * (no hardcoded IDs) and tears them all down.
+ */
+
+import { type Page } from '@playwright/test';
+import { test, expect } from '../helpers/fixtures';
+import { civiLogin } from '../helpers/civicrm-login';
+import { CiviCrmApi } from '../helpers/civicrm-api';
+
+const GROUP_TITLE = 'ZZ E2E Export Repeat Case';
+const FIELD_LABEL = 'E2E Export Name';
+
+let groupName = '';
+let fieldName = '';
+let caseId = 0;
+let caseTypeId = 0;
+let contactId = 0;
+
+async function api4(page: Page, entity: string, action: string, params: Record<string, unknown>): Promise<any> {
+  await page.waitForFunction(() => typeof (window as unknown as { CRM?: { api4?: unknown } }).CRM?.api4 === 'function');
+  return page.evaluate(
+    ([e, a, p]) => (window as unknown as { CRM: { api4: (e: string, a: string, p: unknown) => Promise<any> } }).CRM.api4(e, a, p),
+    [entity, action, params] as const,
+  );
+}
+
+test.beforeAll(async () => {
+  const civi = CiviCrmApi.fromEnv();
+  await civi.deleteCustomGroupByTitle(GROUP_TITLE);
+
+  const group = civi.values(await civi.api3('CustomGroup', 'create', {
+    title: GROUP_TITLE, extends: 'Case', is_multiple: 1, style: 'Tab with table',
+  }))[0];
+  groupName = String(group.name);
+
+  const field = civi.values(await civi.api3('CustomField', 'create', {
+    custom_group_id: group.id, label: FIELD_LABEL,
+    data_type: 'String', html_type: 'Text', is_active: 1, is_searchable: 1,
+  }))[0];
+  fieldName = String(field.name);
+
+  caseTypeId = Number(civi.values(await civi.api3('CaseType', 'get', {
+    is_active: 1, options: { limit: 1, sort: 'id ASC' },
+  }))[0].id);
+  contactId = Number(civi.values(await civi.api3('Contact', 'create', {
+    contact_type: 'Individual', first_name: 'E2E', last_name: 'Export Client',
+  }))[0].id);
+  caseId = Number(civi.values(await civi.api3('Case', 'create', {
+    case_type_id: caseTypeId, contact_id: contactId, creator_id: contactId,
+    subject: 'E2E Export Repeatable', status_id: 'Open',
+  }))[0].id);
+});
+
+test.afterAll(async () => {
+  const civi = CiviCrmApi.fromEnv();
+  if (caseId) await civi.api3('Case', 'delete', { id: caseId }).catch(() => {});
+  await civi.deleteCustomGroupByTitle(GROUP_TITLE).catch(() => {});
+  if (contactId) await civi.api3('Contact', 'delete', { id: contactId, skip_undelete: 1 }).catch(() => {});
+});
+
+test('SearchKit export emits one row per repeatable Case record with parent Case columns', async ({ page }) => {
+  await civiLogin(page);
+  await page.goto('/civicrm/admin/search', { waitUntil: 'domcontentloaded' });
+
+  // Two repeatable records on the Case.
+  await api4(page, `Custom_${groupName}`, 'save', {
+    records: [
+      { entity_id: caseId, [fieldName]: 'Export A' },
+      { entity_id: caseId, [fieldName]: 'Export B' },
+    ],
+  });
+
+  // The SearchKit "Export" button calls SearchDisplay.download, which serialises
+  // the display's rows to CSV/XLSX. Those rows are exactly what SearchDisplay.run
+  // returns, so we assert on the run result (the download action only streams a
+  // file, which isn't returnable via api4). Case joined to the repeatable group
+  // with NO group-by => each repeatable record is its own export row.
+  const rows = await api4(page, 'SearchDisplay', 'run', {
+    savedSearch: {
+      api_entity: 'Case',
+      api_params: {
+        version: 4,
+        select: ['id', 'subject', `m.${fieldName}`],
+        join: [[`Custom_${groupName} AS m`, 'INNER', ['id', '=', 'm.entity_id']]],
+        where: [['id', '=', caseId]],
+      },
+    },
+    display: null,
+    return: 'page:1',
+  });
+
+  const data = (Array.isArray(rows) ? rows : []).map((r: any) => r.data || r);
+  // AC2: two records -> two exported rows.
+  expect(data).toHaveLength(2);
+  // AC3: every row carries the parent Case id.
+  for (const d of data) expect(Number(d.id)).toBe(caseId);
+  // AC4: the custom values are present, one per record.
+  const values = data.map((d: any) => d[`m.${fieldName}`] ?? d[fieldName]).sort();
+  expect(values).toEqual(['Export A', 'Export B']);
+});

--- a/tests/e2e/specs/export-repeatable-case-custom-data.spec.ts
+++ b/tests/e2e/specs/export-repeatable-case-custom-data.spec.ts
@@ -2,19 +2,23 @@
  * TCOSB-62 — 1.7 CiviCRM Exports: Support Repeatable Case Custom Field Sets.
  *
  * Core's legacy Export UI cannot export multi-record custom data (true even for
- * Contacts — see the spec's open question), so the sanctioned path is SearchKit
- * export. Because a repeatable Case group is a native SearchKit join (see 1.5),
- * SearchKit's export emits each repeatable record as its own row with the parent
- * Case columns repeated — no civicase runtime code.
+ * Contacts — see the spec's open question), and for Cases it has no custom-data
+ * export path at all. The sanctioned route is SearchKit's "Download Spreadsheet"
+ * (SearchDisplay.download), which is self-contained (League\Csv over the
+ * display's rows — it does NOT use the legacy export field-select; that is the
+ * separate "Export Cases" task). Because a repeatable Case group is a native
+ * SearchKit join (see 1.5), export works with no civicase runtime code.
  *
- * This spec is a regression guard driving `SearchDisplay.download` (the exact
- * action the SearchKit "Export" button calls) in the authenticated session:
- *  - AC2: every repeatable record on the Case is exported as a separate row.
+ * Regression guard driving the export row-set in the authenticated session.
+ * SearchDisplay.download streams a file (not returnable via api4), so we assert
+ * on SearchDisplay.run — the exact rows the download serialises.
+ *  - AC2: every repeatable record on the Case is a separate export row.
  *  - AC3: each row carries the parent Case's identifying columns.
- *  - AC4: custom field values are exported.
+ *  - AC4: values of multiple field types (text, date, number) are exported.
+ *  - AC5: a non-repeatable Case custom field still exports (no regression).
  *
- * Self-contained: creates its own repeatable Case group + field + Case + records
- * (no hardcoded IDs) and tears them all down.
+ * Self-contained: creates its own groups + fields + Case + records (no hardcoded
+ * IDs) and tears them all down.
  */
 
 import { type Page } from '@playwright/test';
@@ -23,10 +27,14 @@ import { civiLogin } from '../helpers/civicrm-login';
 import { CiviCrmApi } from '../helpers/civicrm-api';
 
 const GROUP_TITLE = 'ZZ E2E Export Repeat Case';
-const FIELD_LABEL = 'E2E Export Name';
+const STD_GROUP_TITLE = 'ZZ E2E Export Std Case';
 
 let groupName = '';
-let fieldName = '';
+let fName = '';   // text
+let fDate = '';   // date
+let fNum = '';    // integer
+let stdGroupName = '';
+let stdFieldName = '';
 let caseId = 0;
 let caseTypeId = 0;
 let contactId = 0;
@@ -42,21 +50,33 @@ async function api4(page: Page, entity: string, action: string, params: Record<s
 test.beforeAll(async () => {
   const civi = CiviCrmApi.fromEnv();
   await civi.deleteCustomGroupByTitle(GROUP_TITLE);
+  await civi.deleteCustomGroupByTitle(STD_GROUP_TITLE);
 
+  // Repeatable group with three field types (text / date / integer).
   const group = civi.values(await civi.api3('CustomGroup', 'create', {
     title: GROUP_TITLE, extends: 'Case', is_multiple: 1, style: 'Tab with table',
   }))[0];
   groupName = String(group.name);
+  fName = String(civi.values(await civi.api3('CustomField', 'create', {
+    custom_group_id: group.id, label: 'Entry Name', data_type: 'String', html_type: 'Text', is_active: 1, is_searchable: 1,
+  }))[0].name);
+  fDate = String(civi.values(await civi.api3('CustomField', 'create', {
+    custom_group_id: group.id, label: 'Entry Date', data_type: 'Date', html_type: 'Select Date', is_active: 1, is_searchable: 1,
+  }))[0].name);
+  fNum = String(civi.values(await civi.api3('CustomField', 'create', {
+    custom_group_id: group.id, label: 'Entry Num', data_type: 'Int', html_type: 'Text', is_active: 1, is_searchable: 1,
+  }))[0].name);
 
-  const field = civi.values(await civi.api3('CustomField', 'create', {
-    custom_group_id: group.id, label: FIELD_LABEL,
-    data_type: 'String', html_type: 'Text', is_active: 1, is_searchable: 1,
+  // A non-repeatable Case custom group (AC5 regression check).
+  const stdGroup = civi.values(await civi.api3('CustomGroup', 'create', {
+    title: STD_GROUP_TITLE, extends: 'Case', is_multiple: 0, style: 'Inline',
   }))[0];
-  fieldName = String(field.name);
+  stdGroupName = String(stdGroup.name);
+  stdFieldName = String(civi.values(await civi.api3('CustomField', 'create', {
+    custom_group_id: stdGroup.id, label: 'Std Field', data_type: 'String', html_type: 'Text', is_active: 1, is_searchable: 1,
+  }))[0].name);
 
-  caseTypeId = Number(civi.values(await civi.api3('CaseType', 'get', {
-    is_active: 1, options: { limit: 1, sort: 'id ASC' },
-  }))[0].id);
+  caseTypeId = Number(civi.values(await civi.api3('CaseType', 'get', { is_active: 1, options: { limit: 1, sort: 'id ASC' } }))[0].id);
   contactId = Number(civi.values(await civi.api3('Contact', 'create', {
     contact_type: 'Individual', first_name: 'E2E', last_name: 'Export Client',
   }))[0].id);
@@ -70,46 +90,63 @@ test.afterAll(async () => {
   const civi = CiviCrmApi.fromEnv();
   if (caseId) await civi.api3('Case', 'delete', { id: caseId }).catch(() => {});
   await civi.deleteCustomGroupByTitle(GROUP_TITLE).catch(() => {});
+  await civi.deleteCustomGroupByTitle(STD_GROUP_TITLE).catch(() => {});
   if (contactId) await civi.api3('Contact', 'delete', { id: contactId, skip_undelete: 1 }).catch(() => {});
 });
 
-test('SearchKit export emits one row per repeatable Case record with parent Case columns', async ({ page }) => {
+test('SearchKit export emits one row per repeatable Case record (all field types), non-repeatable unaffected', async ({ page }) => {
   await civiLogin(page);
   await page.goto('/civicrm/admin/search', { waitUntil: 'domcontentloaded' });
 
-  // Two repeatable records on the Case.
+  // Two repeatable records with text / date / number values.
   await api4(page, `Custom_${groupName}`, 'save', {
     records: [
-      { entity_id: caseId, [fieldName]: 'Export A' },
-      { entity_id: caseId, [fieldName]: 'Export B' },
+      { entity_id: caseId, [fName]: 'Export A', [fDate]: '2026-08-01', [fNum]: 11 },
+      { entity_id: caseId, [fName]: 'Export B', [fDate]: '2026-08-02', [fNum]: 22 },
     ],
   });
+  // A value for the non-repeatable group's field on the same Case.
+  await api4(page, 'Case', 'update', {
+    values: { [`${stdGroupName}.${stdFieldName}`]: 'StdValue' },
+    where: [['id', '=', caseId]],
+  });
 
-  // The SearchKit "Export" button calls SearchDisplay.download, which serialises
-  // the display's rows to CSV/XLSX. Those rows are exactly what SearchDisplay.run
-  // returns, so we assert on the run result (the download action only streams a
-  // file, which isn't returnable via api4). Case joined to the repeatable group
-  // with NO group-by => each repeatable record is its own export row.
+  // Export shape: Case joined to the repeatable group, NO group-by => one row
+  // per record (this is what "Download Spreadsheet" serialises).
   const rows = await api4(page, 'SearchDisplay', 'run', {
     savedSearch: {
       api_entity: 'Case',
       api_params: {
         version: 4,
-        select: ['id', 'subject', `m.${fieldName}`],
+        select: ['id', 'subject', `m.${fName}`, `m.${fDate}`, `m.${fNum}`],
         join: [[`Custom_${groupName} AS m`, 'INNER', ['id', '=', 'm.entity_id']]],
         where: [['id', '=', caseId]],
+        orderBy: { [`m.${fNum}`]: 'ASC' },
       },
     },
     display: null,
     return: 'page:1',
   });
-
   const data = (Array.isArray(rows) ? rows : []).map((r: any) => r.data || r);
-  // AC2: two records -> two exported rows.
+
+  // AC2: two records -> two rows. AC3: each row carries the parent Case id.
   expect(data).toHaveLength(2);
-  // AC3: every row carries the parent Case id.
   for (const d of data) expect(Number(d.id)).toBe(caseId);
-  // AC4: the custom values are present, one per record.
-  const values = data.map((d: any) => d[`m.${fieldName}`] ?? d[fieldName]).sort();
-  expect(values).toEqual(['Export A', 'Export B']);
+  // AC4: text / date / number values all exported.
+  expect(data.map((d: any) => d[`m.${fName}`])).toEqual(['Export A', 'Export B']);
+  expect(data.map((d: any) => Number(d[`m.${fNum}`]))).toEqual([11, 22]);
+  for (const d of data) expect(String(d[`m.${fDate}`])).toContain('2026-08-0');
+
+  // AC5: a non-repeatable Case custom field still exports normally.
+  const std = await api4(page, 'SearchDisplay', 'run', {
+    savedSearch: {
+      api_entity: 'Case',
+      api_params: { version: 4, select: ['id', `${stdGroupName}.${stdFieldName}`], where: [['id', '=', caseId]] },
+    },
+    display: null,
+    return: 'page:1',
+  });
+  const stdData = (Array.isArray(std) ? std : []).map((r: any) => r.data || r);
+  expect(stdData).toHaveLength(1);
+  expect(stdData[0][`${stdGroupName}.${stdFieldName}`]).toBe('StdValue');
 });

--- a/tests/e2e/specs/export-repeatable-case-custom-data.spec.ts
+++ b/tests/e2e/specs/export-repeatable-case-custom-data.spec.ts
@@ -127,15 +127,15 @@ test('SearchKit export emits one row per repeatable Case record (all field types
     display: null,
     return: 'page:1',
   });
-  const data = (Array.isArray(rows) ? rows : []).map((r: any) => r.data || r);
+  const data = (Array.isArray(rows) ? rows : []).map((r: any) => r?.data ?? r);
 
   // AC2: two records -> two rows. AC3: each row carries the parent Case id.
   expect(data).toHaveLength(2);
-  for (const d of data) expect(Number(d.id)).toBe(caseId);
+  for (const d of data) expect(Number(d?.id)).toBe(caseId);
   // AC4: text / date / number values all exported.
-  expect(data.map((d: any) => d[`m.${fName}`])).toEqual(['Export A', 'Export B']);
-  expect(data.map((d: any) => Number(d[`m.${fNum}`]))).toEqual([11, 22]);
-  for (const d of data) expect(String(d[`m.${fDate}`])).toContain('2026-08-0');
+  expect(data.map((d: any) => d?.[`m.${fName}`])).toEqual(['Export A', 'Export B']);
+  expect(data.map((d: any) => Number(d?.[`m.${fNum}`]))).toEqual([11, 22]);
+  for (const d of data) expect(String(d?.[`m.${fDate}`])).toContain('2026-08-0');
 
   // AC5: a non-repeatable Case custom field still exports normally.
   const std = await api4(page, 'SearchDisplay', 'run', {
@@ -146,7 +146,7 @@ test('SearchKit export emits one row per repeatable Case record (all field types
     display: null,
     return: 'page:1',
   });
-  const stdData = (Array.isArray(std) ? std : []).map((r: any) => r.data || r);
+  const stdData = (Array.isArray(std) ? std : []).map((r: any) => r?.data ?? r);
   expect(stdData).toHaveLength(1);
-  expect(stdData[0][`${stdGroupName}.${stdFieldName}`]).toBe('StdValue');
+  expect(stdData[0]?.[`${stdGroupName}.${stdFieldName}`]).toBe('StdValue');
 });


### PR DESCRIPTION
## Overview

Requirement **1.7** of the Repeatable Custom Field Sets for Cases epic: users can **export** repeatable ("Tab with table", multi-record) Case custom field data, with each record exported as its own row against its parent Case.

Investigation found this works **natively via SearchKit export, with no runtime code** (see Technical Details). This PR adds an automated **regression guard**.

## Before

Core's legacy Export UI cannot export multi-record custom data — true even for Contacts (see the spec's own open question) — so there was no supported way to export repeatable Case custom data, and nothing pinning the SearchKit-export behaviour.

## After

A SearchKit search on Cases joined to a repeatable Case custom group exports (CSV/XLSX) **one row per repeatable record**, with the parent Case columns repeated on each row.

_(Optional screenshot: a SearchKit display of a Case + repeatable group, with the Export button.)_

Verified via `SearchDisplay.run` (the rows the export serialises), as an authenticated user: a Case with two repeatable records produces two export rows, each carrying the Case id and the record's values.

## Technical Details

A repeatable Case custom group is a native SearchKit join (`Custom_<name>` with `entity_id.fk_entity = Case`; see 1.5). SearchKit's export actions (`SearchDisplay.download` / `export`) therefore serialise the display's rows to CSV/XLSX with no extension code. With no group-by, each repeatable record is its own row and the parent Case columns are duplicated — exactly the required export shape.

This PR adds one Playwright E2E (`tests/e2e/specs/export-repeatable-case-custom-data.spec.ts`) that provisions a repeatable Case group + field + Case + two records, then asserts the export row-set. Note: `SearchDisplay.download` streams a file (not returnable via api4), so the spec asserts on `SearchDisplay.run` — the exact rows the download serialises. Fixtures use no hardcoded IDs and are fully torn down.

### Core overrides

None. Purely additive (a test) — no core files overridden or patched.

## Manual QA Steps

Prerequisite: a repeatable Case custom group (1.1) with a couple of fields, and a Case with **2+ records** in that group (via the case's custom-data tab from 1.2).

1. Go to **Administer → Search Kit** and create a **New Search**; set **Search for = Cases**.
2. Add the repeatable Case custom group as a **join** (the "+ Entity" control, e.g. "Test Case multiple — Custom group for Cases"). Do **not** add a Group By.
3. Under **Select Fields**, add Case columns (e.g. Case ID, Subject) and the group's custom fields.
4. Add a **Table** display and **Save**.
5. On the display, use the **Export** action (CSV or XLSX).
6. Open the exported file: confirm there is **one row per repeatable record**, and that each row repeats the **parent Case** columns (so records are traceable to their Case).
7. **Regression:** an export of a standard (non-repeatable) Case SearchKit search is unaffected.

## Comments

- No production code changes — 1.7 is delivered as verification + a regression test.
- Full local E2E suite green (5/5: 1.1, 1.2, 1.5, 1.6, 1.7). CI does not run Playwright (local-only), consistent with the earlier PRs.


## Scope note — which export path

This delivers export via SearchKit's **Download Spreadsheet** action (`SearchDisplay.download`), which is **self-contained**: it `extends AbstractRunAction` (the same APIv4 query as the display) and serialises the display's own rows via `League\Csv` — it does **not** use the legacy export field-select. The separate **"Export Cases"** task in the same ACTION menu *does* route to the legacy exporter (with its multi-record limitations); it is **not** used here.

For completeness: CiviCRM's legacy/core export has no path to export **Case** custom data at all (Export Contacts only exports contact fields; Find Cases export is minimal), so SearchKit's Download Spreadsheet is the mechanism for 1.7, not a substitute. **Please confirm SearchKit export is the accepted delivery surface for 1.7.**

E2E coverage now includes AC2/AC3 (one row per record + parent Case columns), AC4 (text/date/number values), and AC5 (a non-repeatable Case custom field still exports).
