### PR TITLE
TCOSB-57: Show option/reference custom-field labels in case tabs

### DIFF
--- a/CRM/Civicase/Service/RepeatableCaseCustomGroupAfforms.php
+++ b/CRM/Civicase/Service/RepeatableCaseCustomGroupAfforms.php
@@ -2,6 +2,7 @@
 
 use Civi\Api4\CustomGroup;
 use Civi\Api4\Managed;
+use Civi\Api4\Utils\CoreUtil;
 
 /**
  * Provides Afform + SearchKit artifacts for repeatable Case custom groups.
@@ -251,9 +252,9 @@ class CRM_Civicase_Service_RepeatableCaseCustomGroupAfforms {
       'key' => $this->fieldDisplayKey($field),
       'label' => $field['label'],
       'sortable' => TRUE,
-      // A reference value is rendered via a read-only join (the contact's name),
-      // so it cannot be inline-edited in the table — it is changed through the
-      // row Edit form. Option and plain fields stay inline-editable.
+      // A reference renders as a read-only join (e.g. the contact's name),
+      // so it cannot be inline-edited here; it is changed via the row Edit
+      // form. Option and plain fields stay inline-editable.
       'editable' => !$this->fieldIsReference($field),
     ];
   }
@@ -264,8 +265,8 @@ class CRM_Civicase_Service_RepeatableCaseCustomGroupAfforms {
    * SearchKit shows the raw stored value unless told otherwise, so:
    *  - option-list / pseudoconstant fields (Select, Radio, Country, State,
    *    Boolean, …) use the "<name>:label" suffix;
-   *  - entity-reference fields (e.g. ContactReference) use a join to the target
-   *    entity's label field, "<name>.<labelField>" (e.g. "<name>.display_name");
+   *  - entity-reference fields (e.g. ContactReference) join to the target
+   *    entity's label field: "<name>.<labelField>" (e.g. ".display_name");
    *  - plain fields (text, number, date, …) use the field name as-is.
    *
    * @param array $field
@@ -291,7 +292,7 @@ class CRM_Civicase_Service_RepeatableCaseCustomGroupAfforms {
    *   Custom field record.
    *
    * @return bool
-   *   TRUE for option groups and the built-in Country/State/Boolean pseudoconstants.
+   *   TRUE for option groups and Country/State/Boolean pseudoconstants.
    */
   protected function fieldHasOptions(array $field): bool {
     if (!empty($field['option_group_id'])) {
@@ -320,9 +321,9 @@ class CRM_Civicase_Service_RepeatableCaseCustomGroupAfforms {
   /**
    * The label field on the entity a reference field points at.
    *
-   * A ContactReference targets a contact (fk_entity may be empty, so default to
-   * Contact); an EntityReference names its target in fk_entity. Either way the
-   * target's label field (e.g. Contact -> display_name) is resolved generically.
+   * A ContactReference targets a contact (fk_entity may be empty, so default
+   * to Contact); an EntityReference names its target in fk_entity. Either way
+   * the target's label field (Contact -> display_name) resolves generically.
    *
    * @param array $field
    *   Custom field record.
@@ -332,7 +333,7 @@ class CRM_Civicase_Service_RepeatableCaseCustomGroupAfforms {
    */
   protected function referenceLabelField(array $field): string {
     $fkEntity = !empty($field['fk_entity']) ? $field['fk_entity'] : 'Contact';
-    return \Civi\Api4\Utils\CoreUtil::getInfoItem($fkEntity, 'label_field') ?: 'display_name';
+    return CoreUtil::getInfoItem($fkEntity, 'label_field') ?: 'display_name';
   }
 
   /**

--- a/CRM/Civicase/Service/RepeatableCaseCustomGroupAfforms.php
+++ b/CRM/Civicase/Service/RepeatableCaseCustomGroupAfforms.php
@@ -175,7 +175,7 @@ class CRM_Civicase_Service_RepeatableCaseCustomGroupAfforms {
     $fields = $groupDetails['fields'] ?? [];
     $displayFields = array_filter($fields, fn ($f) => !empty($f['is_active']));
 
-    $select = array_column($fields, 'name');
+    $select = array_map([$this, 'fieldDisplayKey'], array_values($displayFields));
     $select[] = 'id';
     $select[] = 'entity_id';
 
@@ -248,11 +248,86 @@ class CRM_Civicase_Service_RepeatableCaseCustomGroupAfforms {
   protected function searchColumnForField(array $field): array {
     return [
       'type' => 'field',
-      'key' => $field['name'],
+      'key' => $this->fieldDisplayKey($field),
       'label' => $field['label'],
       'sortable' => TRUE,
-      'editable' => TRUE,
+      // A reference value is rendered via a read-only join (the contact's name),
+      // so it cannot be inline-edited in the table — it is changed through the
+      // row Edit form. Option and plain fields stay inline-editable.
+      'editable' => !$this->fieldIsReference($field),
     ];
+  }
+
+  /**
+   * The APIv4 select/column key that renders a field's human-readable value.
+   *
+   * SearchKit shows the raw stored value unless told otherwise, so:
+   *  - option-list / pseudoconstant fields (Select, Radio, Country, State,
+   *    Boolean, …) use the "<name>:label" suffix;
+   *  - entity-reference fields (e.g. ContactReference) use a join to the target
+   *    entity's label field, "<name>.<labelField>" (e.g. "<name>.display_name");
+   *  - plain fields (text, number, date, …) use the field name as-is.
+   *
+   * @param array $field
+   *   Custom field record.
+   *
+   * @return string
+   *   The select expression / column key.
+   */
+  protected function fieldDisplayKey(array $field): string {
+    if ($this->fieldIsReference($field)) {
+      return $field['name'] . '.' . $this->referenceLabelField($field);
+    }
+    if ($this->fieldHasOptions($field)) {
+      return $field['name'] . ':label';
+    }
+    return $field['name'];
+  }
+
+  /**
+   * Whether a field's value is a coded option that has a separate label.
+   *
+   * @param array $field
+   *   Custom field record.
+   *
+   * @return bool
+   *   TRUE for option groups and the built-in Country/State/Boolean pseudoconstants.
+   */
+  protected function fieldHasOptions(array $field): bool {
+    if (!empty($field['option_group_id'])) {
+      return TRUE;
+    }
+    return in_array($field['data_type'] ?? '', ['Boolean', 'Country', 'StateProvince'], TRUE);
+  }
+
+  /**
+   * Whether a field is an entity reference (e.g. a ContactReference).
+   *
+   * @param array $field
+   *   Custom field record.
+   *
+   * @return bool
+   *   TRUE if the field stores a reference to another entity.
+   */
+  protected function fieldIsReference(array $field): bool {
+    return ($field['data_type'] ?? '') === 'ContactReference';
+  }
+
+  /**
+   * The label field on the entity a reference field points at.
+   *
+   * Custom reference fields target Contact, whose label field is display_name;
+   * resolved generically so it stays correct if that ever changes.
+   *
+   * @param array $field
+   *   Custom field record.
+   *
+   * @return string
+   *   The target entity's label field name.
+   */
+  protected function referenceLabelField(array $field): string {
+    $fkEntity = !empty($field['fk_entity']) ? $field['fk_entity'] : 'Contact';
+    return \Civi\Api4\Utils\CoreUtil::getInfoItem($fkEntity, 'label_field') ?: 'display_name';
   }
 
   /**

--- a/CRM/Civicase/Service/RepeatableCaseCustomGroupAfforms.php
+++ b/CRM/Civicase/Service/RepeatableCaseCustomGroupAfforms.php
@@ -301,7 +301,11 @@ class CRM_Civicase_Service_RepeatableCaseCustomGroupAfforms {
   }
 
   /**
-   * Whether a field is an entity reference (e.g. a ContactReference).
+   * Whether a field is a reference to another entity.
+   *
+   * Covers both ContactReference (targets a contact) and the generic
+   * EntityReference (targets any entity, named in fk_entity) — core treats the
+   * two together, so both must render as a label join, not a raw id.
    *
    * @param array $field
    *   Custom field record.
@@ -310,14 +314,15 @@ class CRM_Civicase_Service_RepeatableCaseCustomGroupAfforms {
    *   TRUE if the field stores a reference to another entity.
    */
   protected function fieldIsReference(array $field): bool {
-    return ($field['data_type'] ?? '') === 'ContactReference';
+    return in_array($field['data_type'] ?? '', ['ContactReference', 'EntityReference'], TRUE);
   }
 
   /**
    * The label field on the entity a reference field points at.
    *
-   * Custom reference fields target Contact, whose label field is display_name;
-   * resolved generically so it stays correct if that ever changes.
+   * A ContactReference targets a contact (fk_entity may be empty, so default to
+   * Contact); an EntityReference names its target in fk_entity. Either way the
+   * target's label field (e.g. Contact -> display_name) is resolved generically.
    *
    * @param array $field
    *   Custom field record.

--- a/tests/phpunit/CRM/Civicase/Service/RepeatableCaseCustomGroupAfformsTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/RepeatableCaseCustomGroupAfformsTest.php
@@ -96,4 +96,25 @@ class CRM_Civicase_Service_RepeatableCaseCustomGroupAfformsTest extends BaseHead
     $this->assertEquals('view', $links[0]['ui_action']);
   }
 
+  /**
+   * Option, pseudoconstant and reference fields resolve to readable keys.
+   *
+   * Option groups and the Country/State/Boolean pseudoconstants use the
+   * ":label" suffix; a ContactReference joins to the target's label field
+   * (display_name); plain fields are unchanged. This is what makes the case
+   * tab render labels instead of coded values / contact ids.
+   */
+  public function testFieldDisplayKeyResolvesLabelsAndReferences() {
+    $service = new Service();
+    $method = new ReflectionMethod(Service::class, 'fieldDisplayKey');
+    $method->setAccessible(TRUE);
+    $key = fn (array $field) => $method->invoke($service, $field);
+
+    $this->assertEquals('plain_text', $key(['name' => 'plain_text', 'data_type' => 'String', 'html_type' => 'Text']));
+    $this->assertEquals('a_select:label', $key(['name' => 'a_select', 'data_type' => 'String', 'option_group_id' => 7]));
+    $this->assertEquals('a_country:label', $key(['name' => 'a_country', 'data_type' => 'Country']));
+    $this->assertEquals('a_bool:label', $key(['name' => 'a_bool', 'data_type' => 'Boolean']));
+    $this->assertEquals('a_contact.display_name', $key(['name' => 'a_contact', 'data_type' => 'ContactReference']));
+  }
+
 }

--- a/tests/phpunit/CRM/Civicase/Service/RepeatableCaseCustomGroupAfformsTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/RepeatableCaseCustomGroupAfformsTest.php
@@ -115,7 +115,8 @@ class CRM_Civicase_Service_RepeatableCaseCustomGroupAfformsTest extends BaseHead
     $this->assertEquals('a_country:label', $key(['name' => 'a_country', 'data_type' => 'Country']));
     $this->assertEquals('a_bool:label', $key(['name' => 'a_bool', 'data_type' => 'Boolean']));
     $this->assertEquals('a_contact.display_name', $key(['name' => 'a_contact', 'data_type' => 'ContactReference']));
-    $this->assertEquals('an_entity.display_name', $key(['name' => 'an_entity', 'data_type' => 'EntityReference', 'fk_entity' => 'Contact']));
+    $entityRef = ['name' => 'an_entity', 'data_type' => 'EntityReference', 'fk_entity' => 'Contact'];
+    $this->assertEquals('an_entity.display_name', $key($entityRef));
   }
 
 }

