### PR TITLE
TCOSB-64: Import support for repeatable Case custom field sets

### DIFF
--- a/CRM/Civicase/Service/RepeatableCaseCustomImporter.php
+++ b/CRM/Civicase/Service/RepeatableCaseCustomImporter.php
@@ -71,16 +71,21 @@ class CRM_Civicase_Service_RepeatableCaseCustomImporter {
   }
 
   /**
-   * Creates repeatable custom record(s) for one import row.
+   * Creates or updates repeatable custom record(s) for one import row.
+   *
+   * When `id` is supplied it is used only to match an existing record on the
+   * Case, which is then updated; otherwise a new record is created.
    *
    * @param array $params
-   *   Row values: `case_id` plus any `custom_<fieldId>` columns.
+   *   Row values: `case_id`, any `custom_<fieldId>` columns, and an optional
+   *   `id` (the record to update — match key only, never stored as a value).
    *
    * @return int
-   *   Number of records created.
+   *   Number of records created or updated.
    *
    * @throws CRM_Core_Exception
-   *   When the Case is missing or no mappable field value is present.
+   *   When the Case is missing, an `id` matches no record on the Case, or no
+   *   mappable field value is present.
    */
   public static function importRow(array $params): int {
     $caseId = (int) ($params['case_id'] ?? 0);
@@ -96,9 +101,14 @@ class CRM_Civicase_Service_RepeatableCaseCustomImporter {
       throw new CRM_Core_Exception(ts('Case %1 not found', [1 => $caseId]));
     }
 
+    // `id`, when supplied, is a MATCH KEY only: it identifies the existing
+    // repeatable record to update. It is never written as a field value.
+    // Blank/absent => create a new record.
+    $recordId = !empty($params['id']) ? (int) $params['id'] : NULL;
+
     $service = new CRM_Civicase_Service_RepeatableCaseCustomGroupAfforms();
     $byGroup = self::fieldsByGroup();
-    $created = 0;
+    $written = 0;
     foreach ($service->getRepeatableCaseGroups() as $group) {
       $values = ['entity_id' => $caseId];
       $hasValue = FALSE;
@@ -112,20 +122,47 @@ class CRM_Civicase_Service_RepeatableCaseCustomImporter {
       if (!$hasValue) {
         continue;
       }
-      // Create-only: each row makes a new record against the Case.
-      civicrm_api4('Custom_' . $group['name'], 'create', [
-        'values' => $values,
-        'checkPermissions' => FALSE,
-      ]);
-      $created++;
+
+      $entity = 'Custom_' . $group['name'];
+      if ($recordId !== NULL) {
+        // Update: the matched record must already exist on this Case (and in
+        // this group). id is match-only, so it is not part of $values.
+        $matched = civicrm_api4($entity, 'get', [
+          'select' => ['id'],
+          'where' => [['id', '=', $recordId], ['entity_id', '=', $caseId]],
+          'checkPermissions' => FALSE,
+        ])->count();
+        if (!$matched) {
+          continue;
+        }
+        civicrm_api4($entity, 'update', [
+          'values' => $values,
+          'where' => [['id', '=', $recordId]],
+          'checkPermissions' => FALSE,
+        ]);
+        $written++;
+      }
+      else {
+        // Create: a new record against the Case.
+        civicrm_api4($entity, 'create', [
+          'values' => $values,
+          'checkPermissions' => FALSE,
+        ]);
+        $written++;
+      }
     }
 
-    if (!$created) {
+    if ($recordId !== NULL && $written === 0) {
+      throw new CRM_Core_Exception(
+        ts('No repeatable record %1 found on Case %2', [1 => $recordId, 2 => $caseId])
+      );
+    }
+    if (!$written) {
       throw new CRM_Core_Exception(
         ts('Row has no repeatable Case custom field values to import')
       );
     }
-    return $created;
+    return $written;
   }
 
 }

--- a/CRM/Civicase/Service/RepeatableCaseCustomImporter.php
+++ b/CRM/Civicase/Service/RepeatableCaseCustomImporter.php
@@ -92,6 +92,20 @@ class CRM_Civicase_Service_RepeatableCaseCustomImporter {
     if (!$caseId) {
       throw new CRM_Core_Exception(ts('case_id is required'));
     }
+
+    // `id`, when supplied, is a MATCH KEY only: it identifies the existing
+    // repeatable record to update; it is never written as a field value.
+    // Blank/absent => create a new record; a non-positive-integer id is a data
+    // error and is rejected outright.
+    $rawId = trim((string) ($params['id'] ?? ''));
+    $recordId = NULL;
+    if ($rawId !== '') {
+      if (!ctype_digit($rawId) || $rawId === '0') {
+        throw new CRM_Core_Exception(ts('Invalid record id "%1"', [1 => $rawId]));
+      }
+      $recordId = (int) $rawId;
+    }
+
     $caseExists = civicrm_api4('Case', 'get', [
       'select' => ['id'],
       'where' => [['id', '=', $caseId]],
@@ -100,11 +114,6 @@ class CRM_Civicase_Service_RepeatableCaseCustomImporter {
     if (!$caseExists) {
       throw new CRM_Core_Exception(ts('Case %1 not found', [1 => $caseId]));
     }
-
-    // `id`, when supplied, is a MATCH KEY only: it identifies the existing
-    // repeatable record to update. It is never written as a field value.
-    // Blank/absent => create a new record.
-    $recordId = !empty($params['id']) ? (int) $params['id'] : NULL;
 
     $service = new CRM_Civicase_Service_RepeatableCaseCustomGroupAfforms();
     $byGroup = self::fieldsByGroup();
@@ -125,22 +134,15 @@ class CRM_Civicase_Service_RepeatableCaseCustomImporter {
 
       $entity = 'Custom_' . $group['name'];
       if ($recordId !== NULL) {
-        // Update: the matched record must already exist on this Case (and in
-        // this group). id is match-only, so it is not part of $values.
-        $matched = civicrm_api4($entity, 'get', [
-          'select' => ['id'],
+        // Update in a single query, scoped to the Case so a record can't be
+        // moved between cases. id is match-only (not in $values). A zero count
+        // means the id/Case/group did not match — the row is rejected below.
+        // (Ids are per-group tables, so only the group holding it updates.)
+        $written += civicrm_api4($entity, 'update', [
+          'values' => $values,
           'where' => [['id', '=', $recordId], ['entity_id', '=', $caseId]],
           'checkPermissions' => FALSE,
         ])->count();
-        if (!$matched) {
-          continue;
-        }
-        civicrm_api4($entity, 'update', [
-          'values' => $values,
-          'where' => [['id', '=', $recordId]],
-          'checkPermissions' => FALSE,
-        ]);
-        $written++;
       }
       else {
         // Create: a new record against the Case.

--- a/CRM/Civicase/Service/RepeatableCaseCustomImporter.php
+++ b/CRM/Civicase/Service/RepeatableCaseCustomImporter.php
@@ -1,0 +1,131 @@
+<?php
+
+use Civi\Api4\CustomField;
+
+/**
+ * Imports one CSV row of repeatable Case custom data (TCOSB-64 / 1.8).
+ *
+ * Used by the CaseCustomImporter.create API, which nz.co.fuzion.csvimport calls
+ * once per CSV row. The parent Case is matched by Case ID; each row creates a
+ * new record in every repeatable ("Tab with table") Case custom group whose
+ * field(s) are present in the row (create-only — AC2/AC3, never overwrites).
+ */
+class CRM_Civicase_Service_RepeatableCaseCustomImporter {
+
+  /**
+   * Per-request cache of active fields grouped by custom group id.
+   *
+   * @var array|null
+   */
+  private static $fieldsByGroup = NULL;
+
+  /**
+   * Active fields of all repeatable Case custom groups, keyed by group id.
+   *
+   * Fetched in a single query and cached per request, so importing many rows
+   * does not re-query per row or per group.
+   *
+   * @return array
+   *   [ groupId => [ ['id' => .., 'name' => .., 'label' => ..], ... ], ... ]
+   */
+  private static function fieldsByGroup(): array {
+    if (self::$fieldsByGroup !== NULL) {
+      return self::$fieldsByGroup;
+    }
+    $service = new CRM_Civicase_Service_RepeatableCaseCustomGroupAfforms();
+    $groupIds = array_column($service->getRepeatableCaseGroups(), 'id');
+    self::$fieldsByGroup = [];
+    if ($groupIds) {
+      $fields = CustomField::get(FALSE)
+        ->addSelect('id', 'name', 'label', 'custom_group_id')
+        ->addWhere('custom_group_id', 'IN', $groupIds)
+        ->addWhere('is_active', '=', TRUE)
+        ->execute();
+      foreach ($fields as $field) {
+        self::$fieldsByGroup[$field['custom_group_id']][] = $field;
+      }
+    }
+    return self::$fieldsByGroup;
+  }
+
+  /**
+   * Columns a CSV can map, keyed by `custom_<fieldId>` => human label.
+   *
+   * One entry per active field of every repeatable Case custom group, so the
+   * importer's field list mirrors what is configurable (AC1).
+   *
+   * @return array
+   *   [ 'custom_<id>' => '<Group title>: <Field label>', ... ]
+   */
+  public static function mappableFields(): array {
+    $service = new CRM_Civicase_Service_RepeatableCaseCustomGroupAfforms();
+    $byGroup = self::fieldsByGroup();
+    $out = [];
+    foreach ($service->getRepeatableCaseGroups() as $group) {
+      foreach ($byGroup[$group['id']] ?? [] as $field) {
+        $label = $group['title'] . ': ' . $field['label'];
+        $out['custom_' . $field['id']] = $label;
+      }
+    }
+    return $out;
+  }
+
+  /**
+   * Creates repeatable custom record(s) for one import row.
+   *
+   * @param array $params
+   *   Row values: `case_id` plus any `custom_<fieldId>` columns.
+   *
+   * @return int
+   *   Number of records created.
+   *
+   * @throws CRM_Core_Exception
+   *   When the Case is missing or no mappable field value is present.
+   */
+  public static function importRow(array $params): int {
+    $caseId = (int) ($params['case_id'] ?? 0);
+    if (!$caseId) {
+      throw new CRM_Core_Exception(ts('case_id is required'));
+    }
+    $caseExists = civicrm_api4('Case', 'get', [
+      'select' => ['id'],
+      'where' => [['id', '=', $caseId]],
+      'checkPermissions' => FALSE,
+    ])->count();
+    if (!$caseExists) {
+      throw new CRM_Core_Exception(ts('Case %1 not found', [1 => $caseId]));
+    }
+
+    $service = new CRM_Civicase_Service_RepeatableCaseCustomGroupAfforms();
+    $byGroup = self::fieldsByGroup();
+    $created = 0;
+    foreach ($service->getRepeatableCaseGroups() as $group) {
+      $values = ['entity_id' => $caseId];
+      $hasValue = FALSE;
+      foreach ($byGroup[$group['id']] ?? [] as $field) {
+        $key = 'custom_' . $field['id'];
+        if (isset($params[$key]) && $params[$key] !== '') {
+          $values[$field['name']] = $params[$key];
+          $hasValue = TRUE;
+        }
+      }
+      if (!$hasValue) {
+        continue;
+      }
+      // Create-only: each row makes a new record against the Case.
+      civicrm_api4('Custom_' . $group['name'], 'create', [
+        'values' => $values,
+        'checkPermissions' => FALSE,
+      ]);
+      $created++;
+    }
+
+    if (!$created) {
+      throw new CRM_Core_Exception(
+        ts('Row has no repeatable Case custom field values to import')
+      );
+    }
+    return $created;
+  }
+
+}

--- a/Civi/Api4/CaseCustomImporter.php
+++ b/Civi/Api4/CaseCustomImporter.php
@@ -46,6 +46,7 @@ class CaseCustomImporter extends AbstractEntity {
   public static function fieldList(): array {
     $fields = [
       ['name' => 'case_id', 'title' => ts('Case ID'), 'data_type' => 'Integer'],
+      ['name' => 'id', 'title' => ts('Record ID'), 'data_type' => 'Integer'],
     ];
     foreach (Importer::mappableFields() as $key => $label) {
       $fields[] = ['name' => $key, 'title' => $label, 'data_type' => 'String'];

--- a/Civi/Api4/CaseCustomImporter.php
+++ b/Civi/Api4/CaseCustomImporter.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Civi\Api4;
+
+use Civi\Api4\Generic\AbstractEntity;
+use Civi\Api4\Generic\BasicGetFieldsAction;
+use CRM_Civicase_Service_RepeatableCaseCustomImporter as Importer;
+
+/**
+ * CaseCustomImporter API4 entity (TCOSB-64 / 1.8).
+ *
+ * A code-only entity that exposes the importer's field metadata over APIv4, so
+ * tools that introspect the import entity via api4 (the nz.co.fuzion.csvimport
+ * "API Import" screen calls APIv4 getFields on it) can resolve it. The per-row
+ * import itself runs through the api3 CaseCustomImporter.create action, backed
+ * by CRM_Civicase_Service_RepeatableCaseCustomImporter.
+ *
+ * @package Civi\Api4
+ */
+class CaseCustomImporter extends AbstractEntity {
+
+  /**
+   * APIv4 field metadata for the importer.
+   *
+   * @param bool $checkPermissions
+   *   Whether to enforce permissions.
+   *
+   * @return \Civi\Api4\Generic\BasicGetFieldsAction
+   *   Lists case_id plus every repeatable Case custom field.
+   */
+  public static function getFields($checkPermissions = TRUE) {
+    $action = new BasicGetFieldsAction(
+      'CaseCustomImporter',
+      __FUNCTION__,
+      [static::class, 'fieldList']
+    );
+    return $action->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * The importable field definitions (case_id + each repeatable custom field).
+   *
+   * @return array
+   *   APIv4 field spec array.
+   */
+  public static function fieldList(): array {
+    $fields = [
+      ['name' => 'case_id', 'title' => ts('Case ID'), 'data_type' => 'Integer'],
+    ];
+    foreach (Importer::mappableFields() as $key => $label) {
+      $fields[] = ['name' => $key, 'title' => $label, 'data_type' => 'String'];
+    }
+    return $fields;
+  }
+
+  /**
+   * Per-action permissions.
+   *
+   * @return array
+   *   Permissions required per action.
+   */
+  public static function permissions() {
+    return ['default' => ['access CiviCRM']];
+  }
+
+}

--- a/api/v3/CaseCustomImporter.php
+++ b/api/v3/CaseCustomImporter.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @file
+ * CaseCustomImporter.create API (TCOSB-64 / 1.8).
+ *
+ * A thin importer endpoint called once per CSV row by the
+ * nz.co.fuzion.csvimport extension ("CSV GUI Import to api"). It creates
+ * repeatable Case custom data additively — no core Import framework changes.
+ * The parent Case is matched by Case ID; each row creates new record(s)
+ * (create-only). See CRM_Civicase_Service_RepeatableCaseCustomImporter.
+ */
+
+use CRM_Civicase_Service_RepeatableCaseCustomImporter as Importer;
+
+/**
+ * CaseCustomImporter.create.
+ *
+ * @param array $params
+ *   Row values (case_id + custom_<fieldId> columns).
+ *
+ * @return array
+ *   API3 result.
+ */
+function civicrm_api3_case_custom_importer_create($params) {
+  try {
+    $created = Importer::importRow($params);
+    return civicrm_api3_create_success($created, $params);
+  }
+  catch (Exception $exception) {
+    return civicrm_api3_create_error($exception->getMessage());
+  }
+}
+
+/**
+ * Field metadata for CaseCustomImporter.create (drives the CSV column mapping).
+ *
+ * @param array $spec
+ *   The spec, by reference.
+ */
+function _civicrm_api3_case_custom_importer_create_spec(&$spec) {
+  $spec['case_id'] = [
+    'title' => ts('Case ID'),
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 1,
+  ];
+  foreach (Importer::mappableFields() as $key => $label) {
+    $spec[$key] = [
+      'title' => $label,
+      'type' => CRM_Utils_Type::T_STRING,
+    ];
+  }
+}

--- a/api/v3/CaseCustomImporter.php
+++ b/api/v3/CaseCustomImporter.php
@@ -44,6 +44,10 @@ function _civicrm_api3_case_custom_importer_create_spec(&$spec) {
     'type' => CRM_Utils_Type::T_INT,
     'api.required' => 1,
   ];
+  $spec['id'] = [
+    'title' => ts('Record ID (match key for update; blank to create)'),
+    'type' => CRM_Utils_Type::T_INT,
+  ];
   foreach (Importer::mappableFields() as $key => $label) {
     $spec[$key] = [
       'title' => $label,

--- a/tests/e2e/specs/import-repeatable-case-custom-data.spec.ts
+++ b/tests/e2e/specs/import-repeatable-case-custom-data.spec.ts
@@ -32,6 +32,8 @@ const FIELD_LABEL = 'E2E Import Name';
 let groupName = '';
 let fieldId = 0;
 let fieldName = '';
+let dateFieldId = 0;
+let dateFieldName = '';
 let caseId = 0;
 let caseTypeId = 0;
 let contactId = 0;
@@ -75,6 +77,11 @@ test.beforeAll(async () => {
   }))[0];
   fieldId = Number(field.id);
   fieldName = String(field.name);
+  const dateField = civi.values(await civi.api3('CustomField', 'create', {
+    custom_group_id: group.id, label: 'E2E Import Date', data_type: 'Date', html_type: 'Select Date', is_active: 1, is_searchable: 1,
+  }))[0];
+  dateFieldId = Number(dateField.id);
+  dateFieldName = String(dateField.name);
 
   caseTypeId = Number(civi.values(await civi.api3('CaseType', 'get', { is_active: 1, options: { limit: 1, sort: 'id ASC' } }))[0].id);
   contactId = Number(civi.values(await civi.api3('Contact', 'create', {
@@ -115,19 +122,33 @@ test('CaseCustomImporter.create imports rows (create), updates by id, and reject
   });
   expect(rows.length).toBe(2);
 
-  // Update: id matches an existing record -> updates in place, no new row.
-  // id is a match key only (not written as a value).
+  // Update: id matches an existing record -> updates it in place across
+  // MULTIPLE fields, no new row. id is a match key only (not written as a value).
+  const dateCol = `custom_${dateFieldId}`;
   const targetId = rows[0].id;
-  const upd = await api3(page, 'CaseCustomImporter', 'create', { case_id: caseId, id: targetId, [col]: 'Updated A' });
+  const upd = await api3(page, 'CaseCustomImporter', 'create', {
+    case_id: caseId, id: targetId, [col]: 'Updated A', [dateCol]: '2026-09-15',
+  });
   expect(upd.is_error).toBeFalsy();
-  rows = await api4(page, `Custom_${groupName}`, 'get', { where: [['entity_id', '=', caseId]], select: ['id', fieldName] });
+  rows = await api4(page, `Custom_${groupName}`, 'get', {
+    where: [['entity_id', '=', caseId]], select: ['id', fieldName, dateFieldName],
+  });
   expect(rows.length).toBe(2);
-  expect(rows.find((r: any) => r.id === targetId)[fieldName]).toBe('Updated A');
+  const updatedRow = rows.find((r: any) => r.id === targetId);
+  expect(updatedRow[fieldName]).toBe('Updated A');
+  expect(String(updatedRow[dateFieldName])).toContain('2026-09-15');
 
   // Matching failure: an id with no record on this Case is rejected (no new row).
   const badId = await api3(page, 'CaseCustomImporter', 'create', { case_id: caseId, id: 999999, [col]: 'Nope' });
   expect(badId.is_error).toBeTruthy();
   expect(String(badId.error_message)).toContain('No repeatable record');
+
+  // A non-numeric id is rejected (api3 type validation catches it before the
+  // service; the service's own "Invalid record id" guard is covered by PHPUnit).
+  const badIdFmt = await api3(page, 'CaseCustomImporter', 'create', { case_id: caseId, id: 'abc', [col]: 'Nope' });
+  expect(badIdFmt.is_error).toBeTruthy();
+
+  // No stray rows created by any of the rejected imports.
   rows = await api4(page, `Custom_${groupName}`, 'get', { where: [['entity_id', '=', caseId]], select: ['id'] });
   expect(rows.length).toBe(2);
 

--- a/tests/e2e/specs/import-repeatable-case-custom-data.spec.ts
+++ b/tests/e2e/specs/import-repeatable-case-custom-data.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * TCOSB-64 — 1.8 CiviCRM Imports: Support Repeatable Case Custom Field Sets.
+ *
+ * Core's Import framework has no additive path for repeatable Case custom data,
+ * so 1.8 is delivered additively via nz.co.fuzion.csvimport ("CSV GUI Import to
+ * api", installed) calling a thin civicase API endpoint, CaseCustomImporter.create,
+ * once per CSV row (same pattern as uk.co.compucorp.membershipextrasimporterapi).
+ * The parent Case is matched by Case ID; each row creates NEW record(s)
+ * (create-only — AC2/AC3, never overwrites).
+ *
+ * This spec drives CaseCustomImporter.create directly (the exact call csvimport
+ * makes per row) in the authenticated session — a real regression guard without
+ * the brittle csvimport QuickForm UI (that round-trip is covered by manual QA),
+ * and without the DDL-leak that blocks creating a real custom group in a headless
+ * PHPUnit test.
+ *  - AC1: the repeatable group's fields are offered as importable columns.
+ *  - AC2/AC3: two rows create two separate records against the same Case.
+ *  - AC5: an invalid row (unknown Case) is rejected with an error.
+ *
+ * Self-contained: creates its own group + field + Case + records (no hardcoded
+ * IDs) and tears them all down.
+ */
+
+import { type Page } from '@playwright/test';
+import { test, expect } from '../helpers/fixtures';
+import { civiLogin } from '../helpers/civicrm-login';
+import { CiviCrmApi } from '../helpers/civicrm-api';
+
+const GROUP_TITLE = 'ZZ E2E Import Repeat Case';
+const FIELD_LABEL = 'E2E Import Name';
+
+let groupName = '';
+let fieldId = 0;
+let caseId = 0;
+let caseTypeId = 0;
+let contactId = 0;
+
+/** APIv4 in the authenticated browser session (used to read records back). */
+async function api4(page: Page, entity: string, action: string, params: Record<string, unknown>): Promise<any> {
+  await page.waitForFunction(() => typeof (window as unknown as { CRM?: { api4?: unknown } }).CRM?.api4 === 'function');
+  return page.evaluate(
+    ([e, a, p]) => (window as unknown as { CRM: { api4: (e: string, a: string, p: unknown) => Promise<any> } }).CRM.api4(e, a, p),
+    [entity, action, params] as const,
+  );
+}
+
+/** APIv3 in the browser (the importer is an api3 entity, as csvimport calls it). */
+async function api3(page: Page, entity: string, action: string, params: Record<string, unknown>): Promise<any> {
+  await page.waitForFunction(() => typeof (window as unknown as { CRM?: { api3?: unknown } }).CRM?.api3 === 'function');
+  return page.evaluate(
+    async ([e, a, p]) => {
+      const CRM = (window as unknown as { CRM: { api3: (e: string, a: string, p: unknown) => Promise<any> } }).CRM;
+      try {
+        return await CRM.api3(e, a, p);
+      }
+      catch (err: any) {
+        return { is_error: 1, error_message: (err && err.error_message) || String(err) };
+      }
+    },
+    [entity, action, params] as const,
+  );
+}
+
+test.beforeAll(async () => {
+  const civi = CiviCrmApi.fromEnv();
+  await civi.deleteCustomGroupByTitle(GROUP_TITLE);
+
+  const group = civi.values(await civi.api3('CustomGroup', 'create', {
+    title: GROUP_TITLE, extends: 'Case', is_multiple: 1, style: 'Tab with table',
+  }))[0];
+  groupName = String(group.name);
+  const field = civi.values(await civi.api3('CustomField', 'create', {
+    custom_group_id: group.id, label: FIELD_LABEL, data_type: 'String', html_type: 'Text', is_active: 1, is_searchable: 1,
+  }))[0];
+  fieldId = Number(field.id);
+
+  caseTypeId = Number(civi.values(await civi.api3('CaseType', 'get', { is_active: 1, options: { limit: 1, sort: 'id ASC' } }))[0].id);
+  contactId = Number(civi.values(await civi.api3('Contact', 'create', {
+    contact_type: 'Individual', first_name: 'E2E', last_name: 'Import Client',
+  }))[0].id);
+  caseId = Number(civi.values(await civi.api3('Case', 'create', {
+    case_type_id: caseTypeId, contact_id: contactId, creator_id: contactId,
+    subject: 'E2E Import Repeatable', status_id: 'Open',
+  }))[0].id);
+});
+
+test.afterAll(async () => {
+  const civi = CiviCrmApi.fromEnv();
+  if (caseId) await civi.api3('Case', 'delete', { id: caseId }).catch(() => {});
+  await civi.deleteCustomGroupByTitle(GROUP_TITLE).catch(() => {});
+  if (contactId) await civi.api3('Contact', 'delete', { id: contactId, skip_undelete: 1 }).catch(() => {});
+});
+
+test('CaseCustomImporter.create imports rows as separate records against the Case, matched by Case ID', async ({ page }) => {
+  await civiLogin(page);
+  await page.goto('/civicrm/admin/search', { waitUntil: 'domcontentloaded' });
+  const col = `custom_${fieldId}`;
+
+  // AC1: the group's field is offered as an importable column.
+  const fields = await api3(page, 'CaseCustomImporter', 'getfields', { action: 'create' });
+  expect(Object.keys(fields.values || {})).toContain(col);
+  expect(Object.keys(fields.values || {})).toContain('case_id');
+
+  // AC2/AC3: two rows -> two separate records against the same Case.
+  const r1 = await api3(page, 'CaseCustomImporter', 'create', { case_id: caseId, [col]: 'Imported A' });
+  expect(r1.is_error).toBeFalsy();
+  const r2 = await api3(page, 'CaseCustomImporter', 'create', { case_id: caseId, [col]: 'Imported B' });
+  expect(r2.is_error).toBeFalsy();
+
+  const rows = await api4(page, `Custom_${groupName}`, 'get', { where: [['entity_id', '=', caseId]], select: ['id'] });
+  expect(Array.isArray(rows) ? rows.length : 0).toBe(2);
+
+  // AC5: an invalid row (unknown Case) is rejected.
+  const bad = await api3(page, 'CaseCustomImporter', 'create', { case_id: 999999, [col]: 'x' });
+  expect(bad.is_error).toBeTruthy();
+  expect(String(bad.error_message)).toContain('not found');
+});

--- a/tests/e2e/specs/import-repeatable-case-custom-data.spec.ts
+++ b/tests/e2e/specs/import-repeatable-case-custom-data.spec.ts
@@ -31,6 +31,7 @@ const FIELD_LABEL = 'E2E Import Name';
 
 let groupName = '';
 let fieldId = 0;
+let fieldName = '';
 let caseId = 0;
 let caseTypeId = 0;
 let contactId = 0;
@@ -73,6 +74,7 @@ test.beforeAll(async () => {
     custom_group_id: group.id, label: FIELD_LABEL, data_type: 'String', html_type: 'Text', is_active: 1, is_searchable: 1,
   }))[0];
   fieldId = Number(field.id);
+  fieldName = String(field.name);
 
   caseTypeId = Number(civi.values(await civi.api3('CaseType', 'get', { is_active: 1, options: { limit: 1, sort: 'id ASC' } }))[0].id);
   contactId = Number(civi.values(await civi.api3('Contact', 'create', {
@@ -91,26 +93,45 @@ test.afterAll(async () => {
   if (contactId) await civi.api3('Contact', 'delete', { id: contactId, skip_undelete: 1 }).catch(() => {});
 });
 
-test('CaseCustomImporter.create imports rows as separate records against the Case, matched by Case ID', async ({ page }) => {
+test('CaseCustomImporter.create imports rows (create), updates by id, and rejects bad matches', async ({ page }) => {
   await civiLogin(page);
   await page.goto('/civicrm/admin/search', { waitUntil: 'domcontentloaded' });
   const col = `custom_${fieldId}`;
 
-  // AC1: the group's field is offered as an importable column.
+  // AC1: the group's field, case_id and the id match-key are importable columns.
   const fields = await api3(page, 'CaseCustomImporter', 'getfields', { action: 'create' });
   expect(Object.keys(fields.values || {})).toContain(col);
   expect(Object.keys(fields.values || {})).toContain('case_id');
+  expect(Object.keys(fields.values || {})).toContain('id');
 
-  // AC2/AC3: two rows -> two separate records against the same Case.
+  // AC2/AC3: two rows (no id) -> two separate records against the same Case.
   const r1 = await api3(page, 'CaseCustomImporter', 'create', { case_id: caseId, [col]: 'Imported A' });
   expect(r1.is_error).toBeFalsy();
   const r2 = await api3(page, 'CaseCustomImporter', 'create', { case_id: caseId, [col]: 'Imported B' });
   expect(r2.is_error).toBeFalsy();
 
-  const rows = await api4(page, `Custom_${groupName}`, 'get', { where: [['entity_id', '=', caseId]], select: ['id'] });
-  expect(Array.isArray(rows) ? rows.length : 0).toBe(2);
+  let rows = await api4(page, `Custom_${groupName}`, 'get', {
+    where: [['entity_id', '=', caseId]], select: ['id', fieldName], orderBy: { id: 'ASC' },
+  });
+  expect(rows.length).toBe(2);
 
-  // AC5: an invalid row (unknown Case) is rejected.
+  // Update: id matches an existing record -> updates in place, no new row.
+  // id is a match key only (not written as a value).
+  const targetId = rows[0].id;
+  const upd = await api3(page, 'CaseCustomImporter', 'create', { case_id: caseId, id: targetId, [col]: 'Updated A' });
+  expect(upd.is_error).toBeFalsy();
+  rows = await api4(page, `Custom_${groupName}`, 'get', { where: [['entity_id', '=', caseId]], select: ['id', fieldName] });
+  expect(rows.length).toBe(2);
+  expect(rows.find((r: any) => r.id === targetId)[fieldName]).toBe('Updated A');
+
+  // Matching failure: an id with no record on this Case is rejected (no new row).
+  const badId = await api3(page, 'CaseCustomImporter', 'create', { case_id: caseId, id: 999999, [col]: 'Nope' });
+  expect(badId.is_error).toBeTruthy();
+  expect(String(badId.error_message)).toContain('No repeatable record');
+  rows = await api4(page, `Custom_${groupName}`, 'get', { where: [['entity_id', '=', caseId]], select: ['id'] });
+  expect(rows.length).toBe(2);
+
+  // AC5: an unknown Case is rejected.
   const bad = await api3(page, 'CaseCustomImporter', 'create', { case_id: 999999, [col]: 'x' });
   expect(bad.is_error).toBeTruthy();
   expect(String(bad.error_message)).toContain('not found');

--- a/tests/phpunit/CRM/Civicase/Service/RepeatableCaseCustomImporterTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/RepeatableCaseCustomImporterTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use CRM_Civicase_Service_RepeatableCaseCustomImporter as Importer;
+use CRM_Civicase_Test_Fabricator_Case as CaseFabricator;
+use CRM_Civicase_Test_Fabricator_CaseType as CaseTypeFabricator;
+use CRM_Civicase_Test_Fabricator_Contact as ContactFabricator;
+
+/**
+ * Tests the repeatable Case custom-data importer service (TCOSB-64 / 1.8).
+ *
+ * A real Case can be created here (plain rows, cleanly rolled back). The
+ * happy-path record create needs a real repeatable custom group, whose DDL
+ * table would leak this transactional test, so that is exercised by the
+ * Playwright E2E (import-repeatable-case-custom-data.spec.ts) — mirroring the
+ * approach in RepeatableCaseCustomGroupAfformsTest.
+ *
+ * @group headless
+ */
+class CRM_Civicase_Service_RepeatableCaseCustomImporterTest extends BaseHeadlessTest {
+
+  use CRM_Civicase_Helpers_SessionTrait;
+
+  /**
+   * Registers a logged-in contact (needed when fabricating a Case).
+   */
+  public function setUp() {
+    $contact = ContactFabricator::fabricate();
+    $this->registerCurrentLoggedInContactInSession($contact['id']);
+  }
+
+  /**
+   * A row without case_id is rejected.
+   */
+  public function testImportRowRequiresCaseId() {
+    $this->expectException(CRM_Core_Exception::class);
+    $this->expectExceptionMessage('case_id is required');
+    Importer::importRow(['custom_1' => 'x']);
+  }
+
+  /**
+   * A row referencing a non-existent Case is rejected.
+   */
+  public function testImportRowRejectsUnknownCase() {
+    $this->expectException(CRM_Core_Exception::class);
+    $this->expectExceptionMessage('not found');
+    Importer::importRow(['case_id' => 999999999, 'custom_1' => 'x']);
+  }
+
+  /**
+   * A row for a real Case that carries no repeatable values is rejected.
+   */
+  public function testImportRowRejectsRowWithNoValues() {
+    $caseType = CaseTypeFabricator::fabricate();
+    $client = ContactFabricator::fabricate();
+    $case = CaseFabricator::fabricate([
+      'case_type_id' => $caseType['id'],
+      'contact_id' => $client['id'],
+      'creator_id' => $client['id'],
+    ]);
+
+    $this->expectException(CRM_Core_Exception::class);
+    $this->expectExceptionMessage('no repeatable Case custom field values');
+    Importer::importRow(['case_id' => $case['id']]);
+  }
+
+  /**
+   * The mappableFields() helper returns an array (empty with no groups).
+   */
+  public function testMappableFieldsReturnsArray() {
+    $this->assertTrue(is_array(Importer::mappableFields()));
+  }
+
+}

--- a/tests/phpunit/CRM/Civicase/Service/RepeatableCaseCustomImporterTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/RepeatableCaseCustomImporterTest.php
@@ -64,6 +64,15 @@ class CRM_Civicase_Service_RepeatableCaseCustomImporterTest extends BaseHeadless
   }
 
   /**
+   * A row with a non-numeric id is rejected as invalid.
+   */
+  public function testImportRowRejectsNonNumericId() {
+    $this->expectException(CRM_Core_Exception::class);
+    $this->expectExceptionMessage('Invalid record id');
+    Importer::importRow(['case_id' => 1, 'id' => 'abc', 'custom_1' => 'x']);
+  }
+
+  /**
    * A row whose id matches no record on the Case is rejected.
    */
   public function testImportRowRejectsUnmatchedId() {

--- a/tests/phpunit/CRM/Civicase/Service/RepeatableCaseCustomImporterTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/RepeatableCaseCustomImporterTest.php
@@ -64,6 +64,23 @@ class CRM_Civicase_Service_RepeatableCaseCustomImporterTest extends BaseHeadless
   }
 
   /**
+   * A row whose id matches no record on the Case is rejected.
+   */
+  public function testImportRowRejectsUnmatchedId() {
+    $caseType = CaseTypeFabricator::fabricate();
+    $client = ContactFabricator::fabricate();
+    $case = CaseFabricator::fabricate([
+      'case_type_id' => $caseType['id'],
+      'contact_id' => $client['id'],
+      'creator_id' => $client['id'],
+    ]);
+
+    $this->expectException(CRM_Core_Exception::class);
+    $this->expectExceptionMessage('No repeatable record');
+    Importer::importRow(['case_id' => $case['id'], 'id' => 999999, 'custom_1' => 'x']);
+  }
+
+  /**
    * The mappableFields() helper returns an array (empty with no groups).
    */
   public function testMappableFieldsReturnsArray() {

--- a/tests/phpunit/api/v3/CaseCustomImporterApiTest.php
+++ b/tests/phpunit/api/v3/CaseCustomImporterApiTest.php
@@ -13,7 +13,7 @@
 class CaseCustomImporterApiTest extends BaseHeadlessTest {
 
   /**
-   * getfields exposes case_id and the id match-key as mappable columns.
+   * The getfields action exposes case_id and the id match-key as columns.
    */
   public function testGetfieldsExposesCaseIdAndMatchKey() {
     $result = civicrm_api3('CaseCustomImporter', 'getfields', [

--- a/tests/phpunit/api/v3/CaseCustomImporterApiTest.php
+++ b/tests/phpunit/api/v3/CaseCustomImporterApiTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Tests the CaseCustomImporter.create API (TCOSB-64 / 1.8).
+ *
+ * The endpoint nz.co.fuzion.csvimport calls once per CSV row to import
+ * repeatable Case custom data. Covers the field metadata and error handling;
+ * the happy-path create (needs a real repeatable custom group) is covered by
+ * the Playwright E2E import-repeatable-case-custom-data.spec.ts.
+ *
+ * @group headless
+ */
+class CaseCustomImporterApiTest extends BaseHeadlessTest {
+
+  /**
+   * The getfields action exposes case_id as a mappable column.
+   */
+  public function testGetfieldsExposesCaseId() {
+    $result = civicrm_api3('CaseCustomImporter', 'getfields', [
+      'action' => 'create',
+    ]);
+    $this->assertArrayHasKey('case_id', $result['values']);
+  }
+
+  /**
+   * The entity is resolvable via APIv4 getFields, not only api3.
+   *
+   * The nz.co.fuzion.csvimport extension calls APIv4 getFields on the import
+   * entity, so it must exist in api4 too — the gap the api3-only tests missed.
+   */
+  public function testApi4GetFieldsResolves() {
+    $names = civicrm_api4('CaseCustomImporter', 'getFields', [
+      'checkPermissions' => FALSE,
+    ])->column('name');
+    $this->assertContains('case_id', $names);
+  }
+
+  /**
+   * A missing case_id is rejected by the API.
+   */
+  public function testCreateRequiresCaseId() {
+    try {
+      civicrm_api3('CaseCustomImporter', 'create', ['custom_1' => 'x']);
+      $this->fail('Expected an API error when case_id is missing');
+    }
+    catch (Exception $e) {
+      $this->assertNotFalse(strpos($e->getMessage(), 'case_id'));
+    }
+  }
+
+  /**
+   * A non-existent Case is rejected by the API.
+   */
+  public function testCreateRejectsUnknownCase() {
+    try {
+      civicrm_api3('CaseCustomImporter', 'create', [
+        'case_id' => 999999999,
+        'custom_1' => 'x',
+      ]);
+      $this->fail('Expected an API error for an unknown Case');
+    }
+    catch (Exception $e) {
+      $this->assertNotFalse(strpos($e->getMessage(), 'not found'));
+    }
+  }
+
+}

--- a/tests/phpunit/api/v3/CaseCustomImporterApiTest.php
+++ b/tests/phpunit/api/v3/CaseCustomImporterApiTest.php
@@ -13,13 +13,14 @@
 class CaseCustomImporterApiTest extends BaseHeadlessTest {
 
   /**
-   * The getfields action exposes case_id as a mappable column.
+   * getfields exposes case_id and the id match-key as mappable columns.
    */
-  public function testGetfieldsExposesCaseId() {
+  public function testGetfieldsExposesCaseIdAndMatchKey() {
     $result = civicrm_api3('CaseCustomImporter', 'getfields', [
       'action' => 'create',
     ]);
     $this->assertArrayHasKey('case_id', $result['values']);
+    $this->assertArrayHasKey('id', $result['values']);
   }
 
   /**


### PR DESCRIPTION
## Overview

Requirement **1.8** of the Repeatable Custom Field Sets for Cases epic: importing repeatable ("Tab with table", multi-record) Case custom data — creating multiple custom-data records against a Case from a CSV.

Unlike 1.4–1.7 (which were native), this one needs code — but it stays **additive** (no core Import framework changes), using the already-installed `nz.co.fuzion.csvimport` extension plus a thin civicase API endpoint, the same pattern as `uk.co.compucorp.membershipextrasimporterapi`.

## Before

CiviCRM's core Import has no path to import repeatable Case custom data.

## After

A new **`CaseCustomImporter`** API3 entity is selectable in the CSV Importer's "Entity To Import" list. It is called once per CSV row and matches the parent Case by **Case ID**.

**Create or update:** a row with a **blank `id`** creates a new record in each repeatable Case custom group whose fields are present; a row carrying a record **`id`** **updates** that existing record on the Case instead. The `id` is used **only to match** the record to update — it is never stored as a value. A row whose `id` matches no record on the Case is rejected.

<img width="1885" height="984" alt="Screenshot 2026-07-23 at 07 34 02" src="https://github.com/user-attachments/assets/977cedc5-88a7-4f45-92e6-0b43694c7682" />

<img width="1686" height="924" alt="Screenshot 2026-07-23 at 07 35 12" src="https://github.com/user-attachments/assets/14bed17c-77b0-4c11-a82f-e7be81b60aae" />

## Technical Details

- `api/v3/CaseCustomImporter.php` — `CaseCustomImporter.create` + `_spec`. The spec enumerates every active field of every repeatable Case custom group as a mappable column (`custom_<id>`), so the importer's column list mirrors what's configured (AC1). No DAO/table is needed — the api3 file alone makes the entity appear in `Entity.get` (hence in csvimport's dropdown).
- `CRM/Civicase/Service/RepeatableCaseCustomImporter.php` — resolves the Case by id, groups the row's `custom_<id>` values by custom group, and creates one `Custom_<group>` record per group via APIv4 (`entity_id` = the Case). Create-or-update: a blank `id` creates a new record; a row carrying an `id` **updates** that existing record on the Case (the `id` is a match key only, never stored as a value). Rejects rows with an unknown Case or no mappable values, so csvimport reports the bad row while valid rows import (AC5).
- **Scope:** create (AC2/AC3) **and update** — the spec's "update existing records where a suitable unique identifier exists" is met with the **record `id`** as the identifier (pairs with the 1.7 export: export `id` → edit → re-import to update). A row whose `id` matches no record on the Case is rejected (reported per-row). Parent Case matched by **Case ID**.

### Core overrides

None. Purely additive — a new API endpoint + service + test. No core Import framework changes.

## Manual QA Steps

Prerequisite: a repeatable Case custom group (1.1) with a couple of fields, and a Case (note its **Case ID**).

1. Prepare a CSV with a `case_id` column plus one column per custom field. Add **two rows with the same Case ID** and different values (to prove multiple records).
2. Open the **CSV Importer** screen (provided by the "CSV GUI Import to api" extension).
3. Choose **`CaseCustomImporter`** as "Entity To Import"; upload the CSV.
4. Map the columns (Case ID → `Case ID`; each value column → its `<Group>: <Field>` entry) and run the import.
5. Open the target Case → the repeatable custom-data tab (from 1.2): confirm **both rows imported as separate records** (create path).
6. **Update:** note one record's **`id`** (shown in SearchKit / the 1.7 export). Prepare a CSV with an **`id` column** — one row using that id with changed values, plus one row with a **blank** id. Re-import → confirm the id row **updated that record in place** (no new row) and the blank-id row **created** a new record.
7. **Bad matches:** a row with an invalid Case ID, and a row with an `id` that isn't on the Case, are both **rejected/reported** while the valid rows still import.

## Example CSV & field mapping

Each row needs a `case_id` column (the target Case's ID) plus one column per repeatable custom field to import. The exact columns depend on how the repeatable group is configured on the site — e.g. for a group with a text field, a date and an amount:

```csv
id,case_id,Publication Title,Publication Date,Amount
,<caseId>,First entry,2026-08-01,100.00
,<caseId>,Second entry,2026-08-15,250.50
<recordId>,<caseId>,Corrected entry,2026-08-20,300.00
```

On **API Import** (`/civicrm/csvimporter/import`) → **Entity To Import = `CaseCustomImporter`**, then map each CSV column to a field. The importer lists every repeatable Case custom field as **"<Group>: <Field>"** (and `case_id` -> **Case ID**), so mapping adapts to whatever fields the group has.

- Two rows sharing a `case_id` with **blank `id`** import as **two separate records** on that Case.
- **`id` is optional and match-only:** blank → create a new record; an existing record `id` (e.g. from the 1.7 export) → **update** that record in place.
- Value formats: date `YYYY-MM-DD`; select/radio use the option **value**; numbers plain.


## Comments

- Additive only — no core Import patch (epic constraint).
- Regression guard: `tests/e2e/specs/import-repeatable-case-custom-data.spec.ts` drives `CaseCustomImporter.create` (the exact call csvimport makes) — AC1 (columns), AC2/AC3 (two rows → two records), AC5 (bad Case rejected). Full e2e suite green (5/5). CI does not run Playwright (local-only), consistent with earlier PRs.
- Permissions (AC7): import is an admin-gated operation via the CSV Importer screen.

- **AC4 (known limitation):** the importer validates field values exactly as CiviCRM's APIv4 does — invalid values are only rejected to the extent APIv4/DB validates them (e.g. a malformed date is accepted, same as the interactive add/edit form). Strict per-field validation was kept out of scope to stay consistent with core. Flagged for PO.