--- a/tests/phpunit/CRM/Civicase/Service/RepeatableCaseCustomGroupAfformsTest.php
+++ b/tests/phpunit/CRM/Civicase/Service/RepeatableCaseCustomGroupAfformsTest.php
@@ -115,6 +115,7 @@ class CRM_Civicase_Service_RepeatableCaseCustomGroupAfformsTest extends BaseHead
     $this->assertEquals('a_country:label', $key(['name' => 'a_country', 'data_type' => 'Country']));
     $this->assertEquals('a_bool:label', $key(['name' => 'a_bool', 'data_type' => 'Boolean']));
     $this->assertEquals('a_contact.display_name', $key(['name' => 'a_contact', 'data_type' => 'ContactReference']));
+    $this->assertEquals('an_entity.display_name', $key(['name' => 'an_entity', 'data_type' => 'EntityReference', 'fk_entity' => 'Contact']));
   }
 
 }


### PR DESCRIPTION
## Overview
Repeatable Case custom-data tabs (the "Tab with table" display) showed the **raw stored value** for option and reference fields — a select showed its coded value, and a Contact/Entity reference showed the referenced record's **id** — instead of the human-readable label. This makes those columns render labels.

## Before
On a repeatable Case custom group tab, e.g. an *Another multi* record: a ContactReference column shows `3` (the contact id) and option/select fields show their stored value rather than the label.

## After
- Option / select / Country / State / Boolean fields show their **label**.
- Contact/entity references (`ContactReference`, `EntityReference`) show the referenced record's **name**.
- Plain fields (text, number, date) are unchanged and stay inline-editable.
- 
<img width="1910" height="831" alt="Screenshot 2026-07-24 at 08 27 40" src="https://github.com/user-attachments/assets/277d0f16-eb38-4f23-9c58-d8f580a98d7e" />

## Technical Details
The per-group SavedSearch + SearchDisplay are auto-provisioned in `RepeatableCaseCustomGroupAfforms::searchKitManaged()`, which built the `select` and each column `key` from the **raw field name** — so SearchKit rendered the stored value.

Added `fieldDisplayKey()` to pick the readable APIv4 expression per field, used for **both** the SavedSearch `select` and the SearchDisplay column `key`:
- option group / `Country` / `StateProvince` / `Boolean` → `<name>:label`
- reference fields — `ContactReference` **and** `EntityReference` — → join `<name>.<labelField>` (label field resolved via `CoreUtil::getInfoItem($fk, 'label_field')`; Contact → `display_name`), rendered **read-only** (edited via the row Edit form)
- plain fields → `<name>` unchanged (still inline-editable)

`fk_entity` names the target for `EntityReference`; for `ContactReference` it may be empty, so it defaults to Contact — mirroring how core treats the two data types together. New/edited fields are picked up automatically by the existing reconcile hook (`ReconcileRepeatableCaseCustomArtifacts`) / `hook_civicrm_managed`, so no per-field work is needed. A unit test asserts the mapping (option/country/boolean → `:label`, ContactReference & EntityReference → `.display_name`, plain → name).

### Core overrides
None — additive only.

## Comments
- Reference columns are read-only in the table (a joined value can't be inline-edited); they're changed through the row Edit form.
- Verified on a live group: the generated select becomes `["Okay1","Okay2.display_name","id","entity_id"]` and the tab renders the contact name instead of the id.
- Addressed the automated review: reference handling now covers `EntityReference` as well as `ContactReference` (+ test).
